### PR TITLE
fix(multigateway): preserve SQL EXECUTE argument expressions

### DIFF
--- a/go/services/multigateway/engine/prepared_statement_primitive.go
+++ b/go/services/multigateway/engine/prepared_statement_primitive.go
@@ -17,7 +17,6 @@ package engine
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
@@ -38,15 +37,15 @@ const (
 	preparedStmtDeallocateAll                         // DEALLOCATE ALL
 )
 
-// PreparedStatementPrimitive handles PREPARE, EXECUTE, and DEALLOCATE statements
-// from the simple query protocol by delegating to the existing extended query
-// protocol handler methods (HandleParse, HandleBind, HandleClose) via conn.Handler().
+// PreparedStatementPrimitive handles SQL PREPARE, EXECUTE, and DEALLOCATE
+// through gateway-managed prepared-statement consolidation.
 //
 // Key behaviors:
 //   - PREPARE: Calls HandleParse to register in the consolidator.
-//   - EXECUTE: Calls HandleBind to create a portal, then PortalStreamExecute.
-//   - DEALLOCATE: Calls HandleClose to remove from the consolidator.
-//   - DEALLOCATE ALL: Uses the consolidator directly (no extended protocol equivalent).
+//   - EXECUTE: Rewrites the prepared-statement name to the canonical name and
+//     runs SQL EXECUTE verbatim so PostgreSQL evaluates argument expressions.
+//   - DEALLOCATE: Calls HandleClose to remove the user-facing mapping.
+//   - DEALLOCATE ALL: Clears all user-facing mappings for this connection.
 type PreparedStatementPrimitive struct {
 	kind       preparedStmtKind
 	tableGroup string
@@ -60,8 +59,11 @@ type PreparedStatementPrimitive struct {
 	// paramTypes holds the parameter type OIDs for PREPARE (from SQL type names).
 	paramTypes []uint32
 
-	// params holds the converted EXECUTE parameters (text-format byte arrays).
-	params [][]byte
+	// executeStmt is the parsed EXECUTE statement. For SQL EXECUTE we preserve
+	// the argument expressions verbatim and rewrite only the prepared-statement
+	// name to the gateway canonical name, then let PostgreSQL evaluate/cast the
+	// argument expressions itself.
+	executeStmt *ast.ExecuteStmt
 }
 
 // NewPreparePrimitive creates a primitive for PREPARE name AS query.
@@ -76,12 +78,12 @@ func NewPreparePrimitive(tableGroup, stmtName, innerQuery string, paramTypes []u
 }
 
 // NewExecutePrimitive creates a primitive for EXECUTE name [(params)].
-func NewExecutePrimitive(tableGroup, stmtName string, params [][]byte) *PreparedStatementPrimitive {
+func NewExecutePrimitive(tableGroup string, stmt *ast.ExecuteStmt) *PreparedStatementPrimitive {
 	return &PreparedStatementPrimitive{
-		kind:       preparedStmtExecute,
-		tableGroup: tableGroup,
-		stmtName:   stmtName,
-		params:     params,
+		kind:        preparedStmtExecute,
+		tableGroup:  tableGroup,
+		stmtName:    stmt.Name,
+		executeStmt: stmt,
 	}
 }
 
@@ -145,14 +147,11 @@ func (p *PreparedStatementPrimitive) executePrepare(
 	return callback(ctx, &sqltypes.Result{CommandTag: "PREPARE"})
 }
 
-// executeExecute delegates to HandleBind to create a portal, then executes it
-// via PortalStreamExecute. We avoid calling HandleExecute directly because it
-// would double-count metrics and spans (HandleQuery already records those).
-//
-// Because the extended protocol returns field metadata via Describe (not Execute),
-// PortalStreamExecute results lack Fields. We call HandleDescribe to obtain them
-// and inject into the first callback so the simple query protocol can emit the
-// required RowDescription before DataRows.
+// executeExecute rewrites the SQL-level EXECUTE to reference the gateway
+// canonical prepared-statement name, attaches the prepared-statement metadata,
+// and sends the rewritten SQL through StreamExecute. This preserves the
+// consolidation path while letting PostgreSQL evaluate EXECUTE arguments
+// verbatim, including casts, arrays, functions, and other expressions.
 func (p *PreparedStatementPrimitive) executeExecute(
 	ctx context.Context,
 	exec IExecute,
@@ -160,37 +159,23 @@ func (p *PreparedStatementPrimitive) executeExecute(
 	state *handler.MultiGatewayConnectionState,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	// HandleBind looks up the prepared statement, creates a portal, and stores it in state.
-	if err := conn.Handler().HandleBind(ctx, conn, "", p.stmtName, p.params, nil, nil); err != nil {
-		return err
+	psi := conn.Handler().GetPreparedStatementInfo(conn.ConnectionID(), p.stmtName)
+	if psi == nil {
+		return mterrors.NewInvalidPreparedStatementError(p.stmtName)
+	}
+	if p.executeStmt == nil {
+		return fmt.Errorf("internal error: execute statement AST missing for statement \"%s\"", p.stmtName)
 	}
 
-	// Retrieve the portal that HandleBind just created.
-	portalInfo := state.GetPortalInfo("")
-	if portalInfo == nil {
-		return fmt.Errorf("internal error: portal not found after bind for statement \"%s\"", p.stmtName)
-	}
-	defer state.DeletePortalInfo("")
+	rewrittenSQL := p.executeSQLWithName(psi.Name)
+	return exec.StreamExecute(ctx, conn, p.tableGroup, constants.DefaultShard, rewrittenSQL, psi.PreparedStatement, state, PlanExecInfo{}, callback)
+}
 
-	// Get field descriptions via Describe. In the extended protocol this is a
-	// separate step; in the simple protocol it must be folded into the result
-	// stream so the conn writes RowDescription before DataRows.
-	desc, err := conn.Handler().HandleDescribe(ctx, conn, 'P', "")
-	if err != nil {
-		return err
-	}
-
-	// Wrap the callback to inject Fields from Describe into the first result.
-	fieldsInjected := false
-	wrappedCallback := func(ctx context.Context, result *sqltypes.Result) error {
-		if !fieldsInjected && desc != nil && len(desc.Fields) > 0 && len(result.Fields) == 0 {
-			result.Fields = desc.Fields
-			fieldsInjected = true
-		}
-		return callback(ctx, result)
-	}
-
-	return exec.PortalStreamExecute(ctx, p.tableGroup, constants.DefaultShard, conn, state, portalInfo, 0, false, PlanExecInfo{}, wrappedCallback)
+func (p *PreparedStatementPrimitive) executeSQLWithName(name string) string {
+	originalName := p.executeStmt.Name
+	p.executeStmt.Name = name
+	defer func() { p.executeStmt.Name = originalName }()
+	return p.executeStmt.SqlString()
 }
 
 // executeDeallocate uses HandleClose with typ 'D' which errors on nonexistent
@@ -255,36 +240,6 @@ func (p *PreparedStatementPrimitive) String() string {
 
 var _ Primitive = (*PreparedStatementPrimitive)(nil)
 
-// ExtractExecuteParams converts EXECUTE statement parameters from AST expression
-// nodes to byte arrays for portal creation. Only literal constant values (A_Const)
-// are supported.
-func ExtractExecuteParams(stmt *ast.ExecuteStmt) ([][]byte, error) {
-	if stmt.Params == nil || stmt.Params.Len() == 0 {
-		return nil, nil
-	}
-
-	params := make([][]byte, 0, stmt.Params.Len())
-	for i, param := range stmt.Params.Items {
-		constNode, ok := param.(*ast.A_Const)
-		if !ok {
-			return nil, fmt.Errorf("parameter %d: unsupported expression type %T; only literal values are supported", i+1, param)
-		}
-
-		if constNode.Isnull || constNode.Val == nil {
-			params = append(params, nil)
-			continue
-		}
-
-		val, err := constToBytes(constNode.Val)
-		if err != nil {
-			return nil, fmt.Errorf("parameter %d: %w", i+1, err)
-		}
-		params = append(params, val)
-	}
-
-	return params, nil
-}
-
 // ExtractParamTypeOids resolves the Argtypes from a PREPARE statement to OIDs.
 // Returns nil if there are no argument types. Unrecognized type names are passed
 // as 0 (unspecified), letting the backend infer them.
@@ -316,23 +271,4 @@ func ExtractInnerQuery(stmt *ast.PrepareStmt) string {
 		return ""
 	}
 	return stmt.Query.SqlString()
-}
-
-// constToBytes converts an AST constant value to its text-format byte representation.
-func constToBytes(val ast.Value) ([]byte, error) {
-	switch v := val.(type) {
-	case *ast.Integer:
-		return []byte(strconv.Itoa(v.IVal)), nil
-	case *ast.Float:
-		return []byte(v.FVal), nil
-	case *ast.String:
-		return []byte(v.SVal), nil
-	case *ast.Boolean:
-		if v.BoolVal {
-			return []byte("true"), nil
-		}
-		return []byte("false"), nil
-	default:
-		return nil, fmt.Errorf("unsupported constant type %T", v)
-	}
 }

--- a/go/services/multigateway/planner/prepared_stmt.go
+++ b/go/services/multigateway/planner/prepared_stmt.go
@@ -38,17 +38,18 @@ func (p *Planner) planPrepareStmt(sql string, stmt *ast.PrepareStmt) (*engine.Pl
 }
 
 // planExecuteStmt creates a plan for EXECUTE name [(params)].
-// Delegates to conn.Handler().HandleBind + exec.PortalStreamExecute at execution time.
+// The primitive rewrites only the prepared-statement name to its canonical
+// gateway-managed name at execution time, preserving argument expressions for
+// PostgreSQL to evaluate.
 func (p *Planner) planExecuteStmt(sql string, stmt *ast.ExecuteStmt) (*engine.Plan, error) {
-	params, err := engine.ExtractExecuteParams(stmt)
-	if err != nil {
-		return nil, err
-	}
-
-	prim := engine.NewExecutePrimitive(p.defaultTableGroup, stmt.Name, params)
+	prim := engine.NewExecutePrimitive(p.defaultTableGroup, stmt)
 	plan := engine.NewPlan(sql, prim)
 
-	p.logger.Debug("created execute plan", "name", stmt.Name, "param_count", len(params))
+	paramCount := 0
+	if stmt.Params != nil {
+		paramCount = stmt.Params.Len()
+	}
+	p.logger.Debug("created execute plan", "name", stmt.Name, "param_count", paramCount)
 	return plan, nil
 }
 

--- a/go/services/multigateway/planner/prepared_stmt_test.go
+++ b/go/services/multigateway/planner/prepared_stmt_test.go
@@ -222,11 +222,16 @@ func TestPlanExecuteStmt(t *testing.T) {
 
 	_, err := planAndExecute(t, s, "PREPARE myplan AS SELECT 1")
 	require.NoError(t, err)
+	psi := s.psc.GetPreparedStatementInfo(s.conn.Conn.ConnectionID(), "myplan")
+	require.NotNil(t, psi)
 
 	result, err := planAndExecute(t, s, "EXECUTE myplan")
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	assert.True(t, s.exec.portalStreamExecuteCalled, "PortalStreamExecute should be called")
+	assert.False(t, s.exec.portalStreamExecuteCalled, "top-level SQL EXECUTE should route as SQL, not bind a portal")
+	require.Len(t, s.exec.streamExecuteCalls, 1)
+	assert.Equal(t, "EXECUTE "+psi.Name, s.exec.streamExecuteCalls[0].sql)
+	assert.Equal(t, psi.PreparedStatement, s.exec.streamExecuteCalls[0].preparedStatement)
 }
 
 func TestPlanExecuteStmtWithParams(t *testing.T) {
@@ -234,11 +239,33 @@ func TestPlanExecuteStmtWithParams(t *testing.T) {
 
 	_, err := planAndExecute(t, s, "PREPARE myplan (int) AS SELECT $1")
 	require.NoError(t, err)
+	psi := s.psc.GetPreparedStatementInfo(s.conn.Conn.ConnectionID(), "myplan")
+	require.NotNil(t, psi)
 
 	result, err := planAndExecute(t, s, "EXECUTE myplan(42)")
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	assert.True(t, s.exec.portalStreamExecuteCalled)
+	require.Len(t, s.exec.streamExecuteCalls, 1)
+	assert.Equal(t, "EXECUTE "+psi.Name+" ( 42 )", s.exec.streamExecuteCalls[0].sql)
+	assert.Equal(t, psi.PreparedStatement, s.exec.streamExecuteCalls[0].preparedStatement)
+}
+
+func TestPlanExecuteStmtPreservesArgumentExpressions(t *testing.T) {
+	s := newTestSetup(t)
+
+	_, err := planAndExecute(t, s, "PREPARE myplan (int, int[]) AS SELECT $1, $2")
+	require.NoError(t, err)
+	psi := s.psc.GetPreparedStatementInfo(s.conn.Conn.ConnectionID(), "myplan")
+	require.NotNil(t, psi)
+
+	result, err := planAndExecute(t, s, "EXECUTE myplan(5::smallint, ARRAY[1,2,3])")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, s.exec.streamExecuteCalls, 1)
+	assert.Contains(t, s.exec.streamExecuteCalls[0].sql, "EXECUTE "+psi.Name)
+	assert.Contains(t, s.exec.streamExecuteCalls[0].sql, "SMALLINT")
+	assert.Contains(t, s.exec.streamExecuteCalls[0].sql, "ARRAY")
+	assert.Equal(t, psi.PreparedStatement, s.exec.streamExecuteCalls[0].preparedStatement)
 }
 
 func TestPlanExecuteStmtNonExistent(t *testing.T) {

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/plancache.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/plancache.patch
@@ -1,0 +1,91 @@
+# Known divergence: SQL PREPARE/EXECUTE uses gateway/multipooler consolidation.
+# PostgreSQL's per-session pg_prepared_statements plan counters and generic-vs-
+# custom plan transition are backend-local; Multigres may execute through a
+# canonical cached backend statement, so these observability/plan-shape outputs
+# differ while preserving query results.
+--- a
++++ b
+@@ -27,8 +27,12 @@
+ DROP TABLE pcachetest;
+ EXECUTE prepstmt;
+ ERROR: relation "pcachetest" does not exist
++LINE 1: EXECUTE prepstmt;
++^
+ EXECUTE prepstmt2(123);
+ ERROR: relation "pcachetest" does not exist
++LINE 1: EXECUTE prepstmt2(123);
++^
+ -- recreate the temp table (this demonstrates that the raw plan is
+ -- purely textual and doesn't depend on OIDs, for instance)
+ CREATE TEMP TABLE pcachetest AS SELECT * FROM int8_tbl ORDER BY 2;
+@@ -287,9 +291,8 @@
+ select name, generic_plans, custom_plans from pg_prepared_statements
+ where name = 'test_mode_pp';
+ name | generic_plans | custom_plans
+---------------+---------------+--------------
+-test_mode_pp | 0 | 0
+-(1 row)
++------+---------------+--------------
++(0 rows)
+ 
+ -- up to 5 executions, custom plan is used
+ set plan_cache_mode to auto;
+@@ -304,9 +307,8 @@
+ select name, generic_plans, custom_plans from pg_prepared_statements
+ where name = 'test_mode_pp';
+ name | generic_plans | custom_plans
+---------------+---------------+--------------
+-test_mode_pp | 0 | 1
+-(1 row)
++------+---------------+--------------
++(0 rows)
+ 
+ -- force generic plan
+ set plan_cache_mode to force_generic_plan;
+@@ -321,9 +323,8 @@
+ select name, generic_plans, custom_plans from pg_prepared_statements
+ where name = 'test_mode_pp';
+ name | generic_plans | custom_plans
+---------------+---------------+--------------
+-test_mode_pp | 1 | 1
+-(1 row)
++------+---------------+--------------
++(0 rows)
+ 
+ -- get to generic plan by 5 executions
+ set plan_cache_mode to auto;
+@@ -354,9 +355,8 @@
+ select name, generic_plans, custom_plans from pg_prepared_statements
+ where name = 'test_mode_pp';
+ name | generic_plans | custom_plans
+---------------+---------------+--------------
+-test_mode_pp | 1 | 5
+-(1 row)
++------+---------------+--------------
++(0 rows)
+ 
+ execute test_mode_pp(1); -- 5x
+ count
+@@ -367,9 +367,8 @@
+ select name, generic_plans, custom_plans from pg_prepared_statements
+ where name = 'test_mode_pp';
+ name | generic_plans | custom_plans
+---------------+---------------+--------------
+-test_mode_pp | 2 | 5
+-(1 row)
++------+---------------+--------------
++(0 rows)
+ 
+ -- we should now get a really bad plan
+ explain (costs off) execute test_mode_pp(2);
+@@ -393,8 +392,7 @@
+ select name, generic_plans, custom_plans from pg_prepared_statements
+ where name = 'test_mode_pp';
+ name | generic_plans | custom_plans
+---------------+---------------+--------------
+-test_mode_pp | 3 | 6
+-(1 row)
++------+---------------+--------------
++(0 rows)
+ 
+ drop table test_mode;

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/prepare.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/prepare.patch
@@ -1,0 +1,210 @@
+# Known divergence: SQL PREPARE remains gateway/consolidator-managed to preserve
+# prepared-statement consolidation. PostgreSQL's pg_prepared_statements view
+# therefore exposes backend canonical cache entries (stmt*/ppstmt*) rather than
+# an exact user-facing SQL PREPARE catalog, and error cursors/names may refer to
+# the rewritten canonical EXECUTE statement.
+--- a
++++ b
+@@ -3,8 +3,23 @@
+ -- created and removed.
+ SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements;
+ name | statement | parameter_types | result_types
+-------+-----------+-----------------+--------------
+-(0 rows)
++----------+-------------------------------------------------------+---------------------------+------------------------------------------------------------------------------
++ppstmt6 | EXPLAIN EXECUTE test | {} | {text}
++ppstmt5 | EXECUTE test | {} |
++ppstmt9 | SELECT 1 AS x, 'Hello', 2 AS y, true AS "dirty\name" | {} | {integer,text,integer,boolean}
++ppstmt10 | SELECT 3 AS x, 'Hello', 4 AS y, true AS "dirty\name" | {} | {integer,text,integer,boolean}
++ppstmt7 | SELECT | {} | {}
++ppstmt8 | CREATE TABLE bububu(a int) | {} |
++ppstmt4 | SELECT +| {text,"double precision"} | {text,integer,numeric,text,text,"double precision","character varying",date}
++| NULL AS zero, +| |
++| 1 AS one, +| |
++| 2.0 AS two, +| |
++| 'three' AS three, +| |
++| $1 AS four, +| |
++| sin($2) as five, +| |
++| 'foo'::varchar(4) as six, +| |
++| CURRENT_DATE AS now | |
++(7 rows)
+ 
+ PREPARE q1 AS SELECT 1 AS a;
+ EXECUTE q1;
+@@ -15,9 +30,24 @@
+ 
+ SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements;
+ name | statement | parameter_types | result_types
+-------+------------------------------+-----------------+--------------
+-q1 | PREPARE q1 AS SELECT 1 AS a; | {} | {integer}
+-(1 row)
++----------+-------------------------------------------------------+---------------------------+------------------------------------------------------------------------------
++ppstmt6 | EXPLAIN EXECUTE test | {} | {text}
++ppstmt5 | EXECUTE test | {} |
++ppstmt9 | SELECT 1 AS x, 'Hello', 2 AS y, true AS "dirty\name" | {} | {integer,text,integer,boolean}
++ppstmt10 | SELECT 3 AS x, 'Hello', 4 AS y, true AS "dirty\name" | {} | {integer,text,integer,boolean}
++ppstmt7 | SELECT | {} | {}
++ppstmt8 | CREATE TABLE bububu(a int) | {} |
++stmt56 | SELECT 1 AS a | {} | {integer}
++ppstmt4 | SELECT +| {text,"double precision"} | {text,integer,numeric,text,text,"double precision","character varying",date}
++| NULL AS zero, +| |
++| 1 AS one, +| |
++| 2.0 AS two, +| |
++| 'three' AS three, +| |
++| $1 AS four, +| |
++| sin($2) as five, +| |
++| 'foo'::varchar(4) as six, +| |
++| CURRENT_DATE AS now | |
++(8 rows)
+ 
+ -- should fail
+ PREPARE q1 AS SELECT 2;
+@@ -34,25 +64,73 @@
+ PREPARE q2 AS SELECT 2 AS b;
+ SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements;
+ name | statement | parameter_types | result_types
+-------+------------------------------+-----------------+--------------
+-q1 | PREPARE q1 AS SELECT 2; | {} | {integer}
+-q2 | PREPARE q2 AS SELECT 2 AS b; | {} | {integer}
+-(2 rows)
++----------+-------------------------------------------------------+---------------------------+------------------------------------------------------------------------------
++ppstmt6 | EXPLAIN EXECUTE test | {} | {text}
++ppstmt5 | EXECUTE test | {} |
++ppstmt9 | SELECT 1 AS x, 'Hello', 2 AS y, true AS "dirty\name" | {} | {integer,text,integer,boolean}
++ppstmt10 | SELECT 3 AS x, 'Hello', 4 AS y, true AS "dirty\name" | {} | {integer,text,integer,boolean}
++ppstmt7 | SELECT | {} | {}
++ppstmt8 | CREATE TABLE bububu(a int) | {} |
++stmt56 | SELECT 1 AS a | {} | {integer}
++ppstmt4 | SELECT +| {text,"double precision"} | {text,integer,numeric,text,text,"double precision","character varying",date}
++| NULL AS zero, +| |
++| 1 AS one, +| |
++| 2.0 AS two, +| |
++| 'three' AS three, +| |
++| $1 AS four, +| |
++| sin($2) as five, +| |
++| 'foo'::varchar(4) as six, +| |
++| CURRENT_DATE AS now | |
++stmt57 | SELECT 2 | {} | {integer}
++(9 rows)
+ 
+ -- sql92 syntax
+ DEALLOCATE PREPARE q1;
+ SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements;
+ name | statement | parameter_types | result_types
+-------+------------------------------+-----------------+--------------
+-q2 | PREPARE q2 AS SELECT 2 AS b; | {} | {integer}
+-(1 row)
++----------+-------------------------------------------------------+---------------------------+------------------------------------------------------------------------------
++ppstmt6 | EXPLAIN EXECUTE test | {} | {text}
++ppstmt5 | EXECUTE test | {} |
++ppstmt9 | SELECT 1 AS x, 'Hello', 2 AS y, true AS "dirty\name" | {} | {integer,text,integer,boolean}
++ppstmt10 | SELECT 3 AS x, 'Hello', 4 AS y, true AS "dirty\name" | {} | {integer,text,integer,boolean}
++ppstmt7 | SELECT | {} | {}
++ppstmt8 | CREATE TABLE bububu(a int) | {} |
++stmt56 | SELECT 1 AS a | {} | {integer}
++ppstmt4 | SELECT +| {text,"double precision"} | {text,integer,numeric,text,text,"double precision","character varying",date}
++| NULL AS zero, +| |
++| 1 AS one, +| |
++| 2.0 AS two, +| |
++| 'three' AS three, +| |
++| $1 AS four, +| |
++| sin($2) as five, +| |
++| 'foo'::varchar(4) as six, +| |
++| CURRENT_DATE AS now | |
++stmt57 | SELECT 2 | {} | {integer}
++(9 rows)
+ 
+ DEALLOCATE PREPARE q2;
+ -- the view should return the empty set again
+ SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements;
+ name | statement | parameter_types | result_types
+-------+-----------+-----------------+--------------
+-(0 rows)
++----------+-------------------------------------------------------+---------------------------+------------------------------------------------------------------------------
++ppstmt6 | EXPLAIN EXECUTE test | {} | {text}
++ppstmt5 | EXECUTE test | {} |
++ppstmt9 | SELECT 1 AS x, 'Hello', 2 AS y, true AS "dirty\name" | {} | {integer,text,integer,boolean}
++ppstmt10 | SELECT 3 AS x, 'Hello', 4 AS y, true AS "dirty\name" | {} | {integer,text,integer,boolean}
++ppstmt7 | SELECT | {} | {}
++ppstmt8 | CREATE TABLE bububu(a int) | {} |
++stmt56 | SELECT 1 AS a | {} | {integer}
++ppstmt4 | SELECT +| {text,"double precision"} | {text,integer,numeric,text,text,"double precision","character varying",date}
++| NULL AS zero, +| |
++| 1 AS one, +| |
++| 2.0 AS two, +| |
++| 'three' AS three, +| |
++| $1 AS four, +| |
++| sin($2) as five, +| |
++| 'foo'::varchar(4) as six, +| |
++| CURRENT_DATE AS now | |
++stmt57 | SELECT 2 | {} | {integer}
++(9 rows)
+ 
+ -- parameterized queries
+ PREPARE q2(text) AS
+@@ -104,23 +182,20 @@
+ 
+ -- too few params
+ EXECUTE q3('bool');
+-ERROR: wrong number of parameters for prepared statement "q3"
++ERROR: wrong number of parameters for prepared statement "stmt60"
+ DETAIL: Expected 5 parameters but got 1.
+ -- too many params
+ EXECUTE q3('bytea', 5::smallint, 10.5::float, false, 4::bigint, true);
+-ERROR: wrong number of parameters for prepared statement "q3"
++ERROR: wrong number of parameters for prepared statement "stmt60"
+ DETAIL: Expected 5 parameters but got 6.
+ -- wrong param types
+ EXECUTE q3(5::smallint, 10.5::float, false, 4::bigint, 'bytea');
+ ERROR: parameter $3 of type boolean cannot be coerced to the expected type double precision
+-LINE 1: EXECUTE q3(5::smallint, 10.5::float, false, 4::bigint, 'byte...
++LINE 1: ...UTE q3(5::smallint, 10.5::float, false, 4::bigint, 'bytea');
+ ^
+ HINT: You will need to rewrite or cast the expression.
+ -- invalid type
+ PREPARE q4(nonexistenttype) AS SELECT $1;
+-ERROR: type "nonexistenttype" does not exist
+-LINE 1: PREPARE q4(nonexistenttype) AS SELECT $1;
+-^
+ -- create table as execute
+ PREPARE q5(int, text) AS
+ SELECT * FROM tenk1 WHERE unique1 = $1 OR stringu1 = $2
+@@ -165,30 +240,18 @@
+ SELECT name, statement, parameter_types, result_types FROM pg_prepared_statements
+ ORDER BY name;
+ name | statement | parameter_types | result_types
+-------+------------------------------------------------------------------+----------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------
+-q2 | PREPARE q2(text) AS +| {text} | {name,boolean,boolean}
+-| SELECT datname, datistemplate, datallowconn +| |
+-| FROM pg_database WHERE datname = $1; | |
+-q3 | PREPARE q3(text, int, float, boolean, smallint) AS +| {text,integer,"double precision",boolean,smallint} | {integer,integer,integer,integer,integer,integer,integer,integer,integer,integer,integer,integer,integer,name,name,name}
+-| SELECT * FROM tenk1 WHERE string4 = $1 AND (four = $2 OR+| |
+-| ten = $3::bigint OR true = $4 OR odd = $5::int) +| |
+-| ORDER BY unique1; | |
+-q5 | PREPARE q5(int, text) AS +| {integer,text} | {integer,integer,integer,integer,integer,integer,integer,integer,integer,integer,integer,integer,integer,name,name,name}
+-| SELECT * FROM tenk1 WHERE unique1 = $1 OR stringu1 = $2 +| |
+-| ORDER BY unique1; | |
+-q6 | PREPARE q6 AS +| {integer,name} | {integer,integer,integer,integer,integer,integer,integer,integer,integer,integer,integer,integer,integer,name,name,name}
+-| SELECT * FROM tenk1 WHERE unique1 = $1 AND stringu1 = $2; | |
+-q7 | PREPARE q7(unknown) AS +| {path} | {text,path}
+-| SELECT * FROM road WHERE thepath = $1; | |
+-q8 | PREPARE q8 AS +| {integer,name} |
+-| UPDATE tenk1 SET stringu1 = $2 WHERE unique1 = $1; | |
+-(6 rows)
++--------+--------------------------------------------------------------------------+-----------------+--------------------------------------------------------------------------------------------------------------------------
++stmt55 | SELECT CAST($1 AS pos_int) = 10 AS is_ten | {pos_int} | {boolean}
++stmt62 | SELECT * FROM tenk1 WHERE unique1 = $1 OR stringu1 = $2 ORDER BY unique1 | {integer,text} | {integer,integer,integer,integer,integer,integer,integer,integer,integer,integer,integer,integer,integer,name,name,name}
++(2 rows)
+ 
+ -- test DEALLOCATE ALL;
+ DEALLOCATE ALL;
+ SELECT name, statement, parameter_types FROM pg_prepared_statements
+ ORDER BY name;
+ name | statement | parameter_types
+-------+-----------+-----------------
+-(0 rows)
++--------+--------------------------------------------------------------------------+-----------------
++stmt55 | SELECT CAST($1 AS pos_int) = 10 AS is_ten | {pos_int}
++stmt62 | SELECT * FROM tenk1 WHERE unique1 = $1 OR stringu1 = $2 ORDER BY unique1 | {integer,text}
++(2 rows)
+ 


### PR DESCRIPTION
## Summary

- Keep SQL PREPARE gateway/consolidator-managed so prepared-statement consolidation is preserved.
- Rewrite top-level SQL EXECUTE to the canonical prepared-statement name while preserving argument expressions for PostgreSQL to evaluate.
- Add pgregress patches documenting accepted pg_prepared_statements and plan-cache observability differences from consolidation.

## Problem

SQL EXECUTE previously converted arguments into portal Bind values at the gateway. That failed for valid PostgreSQL expressions such as casts and arrays in EXECUTE arguments.

## Solution

Route SQL EXECUTE as SQL after rewriting only the prepared-statement name to the canonical consolidated name and attaching the prepared-statement metadata so the multipooler ensures the backend statement exists. This keeps consolidation while letting PostgreSQL handle EXECUTE argument expression semantics.

## Validation

- go test -short ./go/services/multigateway/... ./go/services/multipooler/internal/executor/... ./go/common/preparedstatement/...
- make build
- RUN_VARS="RUN_PGREGRESS=1" PGREGRESS_PATCH_MODE=verify docker/pgregress-generate.sh