### PR TITLE
fix(query): preserve reserved state and notices

### DIFF
--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -981,6 +981,9 @@ func (c *Conn) handleQuery() error {
 			if err := c.writeNoticeResponse(notice); err != nil {
 				return fmt.Errorf("writing notice response: %w", err)
 			}
+			if err := c.flush(); err != nil {
+				return fmt.Errorf("flushing notice response: %w", err)
+			}
 		}
 
 		// On first callback with fields for this result set, send RowDescription.
@@ -1299,6 +1302,9 @@ func (c *Conn) handleExecute() error {
 		for _, notice := range result.Notices {
 			if err := c.writeNoticeResponse(notice); err != nil {
 				return fmt.Errorf("writing notice response: %w", err)
+			}
+			if err := c.flush(); err != nil {
+				return fmt.Errorf("flushing notice response: %w", err)
 			}
 		}
 

--- a/go/common/sqltypes/sqltypes.go
+++ b/go/common/sqltypes/sqltypes.go
@@ -178,12 +178,17 @@ func (r *Result) ToProto() *query.QueryResult {
 	for i, row := range r.Rows {
 		protoRows[i] = row.ToProto()
 	}
+	protoNotices := make([]*query.PgDiagnostic, len(r.Notices))
+	for i, notice := range r.Notices {
+		protoNotices[i] = mterrors.PgDiagnosticToProto(notice)
+	}
 	return &query.QueryResult{
 		Fields:       r.Fields,
 		HasFields:    r.Fields != nil,
 		RowsAffected: r.RowsAffected,
 		Rows:         protoRows,
 		CommandTag:   r.CommandTag,
+		Notices:      protoNotices,
 	}
 }
 
@@ -203,11 +208,16 @@ func ResultFromProto(pr *query.QueryResult) *Result {
 	if pr.HasFields && fields == nil {
 		fields = []*query.Field{}
 	}
+	notices := make([]*mterrors.PgDiagnostic, len(pr.Notices))
+	for i, notice := range pr.Notices {
+		notices[i] = mterrors.PgDiagnosticFromProto(notice)
+	}
 	return &Result{
 		Fields:       fields,
 		RowsAffected: pr.RowsAffected,
 		Rows:         rows,
 		CommandTag:   pr.CommandTag,
+		Notices:      notices,
 	}
 }
 

--- a/go/common/sqltypes/sqltypes_test.go
+++ b/go/common/sqltypes/sqltypes_test.go
@@ -199,6 +199,9 @@ func TestResultToProtoAndBack(t *testing.T) {
 			{Values: []Value{Value("test"), nil}},
 		},
 		CommandTag: "SELECT 3",
+		Notices: []*mterrors.PgDiagnostic{
+			{Severity: "NOTICE", Code: "00000", Message: "hello notice"},
+		},
 	}
 
 	// Convert to proto
@@ -208,6 +211,7 @@ func TestResultToProtoAndBack(t *testing.T) {
 	assert.Equal(t, original.CommandTag, protoResult.CommandTag)
 	assert.Len(t, protoResult.Fields, 2)
 	assert.Len(t, protoResult.Rows, 3)
+	assert.Len(t, protoResult.Notices, 1)
 
 	// Convert back
 	recovered := ResultFromProto(protoResult)
@@ -216,6 +220,10 @@ func TestResultToProtoAndBack(t *testing.T) {
 	assert.Equal(t, original.CommandTag, recovered.CommandTag)
 	assert.Len(t, recovered.Fields, 2)
 	assert.Len(t, recovered.Rows, 3)
+	assert.Len(t, recovered.Notices, 1)
+	assert.Equal(t, "NOTICE", recovered.Notices[0].Severity)
+	assert.Equal(t, "00000", recovered.Notices[0].Code)
+	assert.Equal(t, "hello notice", recovered.Notices[0].Message)
 
 	// Verify rows preserved NULL vs empty string
 	// Row 0: [NULL, "hello"]

--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -229,7 +229,12 @@ type QueryResult struct {
 	// "zero-column result set" (true, fields is empty). Protobuf cannot
 	// distinguish a nil repeated field from an empty one, so this bool
 	// preserves the distinction across the gRPC boundary.
-	HasFields     bool `protobuf:"varint,5,opt,name=has_fields,json=hasFields,proto3" json:"has_fields,omitempty"`
+	HasFields bool `protobuf:"varint,5,opt,name=has_fields,json=hasFields,proto3" json:"has_fields,omitempty"`
+	// notices contains PostgreSQL NoticeResponse diagnostics that belong to this
+	// result. Streaming RPCs usually send notices as separate QueryResultPayload
+	// diagnostics for zero-buffering delivery; unary RPCs (for example COMMIT via
+	// ConcludeTransaction) use this field to preserve backend notice ordering.
+	Notices       []*PgDiagnostic `protobuf:"bytes,6,rep,name=notices,proto3" json:"notices,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -297,6 +302,13 @@ func (x *QueryResult) GetHasFields() bool {
 		return x.HasFields
 	}
 	return false
+}
+
+func (x *QueryResult) GetNotices() []*PgDiagnostic {
+	if x != nil {
+		return x.Notices
+	}
+	return nil
 }
 
 // Field represents metadata about a column in the result set.
@@ -1247,10 +1259,10 @@ type ExecuteOptions struct {
 	// sessions that did not authenticate via SCRAM.
 	UserAuth *UserAuth `protobuf:"bytes,7,opt,name=user_auth,json=userAuth,proto3" json:"user_auth,omitempty"`
 	// client_connection_id is the multigateway's virtual PID for this client
-	// connection. The multipooler stamps it onto the underlying PostgreSQL
-	// backend's application_name as `multigres_vpid:<id>` so lock-detection
-	// functions can map virtual PIDs (visible to clients) back to real
-	// backend PIDs via pg_stat_activity.
+	// connection. The multipooler can register it against the underlying
+	// PostgreSQL backend PID so lock-detection functions can map virtual PIDs
+	// (visible to clients) back to real backend PIDs without altering the
+	// client-visible application_name.
 	ClientConnectionId uint32 `protobuf:"varint,8,opt,name=client_connection_id,json=clientConnectionId,proto3" json:"client_connection_id,omitempty"`
 	// execute_sql_prepared_statement, if set, describes a SQL-level EXECUTE
 	// wrapper that references a gateway-managed prepared statement. The
@@ -1545,7 +1557,7 @@ const file_query_proto_rawDesc = "" +
 	"diagnostic\x18\x02 \x01(\v2\x13.query.PgDiagnosticH\x00R\n" +
 	"diagnostic\x12;\n" +
 	"\fnotification\x18\x03 \x01(\v2\x15.query.PgNotificationH\x00R\fnotificationB\t\n" +
-	"\apayload\"\xb8\x01\n" +
+	"\apayload\"\xe7\x01\n" +
 	"\vQueryResult\x12$\n" +
 	"\x06fields\x18\x01 \x03(\v2\f.query.FieldR\x06fields\x12#\n" +
 	"\rrows_affected\x18\x02 \x01(\x04R\frowsAffected\x12\x1e\n" +
@@ -1554,7 +1566,8 @@ const file_query_proto_rawDesc = "" +
 	"\vcommand_tag\x18\x04 \x01(\tR\n" +
 	"commandTag\x12\x1d\n" +
 	"\n" +
-	"has_fields\x18\x05 \x01(\bR\thasFields\"\x89\x02\n" +
+	"has_fields\x18\x05 \x01(\bR\thasFields\x12-\n" +
+	"\anotices\x18\x06 \x03(\v2\x13.query.PgDiagnosticR\anotices\"\x89\x02\n" +
 	"\x05Field\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x1b\n" +
@@ -1698,20 +1711,21 @@ var file_query_proto_depIdxs = []int32{
 	6,  // 2: query.QueryResultPayload.notification:type_name -> query.PgNotification
 	3,  // 3: query.QueryResult.fields:type_name -> query.Field
 	4,  // 4: query.QueryResult.rows:type_name -> query.Row
-	8,  // 5: query.StatementDescription.parameters:type_name -> query.ParameterDescription
-	3,  // 6: query.StatementDescription.fields:type_name -> query.Field
-	18, // 7: query.Target.shard_key:type_name -> clustermetadata.ShardKey
-	0,  // 8: query.Target.mode:type_name -> query.Mode
-	10, // 9: query.ExecuteSqlPreparedStatement.prepared_statement:type_name -> query.PreparedStatement
-	19, // 10: query.ReservedState.pooler_id:type_name -> clustermetadata.ID
-	17, // 11: query.ExecuteOptions.session_settings:type_name -> query.ExecuteOptions.SessionSettingsEntry
-	15, // 12: query.ExecuteOptions.user_auth:type_name -> query.UserAuth
-	11, // 13: query.ExecuteOptions.execute_sql_prepared_statement:type_name -> query.ExecuteSqlPreparedStatement
-	14, // [14:14] is the sub-list for method output_type
-	14, // [14:14] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	5,  // 5: query.QueryResult.notices:type_name -> query.PgDiagnostic
+	8,  // 6: query.StatementDescription.parameters:type_name -> query.ParameterDescription
+	3,  // 7: query.StatementDescription.fields:type_name -> query.Field
+	18, // 8: query.Target.shard_key:type_name -> clustermetadata.ShardKey
+	0,  // 9: query.Target.mode:type_name -> query.Mode
+	10, // 10: query.ExecuteSqlPreparedStatement.prepared_statement:type_name -> query.PreparedStatement
+	19, // 11: query.ReservedState.pooler_id:type_name -> clustermetadata.ID
+	17, // 12: query.ExecuteOptions.session_settings:type_name -> query.ExecuteOptions.SessionSettingsEntry
+	15, // 13: query.ExecuteOptions.user_auth:type_name -> query.UserAuth
+	11, // 14: query.ExecuteOptions.execute_sql_prepared_statement:type_name -> query.ExecuteSqlPreparedStatement
+	15, // [15:15] is the sub-list for method output_type
+	15, // [15:15] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_query_proto_init() }

--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -1274,8 +1274,22 @@ type ExecuteOptions struct {
 	// This field is only consumed by StreamExecute. PortalStreamExecute has its
 	// own top-level prepared_statement field.
 	ExecuteSqlPreparedStatement *ExecuteSqlPreparedStatement `protobuf:"bytes,9,opt,name=execute_sql_prepared_statement,json=executeSqlPreparedStatement,proto3" json:"execute_sql_prepared_statement,omitempty"`
-	unknownFields               protoimpl.UnknownFields
-	sizeCache                   protoimpl.SizeCache
+	// has_post_query_session_settings indicates that post_query_session_settings
+	// is authoritative for the backend's session state after this statement
+	// succeeds. This is distinct from session_settings, which is the desired
+	// state before execution. Route-first SELECT set_config(...) uses this so the
+	// multipooler can recycle a backend into the correct settings bucket without
+	// mutating gateway state until PostgreSQL accepts the statement. The explicit
+	// boolean preserves an intentionally-empty post state (for example, a reset to
+	// clean) because proto3 maps cannot distinguish nil from empty on the wire.
+	HasPostQuerySessionSettings bool `protobuf:"varint,10,opt,name=has_post_query_session_settings,json=hasPostQuerySessionSettings,proto3" json:"has_post_query_session_settings,omitempty"`
+	// post_query_session_settings contains the backend session settings that will
+	// be true after the statement succeeds. The multipooler must only apply this
+	// to connection-state bookkeeping after PostgreSQL success; it must not issue
+	// SET commands from this map before running the query.
+	PostQuerySessionSettings map[string]string `protobuf:"bytes,11,rep,name=post_query_session_settings,json=postQuerySessionSettings,proto3" json:"post_query_session_settings,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *ExecuteOptions) Reset() {
@@ -1353,6 +1367,20 @@ func (x *ExecuteOptions) GetClientConnectionId() uint32 {
 func (x *ExecuteOptions) GetExecuteSqlPreparedStatement() *ExecuteSqlPreparedStatement {
 	if x != nil {
 		return x.ExecuteSqlPreparedStatement
+	}
+	return nil
+}
+
+func (x *ExecuteOptions) GetHasPostQuerySessionSettings() bool {
+	if x != nil {
+		return x.HasPostQuerySessionSettings
+	}
+	return false
+}
+
+func (x *ExecuteOptions) GetPostQuerySessionSettings() map[string]string {
+	if x != nil {
+		return x.PostQuerySessionSettings
 	}
 	return nil
 }
@@ -1638,7 +1666,7 @@ const file_query_proto_rawDesc = "" +
 	"\x16reserved_connection_id\x18\x01 \x01(\x04R\x14reservedConnectionId\x120\n" +
 	"\tpooler_id\x18\x02 \x01(\v2\x13.clustermetadata.IDR\bpoolerId\x12/\n" +
 	"\x13reservation_reasons\x18\x03 \x01(\rR\x12reservationReasons\x12,\n" +
-	"\x12backend_process_id\x18\x04 \x01(\rR\x10backendProcessId\"\xd9\x03\n" +
+	"\x12backend_process_id\x18\x04 \x01(\rR\x10backendProcessId\"\xe0\x05\n" +
 	"\x0eExecuteOptions\x12U\n" +
 	"\x10session_settings\x18\x01 \x03(\v2*.query.ExecuteOptions.SessionSettingsEntryR\x0fsessionSettings\x12\x12\n" +
 	"\x04user\x18\x02 \x01(\tR\x04user\x12\x19\n" +
@@ -1646,8 +1674,14 @@ const file_query_proto_rawDesc = "" +
 	"\x16reserved_connection_id\x18\x05 \x01(\x04R\x14reservedConnectionId\x12,\n" +
 	"\tuser_auth\x18\a \x01(\v2\x0f.query.UserAuthR\buserAuth\x120\n" +
 	"\x14client_connection_id\x18\b \x01(\rR\x12clientConnectionId\x12g\n" +
-	"\x1eexecute_sql_prepared_statement\x18\t \x01(\v2\".query.ExecuteSqlPreparedStatementR\x1bexecuteSqlPreparedStatement\x1aB\n" +
+	"\x1eexecute_sql_prepared_statement\x18\t \x01(\v2\".query.ExecuteSqlPreparedStatementR\x1bexecuteSqlPreparedStatement\x12D\n" +
+	"\x1fhas_post_query_session_settings\x18\n" +
+	" \x01(\bR\x1bhasPostQuerySessionSettings\x12r\n" +
+	"\x1bpost_query_session_settings\x18\v \x03(\v23.query.ExecuteOptions.PostQuerySessionSettingsEntryR\x18postQuerySessionSettings\x1aB\n" +
 	"\x14SessionSettingsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1aK\n" +
+	"\x1dPostQuerySessionSettingsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"R\n" +
 	"\bUserAuth\x12\"\n" +
@@ -1682,7 +1716,7 @@ func file_query_proto_rawDescGZIP() []byte {
 }
 
 var file_query_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_query_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_query_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_query_proto_goTypes = []any{
 	(Mode)(0),                           // 0: query.Mode
 	(*QueryResultPayload)(nil),          // 1: query.QueryResultPayload
@@ -1702,8 +1736,9 @@ var file_query_proto_goTypes = []any{
 	(*UserAuth)(nil),                    // 15: query.UserAuth
 	(*ReservationOptions)(nil),          // 16: query.ReservationOptions
 	nil,                                 // 17: query.ExecuteOptions.SessionSettingsEntry
-	(*clustermetadata.ShardKey)(nil),    // 18: clustermetadata.ShardKey
-	(*clustermetadata.ID)(nil),          // 19: clustermetadata.ID
+	nil,                                 // 18: query.ExecuteOptions.PostQuerySessionSettingsEntry
+	(*clustermetadata.ShardKey)(nil),    // 19: clustermetadata.ShardKey
+	(*clustermetadata.ID)(nil),          // 20: clustermetadata.ID
 }
 var file_query_proto_depIdxs = []int32{
 	2,  // 0: query.QueryResultPayload.result:type_name -> query.QueryResult
@@ -1714,18 +1749,19 @@ var file_query_proto_depIdxs = []int32{
 	5,  // 5: query.QueryResult.notices:type_name -> query.PgDiagnostic
 	8,  // 6: query.StatementDescription.parameters:type_name -> query.ParameterDescription
 	3,  // 7: query.StatementDescription.fields:type_name -> query.Field
-	18, // 8: query.Target.shard_key:type_name -> clustermetadata.ShardKey
+	19, // 8: query.Target.shard_key:type_name -> clustermetadata.ShardKey
 	0,  // 9: query.Target.mode:type_name -> query.Mode
 	10, // 10: query.ExecuteSqlPreparedStatement.prepared_statement:type_name -> query.PreparedStatement
-	19, // 11: query.ReservedState.pooler_id:type_name -> clustermetadata.ID
+	20, // 11: query.ReservedState.pooler_id:type_name -> clustermetadata.ID
 	17, // 12: query.ExecuteOptions.session_settings:type_name -> query.ExecuteOptions.SessionSettingsEntry
 	15, // 13: query.ExecuteOptions.user_auth:type_name -> query.UserAuth
 	11, // 14: query.ExecuteOptions.execute_sql_prepared_statement:type_name -> query.ExecuteSqlPreparedStatement
-	15, // [15:15] is the sub-list for method output_type
-	15, // [15:15] is the sub-list for method input_type
-	15, // [15:15] is the sub-list for extension type_name
-	15, // [15:15] is the sub-list for extension extendee
-	0,  // [0:15] is the sub-list for field type_name
+	18, // 15: query.ExecuteOptions.post_query_session_settings:type_name -> query.ExecuteOptions.PostQuerySessionSettingsEntry
+	16, // [16:16] is the sub-list for method output_type
+	16, // [16:16] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_query_proto_init() }
@@ -1744,7 +1780,7 @@ func file_query_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_query_proto_rawDesc), len(file_query_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   17,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/services/multigateway/engine/apply_session_state.go
+++ b/go/services/multigateway/engine/apply_session_state.go
@@ -40,8 +40,8 @@ import (
 // an invalid name/value errors at SET time (but leaves no backend state behind),
 // and this primitive runs only if that succeeded — recording the setting and
 // emitting CommandComplete("SET"). A silent variant of this primitive is also
-// used for `SELECT set_config(...)` (see planner.planSelectStmt), where a
-// trailing Route owns the client response.
+// used for `SELECT set_config(...)` (see planner.planSelectStmt), where the
+// paired Route owns the client response.
 //
 // RESET/RESET ALL run through this primitive directly (no backend round-trip):
 // the variable is removed from SessionSettings, and on the next query the merged
@@ -57,9 +57,9 @@ type ApplySessionState struct {
 	// SilentTracking, when true, updates SessionSettings but does NOT invoke
 	// the callback. Used inside a Sequence where a sibling primitive (like
 	// Route) owns the client-facing result — if both called back, the client
-	// would see a stray CommandComplete before the real row data. This is
-	// the shape a `SELECT set_config(...)` plan takes: silent tracking step
-	// first, then a Route that sends the query to PG and streams the result.
+	// would see a stray CommandComplete after the real row data. This is
+	// the shape a `SELECT set_config(...)` plan takes: a Route sends the query
+	// to PG and streams the result first, then silent tracking records the state.
 	SilentTracking bool
 
 	// BindRefs, when non-nil, marks this primitive as a deferred-resolution
@@ -126,8 +126,8 @@ func NewApplySessionStateSilent(sql string, stmt *ast.VariableSetStmt) *ApplySes
 // SqlString-based debug output structurally valid.
 //
 // Always silent: a bound set_config is only emitted as part of the
-// Sequence[ApplySessionState, Route] plan, where the trailing Route owns
-// the client-facing CommandComplete.
+// Sequence[Route, ApplySessionState] plan, where the Route owns the
+// client-facing CommandComplete.
 func NewApplySessionStateFromBind(sql string, stmt *ast.VariableSetStmt, refs *BoundSetConfigRefs) *ApplySessionState {
 	return &ApplySessionState{
 		VariableStmt:   stmt,
@@ -185,14 +185,18 @@ func (s *ApplySessionState) executeSetWithBinds(
 	portalInfo *preparedstatement.PortalInfo,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	return s.executeSetWithResolvedParams(ctx, conn, state, setConfigParamResolver{
+	return s.executeSetWithResolvedParams(ctx, conn, state, portalSetConfigResolver(portalInfo), callback)
+}
+
+func portalSetConfigResolver(portalInfo *preparedstatement.PortalInfo) setConfigParamResolver {
+	return setConfigParamResolver{
 		resolveBool: func(ref *ast.ParamRef, what string) (bool, error) {
 			return preparedstatement.DecodeBindAsBool(portalInfo, ref, what)
 		},
 		resolveText: func(ref *ast.ParamRef, what string) (string, error) {
 			return preparedstatement.DecodeBindAsText(portalInfo, ref, what)
 		},
-	}, callback)
+	}
 }
 
 // executeSetWithNormalizedBinds is StreamExecute's counterpart to
@@ -209,7 +213,11 @@ func (s *ApplySessionState) executeSetWithNormalizedBinds(
 	bindVars []*ast.A_Const,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	return s.executeSetWithResolvedParams(ctx, conn, state, setConfigParamResolver{
+	return s.executeSetWithResolvedParams(ctx, conn, state, normalizedSetConfigResolver(bindVars), callback)
+}
+
+func normalizedSetConfigResolver(bindVars []*ast.A_Const) setConfigParamResolver {
+	return setConfigParamResolver{
 		resolveBool: func(ref *ast.ParamRef, what string) (bool, error) {
 			c, err := normalizedBindConst(bindVars, ref, what)
 			if err != nil {
@@ -229,20 +237,21 @@ func (s *ApplySessionState) executeSetWithNormalizedBinds(
 			}
 			return extractConstValue(c), nil
 		},
-	}, callback)
+	}
 }
 
-// executeSetWithResolvedParams owns the protocol-independent set_config bind
-// flow: resolve is_local first because it decides whether tracking happens at
-// all, resolve name next so the gateway-managed guard can run, and resolve the
-// value only when a tracker write will actually fire.
-func (s *ApplySessionState) executeSetWithResolvedParams(
-	ctx context.Context,
-	conn *server.Conn,
-	state *handler.MultigatewayConnectionState,
-	resolver setConfigParamResolver,
-	callback func(context.Context, *sqltypes.Result) error,
-) error {
+type resolvedSetConfig struct {
+	name        string
+	value       string
+	isLocal     bool
+	shouldTrack bool
+}
+
+// resolveSetConfig owns the protocol-independent set_config bind flow: resolve
+// is_local first because it decides whether tracking happens at all, resolve
+// name next so the gateway-managed guard can run, and resolve the value only
+// when a tracker write will actually fire.
+func (s *ApplySessionState) resolveSetConfig(resolver setConfigParamResolver) (resolvedSetConfig, error) {
 	// is_local resolves from the bound value when present; otherwise it falls
 	// back to the literal baked into the synthetic VariableStmt (true only for a
 	// gateway-managed set_config(..., true) — see planner.syntheticSetStmt).
@@ -250,7 +259,7 @@ func (s *ApplySessionState) executeSetWithResolvedParams(
 	if s.BindRefs.IsLocalParam != nil {
 		b, err := resolver.resolveBool(s.BindRefs.IsLocalParam, "set_config is_local argument")
 		if err != nil {
-			return err
+			return resolvedSetConfig{}, err
 		}
 		isLocal = b
 	}
@@ -259,30 +268,54 @@ func (s *ApplySessionState) executeSetWithResolvedParams(
 	if s.BindRefs.NameParam != nil {
 		v, err := resolver.resolveText(s.BindRefs.NameParam, "set_config name argument")
 		if err != nil {
-			return err
+			return resolvedSetConfig{}, err
 		}
 		name = v
 	}
 
 	// A transaction-scoped set_config of an ordinary (non-gateway-managed)
-	// variable is owned by PostgreSQL via the trailing Route — the gateway
+	// variable is owned by PostgreSQL via the paired Route — the gateway
 	// tracks nothing and can skip resolving the value. Gateway-managed
 	// variables fall through so the transaction-local override is applied to
 	// gateway state.
 	if isLocal && !handler.IsGatewayManagedVariable(name) {
-		return nil
+		return resolvedSetConfig{shouldTrack: false}, nil
 	}
 
 	value := extractVariableValue(s.VariableStmt.Args)
 	if s.BindRefs.ValueParam != nil {
 		v, err := resolver.resolveText(s.BindRefs.ValueParam, "set_config value argument")
 		if err != nil {
-			return err
+			return resolvedSetConfig{}, err
 		}
 		value = v
 	}
 
-	return s.applyTracked(ctx, conn, state, name, value, isLocal, callback)
+	return resolvedSetConfig{
+		name:        name,
+		value:       value,
+		isLocal:     isLocal,
+		shouldTrack: true,
+	}, nil
+}
+
+// executeSetWithResolvedParams resolves bound set_config slots and applies the
+// resulting tracker update immediately.
+func (s *ApplySessionState) executeSetWithResolvedParams(
+	ctx context.Context,
+	conn *server.Conn,
+	state *handler.MultigatewayConnectionState,
+	resolver setConfigParamResolver,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	resolved, err := s.resolveSetConfig(resolver)
+	if err != nil {
+		return err
+	}
+	if !resolved.shouldTrack {
+		return nil
+	}
+	return s.applyTracked(ctx, conn, state, resolved.name, resolved.value, resolved.isLocal, callback)
 }
 
 // normalizedBindConst returns the normalizer-extracted literal that ref
@@ -290,9 +323,8 @@ func (s *ApplySessionState) executeSetWithResolvedParams(
 // normalizer mints them from a single counter; ast.ReconstructSQL uses the
 // same mapping for the Route's SQL reconstruction). An out-of-range
 // reference means the statement carried a user-typed $N the normalizer
-// never extracted a literal for — invalid in the simple protocol, so fail
-// here, before any gateway state is written (the trailing Route would
-// reject it anyway with "there is no parameter $N").
+// never extracted a literal for — invalid in the simple protocol, so fail here
+// before any gateway state is written.
 func normalizedBindConst(bindVars []*ast.A_Const, ref *ast.ParamRef, what string) (*ast.A_Const, error) {
 	idx := ref.Number - 1 // ParamRef is 1-based
 	if idx < 0 || idx >= len(bindVars) {
@@ -305,6 +337,78 @@ func normalizedBindConst(bindVars []*ast.A_Const, ref *ast.ParamRef, what string
 		return nil, mterrors.NewFeatureNotSupported(fmt.Sprintf("%s ($%d) cannot be NULL", what, ref.Number))
 	}
 	return c, nil
+}
+
+func (s *ApplySessionState) prepareStreamSilentTrackingAction(
+	conn *server.Conn,
+	state *handler.MultigatewayConnectionState,
+	bindVars []*ast.A_Const,
+) (func(), bool, error) {
+	if !s.SilentTracking {
+		return nil, false, nil
+	}
+	return s.prepareSilentTrackingAction(conn, state, func() (resolvedSetConfig, error) {
+		if s.BindRefs != nil {
+			return s.resolveSetConfig(normalizedSetConfigResolver(bindVars))
+		}
+		return resolvedSetConfig{
+			name:        s.VariableStmt.Name,
+			value:       extractVariableValue(s.VariableStmt.Args),
+			isLocal:     s.VariableStmt.IsLocal,
+			shouldTrack: true,
+		}, nil
+	})
+}
+
+func (s *ApplySessionState) preparePortalSilentTrackingAction(
+	conn *server.Conn,
+	state *handler.MultigatewayConnectionState,
+	portalInfo *preparedstatement.PortalInfo,
+) (func(), bool, error) {
+	if !s.SilentTracking {
+		return nil, false, nil
+	}
+	return s.prepareSilentTrackingAction(conn, state, func() (resolvedSetConfig, error) {
+		if s.BindRefs != nil {
+			return s.resolveSetConfig(portalSetConfigResolver(portalInfo))
+		}
+		return resolvedSetConfig{
+			name:        s.VariableStmt.Name,
+			value:       extractVariableValue(s.VariableStmt.Args),
+			isLocal:     s.VariableStmt.IsLocal,
+			shouldTrack: true,
+		}, nil
+	})
+}
+
+func (s *ApplySessionState) prepareSilentTrackingAction(
+	conn *server.Conn,
+	state *handler.MultigatewayConnectionState,
+	resolveSet func() (resolvedSetConfig, error),
+) (func(), bool, error) {
+	switch s.VariableStmt.Kind {
+	case ast.VAR_SET_VALUE:
+		resolved, err := resolveSet()
+		if err != nil {
+			return nil, true, err
+		}
+		if !resolved.shouldTrack {
+			return func() {}, true, nil
+		}
+		action, err := prepareTrackedSetAction(conn, state, resolved.name, resolved.value, resolved.isLocal)
+		return action, true, err
+	case ast.VAR_SET_DEFAULT:
+		return func() { resetTrackedSessionVariable(state, s.VariableStmt.Name) }, true, nil
+	case ast.VAR_RESET:
+		return func() { resetTrackedSessionVariable(state, s.VariableStmt.Name) }, true, nil
+	case ast.VAR_RESET_ALL:
+		return func() {
+			resetAllSessionVariablesPreservingRoleAuth(state)
+			state.ResetGatewayManagedVariables()
+		}, true, nil
+	default:
+		return nil, true, mterrors.NewFeatureNotSupported(fmt.Sprintf("SET/RESET kind %d is not supported", s.VariableStmt.Kind))
+	}
 }
 
 // StreamExecute handles the SET/RESET command.
@@ -380,14 +484,11 @@ func (s *ApplySessionState) applyTracked(
 	isLocal bool,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	skipLeakyLocal := isLocal && !conn.IsInTransaction() && handler.IsGatewayManagedVariable(name)
-	if !skipLeakyLocal {
-		if handled, err := state.ApplyGatewayManagedVariable(name, value, isLocal); err != nil {
-			return err
-		} else if !handled {
-			applyTrackedSessionVariable(state, name, value)
-		}
+	action, err := prepareTrackedSetAction(conn, state, name, value, isLocal)
+	if err != nil {
+		return err
 	}
+	action()
 
 	if s.SilentTracking {
 		return nil
@@ -396,6 +497,41 @@ func (s *ApplySessionState) applyTracked(
 	return callback(ctx, &sqltypes.Result{
 		CommandTag: "SET",
 	})
+}
+
+// prepareTrackedSetAction validates and captures a non-failing state update for
+// a tracked SET / set_config. Callers can run this before a client-visible Route
+// and invoke the returned action only after PostgreSQL accepts the statement.
+func prepareTrackedSetAction(conn *server.Conn, state *handler.MultigatewayConnectionState, name, value string, isLocal bool) (func(), error) {
+	skipLeakyLocal := isLocal && !conn.IsInTransaction() && handler.IsGatewayManagedVariable(name)
+	if skipLeakyLocal {
+		return func() {}, nil
+	}
+
+	if handler.IsGatewayManagedVariable(name) {
+		switch strings.ToLower(name) {
+		case "statement_timeout":
+			d, err := handler.ParsePostgresInterval("statement_timeout", value)
+			if err != nil {
+				return nil, err
+			}
+			return func() {
+				if isLocal {
+					state.SetLocalStatementTimeout(d)
+				} else {
+					state.SetStatementTimeout(d)
+				}
+			}, nil
+		default:
+			return nil, mterrors.NewPgError("ERROR", mterrors.PgSSInternalError,
+				"internal error resolving set_config (please report this as a bug)",
+				fmt.Sprintf("unsupported gateway-managed variable %q", name))
+		}
+	}
+
+	return func() {
+		applyTrackedSessionVariable(state, name, value)
+	}, nil
 }
 
 func applyTrackedSessionVariable(state *handler.MultigatewayConnectionState, name, value string) {

--- a/go/services/multigateway/engine/apply_session_state.go
+++ b/go/services/multigateway/engine/apply_session_state.go
@@ -343,9 +343,9 @@ func (s *ApplySessionState) prepareStreamSilentTrackingAction(
 	conn *server.Conn,
 	state *handler.MultigatewayConnectionState,
 	bindVars []*ast.A_Const,
-) (func(), bool, error) {
+) (silentTrackingAction, bool, error) {
 	if !s.SilentTracking {
-		return nil, false, nil
+		return silentTrackingAction{}, false, nil
 	}
 	return s.prepareSilentTrackingAction(conn, state, func() (resolvedSetConfig, error) {
 		if s.BindRefs != nil {
@@ -364,9 +364,9 @@ func (s *ApplySessionState) preparePortalSilentTrackingAction(
 	conn *server.Conn,
 	state *handler.MultigatewayConnectionState,
 	portalInfo *preparedstatement.PortalInfo,
-) (func(), bool, error) {
+) (silentTrackingAction, bool, error) {
 	if !s.SilentTracking {
-		return nil, false, nil
+		return silentTrackingAction{}, false, nil
 	}
 	return s.prepareSilentTrackingAction(conn, state, func() (resolvedSetConfig, error) {
 		if s.BindRefs != nil {
@@ -385,29 +385,29 @@ func (s *ApplySessionState) prepareSilentTrackingAction(
 	conn *server.Conn,
 	state *handler.MultigatewayConnectionState,
 	resolveSet func() (resolvedSetConfig, error),
-) (func(), bool, error) {
+) (silentTrackingAction, bool, error) {
 	switch s.VariableStmt.Kind {
 	case ast.VAR_SET_VALUE:
 		resolved, err := resolveSet()
 		if err != nil {
-			return nil, true, err
+			return silentTrackingAction{}, true, err
 		}
 		if !resolved.shouldTrack {
-			return func() {}, true, nil
+			return silentTrackingAction{apply: func() {}}, true, nil
 		}
-		action, err := prepareTrackedSetAction(conn, state, resolved.name, resolved.value, resolved.isLocal)
-		return action, true, err
+		action, preview, err := prepareTrackedSetActionWithBackendPreview(conn, state, resolved.name, resolved.value, resolved.isLocal)
+		return silentTrackingAction{apply: action, previewPostSessionSettings: preview}, true, err
 	case ast.VAR_SET_DEFAULT:
-		return func() { resetTrackedSessionVariable(state, s.VariableStmt.Name) }, true, nil
+		return silentTrackingAction{apply: func() { resetTrackedSessionVariable(state, s.VariableStmt.Name) }}, true, nil
 	case ast.VAR_RESET:
-		return func() { resetTrackedSessionVariable(state, s.VariableStmt.Name) }, true, nil
+		return silentTrackingAction{apply: func() { resetTrackedSessionVariable(state, s.VariableStmt.Name) }}, true, nil
 	case ast.VAR_RESET_ALL:
-		return func() {
+		return silentTrackingAction{apply: func() {
 			resetAllSessionVariablesPreservingRoleAuth(state)
 			state.ResetGatewayManagedVariables()
-		}, true, nil
+		}}, true, nil
 	default:
-		return nil, true, mterrors.NewFeatureNotSupported(fmt.Sprintf("SET/RESET kind %d is not supported", s.VariableStmt.Kind))
+		return silentTrackingAction{}, true, mterrors.NewFeatureNotSupported(fmt.Sprintf("SET/RESET kind %d is not supported", s.VariableStmt.Kind))
 	}
 }
 
@@ -503,9 +503,15 @@ func (s *ApplySessionState) applyTracked(
 // a tracked SET / set_config. Callers can run this before a client-visible Route
 // and invoke the returned action only after PostgreSQL accepts the statement.
 func prepareTrackedSetAction(conn *server.Conn, state *handler.MultigatewayConnectionState, name, value string, isLocal bool) (func(), error) {
-	skipLeakyLocal := isLocal && !conn.IsInTransaction() && handler.IsGatewayManagedVariable(name)
+	action, _, err := prepareTrackedSetActionWithBackendPreview(conn, state, name, value, isLocal)
+	return action, err
+}
+
+func prepareTrackedSetActionWithBackendPreview(conn *server.Conn, state *handler.MultigatewayConnectionState, name, value string, isLocal bool) (func(), func(map[string]string) map[string]string, error) {
+	inTransaction := conn != nil && conn.IsInTransaction()
+	skipLeakyLocal := isLocal && !inTransaction && handler.IsGatewayManagedVariable(name)
 	if skipLeakyLocal {
-		return func() {}, nil
+		return func() {}, nil, nil
 	}
 
 	if handler.IsGatewayManagedVariable(name) {
@@ -513,7 +519,17 @@ func prepareTrackedSetAction(conn *server.Conn, state *handler.MultigatewayConne
 		case "statement_timeout":
 			d, err := handler.ParsePostgresInterval("statement_timeout", value)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
+			}
+			var preview func(map[string]string) map[string]string
+			if !isLocal {
+				// The gateway does not replay gateway-managed variables through
+				// SessionSettings, but the Route still executed PostgreSQL's
+				// set_config(..., false) on the backend. Record that backend as dirty
+				// under this GUC so it is reset before another clean client can borrow it.
+				preview = func(settings map[string]string) map[string]string {
+					return applyBackendSessionVariableToMap(settings, name, value)
+				}
 			}
 			return func() {
 				if isLocal {
@@ -521,17 +537,21 @@ func prepareTrackedSetAction(conn *server.Conn, state *handler.MultigatewayConne
 				} else {
 					state.SetStatementTimeout(d)
 				}
-			}, nil
+			}, preview, nil
 		default:
-			return nil, mterrors.NewPgError("ERROR", mterrors.PgSSInternalError,
+			return nil, nil, mterrors.NewPgError("ERROR", mterrors.PgSSInternalError,
 				"internal error resolving set_config (please report this as a bug)",
 				fmt.Sprintf("unsupported gateway-managed variable %q", name))
 		}
 	}
 
-	return func() {
+	action := func() {
 		applyTrackedSessionVariable(state, name, value)
-	}, nil
+	}
+	preview := func(settings map[string]string) map[string]string {
+		return applyBackendSessionVariableToMap(settings, name, value)
+	}
+	return action, preview, nil
 }
 
 func applyTrackedSessionVariable(state *handler.MultigatewayConnectionState, name, value string) {
@@ -554,6 +574,29 @@ func applyTrackedSessionVariable(state *handler.MultigatewayConnectionState, nam
 	default:
 		state.SetSessionVariable(name, value)
 	}
+}
+
+func applyBackendSessionVariableToMap(settings map[string]string, name, value string) map[string]string {
+	if settings == nil {
+		settings = make(map[string]string)
+	}
+	switch pgsettings.CanonicalGUCName(name) {
+	case "session_authorization":
+		settings["session_authorization"] = value
+		delete(settings, "role")
+	case "role":
+		if value == "none" {
+			delete(settings, "role")
+		} else {
+			settings["role"] = value
+		}
+	default:
+		settings[pgsettings.CanonicalGUCName(name)] = value
+	}
+	if len(settings) == 0 {
+		return nil
+	}
+	return settings
 }
 
 func resetTrackedSessionVariable(state *handler.MultigatewayConnectionState, name string) {

--- a/go/services/multigateway/engine/apply_session_state_bind_test.go
+++ b/go/services/multigateway/engine/apply_session_state_bind_test.go
@@ -111,8 +111,8 @@ func TestApplySessionState_BoundNameResolves(t *testing.T) {
 // TestApplySessionState_BoundIsLocalTrueSkipsTracking pins the
 // transaction-scoped semantics: when bound is_local resolves to true, the
 // gateway must NOT update SessionSettings. PG handles SET LOCAL via the
-// trailing Route; mirroring it in the tracker would outlive the
-// transaction PG scoped the change to.
+// paired Route; mirroring it in the tracker would outlive the transaction PG
+// scoped the change to.
 func TestApplySessionState_BoundIsLocalTrueSkipsTracking(t *testing.T) {
 	const sql = "SELECT set_config('search_path', 'public', $1)"
 	portalInfo := buildBoundPortalInfo(t, sql, []uint32{uint32(ast.BOOLOID)}, [][]byte{[]byte("true")}, []int16{0})
@@ -377,7 +377,7 @@ func TestApplySessionState_NormalizedBindCacheReuseAcrossValues(t *testing.T) {
 	}{
 		{"100ms", 100 * time.Millisecond},
 		{"2s", 2 * time.Second},
-		{"1m", time.Minute},
+		{"1min", time.Minute},
 	} {
 		state, _, err := runNormalizedExecute(t, prim, txnConn(t),
 			[]*ast.A_Const{ast.NewA_Const(ast.NewString(tc.value), 0)})

--- a/go/services/multigateway/engine/apply_session_state_test.go
+++ b/go/services/multigateway/engine/apply_session_state_test.go
@@ -116,11 +116,16 @@ func TestApplySessionState_RoleValueNoneResetsTrackedRole(t *testing.T) {
 func TestResolveTrackSetConfig_RoleSessionAuthorizationSemantics(t *testing.T) {
 	state := &handler.MultigatewayConnectionState{}
 	state.SetSessionVariable("role", "child")
+	conn := server.NewTestConn(&bytes.Buffer{}).Conn
 
 	resolver := &ResolveTrackSetConfig{Aliases: []string{"set_config"}}
-	resolver.track(state, []*sqltypes.Row{{Values: []sqltypes.Value{
+	actions, err := resolver.prepareTrackActions(conn, state, []*sqltypes.Row{{Values: []sqltypes.Value{
 		[]byte("session_authorization"), []byte("parent"), []byte("false"),
 	}}})
+	require.NoError(t, err)
+	for _, action := range actions {
+		action()
+	}
 
 	sessionAuth, ok := state.GetSessionVariable("session_authorization")
 	require.True(t, ok)
@@ -129,9 +134,13 @@ func TestResolveTrackSetConfig_RoleSessionAuthorizationSemantics(t *testing.T) {
 	require.False(t, ok, "set_config('session_authorization', ...) clears active role")
 
 	state.SetSessionVariable("role", "child")
-	resolver.track(state, []*sqltypes.Row{{Values: []sqltypes.Value{
+	actions, err = resolver.prepareTrackActions(conn, state, []*sqltypes.Row{{Values: []sqltypes.Value{
 		[]byte("role"), []byte("none"), []byte("false"),
 	}}})
+	require.NoError(t, err)
+	for _, action := range actions {
+		action()
+	}
 	_, ok = state.GetSessionVariable("role")
 	require.False(t, ok, "set_config('role', 'none', false) resets role")
 }
@@ -287,8 +296,8 @@ func TestApplySessionState_SetConfig_GatewayManagedLocalOutsideTxnIsNoOp(t *test
 }
 
 // TestApplySessionState_SetConfig_StatementTimeoutInvalidErrors confirms an
-// invalid gateway-managed value surfaces an error at execute time (the Sequence
-// aborts before the trailing Route fires), matching PostgreSQL's set-time check.
+// invalid gateway-managed value surfaces an error when the tracker executes,
+// matching PostgreSQL's set-time check.
 func TestApplySessionState_SetConfig_StatementTimeoutInvalidErrors(t *testing.T) {
 	testConn := server.NewTestConn(&bytes.Buffer{})
 	state := &handler.MultigatewayConnectionState{}

--- a/go/services/multigateway/engine/engine.go
+++ b/go/services/multigateway/engine/engine.go
@@ -65,6 +65,20 @@ type PlanExecInfo struct {
 	// TransactionPrimitive when ROLLBACK TO drops cursors declared after a
 	// savepoint.
 	ReleasePortals []string
+
+	// HasPostQuerySessionSettings indicates that PostQuerySessionSettings is an
+	// authoritative snapshot of the backend session settings after this statement
+	// succeeds. It is used by Route-first SELECT set_config(...) plans so the
+	// multipooler can recycle/bookkeep the backend under the settings PostgreSQL
+	// just applied, while the gateway's live state is still mutated only after the
+	// route reports success. The bool is separate from the map so an intentional
+	// empty post-state can be represented.
+	HasPostQuerySessionSettings bool
+
+	// PostQuerySessionSettings is the backend session-settings snapshot to record
+	// after successful statement execution. It must not be applied before running
+	// the statement.
+	PostQuerySessionSettings map[string]string
 }
 
 // IExecute is the execution interface that provides access to execution

--- a/go/services/multigateway/engine/resolve_set_config.go
+++ b/go/services/multigateway/engine/resolve_set_config.go
@@ -38,7 +38,7 @@ import (
 // A session-scoped (is_local=false) set_config must be tracked in
 // SessionSettings so it survives pool rotation, which needs the concrete GUC
 // name — but here the name is a column reference resolved per row. Rather than
-// reject it (or pin the connection), this primitive runs in three steps:
+// reject it (or pin the connection), this primitive runs in four steps:
 //
 //  1. Resolve: execute the "unroll" projection — the original SELECT with each
 //     set_config(a, b, c) target replaced by its three arguments a, b, c — once,
@@ -47,14 +47,18 @@ import (
 //     ordinary Route (or an AdvisoryLockRoute when a set_config argument
 //     acquires/releases a session advisory lock), so backend pinning and
 //     bindVar reconstruction reuse the existing routing machinery.
-//  2. Apply: synthesize a set_config(...) query from the *captured literals* and
+//  2. Prepare tracking: validate gateway-managed values and capture closures
+//     for the state changes, without mutating gateway state yet.
+//  3. Apply: synthesize a set_config(...) query from the *captured literals* and
 //     run it, forwarding PostgreSQL's authoritative result to the client. Using
 //     the captured literals — not a re-run of the original dynamic query — is
 //     essential: the original could resolve to different rows/values the second
 //     time (concurrent catalog change, volatile FROM).
-//  3. Track: record the session-scoped (is_local=false) tuples in
-//     SessionSettings for pool-rotation replay. is_local=true tuples were
-//     applied by step 2 but are transaction-scoped and deliberately not tracked.
+//  4. Track: run the prepared closures only after step 3 succeeds. Ordinary
+//     session-scoped (is_local=false) tuples are recorded in SessionSettings for
+//     pool-rotation replay. Gateway-managed tuples update gateway-local state;
+//     ordinary is_local=true tuples are transaction-scoped and deliberately not
+//     tracked.
 //
 // Zero resolved rows (e.g. a WHERE that matches nothing — a GUC absent on this
 // server version) means nothing is set and the client gets an empty result,
@@ -140,8 +144,8 @@ func (s *ResolveTrackSetConfig) PortalStreamExecute(
 	return s.execute(ctx, exec, conn, state, bindVars, info, callback)
 }
 
-// execute drives resolve → apply → track. bindVars resolves any $N ParamRefs
-// in the unroll projection (empty when there are none).
+// execute drives resolve → prepare-track → apply → track. bindVars resolves
+// any $N ParamRefs in the unroll projection (empty when there are none).
 func (s *ResolveTrackSetConfig) execute(
 	ctx context.Context,
 	exec IExecute,
@@ -166,6 +170,15 @@ func (s *ResolveTrackSetConfig) execute(
 		return callback(ctx, s.emptyResult())
 	}
 
+	// Prepare tracking before backend apply so gateway-managed validation errors
+	// (for example an unparsable statement_timeout) are returned before any
+	// client-visible result is streamed. The returned closures are intentionally
+	// not executed until after PostgreSQL accepts the synthesized apply query.
+	trackActions, err := s.prepareTrackActions(conn, state, rows)
+	if err != nil {
+		return err
+	}
+
 	// Apply every resolved tuple with literals (is_local := true — see
 	// buildApplySQL) and forward PostgreSQL's authoritative result to the client.
 	applySQL, err := s.buildApplySQL(rows)
@@ -176,9 +189,11 @@ func (s *ResolveTrackSetConfig) execute(
 		return err
 	}
 
-	// Track the session-scoped settings only after a successful apply, so we
-	// never record a setting PostgreSQL rejected.
-	s.track(state, rows)
+	// Track settings only after a successful apply, so we never record a setting
+	// PostgreSQL rejected.
+	for _, action := range trackActions {
+		action()
+	}
 	return nil
 }
 
@@ -255,32 +270,91 @@ func (s *ResolveTrackSetConfig) buildApplySQL(rows []*sqltypes.Row) (string, err
 	return strings.Join(legs, " UNION ALL "), nil
 }
 
-// track records the session-scoped (is_local=false) resolved tuples in
-// SessionSettings. A NULL value resets the GUC to its default
-// (set_config(name, NULL, false) semantics); a NULL name is skipped (the apply
-// query would already have raised PostgreSQL's error).
+// prepareTrackActions validates and captures the state updates for resolved
+// set_config tuples. Ordinary session-scoped (is_local=false) GUCs go to
+// SessionSettings. Gateway-managed GUCs (currently statement_timeout) are
+// routed to gateway-local state for both session and transaction-local scopes.
+// A NULL value resets the GUC to its default (set_config(name, NULL, is_local)
+// semantics); a NULL name is skipped (the apply query would already have raised
+// PostgreSQL's error).
+//
+// It performs gateway-managed validation before the synthesized backend apply
+// query runs, but returns closures so state is mutated only after PostgreSQL
+// successfully applies/rejects the statement. This preserves wire ordering:
+// validation failures happen before any client-visible apply result is sent.
 //
 // It uses the same helper as ApplySessionState for role/session authorization
 // coupling: SET SESSION AUTHORIZATION clears the active role, and role value
 // "none" means RESET ROLE. Building synthetic primitives per tuple would be
 // more code for the same tracking behavior.
-func (s *ResolveTrackSetConfig) track(state *handler.MultigatewayConnectionState, rows []*sqltypes.Row) {
+func (s *ResolveTrackSetConfig) prepareTrackActions(conn *server.Conn, state *handler.MultigatewayConnectionState, rows []*sqltypes.Row) ([]func(), error) {
+	var actions []func()
 	numCalls := len(s.Aliases)
 	for _, row := range rows {
 		for ci := range numCalls {
 			name := row.Values[ci*3]
 			value := row.Values[ci*3+1]
 			isLocal := row.Values[ci*3+2]
-			if name.IsNull() || isLocal.IsTrue() {
+			if name.IsNull() {
 				continue
 			}
+
+			nameStr := string(name)
+			local := isLocal.IsTrue()
+			if local && !handler.IsGatewayManagedVariable(nameStr) {
+				continue
+			}
+			// PostgreSQL treats SET LOCAL outside an explicit transaction as a no-op
+			// (with a warning). The dynamic tracker sees only the successful apply
+			// result, so mirror the static ApplySessionState guard here.
+			if local && !conn.IsInTransaction() {
+				continue
+			}
+
 			if value.IsNull() {
-				resetTrackedSessionVariable(state, string(name))
+				nameCopy := nameStr
+				localCopy := local
+				actions = append(actions, func() {
+					if !state.ResetGatewayManagedVariable(nameCopy, localCopy) {
+						resetTrackedSessionVariable(state, nameCopy)
+					}
+				})
 				continue
 			}
-			applyTrackedSessionVariable(state, string(name), string(value))
+
+			valueStr := string(value)
+			if handler.IsGatewayManagedVariable(nameStr) {
+				switch strings.ToLower(nameStr) {
+				case "statement_timeout":
+					d, err := handler.ParsePostgresInterval("statement_timeout", valueStr)
+					if err != nil {
+						return nil, err
+					}
+					localCopy := local
+					dCopy := d
+					actions = append(actions, func() {
+						if localCopy {
+							state.SetLocalStatementTimeout(dCopy)
+						} else {
+							state.SetStatementTimeout(dCopy)
+						}
+					})
+				default:
+					return nil, mterrors.NewPgError("ERROR", mterrors.PgSSInternalError,
+						"internal error resolving set_config (please report this as a bug)",
+						fmt.Sprintf("unsupported gateway-managed variable %q", nameStr))
+				}
+				continue
+			}
+
+			nameCopy := nameStr
+			valueCopy := valueStr
+			actions = append(actions, func() {
+				applyTrackedSessionVariable(state, nameCopy, valueCopy)
+			})
 		}
 	}
+	return actions, nil
 }
 
 // emptyResult builds a zero-row result carrying the original's columns (text),

--- a/go/services/multigateway/engine/resolve_set_config.go
+++ b/go/services/multigateway/engine/resolve_set_config.go
@@ -29,8 +29,8 @@ import (
 )
 
 // ResolveTrackSetConfig handles a SELECT whose target list is entirely
-// set_config(...) calls where at least one argument can't be resolved at plan
-// time — the shape pg_dump uses on PG17+:
+// set_config(...) calls in the narrow PG17+ pg_dump shape where the GUC name is
+// pg_settings.name and the value/is_local arguments are static:
 //
 //	SELECT set_config(name, 'view, foreign-table', false)
 //	FROM pg_settings WHERE name = 'restrict_nonsystem_relation_kind'
@@ -42,18 +42,18 @@ import (
 //
 //  1. Resolve: execute the "unroll" projection — the original SELECT with each
 //     set_config(a, b, c) target replaced by its three arguments a, b, c — once,
-//     reading the rows internally. This is a pure read that yields the concrete
-//     (name, value, is_local) tuple per row. It runs through ResolveRoute, an
-//     ordinary Route (or an AdvisoryLockRoute when a set_config argument
-//     acquires/releases a session advisory lock), so backend pinning and
-//     bindVar reconstruction reuse the existing routing machinery.
+//     reading the rows internally. The planner restricts this to a simple
+//     pg_settings lookup so the resolve phase is a side-effect-free catalog read
+//     yielding the concrete (name, value, is_local) tuple per row. It runs
+//     through ResolveRoute, an ordinary Route, so bindVar reconstruction reuses
+//     the existing routing machinery.
 //  2. Prepare tracking: validate gateway-managed values and capture closures
 //     for the state changes, without mutating gateway state yet.
 //  3. Apply: synthesize a set_config(...) query from the *captured literals* and
 //     run it, forwarding PostgreSQL's authoritative result to the client. Using
 //     the captured literals — not a re-run of the original dynamic query — is
 //     essential: the original could resolve to different rows/values the second
-//     time (concurrent catalog change, volatile FROM).
+//     time (for example after a concurrent catalog change).
 //  4. Track: run the prepared closures only after step 3 succeeds. Ordinary
 //     session-scoped (is_local=false) tuples are recorded in SessionSettings for
 //     pool-rotation replay. Gateway-managed tuples update gateway-local state;
@@ -73,10 +73,8 @@ type ResolveTrackSetConfig struct {
 	// Query is the original SQL string, kept for GetQuery/debug output.
 	Query string
 
-	// ResolveRoute runs the unroll projection. It is a Route, or an
-	// AdvisoryLockRoute wrapping one when the projection acquires/releases a
-	// session-level advisory lock — so opts/advisory pinning and $N bindVar
-	// reconstruction flow through the same primitives as ordinary queries. It is
+	// ResolveRoute runs the unroll projection. It is a Route, so $N bindVar
+	// reconstruction flows through the same primitives as ordinary queries. It is
 	// executed with a capturing callback: the resolve reads the rows, the client
 	// never sees them.
 	ResolveRoute Primitive

--- a/go/services/multigateway/engine/resolve_set_config_test.go
+++ b/go/services/multigateway/engine/resolve_set_config_test.go
@@ -86,7 +86,7 @@ func (e *resolveApplyExec) StreamExecute(
 	_ string,
 	_ string,
 	sql string,
-	_ *query.PreparedStatement,
+	_ *query.ExecuteSqlPreparedStatement,
 	_ *handler.MultigatewayConnectionState,
 	_ PlanExecInfo,
 	callback func(context.Context, *sqltypes.Result) error,

--- a/go/services/multigateway/engine/resolve_set_config_test.go
+++ b/go/services/multigateway/engine/resolve_set_config_test.go
@@ -1,0 +1,220 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/parser/ast"
+	pgClient "github.com/multigres/multigres/go/common/pgprotocol/client"
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/common/preparedstatement"
+	"github.com/multigres/multigres/go/common/sqltypes"
+	multipoolerpb "github.com/multigres/multigres/go/pb/multipoolerservice"
+	"github.com/multigres/multigres/go/pb/query"
+	"github.com/multigres/multigres/go/services/multigateway/handler"
+)
+
+type resolveRowsPrimitive struct {
+	rows []*sqltypes.Row
+	err  error
+}
+
+func (p *resolveRowsPrimitive) StreamExecute(
+	ctx context.Context,
+	_ IExecute,
+	_ *server.Conn,
+	_ *handler.MultigatewayConnectionState,
+	_ []*ast.A_Const,
+	_ PlanExecInfo,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	if p.err != nil {
+		return p.err
+	}
+	return callback(ctx, &sqltypes.Result{Rows: p.rows, CommandTag: "SELECT 1"})
+}
+
+func (p *resolveRowsPrimitive) PortalStreamExecute(
+	ctx context.Context,
+	exec IExecute,
+	conn *server.Conn,
+	state *handler.MultigatewayConnectionState,
+	_ *preparedstatement.PortalInfo,
+	_ int32,
+	_ bool,
+	info PlanExecInfo,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	return p.StreamExecute(ctx, exec, conn, state, nil, info, callback)
+}
+
+func (p *resolveRowsPrimitive) GetTableGroup() string { return "" }
+func (p *resolveRowsPrimitive) GetQuery() string      { return "resolve" }
+func (p *resolveRowsPrimitive) String() string        { return "resolveRowsPrimitive" }
+
+type resolveApplyExec struct {
+	applyCalls int
+	applySQL   string
+	applyErr   error
+	onCallback func()
+}
+
+func (e *resolveApplyExec) StreamExecute(
+	ctx context.Context,
+	_ *server.Conn,
+	_ string,
+	_ string,
+	sql string,
+	_ *query.PreparedStatement,
+	_ *handler.MultigatewayConnectionState,
+	_ PlanExecInfo,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	e.applyCalls++
+	e.applySQL = sql
+	if e.applyErr != nil {
+		return e.applyErr
+	}
+	if e.onCallback != nil {
+		e.onCallback()
+	}
+	return callback(ctx, &sqltypes.Result{CommandTag: "SELECT 1"})
+}
+
+func (e *resolveApplyExec) PortalStreamExecute(context.Context, string, string, *server.Conn, *handler.MultigatewayConnectionState, *preparedstatement.PortalInfo, int32, bool, PlanExecInfo, func(context.Context, *sqltypes.Result) error) error {
+	return nil
+}
+
+func (e *resolveApplyExec) Describe(context.Context, string, string, *server.Conn, *handler.MultigatewayConnectionState, *preparedstatement.PortalInfo, *preparedstatement.PreparedStatementInfo) (*query.StatementDescription, error) {
+	return nil, nil
+}
+
+func (e *resolveApplyExec) CopyInitiate(context.Context, *server.Conn, string, string, string, *handler.MultigatewayConnectionState, func(context.Context, *sqltypes.Result) error) (int16, []int16, error) {
+	return 0, nil, nil
+}
+
+func (e *resolveApplyExec) CopySendData(context.Context, *server.Conn, string, string, *handler.MultigatewayConnectionState, []byte) error {
+	return nil
+}
+
+func (e *resolveApplyExec) CopyFinalize(context.Context, *server.Conn, string, string, *handler.MultigatewayConnectionState, []byte, func(context.Context, *sqltypes.Result) error) error {
+	return nil
+}
+
+func (e *resolveApplyExec) CopyAbort(context.Context, *server.Conn, string, string, *handler.MultigatewayConnectionState) error {
+	return nil
+}
+
+func (e *resolveApplyExec) CopyOutInitiate(context.Context, *server.Conn, string, string, string, *handler.MultigatewayConnectionState) (int16, []int16, []*mterrors.PgDiagnostic, error) {
+	return 0, nil, nil, nil
+}
+
+func (e *resolveApplyExec) CopyOutStream(context.Context, *server.Conn, string, string, *handler.MultigatewayConnectionState, func(pgClient.CopyOutMessage) error) (*sqltypes.Result, error) {
+	return nil, nil
+}
+
+func (e *resolveApplyExec) ConcludeTransaction(context.Context, *server.Conn, *handler.MultigatewayConnectionState, multipoolerpb.TransactionConclusion, []string, bool, bool, func(context.Context, *sqltypes.Result) error) error {
+	return nil
+}
+
+func (e *resolveApplyExec) DiscardTempTables(context.Context, *server.Conn, *handler.MultigatewayConnectionState, func(context.Context, *sqltypes.Result) error) error {
+	return nil
+}
+
+func (e *resolveApplyExec) ReleaseAllReservedConnections(context.Context, *server.Conn, *handler.MultigatewayConnectionState) error {
+	return nil
+}
+
+func setConfigResolveRow(name, value string, isLocal bool) *sqltypes.Row {
+	local := "f"
+	if isLocal {
+		local = "t"
+	}
+	return &sqltypes.Row{Values: []sqltypes.Value{[]byte(name), []byte(value), []byte(local)}}
+}
+
+func newResolveSetConfigForTest(rows ...*sqltypes.Row) *ResolveTrackSetConfig {
+	return NewResolveTrackSetConfig("", "", "SELECT set_config(...)", &resolveRowsPrimitive{rows: rows}, nil, []string{""})
+}
+
+func TestResolveTrackSetConfig_PrevalidatesGatewayManagedBeforeApply(t *testing.T) {
+	prim := newResolveSetConfigForTest(setConfigResolveRow("statement_timeout", "5 seconds", false))
+	exec := &resolveApplyExec{}
+	conn := server.NewTestConn(&bytes.Buffer{}).Conn
+	state := handler.NewMultigatewayConnectionState()
+	state.InitStatementTimeout(30 * time.Second)
+
+	callbacks := 0
+	err := prim.StreamExecute(context.Background(), exec, conn, state, nil, PlanExecInfo{}, func(context.Context, *sqltypes.Result) error {
+		callbacks++
+		return nil
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid value for parameter "statement_timeout": "5 seconds"`)
+	assert.Equal(t, 0, exec.applyCalls, "invalid gateway-managed value must fail before backend apply streams a result")
+	assert.Equal(t, 0, callbacks, "client-visible apply callback must not run on prevalidation failure")
+	assert.Equal(t, 30*time.Second, state.GetStatementTimeout(), "gateway state must not drift on rejected value")
+}
+
+func TestResolveTrackSetConfig_TracksGatewayManagedOnlyAfterApplySuccess(t *testing.T) {
+	prim := newResolveSetConfigForTest(setConfigResolveRow("statement_timeout", "1min", false))
+	exec := &resolveApplyExec{}
+	conn := server.NewTestConn(&bytes.Buffer{}).Conn
+	state := handler.NewMultigatewayConnectionState()
+	state.InitStatementTimeout(30 * time.Second)
+	exec.onCallback = func() {
+		assert.Equal(t, 30*time.Second, state.GetStatementTimeout(), "tracking must wait until backend apply returns")
+	}
+
+	callbacks := 0
+	err := prim.StreamExecute(context.Background(), exec, conn, state, nil, PlanExecInfo{}, func(context.Context, *sqltypes.Result) error {
+		callbacks++
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, exec.applyCalls)
+	assert.Contains(t, exec.applySQL, "statement_timeout")
+	assert.Equal(t, 1, callbacks)
+	assert.Equal(t, time.Minute, state.GetStatementTimeout())
+}
+
+func TestResolveTrackSetConfig_DoesNotTrackWhenApplyFails(t *testing.T) {
+	prim := newResolveSetConfigForTest(setConfigResolveRow("statement_timeout", "1min", false))
+	applyErr := errors.New("backend rejected apply")
+	exec := &resolveApplyExec{applyErr: applyErr}
+	conn := server.NewTestConn(&bytes.Buffer{}).Conn
+	state := handler.NewMultigatewayConnectionState()
+	state.InitStatementTimeout(30 * time.Second)
+
+	err := prim.StreamExecute(context.Background(), exec, conn, state, nil, PlanExecInfo{}, func(context.Context, *sqltypes.Result) error {
+		t.Fatal("callback must not run when apply returns an error")
+		return nil
+	})
+
+	require.ErrorIs(t, err, applyErr)
+	assert.Equal(t, 1, exec.applyCalls)
+	assert.Equal(t, 30*time.Second, state.GetStatementTimeout(), "state changes must be delayed until backend apply succeeds")
+}

--- a/go/services/multigateway/engine/sequence.go
+++ b/go/services/multigateway/engine/sequence.go
@@ -38,20 +38,68 @@ func NewSequence(primitives []Primitive) *Sequence {
 	return &Sequence{Primitives: primitives}
 }
 
+type silentTrackingPreparer interface {
+	prepareStreamSilentTrackingAction(*server.Conn, *handler.MultigatewayConnectionState, []*ast.A_Const) (func(), bool, error)
+	preparePortalSilentTrackingAction(*server.Conn, *handler.MultigatewayConnectionState, *preparedstatement.PortalInfo) (func(), bool, error)
+}
+
+func (s *Sequence) prepareStreamSilentTrackingActions(
+	conn *server.Conn,
+	state *handler.MultigatewayConnectionState,
+	bindVars []*ast.A_Const,
+) (map[int]func(), error) {
+	prepared := make(map[int]func())
+	for i, p := range s.Primitives {
+		preparer, ok := p.(silentTrackingPreparer)
+		if !ok {
+			continue
+		}
+		action, handled, err := preparer.prepareStreamSilentTrackingAction(conn, state, bindVars)
+		if err != nil {
+			return nil, fmt.Errorf("primitive %d (%s) failed: %w", i, p.String(), err)
+		}
+		if handled {
+			prepared[i] = action
+		}
+	}
+	return prepared, nil
+}
+
+func (s *Sequence) preparePortalSilentTrackingActions(
+	conn *server.Conn,
+	state *handler.MultigatewayConnectionState,
+	portalInfo *preparedstatement.PortalInfo,
+) (map[int]func(), error) {
+	prepared := make(map[int]func())
+	for i, p := range s.Primitives {
+		preparer, ok := p.(silentTrackingPreparer)
+		if !ok {
+			continue
+		}
+		action, handled, err := preparer.preparePortalSilentTrackingAction(conn, state, portalInfo)
+		if err != nil {
+			return nil, fmt.Errorf("primitive %d (%s) failed: %w", i, p.String(), err)
+		}
+		if handled {
+			prepared[i] = action
+		}
+	}
+	return prepared, nil
+}
+
 // StreamExecute executes each primitive in order, stopping on first error.
 //
 // bindVars are forwarded to every child. The current Sequence shape used by
-// planSelectStmt is [silent ApplySessionState..., Route]: all-literal silent
-// steps ignore bindVars (their VariableSetStmt is fully synthesized at plan
-// time from the literal set_config args), BindRefs steps resolve their bound
-// set_config slots from bindVars (the normalizer parameterizes the value of
-// a gateway-managed set_config(..., true) — see
-// ApplySessionState.executeSetWithNormalizedBinds), and the trailing Route
-// uses bindVars + its NormalizedAST to reconstruct the original literals
-// before sending the query to the backend. Dropping bindVars here breaks
-// both: the tracker would record a `__bind_$N__` placeholder, and the
-// normalized `$N` placeholders would reach PG unbound and fail with "there
-// is no parameter $N".
+// planSelectStmt is [Route, silent ApplySessionState...]: the Route uses
+// bindVars + its NormalizedAST to reconstruct the original literals before
+// sending the query to the backend; all-literal silent steps ignore bindVars
+// (their VariableSetStmt is fully synthesized at plan time from the literal
+// set_config args), and BindRefs steps resolve their bound set_config slots
+// from bindVars (the normalizer parameterizes the value of a gateway-managed
+// set_config(..., true) — see ApplySessionState.executeSetWithNormalizedBinds).
+// Dropping bindVars here breaks both: the tracker would record a `__bind_$N__`
+// placeholder, and the normalized `$N` placeholders would reach PG unbound and
+// fail with "there is no parameter $N".
 func (s *Sequence) StreamExecute(
 	ctx context.Context,
 	exec IExecute,
@@ -61,12 +109,22 @@ func (s *Sequence) StreamExecute(
 	info PlanExecInfo,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	// info is forwarded to every child; only the routing child (the trailing
-	// Route) forwards it onward to IExecute. The auxiliary children (silent
-	// ApplySessionState / ResolveTrackSetConfig set_config steps) ignore it and
+	prepared, err := s.prepareStreamSilentTrackingActions(conn, state, bindVars)
+	if err != nil {
+		return err
+	}
+
+	// info is forwarded to every child; only the routing child (the leading
+	// Route in planSelectStmt's Sequence) forwards it onward to IExecute. The
+	// auxiliary children (silent ApplySessionState / ResolveTrackSetConfig
+	// set_config steps) ignore it and
 	// issue their own backend calls with the zero value, so the plan's
 	// reservation directives apply exactly once, on the query that warrants them.
 	for i, p := range s.Primitives {
+		if action, ok := prepared[i]; ok {
+			action()
+			continue
+		}
 		if err := p.StreamExecute(ctx, exec, conn, state, bindVars, info, callback); err != nil {
 			return fmt.Errorf("primitive %d (%s) failed: %w", i, p.String(), err)
 		}
@@ -75,9 +133,9 @@ func (s *Sequence) StreamExecute(
 }
 
 // PortalStreamExecute runs each child's PortalStreamExecute in order. The
-// dispatch lives on each child — silent ApplySessionState steps that compose
-// with a Route in this Sequence simply ignore portalInfo and update tracker
-// state, while the trailing Route reissues the portal to the backend.
+// dispatch lives on each child — the Route reissues the portal to the backend,
+// while silent ApplySessionState steps that compose with it use portalInfo only
+// to resolve bound set_config slots and update tracker state after success.
 //
 // Stops on the first error and reports which child failed.
 func (s *Sequence) PortalStreamExecute(
@@ -91,7 +149,16 @@ func (s *Sequence) PortalStreamExecute(
 	info PlanExecInfo,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
+	prepared, err := s.preparePortalSilentTrackingActions(conn, state, portalInfo)
+	if err != nil {
+		return err
+	}
+
 	for i, p := range s.Primitives {
+		if action, ok := prepared[i]; ok {
+			action()
+			continue
+		}
 		if err := p.PortalStreamExecute(ctx, exec, conn, state, portalInfo, maxRows, includeDescribe, info, callback); err != nil {
 			return fmt.Errorf("primitive %d (%s) failed: %w", i, p.String(), err)
 		}

--- a/go/services/multigateway/engine/sequence.go
+++ b/go/services/multigateway/engine/sequence.go
@@ -38,17 +38,35 @@ func NewSequence(primitives []Primitive) *Sequence {
 	return &Sequence{Primitives: primitives}
 }
 
+type silentTrackingAction struct {
+	apply func()
+
+	// previewPostSessionSettings mutates/returns a copy of the backend session
+	// settings that should be recorded if the routed statement succeeds. It is
+	// deliberately separate from apply: Sequence runs these previews before the
+	// Route so the multipooler can receive post-query bookkeeping, but it runs
+	// apply only after the Route succeeds so gateway state cannot drift from
+	// PostgreSQL.
+	previewPostSessionSettings func(map[string]string) map[string]string
+}
+
+type preparedSilentTrackingActions struct {
+	actions                     map[int]silentTrackingAction
+	hasPostQuerySessionSettings bool
+	postQuerySessionSettings    map[string]string
+}
+
 type silentTrackingPreparer interface {
-	prepareStreamSilentTrackingAction(*server.Conn, *handler.MultigatewayConnectionState, []*ast.A_Const) (func(), bool, error)
-	preparePortalSilentTrackingAction(*server.Conn, *handler.MultigatewayConnectionState, *preparedstatement.PortalInfo) (func(), bool, error)
+	prepareStreamSilentTrackingAction(*server.Conn, *handler.MultigatewayConnectionState, []*ast.A_Const) (silentTrackingAction, bool, error)
+	preparePortalSilentTrackingAction(*server.Conn, *handler.MultigatewayConnectionState, *preparedstatement.PortalInfo) (silentTrackingAction, bool, error)
 }
 
 func (s *Sequence) prepareStreamSilentTrackingActions(
 	conn *server.Conn,
 	state *handler.MultigatewayConnectionState,
 	bindVars []*ast.A_Const,
-) (map[int]func(), error) {
-	prepared := make(map[int]func())
+) (preparedSilentTrackingActions, error) {
+	prepared := preparedSilentTrackingActions{actions: make(map[int]silentTrackingAction)}
 	for i, p := range s.Primitives {
 		preparer, ok := p.(silentTrackingPreparer)
 		if !ok {
@@ -56,10 +74,17 @@ func (s *Sequence) prepareStreamSilentTrackingActions(
 		}
 		action, handled, err := preparer.prepareStreamSilentTrackingAction(conn, state, bindVars)
 		if err != nil {
-			return nil, fmt.Errorf("primitive %d (%s) failed: %w", i, p.String(), err)
+			return preparedSilentTrackingActions{}, fmt.Errorf("primitive %d (%s) failed: %w", i, p.String(), err)
 		}
 		if handled {
-			prepared[i] = action
+			prepared.actions[i] = action
+			if action.previewPostSessionSettings != nil {
+				if !prepared.hasPostQuerySessionSettings {
+					prepared.postQuerySessionSettings = state.GetSessionSettings()
+					prepared.hasPostQuerySessionSettings = true
+				}
+				prepared.postQuerySessionSettings = action.previewPostSessionSettings(prepared.postQuerySessionSettings)
+			}
 		}
 	}
 	return prepared, nil
@@ -69,8 +94,8 @@ func (s *Sequence) preparePortalSilentTrackingActions(
 	conn *server.Conn,
 	state *handler.MultigatewayConnectionState,
 	portalInfo *preparedstatement.PortalInfo,
-) (map[int]func(), error) {
-	prepared := make(map[int]func())
+) (preparedSilentTrackingActions, error) {
+	prepared := preparedSilentTrackingActions{actions: make(map[int]silentTrackingAction)}
 	for i, p := range s.Primitives {
 		preparer, ok := p.(silentTrackingPreparer)
 		if !ok {
@@ -78,10 +103,17 @@ func (s *Sequence) preparePortalSilentTrackingActions(
 		}
 		action, handled, err := preparer.preparePortalSilentTrackingAction(conn, state, portalInfo)
 		if err != nil {
-			return nil, fmt.Errorf("primitive %d (%s) failed: %w", i, p.String(), err)
+			return preparedSilentTrackingActions{}, fmt.Errorf("primitive %d (%s) failed: %w", i, p.String(), err)
 		}
 		if handled {
-			prepared[i] = action
+			prepared.actions[i] = action
+			if action.previewPostSessionSettings != nil {
+				if !prepared.hasPostQuerySessionSettings {
+					prepared.postQuerySessionSettings = state.GetSessionSettings()
+					prepared.hasPostQuerySessionSettings = true
+				}
+				prepared.postQuerySessionSettings = action.previewPostSessionSettings(prepared.postQuerySessionSettings)
+			}
 		}
 	}
 	return prepared, nil
@@ -120,12 +152,21 @@ func (s *Sequence) StreamExecute(
 	// set_config steps) ignore it and
 	// issue their own backend calls with the zero value, so the plan's
 	// reservation directives apply exactly once, on the query that warrants them.
+	postQueryInfoAttached := false
 	for i, p := range s.Primitives {
-		if action, ok := prepared[i]; ok {
-			action()
+		if action, ok := prepared.actions[i]; ok {
+			if action.apply != nil {
+				action.apply()
+			}
 			continue
 		}
-		if err := p.StreamExecute(ctx, exec, conn, state, bindVars, info, callback); err != nil {
+		childInfo := info
+		if prepared.hasPostQuerySessionSettings && !postQueryInfoAttached {
+			childInfo.HasPostQuerySessionSettings = true
+			childInfo.PostQuerySessionSettings = prepared.postQuerySessionSettings
+			postQueryInfoAttached = true
+		}
+		if err := p.StreamExecute(ctx, exec, conn, state, bindVars, childInfo, callback); err != nil {
 			return fmt.Errorf("primitive %d (%s) failed: %w", i, p.String(), err)
 		}
 	}
@@ -154,12 +195,21 @@ func (s *Sequence) PortalStreamExecute(
 		return err
 	}
 
+	postQueryInfoAttached := false
 	for i, p := range s.Primitives {
-		if action, ok := prepared[i]; ok {
-			action()
+		if action, ok := prepared.actions[i]; ok {
+			if action.apply != nil {
+				action.apply()
+			}
 			continue
 		}
-		if err := p.PortalStreamExecute(ctx, exec, conn, state, portalInfo, maxRows, includeDescribe, info, callback); err != nil {
+		childInfo := info
+		if prepared.hasPostQuerySessionSettings && !postQueryInfoAttached {
+			childInfo.HasPostQuerySessionSettings = true
+			childInfo.PostQuerySessionSettings = prepared.postQuerySessionSettings
+			postQueryInfoAttached = true
+		}
+		if err := p.PortalStreamExecute(ctx, exec, conn, state, portalInfo, maxRows, includeDescribe, childInfo, callback); err != nil {
 			return fmt.Errorf("primitive %d (%s) failed: %w", i, p.String(), err)
 		}
 	}

--- a/go/services/multigateway/engine/sequence_test.go
+++ b/go/services/multigateway/engine/sequence_test.go
@@ -34,29 +34,37 @@ import (
 // recordingPrimitive captures which dispatch method was invoked. Used to
 // verify Sequence iterates and dispatches per-child.
 type recordingPrimitive struct {
-	streamCalls int
-	portalCalls int
-	err         error
+	streamCalls   int
+	portalCalls   int
+	streamInfos   []PlanExecInfo
+	portalInfos   []PlanExecInfo
+	stateAtStream map[string]string
+	err           error
 }
 
 func (r *recordingPrimitive) StreamExecute(
-	context.Context, IExecute, *server.Conn,
-	*handler.MultigatewayConnectionState, []*ast.A_Const,
-	PlanExecInfo,
-	func(context.Context, *sqltypes.Result) error,
+	_ context.Context, _ IExecute, _ *server.Conn,
+	state *handler.MultigatewayConnectionState, _ []*ast.A_Const,
+	info PlanExecInfo,
+	_ func(context.Context, *sqltypes.Result) error,
 ) error {
 	r.streamCalls++
+	r.streamInfos = append(r.streamInfos, info)
+	if state != nil {
+		r.stateAtStream = state.GetSessionSettings()
+	}
 	return r.err
 }
 
 func (r *recordingPrimitive) PortalStreamExecute(
-	context.Context, IExecute, *server.Conn,
-	*handler.MultigatewayConnectionState,
-	*preparedstatement.PortalInfo, int32, bool,
-	PlanExecInfo,
-	func(context.Context, *sqltypes.Result) error,
+	_ context.Context, _ IExecute, _ *server.Conn,
+	_ *handler.MultigatewayConnectionState,
+	_ *preparedstatement.PortalInfo, _ int32, _ bool,
+	info PlanExecInfo,
+	_ func(context.Context, *sqltypes.Result) error,
 ) error {
 	r.portalCalls++
+	r.portalInfos = append(r.portalInfos, info)
 	return r.err
 }
 
@@ -68,6 +76,14 @@ func silentStatementTimeoutTrack(value string) *ApplySessionState {
 	return NewApplySessionStateSilent("SELECT set_config('statement_timeout', '"+value+"', false)", &ast.VariableSetStmt{
 		Kind: ast.VAR_SET_VALUE,
 		Name: "statement_timeout",
+		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: value}}}},
+	})
+}
+
+func silentWorkMemTrack(value string) *ApplySessionState {
+	return NewApplySessionStateSilent("SELECT set_config('work_mem', '"+value+"', false)", &ast.VariableSetStmt{
+		Kind: ast.VAR_SET_VALUE,
+		Name: "work_mem",
 		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: value}}}},
 	})
 }
@@ -98,7 +114,31 @@ func TestSequence_StreamExecute_AppliesPreparedTrackingAfterRouteSuccess(t *test
 	err := seq.StreamExecute(context.Background(), nil, conn, state, nil, PlanExecInfo{}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, route.streamCalls)
+	require.Len(t, route.streamInfos, 1)
+	assert.True(t, route.streamInfos[0].HasPostQuerySessionSettings)
+	assert.Equal(t, "5s", route.streamInfos[0].PostQuerySessionSettings["statement_timeout"],
+		"gateway-managed set_config still dirties the backend and must be bucketed/reset safely")
 	assert.Equal(t, 5*time.Second, state.GetStatementTimeout())
+}
+
+func TestSequence_StreamExecute_PostQuerySettingsSentBeforeGatewayMutation(t *testing.T) {
+	route := &recordingPrimitive{}
+	seq := NewSequence([]Primitive{route, silentWorkMemTrack("256MB")})
+
+	conn := server.NewTestConn(&bytes.Buffer{}).Conn
+	state := handler.NewMultigatewayConnectionState()
+
+	err := seq.StreamExecute(context.Background(), nil, conn, state, nil, PlanExecInfo{}, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, route.streamCalls)
+	require.Len(t, route.streamInfos, 1)
+	assert.True(t, route.streamInfos[0].HasPostQuerySessionSettings)
+	assert.Equal(t, map[string]string{"work_mem": "256MB"}, route.streamInfos[0].PostQuerySessionSettings)
+	assert.Nil(t, route.stateAtStream, "gateway state must not mutate before the Route succeeds")
+
+	got, ok := state.GetSessionVariable("work_mem")
+	require.True(t, ok)
+	assert.Equal(t, "256MB", got)
 }
 
 func TestSequence_StreamExecute_DoesNotApplyPreparedTrackingAfterRouteFailure(t *testing.T) {

--- a/go/services/multigateway/engine/sequence_test.go
+++ b/go/services/multigateway/engine/sequence_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -63,13 +64,64 @@ func (r *recordingPrimitive) GetTableGroup() string { return "" }
 func (r *recordingPrimitive) GetQuery() string      { return "" }
 func (r *recordingPrimitive) String() string        { return "recordingPrimitive" }
 
+func silentStatementTimeoutTrack(value string) *ApplySessionState {
+	return NewApplySessionStateSilent("SELECT set_config('statement_timeout', '"+value+"', false)", &ast.VariableSetStmt{
+		Kind: ast.VAR_SET_VALUE,
+		Name: "statement_timeout",
+		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: value}}}},
+	})
+}
+
+func TestSequence_StreamExecute_PrevalidatesSilentGatewayManagedTracking(t *testing.T) {
+	route := &recordingPrimitive{}
+	seq := NewSequence([]Primitive{route, silentStatementTimeoutTrack("5 seconds")})
+
+	conn := server.NewTestConn(&bytes.Buffer{}).Conn
+	state := handler.NewMultigatewayConnectionState()
+	state.InitStatementTimeout(30 * time.Second)
+
+	err := seq.StreamExecute(context.Background(), nil, conn, state, nil, PlanExecInfo{}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid value for parameter "statement_timeout": "5 seconds"`)
+	assert.Equal(t, 0, route.streamCalls, "Route must not stream a success before tracking validation fails")
+	assert.Equal(t, 30*time.Second, state.GetStatementTimeout())
+}
+
+func TestSequence_StreamExecute_AppliesPreparedTrackingAfterRouteSuccess(t *testing.T) {
+	route := &recordingPrimitive{}
+	seq := NewSequence([]Primitive{route, silentStatementTimeoutTrack("5s")})
+
+	conn := server.NewTestConn(&bytes.Buffer{}).Conn
+	state := handler.NewMultigatewayConnectionState()
+	state.InitStatementTimeout(30 * time.Second)
+
+	err := seq.StreamExecute(context.Background(), nil, conn, state, nil, PlanExecInfo{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, route.streamCalls)
+	assert.Equal(t, 5*time.Second, state.GetStatementTimeout())
+}
+
+func TestSequence_StreamExecute_DoesNotApplyPreparedTrackingAfterRouteFailure(t *testing.T) {
+	routeErr := errors.New("backend rejected query")
+	route := &recordingPrimitive{err: routeErr}
+	seq := NewSequence([]Primitive{route, silentStatementTimeoutTrack("5s")})
+
+	conn := server.NewTestConn(&bytes.Buffer{}).Conn
+	state := handler.NewMultigatewayConnectionState()
+	state.InitStatementTimeout(30 * time.Second)
+
+	err := seq.StreamExecute(context.Background(), nil, conn, state, nil, PlanExecInfo{}, nil)
+	require.ErrorIs(t, err, routeErr)
+	assert.Equal(t, 1, route.streamCalls)
+	assert.Equal(t, 30*time.Second, state.GetStatementTimeout())
+}
+
 // TestSequence_PortalStreamExecute_DispatchesPerChild confirms the new
 // uniform dispatch: every child of a Sequence gets PortalStreamExecute
 // called on it (so each primitive can decide to forward the portal,
 // ignore it, or do something else). Earlier the executor reached through
-// the Sequence and called StreamExecute on the silent prefix while
-// shortcutting the trailing Route — both behaviors now live on the
-// primitives themselves.
+// the Sequence and called StreamExecute on silent tracking while shortcutting
+// the Route — both behaviors now live on the primitives themselves.
 func TestSequence_PortalStreamExecute_DispatchesPerChild(t *testing.T) {
 	a, b, c := &recordingPrimitive{}, &recordingPrimitive{}, &recordingPrimitive{}
 	seq := NewSequence([]Primitive{a, b, c})
@@ -87,8 +139,7 @@ func TestSequence_PortalStreamExecute_DispatchesPerChild(t *testing.T) {
 }
 
 // TestSequence_PortalStreamExecute_StopsOnError confirms iteration halts on
-// the first error and reports which primitive failed (so a silent step's
-// failure prevents the trailing Route from forwarding).
+// the first error and reports which primitive failed.
 func TestSequence_PortalStreamExecute_StopsOnError(t *testing.T) {
 	failure := errors.New("boom")
 	a := &recordingPrimitive{}

--- a/go/services/multigateway/executor/executor.go
+++ b/go/services/multigateway/executor/executor.go
@@ -229,11 +229,11 @@ func (e *Executor) PortalStreamExecute(
 	// Hand off to the plan, which delegates to its root primitive's
 	// PortalStreamExecute. Each primitive owns its portal-mode behavior:
 	// Route reissues the portal to the multipooler, Sequence iterates children
-	// (so any silent ApplySessionState prefix runs before the trailing Route
-	// forwards), and gateway-local primitives ignore portalInfo and run their
-	// StreamExecute logic. A plain Route reissuing the portal is exactly what a
-	// raw forward to the multipooler would do, so non-routable utility
-	// statements need no special-casing here.
+	// (so a Route can forward first and a silent ApplySessionState child can
+	// track only after backend success), and gateway-local primitives ignore
+	// portalInfo and run their StreamExecute logic. A plain Route reissuing the
+	// portal is exactly what a raw forward to the multipooler would do, so
+	// non-routable utility statements need no special-casing here.
 	err = plan.PortalStreamExecute(ctx, e.exec, conn, state, portalInfo, maxRows, includeDescribe, callback)
 	if err != nil {
 		e.logger.ErrorContext(ctx, "portal query execution failed",

--- a/go/services/multigateway/executor/executor_test.go
+++ b/go/services/multigateway/executor/executor_test.go
@@ -451,12 +451,11 @@ func TestCacheKey_PortalDifferentDatabasesAreSeparate(t *testing.T) {
 // TestPortalStreamExecute_RunsCacheableSequencePlan verifies that the
 // cacheable extended-protocol path actually runs the planned primitive —
 // not just its routing — so a Sequence built for SELECT set_config(..., false)
-// has both effects: the silent ApplySessionState updates the gateway
-// tracker, and the trailing Route still forwards the portal. Earlier
+// has both effects: the Route forwards the portal, and the silent
+// ApplySessionState updates the gateway tracker after backend success. Earlier
 // the executor short-circuited to extractRouting + exec.PortalStreamExecute
-// directly, dropping the silent prefix entirely; the redesign delegates
-// to plan.PortalStreamExecute so each primitive owns its portal-mode
-// behavior.
+// directly, dropping silent tracking entirely; the redesign delegates to
+// plan.PortalStreamExecute so each primitive owns its portal-mode behavior.
 func TestPortalStreamExecute_RunsCacheableSequencePlan(t *testing.T) {
 	mock := &mockExec{}
 	exec := newTestExecutor(mock)
@@ -470,21 +469,21 @@ func TestPortalStreamExecute_RunsCacheableSequencePlan(t *testing.T) {
 	_, err := exec.PortalStreamExecute(ctx, conn, state, portal, 0, false, noopCallback)
 	require.NoError(t, err)
 
-	// Silent prefix must have written the tracker.
+	// Silent tracking must have written the tracker.
 	got, ok := state.GetSessionVariable("work_mem")
-	require.True(t, ok, "silent ApplySessionState prefix should have updated SessionSettings")
+	require.True(t, ok, "silent ApplySessionState should have updated SessionSettings")
 	assert.Equal(t, "256MB", got)
 
 	// And the portal forward to the backend must still have happened.
 	assert.Equal(t, int32(1), mock.portalStreamExecuteCalls.Load(),
-		"portal must still be forwarded to the backend after silent prefix")
+		"portal must still be forwarded to the backend before silent tracking")
 }
 
 // TestStreamExecute_SetConfigWithSiblingLiteral covers the simple-protocol
 // shape `SELECT set_config(literal, literal, false), <other-literal>`. The
 // normalizer skips the set_config subtree but still parameterizes the
-// sibling literal; the planner emits a Sequence whose trailing Route holds
-// the normalized SQL + NormalizedAST. If Sequence.StreamExecute drops
+// sibling literal; the planner emits a Sequence whose Route holds the
+// normalized SQL + NormalizedAST. If Sequence.StreamExecute drops
 // bindVars on its way to children, Route can't reconstruct and the
 // `$N` placeholder reaches PG unbound — which surfaces as
 // `there is no parameter $1`. Verify the backend receives the literal,
@@ -507,7 +506,7 @@ func TestStreamExecute_SetConfigWithSiblingLiteral(t *testing.T) {
 	assert.NotContains(t, backendSQL, "$1",
 		"normalized placeholder must not reach the backend; backend SQL was %q", backendSQL)
 
-	// Silent ApplySessionState prefix must still have updated the tracker.
+	// Silent ApplySessionState must still have updated the tracker.
 	got, ok := state.GetSessionVariable("work_mem")
 	require.True(t, ok)
 	assert.Equal(t, "256MB", got)
@@ -551,7 +550,7 @@ func TestStreamExecute_SetConfigGMVLocalPlanCacheReuse(t *testing.T) {
 	assert.Equal(t, 2*time.Second, state.GetStatementTimeout(),
 		"cache hit must apply this execution's value, not the first-seen literal or a placeholder")
 
-	// The trailing Route must still reconstruct the literal for PG.
+	// The Route must still reconstruct the literal for PG.
 	backendSQL, _ := mock.lastStreamExecuteSQL.Load().(string)
 	assert.Contains(t, backendSQL, "2s", "backend SQL must carry the reconstructed literal")
 	assert.NotContains(t, backendSQL, "$1", "normalized placeholder must not reach the backend")

--- a/go/services/multigateway/handler/connection_state.go
+++ b/go/services/multigateway/handler/connection_state.go
@@ -583,6 +583,25 @@ func (m *MultigatewayConnectionState) ApplyGatewayManagedVariable(name, value st
 	}
 }
 
+// ResetGatewayManagedVariable applies RESET / set_config(name, NULL, is_local)
+// semantics to a single gateway-managed variable. For a transaction-local reset
+// it installs a local default mask (matching SET LOCAL var TO DEFAULT); callers
+// are responsible for skipping SET LOCAL outside a transaction when PostgreSQL
+// would treat it as a no-op.
+func (m *MultigatewayConnectionState) ResetGatewayManagedVariable(name string, isLocal bool) bool {
+	switch strings.ToLower(name) {
+	case "statement_timeout":
+		if isLocal {
+			m.SetLocalStatementTimeoutToDefault()
+		} else {
+			m.ResetStatementTimeout()
+		}
+		return true
+	default:
+		return false
+	}
+}
+
 // ResetAllLocalGUCs clears all transaction-local overrides for gateway-managed
 // variables. Called at transaction end (COMMIT/ROLLBACK) so the next statement
 // observes the session-level (or default) value.

--- a/go/services/multigateway/handler/gateway_managed_variable_apply_test.go
+++ b/go/services/multigateway/handler/gateway_managed_variable_apply_test.go
@@ -49,6 +49,34 @@ func TestIsGatewayManagedVariable(t *testing.T) {
 // TestApplyGatewayManagedVariable_RoutesToGatewayState confirms gateway-managed
 // variables are applied to gateway-local state (visible via SHOW) and are kept
 // out of SessionSettings, while non-managed variables are left for the caller.
+func TestResetGatewayManagedVariable(t *testing.T) {
+	t.Run("session reset restores default", func(t *testing.T) {
+		s := &MultigatewayConnectionState{}
+		s.InitStatementTimeout(30 * time.Second)
+		s.SetStatementTimeout(5 * time.Second)
+
+		assert.True(t, s.ResetGatewayManagedVariable("statement_timeout", false))
+		assert.Equal(t, "30s", s.ShowStatementTimeout())
+	})
+
+	t.Run("local reset masks session until transaction end", func(t *testing.T) {
+		s := &MultigatewayConnectionState{}
+		s.InitStatementTimeout(30 * time.Second)
+		s.SetStatementTimeout(5 * time.Second)
+
+		assert.True(t, s.ResetGatewayManagedVariable("statement_timeout", true))
+		assert.Equal(t, "30s", s.ShowStatementTimeout())
+
+		s.ResetAllLocalGUCs()
+		assert.Equal(t, "5s", s.ShowStatementTimeout())
+	})
+
+	t.Run("non gateway managed variable", func(t *testing.T) {
+		s := &MultigatewayConnectionState{}
+		assert.False(t, s.ResetGatewayManagedVariable("work_mem", false))
+	})
+}
+
 func TestApplyGatewayManagedVariable_RoutesToGatewayState(t *testing.T) {
 	t.Run("statement_timeout session", func(t *testing.T) {
 		s := &MultigatewayConnectionState{}

--- a/go/services/multigateway/handler/statement_timeout.go
+++ b/go/services/multigateway/handler/statement_timeout.go
@@ -47,9 +47,10 @@ func ParseStatementTimeoutDirective(query ast.Stmt) *time.Duration {
 
 // ParsePostgresInterval parses a PostgreSQL-style interval value for statement_timeout
 // into a time.Duration. Returns PgDiagnostic errors matching PostgreSQL's error format.
-// Supports:
+// Supports PostgreSQL's time-valued GUC syntax:
 //   - Plain integers as milliseconds (e.g., "5000" -> 5s) — PostgreSQL's default unit
-//   - Go-compatible duration strings (e.g., "30s", "200ms", "1m")
+//   - The documented units "us", "ms", "s", "min", "h", and "d", with optional
+//     whitespace between number and unit (e.g., "30s", "1 min", "2d")
 func ParsePostgresInterval(paramName, value string) (time.Duration, error) {
 	value = strings.TrimSpace(value)
 	if value == "" {
@@ -64,11 +65,10 @@ func ParsePostgresInterval(paramName, value string) (time.Duration, error) {
 		return time.Duration(ms) * time.Millisecond, nil
 	}
 
-	// Try Go duration format (e.g., "30s", "200ms", "1m").
-	d, err := time.ParseDuration(value)
-	if err != nil {
+	d, ok := parsePostgresIntervalWithUnit(value)
+	if !ok {
 		return 0, invalidParamError(paramName, value,
-			`Valid units for this parameter are "us", "ms", "s", "m", "h".`)
+			`Valid units for this parameter are "us", "ms", "s", "min", "h", and "d".`)
 	}
 	// PostgreSQL stores statement_timeout as whole milliseconds, so round to the
 	// base unit (rather than truncate) before range-checking and reporting. This
@@ -80,6 +80,56 @@ func ParsePostgresInterval(paramName, value string) (time.Duration, error) {
 		return 0, outOfRangeParamError(paramName, ms)
 	}
 	return time.Duration(ms) * time.Millisecond, nil
+}
+
+func parsePostgresIntervalWithUnit(value string) (time.Duration, bool) {
+	fields := strings.Fields(value)
+	var number, unit string
+	switch len(fields) {
+	case 1:
+		idx := -1
+		for i, r := range fields[0] {
+			if (r < '0' || r > '9') && r != '.' && r != '+' && r != '-' {
+				idx = i
+				break
+			}
+		}
+		if idx <= 0 {
+			return 0, false
+		}
+		number = fields[0][:idx]
+		unit = fields[0][idx:]
+	case 2:
+		number = fields[0]
+		unit = fields[1]
+	default:
+		return 0, false
+	}
+
+	amount, err := strconv.ParseFloat(number, 64)
+	if err != nil {
+		return 0, false
+	}
+
+	var multiplier time.Duration
+	switch unit {
+	case "us":
+		multiplier = time.Microsecond
+	case "ms":
+		multiplier = time.Millisecond
+	case "s":
+		multiplier = time.Second
+	case "min":
+		multiplier = time.Minute
+	case "h":
+		multiplier = time.Hour
+	case "d":
+		multiplier = 24 * time.Hour
+	default:
+		return 0, false
+	}
+
+	return time.Duration(amount * float64(multiplier)), true
 }
 
 // invalidParamError returns a PgDiagnostic for an invalid parameter value (SQLSTATE 22023).

--- a/go/services/multigateway/handler/statement_timeout_test.go
+++ b/go/services/multigateway/handler/statement_timeout_test.go
@@ -81,19 +81,39 @@ func TestParsePostgresInterval(t *testing.T) {
 			want:  5 * time.Second,
 		},
 		{
-			name:  "Go duration 30s",
+			name:  "PostgreSQL seconds unit",
 			value: "30s",
 			want:  30 * time.Second,
 		},
 		{
-			name:  "Go duration 200ms",
+			name:  "PostgreSQL milliseconds unit",
 			value: "200ms",
 			want:  200 * time.Millisecond,
 		},
 		{
-			name:  "Go duration 1m",
-			value: "1m",
+			name:  "PostgreSQL min unit",
+			value: "1min",
 			want:  time.Minute,
+		},
+		{
+			name:  "PostgreSQL min unit with space",
+			value: "1 min",
+			want:  time.Minute,
+		},
+		{
+			name:  "PostgreSQL hour unit",
+			value: "1h",
+			want:  time.Hour,
+		},
+		{
+			name:  "PostgreSQL day unit",
+			value: "1d",
+			want:  24 * time.Hour,
+		},
+		{
+			name:  "PostgreSQL decimal unit with space",
+			value: "1.5 s",
+			want:  1500 * time.Millisecond,
 		},
 		{
 			name:  "zero",
@@ -112,7 +132,7 @@ func TestParsePostgresInterval(t *testing.T) {
 			errContains: `-1 ms is outside the valid range for parameter "statement_timeout" (0 ms .. 2147483647 ms)`,
 		},
 		{
-			name:        "negative Go duration",
+			name:        "negative seconds unit",
 			value:       "-5s",
 			wantErr:     true,
 			errContains: `-5000 ms is outside the valid range for parameter "statement_timeout" (0 ms .. 2147483647 ms)`,
@@ -139,6 +159,31 @@ func TestParsePostgresInterval(t *testing.T) {
 		{
 			name:    "invalid string",
 			value:   "not-a-number",
+			wantErr: true,
+		},
+		{
+			name:    "Go-only minute unit rejected",
+			value:   "1m",
+			wantErr: true,
+		},
+		{
+			name:    "long seconds unit rejected",
+			value:   "5 seconds",
+			wantErr: true,
+		},
+		{
+			name:    "plural minutes unit rejected",
+			value:   "30 mins",
+			wantErr: true,
+		},
+		{
+			name:    "long hour unit rejected",
+			value:   "1 hour",
+			wantErr: true,
+		},
+		{
+			name:    "long day unit rejected",
+			value:   "2 days",
 			wantErr: true,
 		},
 		{

--- a/go/services/multigateway/handler/transaction_helpers.go
+++ b/go/services/multigateway/handler/transaction_helpers.go
@@ -274,7 +274,21 @@ func (h *MultigatewayHandler) executeWithImplicitTransaction(
 	// This matches PostgreSQL's behavior in exec_simple_query(): the commit is
 	// attempted before the last statement's CommandComplete is sent to the client.
 	if isImplicitTx {
-		if err := silentExecute(ast.NewCommitStmt()); err != nil {
+		// Commit may emit NoticeResponse diagnostics while firing deferred
+		// constraint triggers. PostgreSQL sends those notices before the held
+		// CommandComplete for the last statement in the implicit transaction, so use
+		// a custom callback that forwards notices but suppresses the synthetic COMMIT
+		// command tag.
+		commitStmt := ast.NewCommitStmt()
+		stmtCtx, cancel := h.statementTimeoutCtx(ctx, state, commitStmt)
+		_, err := h.executor.StreamExecute(stmtCtx, conn, state, commitStmt.SqlString(), commitStmt, func(ctx context.Context, result *sqltypes.Result) error {
+			if len(result.Notices) > 0 {
+				return callback(ctx, &sqltypes.Result{Notices: result.Notices})
+			}
+			return nil
+		})
+		cancel()
+		if err != nil {
 			// Commit failed — rollback to clean up. The held CommandComplete is
 			// discarded; the caller will send an ErrorResponse instead.
 			rollbackImplicit()

--- a/go/services/multigateway/planner/advisory_lock_test.go
+++ b/go/services/multigateway/planner/advisory_lock_test.go
@@ -87,8 +87,8 @@ func TestPlan_SessionAdvisoryLockRouting(t *testing.T) {
 
 // TestPlan_AdvisoryLockComposesWithSetConfig verifies that a statement which
 // both acquires a session-level advisory lock and tracks a set_config keeps
-// both behaviors: the plan is a Sequence with the set_config ApplySessionState
-// primitives AND a trailing AdvisoryLockRoute that pins the backend.
+// both behaviors: the plan is a Sequence with a leading Route that pins the
+// backend and trailing set_config ApplySessionState primitives.
 func TestPlan_AdvisoryLockComposesWithSetConfig(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
 	p := NewPlanner("default", logger, nil)
@@ -112,11 +112,11 @@ func TestPlan_AdvisoryLockComposesWithSetConfig(t *testing.T) {
 	}
 	assert.True(t, hasApplySessionState, "set_config must still be tracked via ApplySessionState")
 
-	// The trailing primitive is a plain Route; the advisory pin now rides on the
+	// The leading primitive is a plain Route; the advisory pin now rides on the
 	// plan's ExecInfo, which the Sequence forwards to that Route at exec time.
-	last := seq.Primitives[len(seq.Primitives)-1]
-	_, isRoute := last.(*engine.Route)
-	assert.True(t, isRoute, "trailing primitive must be a Route, got %T", last)
+	first := seq.Primitives[0]
+	_, isRoute := first.(*engine.Route)
+	assert.True(t, isRoute, "leading primitive must be a Route, got %T", first)
 	assert.True(t, plan.ExecInfo.AdvisoryLock, "plan must carry the advisory-lock pin intent")
 	assert.True(t, plan.ExecInfo.RecheckAdvisoryLocks, "plan must request the advisory recheck")
 }

--- a/go/services/multigateway/planner/select_stmt.go
+++ b/go/services/multigateway/planner/select_stmt.go
@@ -33,7 +33,9 @@ import (
 //	Sequence[Route(original SQL), ApplySessionState per call]
 //
 // The Route sends the unmodified query to PG, which executes set_config
-// normally and streams the result back. Only after that succeeds do the silent
+// normally and streams the result back. The Sequence precomputes the backend's
+// post-success session settings and attaches them to the Route for multipooler
+// recycle bookkeeping, but only after the Route succeeds do the silent
 // ApplySessionState primitives update the gateway tracker. This preserves
 // PostgreSQL semantics on statement errors: a rejected SELECT must not leave a
 // session GUC recorded in the gateway when the backend never applied it.

--- a/go/services/multigateway/planner/select_stmt.go
+++ b/go/services/multigateway/planner/select_stmt.go
@@ -87,15 +87,16 @@ func (p *Planner) planSelectStmt(
 	return plan, nil
 }
 
-// planResolveSetConfig plans a SELECT whose target list is entirely
-// set_config(...) calls where at least one argument can't be resolved at plan
-// time (the analyzer set DynamicSetConfig). We can't mint a literal SET to
-// track, so the plan is a single ResolveTrackSetConfig primitive that:
+// planResolveSetConfig plans the narrow dynamic SELECT set_config shape the
+// analyzer accepts for pg_dump: the target list is entirely set_config(...), at
+// least one name argument is pg_settings.name, and every value/is_local argument
+// is static. We can't mint a literal SET to track before reading pg_settings, so
+// the plan is a single ResolveTrackSetConfig primitive that:
 //
 //  1. runs an "unroll" projection — the SELECT with each set_config(a, b, c)
 //     target replaced by its three arguments a, b, c — once, to learn the
-//     concrete (name, value, is_local) tuples per row (pure read, no
-//     set_config side effect);
+//     concrete (name, value, is_local) tuples per row (side-effect-free
+//     pg_settings read, no set_config side effect);
 //  2. prepares and validates gateway tracking actions without mutating state;
 //  3. applies all tuples with literals (a synthesized set_config(...) over the
 //     captured values) and forwards that authoritative result to the client;
@@ -103,14 +104,8 @@ func (p *Planner) planSelectStmt(
 //     synthesized apply query.
 //
 // Running the projection once is essential: re-running the original dynamic
-// query could resolve to different rows/values (concurrent catalog change,
-// volatile FROM), so the first resolution is the source of truth.
-//
-// opts carries advisory-lock pinning intent. A set_config argument can itself
-// acquire a session-level advisory lock (e.g.
-// set_config('x', pg_try_advisory_lock(1)::text, false)); that call runs when
-// the resolve projection evaluates the arguments, so the primitive must pin the
-// backend the same way routePrimitive would for an ordinary query.
+// query could resolve to different rows/values after a concurrent catalog
+// change, so the first resolution is the source of truth.
 func (p *Planner) planResolveSetConfig(sql string, stmt *ast.SelectStmt, opts PlanOptions) (*engine.Plan, error) {
 	// Clone before mutating: the AST may be a cached plan's normalized tree
 	// shared across executions.

--- a/go/services/multigateway/planner/select_stmt.go
+++ b/go/services/multigateway/planner/select_stmt.go
@@ -30,14 +30,13 @@ import (
 //
 // With set_configs present the plan is always
 //
-//	Sequence[ApplySessionState per call, Route(original SQL)]
+//	Sequence[Route(original SQL), ApplySessionState per call]
 //
-// The ApplySessionState primitive runs silently — it updates the tracker
-// without emitting anything to the client; the Route then sends the
-// unmodified query to PG, which executes set_config normally and streams
-// the result back. The extra round-trip matters less than keeping the
-// planning logic uniform — we don't try to short-circuit the bare
-// `SELECT set_config(...)` case.
+// The Route sends the unmodified query to PG, which executes set_config
+// normally and streams the result back. Only after that succeeds do the silent
+// ApplySessionState primitives update the gateway tracker. This preserves
+// PostgreSQL semantics on statement errors: a rejected SELECT must not leave a
+// session GUC recorded in the gateway when the backend never applied it.
 //
 // For literal-arg calls the primitive carries the value directly. For
 // calls with one or more bound-parameter args (extended-protocol shape
@@ -62,6 +61,12 @@ func (p *Planner) planSelectStmt(
 	}
 
 	primitives := make([]engine.Primitive, 0, len(setConfigs)+1)
+	// The leading route runs the SELECT itself. Advisory-lock pinning rides on
+	// the plan's ExecInfo (set below); Sequence forwards it to this Route, so a
+	// `SELECT set_config(...), pg_advisory_lock(...)` both pins the backend for
+	// the lock and, if the SELECT succeeds, tracks the session setting via the
+	// silent ApplySessionState primitives below.
+	primitives = append(primitives, engine.NewRoute(p.defaultTableGroup, constants.DefaultShard, sql, stmt))
 	for _, sc := range setConfigs {
 		base := syntheticSetStmt(sc)
 		if sc.hasBoundParams() {
@@ -75,12 +80,6 @@ func (p *Planner) planSelectStmt(
 			primitives = append(primitives, engine.NewApplySessionStateSilent(sql, base))
 		}
 	}
-	// The trailing route runs the SELECT itself. Advisory-lock pinning rides on
-	// the plan's ExecInfo (set below); Sequence forwards it to this trailing
-	// Route, so a `SELECT set_config(...), pg_advisory_lock(...)` both tracks the
-	// session setting (via the ApplySessionState primitives above) and pins the
-	// backend for the lock.
-	primitives = append(primitives, engine.NewRoute(p.defaultTableGroup, constants.DefaultShard, sql, stmt))
 	plan := engine.NewPlan(sql, engine.NewSequence(primitives))
 	plan.ExecInfo = advisoryExecInfo(opts)
 	return plan, nil
@@ -95,10 +94,11 @@ func (p *Planner) planSelectStmt(
 //     target replaced by its three arguments a, b, c — once, to learn the
 //     concrete (name, value, is_local) tuples per row (pure read, no
 //     set_config side effect);
-//  2. tracks the session-scoped (is_local=false) tuples in SessionSettings so
-//     they survive pool rotation;
+//  2. prepares and validates gateway tracking actions without mutating state;
 //  3. applies all tuples with literals (a synthesized set_config(...) over the
-//     captured values) and forwards that authoritative result to the client.
+//     captured values) and forwards that authoritative result to the client;
+//  4. records the prepared tracking actions only after PostgreSQL accepts the
+//     synthesized apply query.
 //
 // Running the projection once is essential: re-running the original dynamic
 // query could resolve to different rows/values (concurrent catalog change,

--- a/go/services/multigateway/planner/set_config_gmv_test.go
+++ b/go/services/multigateway/planner/set_config_gmv_test.go
@@ -48,8 +48,8 @@ func TestSetConfig_GatewayManagedIsLocalTrueIsTracked(t *testing.T) {
 }
 
 // TestPlanSetConfig_GatewayManagedIsLocalTruePlan verifies the full plan: a
-// Sequence[ApplySessionState, Route] whose ApplySessionState carries IsLocal so
-// the executor applies a transaction-local gateway override.
+// Sequence[Route, ApplySessionState] whose ApplySessionState carries IsLocal so
+// the executor applies a transaction-local gateway override after backend success.
 func TestPlanSetConfig_GatewayManagedIsLocalTruePlan(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
 	p := NewPlanner("default", logger, nil)
@@ -64,11 +64,11 @@ func TestPlanSetConfig_GatewayManagedIsLocalTruePlan(t *testing.T) {
 	require.True(t, ok, "expected Sequence primitive, got %T", plan.Primitive)
 	require.GreaterOrEqual(t, len(seq.Primitives), 2)
 
-	ass, ok := seq.Primitives[0].(*engine.ApplySessionState)
-	require.True(t, ok, "first primitive should be ApplySessionState, got %T", seq.Primitives[0])
+	_, ok = seq.Primitives[0].(*engine.Route)
+	assert.True(t, ok, "first primitive should be Route, got %T", seq.Primitives[0])
+
+	ass, ok := seq.Primitives[len(seq.Primitives)-1].(*engine.ApplySessionState)
+	require.True(t, ok, "last primitive should be ApplySessionState, got %T", seq.Primitives[len(seq.Primitives)-1])
 	assert.Equal(t, "statement_timeout", ass.VariableStmt.Name)
 	assert.True(t, ass.VariableStmt.IsLocal, "is_local=true must be carried so the executor applies a transaction-local override")
-
-	_, ok = seq.Primitives[len(seq.Primitives)-1].(*engine.Route)
-	assert.True(t, ok, "last primitive should be Route, got %T", seq.Primitives[len(seq.Primitives)-1])
 }

--- a/go/services/multigateway/planner/unsafe_funccall.go
+++ b/go/services/multigateway/planner/unsafe_funccall.go
@@ -156,16 +156,15 @@ type statementAnalysis struct {
 	SetConfigs []setConfigCall
 
 	// DynamicSetConfig is true when the statement is a SELECT whose target
-	// list is entirely set_config(...) calls and at least one call has an
-	// argument that can't be resolved at plan time (a column reference or
-	// other expression rather than a literal or bound parameter) — the shape
-	// pg_dump uses on PG17+:
+	// list is entirely set_config(...) calls in the narrow pg_dump PG17+ shape:
+	// at least one name argument is pg_settings.name, while value and is_local
+	// arguments remain static.
 	//
 	//	SELECT set_config(name, 'view, foreign-table', false)
 	//	FROM pg_settings WHERE name = 'restrict_nonsystem_relation_kind'
 	//
 	// We can't mint a literal SET to track up front, so the planner emits a
-	// ResolveTrackSetConfig primitive that executes the argument projection
+	// ResolveTrackSetConfig primitive that executes the pg_settings projection
 	// once to learn the concrete (name, value, is_local) tuples, tracks the
 	// session-scoped ones, and applies them with literals. When this is set,
 	// SetConfigs is empty — every call in the target list is handled by the
@@ -312,12 +311,19 @@ func analyzeFunctionCalls(stmt ast.Stmt) (*statementAnalysis, error) {
 
 	// Resolve-and-apply path: the whole target list is set_config(...) and at
 	// least one call has a non-literal, non-bound argument the literal/bound
-	// fast path can't track (pg_dump's column-reference name). Hand the
-	// statement to the planner's ResolveTrackSetConfig primitive rather than
-	// erroring in validateAcceptedSetConfig.
+	// fast path can't track. This path is intentionally narrow: it exists for
+	// pg_dump's PG17+ pg_settings probe, where only the GUC name is dynamic
+	// (`pg_settings.name`) and value/is_local remain static. Arbitrary dynamic
+	// expressions would be evaluated in a separate resolve statement before the
+	// synthesized apply statement, which can break PostgreSQL's single-statement
+	// atomicity and argument type checking. Reject those shapes instead of trying
+	// to emulate them.
 	if targetListAllSetConfig(stmt, allowedSetConfigs) && slices.ContainsFunc(accepted, setConfigNeedsDynamic) {
+		if err := validateDynamicSetConfigShape(stmt, accepted); err != nil {
+			return nil, err
+		}
 		// A cluster-managed GUC is still rejected when the name is a literal;
-		// a dynamic name is a documented gap (matches validateAcceptedSetConfig).
+		// the only supported dynamic name is pg_settings.name.
 		for _, fc := range accepted {
 			if name, ok := constStringArg(fc.Args.Items[0]); ok {
 				if err := restrictedGUCError(name); err != nil {
@@ -450,6 +456,214 @@ func isStaticSetConfigArg(n ast.Node) bool {
 		return true
 	}
 	return false
+}
+
+// validateDynamicSetConfigShape accepts only the pg_dump-safe dynamic shape:
+// every set_config value and is_local argument must be static, and any dynamic
+// name must be the name column from pg_settings. This keeps the resolve step a
+// side-effect-free catalog read and avoids evaluating arbitrary expressions as
+// ordinary SELECT outputs before re-applying them as text literals.
+func validateDynamicSetConfigShape(stmt ast.Stmt, accepted []*ast.FuncCall) error {
+	ss, ok := stmt.(*ast.SelectStmt)
+	if !ok {
+		return mterrors.NewFeatureNotSupported("dynamic set_config is only supported in SELECT statements")
+	}
+
+	pgSettingsQualifiers, pgSettingsOK := pgSettingsNameQualifiers(ss)
+	for _, fc := range accepted {
+		if fc.Args == nil || fc.Args.Len() != 3 {
+			return mterrors.NewFeatureNotSupported(
+				"set_config requires three arguments: (name text, value text, is_local bool)")
+		}
+
+		nameArg := fc.Args.Items[0]
+		if !isStaticSetConfigArg(nameArg) {
+			if !pgSettingsOK || !isPgSettingsNameColumnRef(nameArg, pgSettingsQualifiers) {
+				return mterrors.NewFeatureNotSupported(
+					"dynamic set_config name argument is only supported for pg_settings.name")
+			}
+		} else if !isDynamicTextSetConfigArg(nameArg) {
+			return mterrors.NewFeatureNotSupported(
+				"dynamic set_config name argument must be a text literal, bound text parameter, or pg_settings.name")
+		}
+		if !isDynamicTextSetConfigArg(fc.Args.Items[1]) {
+			if !isStaticSetConfigArg(fc.Args.Items[1]) {
+				return setConfigArgError(fc.Args.Items[1], "value")
+			}
+			return mterrors.NewFeatureNotSupported(
+				"dynamic set_config value argument must be a text literal or bound text parameter")
+		}
+		if !isDynamicBoolSetConfigArg(fc.Args.Items[2]) {
+			if !isStaticSetConfigArg(fc.Args.Items[2]) {
+				return setConfigArgError(fc.Args.Items[2], "is_local")
+			}
+			return mterrors.NewFeatureNotSupported(
+				"dynamic set_config is_local argument must be a literal boolean")
+		}
+	}
+
+	acceptedSet := make(map[*ast.FuncCall]struct{}, len(accepted))
+	for _, fc := range accepted {
+		acceptedSet[fc] = struct{}{}
+	}
+	var walkErr error
+	ast.Rewrite(stmt, func(cursor *ast.Cursor) bool {
+		if walkErr != nil {
+			return false
+		}
+		fc, ok := cursor.Node().(*ast.FuncCall)
+		if !ok {
+			return true
+		}
+		if _, isSetConfigTarget := acceptedSet[fc]; isSetConfigTarget {
+			return true
+		}
+		walkErr = mterrors.NewFeatureNotSupported(
+			"dynamic set_config only supports simple pg_settings lookups; function calls outside set_config are not supported")
+		return false
+	}, nil)
+	return walkErr
+}
+
+// pgSettingsNameQualifiers returns the allowed qualifiers for pg_settings.name
+// in the current SELECT, plus whether the FROM clause is the simple pg_settings
+// scan used by pg_dump. We require a single RangeVar so the resolve projection
+// cannot hide side effects in FROM functions or joins.
+func pgSettingsNameQualifiers(ss *ast.SelectStmt) (map[string]struct{}, bool) {
+	if ss.FromClause == nil || ss.FromClause.Len() != 1 {
+		return nil, false
+	}
+	rv, ok := ss.FromClause.Items[0].(*ast.RangeVar)
+	if !ok {
+		return nil, false
+	}
+	if !strings.EqualFold(rv.RelName, "pg_settings") {
+		return nil, false
+	}
+	if rv.CatalogName != "" || (rv.SchemaName != "" && !strings.EqualFold(rv.SchemaName, "pg_catalog")) {
+		return nil, false
+	}
+
+	qualifiers := map[string]struct{}{"pg_settings": {}}
+	if rv.Alias != nil && rv.Alias.AliasName != "" {
+		qualifiers[strings.ToLower(rv.Alias.AliasName)] = struct{}{}
+	}
+	return qualifiers, true
+}
+
+func isDynamicTextSetConfigArg(n ast.Node) bool {
+	switch c := n.(type) {
+	case *ast.TypeCast:
+		if !isDynamicTextType(c.TypeName) {
+			return false
+		}
+		return isDynamicTextSetConfigArg(c.Arg)
+	case *ast.ParamRef:
+		return true
+	case *ast.A_Const:
+		if c.Isnull {
+			return false
+		}
+		_, ok := c.Val.(*ast.String)
+		return ok
+	default:
+		return false
+	}
+}
+
+func isDynamicBoolSetConfigArg(n ast.Node) bool {
+	switch c := n.(type) {
+	case *ast.TypeCast:
+		if !isDynamicBoolType(c.TypeName) {
+			return false
+		}
+		return isDynamicBoolSetConfigArg(c.Arg)
+	case *ast.A_Const:
+		if c.Isnull {
+			return false
+		}
+		switch v := c.Val.(type) {
+		case *ast.Boolean:
+			return true
+		case *ast.String:
+			switch strings.ToLower(strings.TrimSpace(v.SVal)) {
+			case "t", "true", "y", "yes", "on", "1",
+				"f", "false", "n", "no", "off", "0":
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+func isDynamicTextType(typeName *ast.TypeName) bool {
+	switch dynamicTypeNameOID(typeName) {
+	case ast.TEXTOID, ast.VARCHAROID:
+		return true
+	}
+	return false
+}
+
+func isDynamicBoolType(typeName *ast.TypeName) bool {
+	return dynamicTypeNameOID(typeName) == ast.BOOLOID
+}
+
+func dynamicTypeNameOID(typeName *ast.TypeName) ast.Oid {
+	if typeName == nil {
+		return ast.InvalidOid
+	}
+	if typeName.TypeOid != ast.InvalidOid {
+		return typeName.TypeOid
+	}
+	if typeName.Names == nil || typeName.Names.Len() == 0 {
+		return ast.InvalidOid
+	}
+	parts := make([]string, 0, typeName.Names.Len())
+	for _, item := range typeName.Names.Items {
+		name := lowerStringNode(item)
+		if name == "" {
+			return ast.InvalidOid
+		}
+		if name != "pg_catalog" {
+			parts = append(parts, name)
+		}
+	}
+	if len(parts) == 0 {
+		return ast.InvalidOid
+	}
+	return ast.TypeNameToOid(strings.Join(parts, " "))
+}
+
+func isPgSettingsNameColumnRef(n ast.Node, qualifiers map[string]struct{}) bool {
+	if tc, ok := n.(*ast.TypeCast); ok {
+		if !isDynamicTextType(tc.TypeName) {
+			return false
+		}
+		n = tc.Arg
+	}
+	ref, ok := n.(*ast.ColumnRef)
+	if !ok || ref.Fields == nil {
+		return false
+	}
+	parts := make([]string, 0, ref.Fields.Len())
+	for _, field := range ref.Fields.Items {
+		s, ok := field.(*ast.String)
+		if !ok {
+			return false
+		}
+		parts = append(parts, strings.ToLower(s.SVal))
+	}
+	switch len(parts) {
+	case 1:
+		return parts[0] == "name"
+	case 2:
+		_, ok := qualifiers[parts[0]]
+		return ok && parts[1] == "name"
+	default:
+		return false
+	}
 }
 
 // validateAcceptedSetConfig verifies that an allowed-position set_config

--- a/go/services/multigateway/planner/unsafe_funccall.go
+++ b/go/services/multigateway/planner/unsafe_funccall.go
@@ -498,7 +498,7 @@ func validateAcceptedSetConfig(fc *ast.FuncCall) (*setConfigCall, error) {
 		if isLocal {
 			// is_local literal true. For an ordinary variable we do not track
 			// it: PostgreSQL executes the call transaction-scoped via the
-			// trailing Route and the gateway holds no state (which also keeps
+			// paired Route and the gateway holds no state (which also keeps
 			// the plan cache compact for hot PostgREST set_config(...,true)
 			// patterns). For a gateway-managed variable we DO track it as a
 			// transaction-local override, so SHOW matches the `SET LOCAL <gmv>`

--- a/go/services/multigateway/planner/unsafe_funccall_test.go
+++ b/go/services/multigateway/planner/unsafe_funccall_test.go
@@ -512,9 +512,8 @@ func TestResolveFuncName(t *testing.T) {
 
 // TestPlan_SetConfig_ProducesSequence verifies that every accepted
 // `SELECT set_config(...)` shape — bare or mixed with a FROM/targets —
-// plans as the same Sequence[silent ApplySessionState..., Route]. No
-// fast-path for the bare case: uniform construction is worth the extra
-// round-trip.
+// plans as the same Sequence[Route, silent ApplySessionState...]. No fast-path
+// for the bare case: uniform construction is worth the extra round-trip.
 func TestPlan_SetConfig_ProducesSequence(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -553,15 +552,16 @@ func TestPlan_SetConfig_ProducesSequence(t *testing.T) {
 			require.True(t, ok, "expected Sequence primitive, got %T", plan.Primitive)
 			require.Len(t, seq.Primitives, len(tt.wantTrackers)+1)
 
+			_, ok = seq.Primitives[0].(*engine.Route)
+			require.True(t, ok, "first primitive should be Route, got %T", seq.Primitives[0])
+
 			for i, wantName := range tt.wantTrackers {
-				applyState, ok := seq.Primitives[i].(*engine.ApplySessionState)
-				require.True(t, ok, "primitive %d should be ApplySessionState, got %T", i, seq.Primitives[i])
-				assert.True(t, applyState.SilentTracking, "tracker step %d must be silent; Route owns the client response", i)
+				primIdx := i + 1
+				applyState, ok := seq.Primitives[primIdx].(*engine.ApplySessionState)
+				require.True(t, ok, "primitive %d should be ApplySessionState, got %T", primIdx, seq.Primitives[primIdx])
+				assert.True(t, applyState.SilentTracking, "tracker step %d must be silent; Route owns the client response", primIdx)
 				assert.Equal(t, wantName, applyState.VariableStmt.Name)
 			}
-
-			_, ok = seq.Primitives[len(tt.wantTrackers)].(*engine.Route)
-			require.True(t, ok, "last primitive should be Route, got %T", seq.Primitives[len(tt.wantTrackers)])
 		})
 	}
 }

--- a/go/services/multigateway/planner/unsafe_funccall_test.go
+++ b/go/services/multigateway/planner/unsafe_funccall_test.go
@@ -288,9 +288,11 @@ func TestInspectExpressionFuncCalls_SetConfigRejected(t *testing.T) {
 // TestInspectExpressionFuncCalls_DynamicSetConfigAccepted pins the
 // resolve-and-apply path: a SELECT whose target list is entirely
 // set_config(...) and that has at least one argument the literal/bound fast
-// path can't resolve (a column reference) is accepted with
-// DynamicSetConfig=true (and no SetConfigs) rather than rejected. This is the
-// shape pg_dump uses on PG17+.
+// path can't resolve is accepted with DynamicSetConfig=true only for the
+// pg_dump-safe shape: pg_settings.name as the dynamic GUC name, with static
+// value and is_local arguments. Broader dynamic expressions would require two
+// backend statements (resolve then apply), which cannot preserve native
+// PostgreSQL statement atomicity or argument type checks.
 func TestInspectExpressionFuncCalls_DynamicSetConfigAccepted(t *testing.T) {
 	tests := []struct {
 		name string
@@ -301,24 +303,16 @@ func TestInspectExpressionFuncCalls_DynamicSetConfigAccepted(t *testing.T) {
 			sql:  "SELECT set_config(name, 'view, foreign-table', false) FROM pg_settings WHERE name = 'restrict_nonsystem_relation_kind'",
 		},
 		{
-			name: "dynamic name",
-			sql:  "SELECT set_config(name, '256MB', false) FROM gucs",
+			name: "qualified pg_settings name",
+			sql:  "SELECT set_config(pg_settings.name, '256MB', false) FROM pg_settings WHERE name = 'work_mem'",
 		},
 		{
-			name: "dynamic value",
-			sql:  "SELECT set_config('work_mem', v, false) FROM gucs",
+			name: "aliased pg_settings name",
+			sql:  "SELECT set_config(s.name, '256MB', false) FROM pg_settings AS s WHERE s.name = 'work_mem'",
 		},
 		{
-			name: "dynamic is_local",
-			sql:  "SELECT set_config('work_mem', '256MB', islocal) FROM gucs",
-		},
-		{
-			name: "multiple set_config calls, one dynamic (multi-column)",
-			sql:  "SELECT set_config('a', 'b', false), set_config(name, 'c', false) FROM gucs",
-		},
-		{
-			name: "all dynamic multi-column",
-			sql:  "SELECT set_config(n1, v1, false), set_config(n2, v2, false) FROM gucs",
+			name: "multiple set_config calls with one pg_settings dynamic name",
+			sql:  "SELECT set_config('application_name', 'multigres', false), set_config(name, '256MB', false) FROM pg_settings WHERE name = 'work_mem'",
 		},
 	}
 
@@ -330,6 +324,79 @@ func TestInspectExpressionFuncCalls_DynamicSetConfigAccepted(t *testing.T) {
 			require.NotNil(t, result)
 			assert.True(t, result.DynamicSetConfig, "expected DynamicSetConfig")
 			assert.Empty(t, result.SetConfigs, "dynamic path tracks via the primitive, not SetConfigs")
+		})
+	}
+}
+
+func TestInspectExpressionFuncCalls_DynamicSetConfigRejected(t *testing.T) {
+	tests := []struct {
+		name    string
+		sql     string
+		wantMsg string
+	}{
+		{
+			name:    "dynamic name from arbitrary table rejected",
+			sql:     "SELECT set_config(name, '256MB', false) FROM gucs",
+			wantMsg: "dynamic set_config name argument is only supported for pg_settings.name",
+		},
+		{
+			name:    "dynamic value column rejected",
+			sql:     "SELECT set_config('work_mem', v, false) FROM pg_settings",
+			wantMsg: "set_config value argument must be a literal constant or a bound parameter",
+		},
+		{
+			name:    "dynamic is_local column rejected",
+			sql:     "SELECT set_config('work_mem', '256MB', islocal) FROM pg_settings",
+			wantMsg: "set_config is_local argument must be a literal constant or a bound parameter",
+		},
+		{
+			name:    "bound is_local rejected on dynamic path",
+			sql:     "SELECT set_config(name, '256MB', $1) FROM pg_settings",
+			wantMsg: "dynamic set_config is_local argument must be a literal boolean",
+		},
+		{
+			name:    "integer value rejected on dynamic path",
+			sql:     "SELECT set_config(name, 100, false) FROM pg_settings",
+			wantMsg: "dynamic set_config value argument must be a text literal or bound text parameter",
+		},
+		{
+			name:    "integer name rejected on dynamic path",
+			sql:     "SELECT set_config(100, 'v', false), set_config(name, '256MB', false) FROM pg_settings",
+			wantMsg: "dynamic set_config name argument must be a text literal, bound text parameter, or pg_settings.name",
+		},
+		{
+			name:    "wrong value cast rejected on dynamic path",
+			sql:     "SELECT set_config(name, '256MB'::int, false) FROM pg_settings",
+			wantMsg: "dynamic set_config value argument must be a text literal or bound text parameter",
+		},
+		{
+			name:    "wrong is_local cast rejected on dynamic path",
+			sql:     "SELECT set_config(name, '256MB', false::text) FROM pg_settings",
+			wantMsg: "dynamic set_config is_local argument must be a literal boolean",
+		},
+		{
+			name:    "function value rejected to preserve set_config type checks",
+			sql:     "SELECT set_config('work_mem', now(), false)",
+			wantMsg: "set_config value argument must be a literal constant or a bound parameter",
+		},
+		{
+			name:    "function in WHERE rejected to keep resolve side-effect-free",
+			sql:     "SELECT set_config(name, '256MB', false) FROM pg_settings WHERE nextval('s') > 0",
+			wantMsg: "dynamic set_config only supports simple pg_settings lookups; function calls outside set_config are not supported",
+		},
+		{
+			name:    "computed name rejected",
+			sql:     "SELECT set_config(lower(name), '256MB', false) FROM pg_settings",
+			wantMsg: "dynamic set_config name argument is only supported for pg_settings.name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt := parseOne(t, tt.sql)
+			_, err := analyzeFunctionCalls(stmt)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantMsg)
 		})
 	}
 }
@@ -585,8 +652,8 @@ func TestPlan_DynamicSetConfig_ProducesResolvePrimitive(t *testing.T) {
 		},
 		{
 			name:        "multi-column with alias",
-			sql:         "SELECT set_config(name, '1', false) AS a, set_config('work_mem', v, false) FROM gucs",
-			wantUnroll:  "SELECT name, '1', FALSE, 'work_mem', v, FALSE FROM gucs",
+			sql:         "SELECT set_config(name, '1', false) AS a, set_config('application_name', 'multigres', false) FROM pg_settings WHERE name = 'work_mem'",
+			wantUnroll:  "SELECT name, '1', FALSE, 'application_name', 'multigres', FALSE FROM pg_settings WHERE name = 'work_mem'",
 			wantAliases: []string{"a", ""},
 		},
 	}
@@ -614,29 +681,20 @@ func TestPlan_DynamicSetConfig_ProducesResolvePrimitive(t *testing.T) {
 	}
 }
 
-// TestPlan_DynamicSetConfig_AdvisoryLockPins verifies that a dynamic set_config
-// whose argument acquires a session-level advisory lock still pins the backend.
-// The lock is taken when the resolve projection evaluates the arguments, so the
-// pin must ride on the plan's ExecInfo — which ResolveTrackSetConfig forwards to
-// its (plain) ResolveRoute at exec time.
-func TestPlan_DynamicSetConfig_AdvisoryLockPins(t *testing.T) {
+// TestPlan_DynamicSetConfig_RejectsAdvisoryLockArg verifies that dynamic
+// set_config no longer evaluates arbitrary value expressions during the resolve
+// phase. Such expressions would run in a separate backend statement before the
+// synthesized apply, breaking PostgreSQL's single-statement semantics.
+func TestPlan_DynamicSetConfig_RejectsAdvisoryLockArg(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
 	p := NewPlanner("default", logger, nil)
 	testConn := server.NewTestConn(&bytes.Buffer{})
 
-	// Value argument acquires an advisory lock — both dynamic (a function call,
-	// not a literal/bound param) and advisory-lock-acquiring.
 	sql := "SELECT set_config('x', pg_try_advisory_lock(1)::text, false)"
 	stmt := parseOne(t, sql)
-	plan, err := p.Plan(sql, stmt, testConn.Conn, PlanOptions{})
-	require.NoError(t, err)
-
-	prim, ok := plan.Primitive.(*engine.ResolveTrackSetConfig)
-	require.True(t, ok, "expected ResolveTrackSetConfig, got %T", plan.Primitive)
-	_, isRoute := prim.ResolveRoute.(*engine.Route)
-	require.True(t, isRoute, "resolve must run through a plain Route, got %T", prim.ResolveRoute)
-	assert.True(t, plan.ExecInfo.AdvisoryLock, "advisory-lock acquire must pin the backend via plan ExecInfo")
-	assert.True(t, plan.ExecInfo.RecheckAdvisoryLocks, "advisory statement must request a pg_locks recheck")
+	_, err := p.Plan(sql, stmt, testConn.Conn, PlanOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "set_config value argument must be a literal constant or a bound parameter")
 }
 
 // TestPlan_RejectsUnsafeFuncCalls verifies Plan() itself rejects blocklisted

--- a/go/services/multigateway/poolergateway/grpc_query_service.go
+++ b/go/services/multigateway/poolergateway/grpc_query_service.go
@@ -509,8 +509,18 @@ func (g *grpcQueryService) CopyFinalize(
 	// violation) but the underlying reserved connection is still alive
 	// because of another reason such as a transaction. Forward that state
 	// so the gateway keeps tracking the connection instead of clearing it.
+	// Notices on the ERROR frame are diagnostics PostgreSQL emitted before the
+	// ErrorResponse; return them in a result so ScatterConn can write them before
+	// surfacing the error to the client.
 	if resp.Phase == multipoolerservice.CopyBidiExecuteResponse_ERROR {
-		return nil, resp.GetReservedState(), copyErrorFromResp(resp)
+		var result *sqltypes.Result
+		if len(resp.Notices) > 0 {
+			result = &sqltypes.Result{}
+			for _, pd := range resp.Notices {
+				result.Notices = append(result.Notices, mterrors.PgDiagnosticFromProto(pd))
+			}
+		}
+		return result, resp.GetReservedState(), copyErrorFromResp(resp)
 	}
 
 	// Validate RESULT response
@@ -524,10 +534,8 @@ func (g *grpcQueryService) CopyFinalize(
 	}
 	// Forward NoticeResponse diagnostics that arrived between CopyDone and
 	// CommandComplete (e.g. trigger RAISE NOTICE during COPY FROM STDIN).
-	// The bidi proto carries them in resp.Notices alongside the Result; the
-	// proto Result message itself has no Notices field by design — notices
-	// are streamed as separate frames in the StreamExecute path. For COPY
-	// we batch them onto the final Result so the gateway can re-emit them
+	// COPY bidi carries them in resp.Notices alongside a notice-free Result;
+	// the gateway batches them onto the final Result so it can re-emit them
 	// in order before CommandComplete via the per-result callback chain.
 	if len(resp.Notices) > 0 {
 		for _, pd := range resp.Notices {

--- a/go/services/multigateway/poolergateway/grpc_query_service_test.go
+++ b/go/services/multigateway/poolergateway/grpc_query_service_test.go
@@ -669,6 +669,11 @@ func TestCopyFinalize_ErrorPhasePropagatesReservedState(t *testing.T) {
 			Phase:         multipoolerservice.CopyBidiExecuteResponse_ERROR,
 			Error:         "constraint violation",
 			ReservedState: survivingState,
+			Notices: []*query.PgDiagnostic{{
+				MessageType: int32('N'),
+				Severity:    "NOTICE",
+				Message:     "input = {\"f1\":0}",
+			}},
 		},
 	}
 	mockClient := &mockMultipoolerServiceClient{
@@ -679,7 +684,7 @@ func TestCopyFinalize_ErrorPhasePropagatesReservedState(t *testing.T) {
 	// Pre-register stream as if CopyReady had succeeded earlier.
 	svc.copyStreams[connID] = mockStream
 
-	_, rs, err := svc.CopyFinalize(
+	result, rs, err := svc.CopyFinalize(
 		context.Background(),
 		protoutil.NewTarget("", "test", "", query.Mode_MODE_UNSPECIFIED),
 		nil,
@@ -690,6 +695,9 @@ func TestCopyFinalize_ErrorPhasePropagatesReservedState(t *testing.T) {
 	require.Contains(t, err.Error(), "constraint violation")
 	require.NotNil(t, rs, "ReservedState must be propagated when multipooler attaches it")
 	require.Equal(t, connID, rs.GetReservedConnectionId())
+	require.NotNil(t, result, "notices preceding the COPY error should be returned for forwarding")
+	require.Len(t, result.Notices, 1)
+	require.Equal(t, "input = {\"f1\":0}", result.Notices[0].Message)
 	// CopyFinalize removes the stream regardless of outcome.
 	require.NotContains(t, svc.copyStreams, connID)
 }

--- a/go/services/multigateway/scatterconn/scatter_conn.go
+++ b/go/services/multigateway/scatterconn/scatter_conn.go
@@ -94,6 +94,14 @@ func userAuthFrom(conn *server.Conn) *querypb.UserAuth {
 	}
 }
 
+func attachPostQuerySessionSettings(eo *querypb.ExecuteOptions, info engine.PlanExecInfo) {
+	if eo == nil || !info.HasPostQuerySessionSettings {
+		return
+	}
+	eo.HasPostQuerySessionSettings = true
+	eo.PostQuerySessionSettings = info.PostQuerySessionSettings
+}
+
 // buildTarget constructs a routing target for the given (database,
 // tableGroup, shard). The database comes from the connection's bound
 // database (conn.Database()) so the gateway routes within the database
@@ -214,6 +222,7 @@ func (sc *ScatterConn) StreamExecute(
 		SessionSettings:             state.GetSessionSettings(),
 		ExecuteSqlPreparedStatement: executeSQLPreparedStatement,
 	}
+	attachPostQuerySessionSettings(eo, info)
 
 	ss := state.GetMatchingShardState(target)
 
@@ -475,6 +484,7 @@ func (sc *ScatterConn) PortalStreamExecute(
 		MaxRows:            uint64(maxRows),
 		SessionSettings:    state.GetSessionSettings(),
 	}
+	attachPostQuerySessionSettings(eo, info)
 
 	// When the protocol layer folded a Describe('P') into this Execute, ask
 	// the multipooler to fuse Bind+Describe(P)+Execute+Sync into one

--- a/go/services/multigateway/scatterconn/scatter_conn.go
+++ b/go/services/multigateway/scatterconn/scatter_conn.go
@@ -392,6 +392,13 @@ func (sc *ScatterConn) StreamExecute(
 		reservationOpts.RecheckAdvisoryLocks = recheckAdvisory
 		reservedState, err := sc.gateway.StreamExecute(ctx, target, sql, eo, reservationOpts, callback)
 		if err != nil {
+			// The multipooler can return a surviving ReservedState when the first
+			// statement in an explicit transaction fails with a PostgreSQL error. Keep
+			// tracking it so ROLLBACK is routed to the backend that is now in failed
+			// transaction state.
+			if reservedState.GetReservedConnectionId() != 0 {
+				sc.applyReservedState(conn, state, target, reservedState)
+			}
 			return fmt.Errorf("query execution failed: %w", err)
 		}
 
@@ -566,6 +573,17 @@ func (sc *ScatterConn) PortalStreamExecute(
 	// Use the query from the prepared statement
 	reservedState, err := qs.PortalStreamExecute(ctx, target, portalInfo.PreparedStatementInfo.PreparedStatement, portalInfo.Portal, eo, portalOpts, reservationOpts, callback)
 	if err != nil {
+		// PostgreSQL-level portal errors can leave an existing reserved backend
+		// alive (for example an explicit transaction that is now aborted). Apply any
+		// state the multipooler managed to send before the gRPC error so gateway
+		// cleanup/ROLLBACK stays routed to the same backend.
+		keepReservation := reservedState.GetReservedConnectionId() == 0 &&
+			conn.TxnStatus() != protocol.TxnStatusInBlock &&
+			isCancellationError(err)
+		if !keepReservation {
+			sc.applyReservedState(conn, state, target, reservedState)
+		}
+
 		// If it's a PostgreSQL error, don't wrap it - pass through unchanged
 		var pgDiag *mterrors.PgDiagnostic
 		if errors.As(err, &pgDiag) {
@@ -1195,6 +1213,16 @@ func (sc *ScatterConn) CopyFinalize(
 	// Finalize the COPY operation via gateway
 	result, reservedState, err := sc.gateway.CopyFinalize(ctx, target, finalData, copyOptions)
 	if err != nil {
+		// CopyFinalize may return NoticeResponse diagnostics that PostgreSQL sent
+		// before the ErrorResponse (e.g. a trigger RAISE NOTICE for the failing COPY
+		// row). Forward those before returning the error so the server writer emits
+		// NoticeResponse frames ahead of ErrorResponse, matching backend order.
+		if result != nil && len(result.Notices) > 0 {
+			if cbErr := callback(ctx, &sqltypes.Result{Notices: result.Notices}); cbErr != nil {
+				sc.applyReservedState(conn, state, target, reservedState)
+				return cbErr
+			}
+		}
 		// CopyFinalize returns a non-nil ReservedState when a PG-level error
 		// (e.g., constraint violation) left the underlying reserved connection
 		// alive because it is still holding another reason such as a

--- a/go/services/multigateway/scatterconn/scatter_conn_test.go
+++ b/go/services/multigateway/scatterconn/scatter_conn_test.go
@@ -369,6 +369,65 @@ func TestScatterConn_Portal_ExistingReservedConnNoReserveReasons(t *testing.T) {
 	require.Nil(t, gw.portalReservationOps, "existing reservation needs no new reasons")
 }
 
+func TestScatterConn_Portal_ErrorAppliesReturnedReservedState(t *testing.T) {
+	pgErr := mterrors.NewPgError("ERROR", mterrors.PgSSSyntaxError, "boom", "")
+	gw := &mockGateway{
+		portalErr: pgErr,
+		portalReturnState: &querypb.ReservedState{
+			ReservedConnectionId: 43,
+			PoolerId:             &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"},
+			ReservationReasons:   protoutil.ReasonTransaction,
+		},
+	}
+	sc := NewScatterConn(gw, slog.Default())
+	state := handler.NewMultigatewayConnectionState()
+	conn := newTestConn()
+	conn.SetTxnStatus(protocol.TxnStatusInBlock)
+
+	target := protoutil.NewTarget(conn.Database(), "tg1", "", querypb.Mode_MODE_WRITABLE)
+	state.SetReservedConnection(target, &querypb.ReservedState{
+		ReservedConnectionId: 42,
+		PoolerId:             &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"},
+		ReservationReasons:   protoutil.ReasonTransaction,
+	})
+
+	err := sc.PortalStreamExecute(context.Background(), "tg1", "", conn, state,
+		testPortalInfo(), 0, false,
+		engine.PlanExecInfo{},
+		func(_ context.Context, _ *sqltypes.Result) error { return nil })
+
+	require.ErrorIs(t, err, pgErr)
+	ss := state.GetMatchingShardState(target)
+	require.NotNil(t, ss)
+	require.Equal(t, uint64(43), ss.ReservedState.GetReservedConnectionId(),
+		"gateway must keep the multipooler's surviving reserved state after a portal error")
+}
+
+func TestScatterConn_NewTransactionErrorAppliesReturnedReservedState(t *testing.T) {
+	gw := &mockGateway{
+		streamExecuteErr: errors.New("insert failed"),
+		streamExecuteReturnState: &querypb.ReservedState{
+			ReservedConnectionId: 88,
+			PoolerId:             &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"},
+			ReservationReasons:   protoutil.ReasonTransaction,
+		},
+	}
+	sc := NewScatterConn(gw, slog.Default())
+	state := handler.NewMultigatewayConnectionState()
+	conn := newTestConn()
+	conn.SetTxnStatus(protocol.TxnStatusInBlock)
+
+	err := sc.StreamExecute(context.Background(), conn, "tg1", "", "INSERT INTO t VALUES (1)", nil, state, engine.PlanExecInfo{},
+		func(_ context.Context, _ *sqltypes.Result) error { return nil })
+
+	require.Error(t, err)
+	target := protoutil.NewTarget(conn.Database(), "tg1", "", querypb.Mode_MODE_WRITABLE)
+	ss := state.GetMatchingShardState(target)
+	require.NotNil(t, ss)
+	require.Equal(t, uint64(88), ss.ReservedState.GetReservedConnectionId(),
+		"gateway must track the reserved backend returned with a first-statement transaction error")
+}
+
 func TestScatterConn_Case3_NotInTransaction(t *testing.T) {
 	gw := &mockGateway{
 		callbackResult: &sqltypes.Result{CommandTag: "SELECT 1"},
@@ -698,6 +757,48 @@ func TestScatterConn_CopyFinalize_ErrorPreservesReservedConn(t *testing.T) {
 	ss := state.GetMatchingShardState(target)
 	require.NotNil(t, ss, "reserved connection must survive PG-level COPY error when other reasons remain")
 	require.Equal(t, uint64(42), ss.ReservedState.GetReservedConnectionId())
+	require.Equal(t, protoutil.ReasonTransaction, ss.ReservedState.GetReservationReasons())
+}
+
+func TestScatterConn_CopyFinalize_ErrorForwardsNoticesBeforeError(t *testing.T) {
+	poolerID := &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"}
+	gw := &mockGateway{
+		copyFinalizeResult: &sqltypes.Result{
+			Notices: []*mterrors.PgDiagnostic{{MessageType: 'N', Severity: "NOTICE", Message: "input = {\"f1\":0}"}},
+		},
+		copyFinalizeReturnState: &querypb.ReservedState{
+			ReservedConnectionId: 42,
+			PoolerId:             poolerID,
+			ReservationReasons:   protoutil.ReasonTransaction,
+		},
+		copyFinalizeErr: errors.New("new row violates check constraint"),
+	}
+	sc := NewScatterConn(gw, slog.Default())
+	state := handler.NewMultigatewayConnectionState()
+	conn := newTestConn()
+	conn.SetTxnStatus(protocol.TxnStatusInBlock)
+
+	target := protoutil.NewTarget(conn.Database(), "tg1", "", querypb.Mode_MODE_WRITABLE)
+	state.SetReservedConnection(target, &querypb.ReservedState{
+		ReservedConnectionId: 42,
+		PoolerId:             poolerID,
+		ReservationReasons:   protoutil.ReasonCopy | protoutil.ReasonTransaction,
+	})
+
+	var callbacks []*sqltypes.Result
+	err := sc.CopyFinalize(context.Background(), conn, "tg1", "", state, nil,
+		func(_ context.Context, result *sqltypes.Result) error {
+			callbacks = append(callbacks, result)
+			return nil
+		})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "check constraint")
+	require.Len(t, callbacks, 1, "notice result must be forwarded before returning the COPY error")
+	require.Len(t, callbacks[0].Notices, 1)
+	require.Equal(t, "input = {\"f1\":0}", callbacks[0].Notices[0].Message)
+	ss := state.GetMatchingShardState(target)
+	require.NotNil(t, ss, "surviving reserved connection state should still be applied")
 	require.Equal(t, protoutil.ReasonTransaction, ss.ReservedState.GetReservationReasons())
 }
 

--- a/go/services/multigateway/scatterconn/scatter_conn_test.go
+++ b/go/services/multigateway/scatterconn/scatter_conn_test.go
@@ -445,6 +445,22 @@ func TestScatterConn_Case3_NotInTransaction(t *testing.T) {
 	require.False(t, gw.queryServiceByIDCalled, "should not call QueryServiceByID")
 }
 
+func TestScatterConn_StreamExecute_ForwardsPostQuerySessionSettings(t *testing.T) {
+	gw := &mockGateway{callbackResult: &sqltypes.Result{CommandTag: "SELECT 1"}}
+	sc := NewScatterConn(gw, slog.Default())
+	state := handler.NewMultigatewayConnectionState()
+	post := map[string]string{"work_mem": "256MB"}
+
+	err := sc.StreamExecute(context.Background(), newTestConn(), "tg1", "", "SELECT set_config('work_mem','256MB',false)", nil, state, engine.PlanExecInfo{
+		HasPostQuerySessionSettings: true,
+		PostQuerySessionSettings:    post,
+	}, func(_ context.Context, _ *sqltypes.Result) error { return nil })
+
+	require.NoError(t, err)
+	require.True(t, gw.streamExecuteOpts.GetHasPostQuerySessionSettings())
+	require.Equal(t, post, gw.streamExecuteOpts.GetPostQuerySessionSettings())
+}
+
 func TestScatterConn_Case3_StreamExecuteError(t *testing.T) {
 	gw := &mockGateway{
 		streamExecuteErr: errors.New("query failed"),

--- a/go/services/multipooler/grpcpoolerservice/service.go
+++ b/go/services/multipooler/grpcpoolerservice/service.go
@@ -130,11 +130,15 @@ func (s *poolerService) StreamExecute(req *multipoolerpb.StreamExecuteRequest, s
 			}
 		}
 
-		// Send row data (if any)
+		// Send row data (if any). Notices are streamed above as separate
+		// diagnostics, so keep the result payload notice-free to avoid duplicate
+		// NoticeResponse frames on the gateway.
 		if len(result.Rows) > 0 || result.CommandTag != "" {
+			protoResult := result.ToProto()
+			protoResult.Notices = nil
 			rowPayload := &query.QueryResultPayload{
 				Payload: &query.QueryResultPayload_Result{
-					Result: result.ToProto(),
+					Result: protoResult,
 				},
 			}
 			resp := &multipoolerpb.StreamExecuteResponse{
@@ -370,11 +374,15 @@ func (s *poolerService) PortalStreamExecute(req *multipoolerpb.PortalStreamExecu
 				}
 			}
 
-			// Send row data (if any)
+			// Send row data (if any). Notices are streamed above as separate
+			// diagnostics, so keep the result payload notice-free to avoid duplicate
+			// NoticeResponse frames on the gateway.
 			if len(result.Rows) > 0 || result.CommandTag != "" {
+				protoResult := result.ToProto()
+				protoResult.Notices = nil
 				rowPayload := &query.QueryResultPayload{
 					Payload: &query.QueryResultPayload_Result{
-						Result: result.ToProto(),
+						Result: protoResult,
 					},
 				}
 				response := &multipoolerpb.PortalStreamExecuteResponse{
@@ -386,10 +394,17 @@ func (s *poolerService) PortalStreamExecute(req *multipoolerpb.PortalStreamExecu
 		},
 	)
 	if err != nil {
-		// Note: When PortalStreamExecute returns an error, it also releases any reserved
-		// connection and returns an empty ReservedState. So we don't need to send a
-		// reserved connection ID in the error case.
-		// Convert errors to gRPC format, preserving PostgreSQL error details
+		// A PostgreSQL-level portal error can leave the reserved backend alive
+		// (typically in an aborted transaction, awaiting ROLLBACK). Send the
+		// authoritative state before returning the gRPC error so the gateway doesn't
+		// drift from the multipooler and accidentally route follow-up cleanup to a
+		// different backend.
+		if reservedState.GetReservedConnectionId() > 0 {
+			if sendErr := stream.Send(&multipoolerpb.PortalStreamExecuteResponse{ReservedState: reservedState}); sendErr != nil {
+				return mterrors.ToGRPC(sendErr)
+			}
+		}
+		// Convert errors to gRPC format, preserving PostgreSQL error details.
 		return mterrors.ToGRPC(err)
 	}
 
@@ -555,20 +570,31 @@ func (s *poolerService) CopyBidiExecute(stream multipoolerpb.MultipoolerService_
 				// writing CopyFail on a backend already back in RFQ. Forward
 				// the state CopyFinalize returned. Carry the structured PG
 				// diagnostic so the gateway re-emits a verbatim ErrorResponse.
+				// If PostgreSQL emitted notices before the ErrorResponse, keep them
+				// on the ERROR frame so the gateway can write NoticeResponse before
+				// ErrorResponse in backend order.
 				errorResp := &multipoolerpb.CopyBidiExecuteResponse{
 					Phase:           multipoolerpb.CopyBidiExecuteResponse_ERROR,
 					Error:           err.Error(),
 					ErrorDiagnostic: pgDiagnosticFromError(err),
 					ReservedState:   reservedState,
 				}
+				if result != nil {
+					errorResp.Notices = noticesToProto(result.Notices)
+				}
 				_ = stream.Send(errorResp)
 				return mterrors.ToGRPC(err)
 			}
 
-			// Send RESULT response with final result, notices, and reserved state
+			// Send RESULT response with final result, notices, and reserved state.
+			// COPY bidi has a dedicated Notices field that the gateway folds into the
+			// final Result in wire order, so keep the QueryResult notice-free to avoid
+			// duplicate NoticeResponse frames after QueryResult grew unary notices.
+			protoResult := result.ToProto()
+			protoResult.Notices = nil
 			resultResp := &multipoolerpb.CopyBidiExecuteResponse{
 				Phase:         multipoolerpb.CopyBidiExecuteResponse_RESULT,
-				Result:        result.ToProto(),
+				Result:        protoResult,
 				ReservedState: reservedState,
 				Notices:       noticesToProto(result.Notices),
 			}

--- a/go/services/multipooler/internal/connpoolmanager/interface.go
+++ b/go/services/multipooler/internal/connpoolmanager/interface.go
@@ -107,6 +107,13 @@ type PoolManager interface {
 	// bypass the pool's normal ApplySettings mechanism.
 	ApplySettingsToConn(ctx context.Context, conn *regular.Conn, settings map[string]string) error
 
+	// RecordSettingsOnConn updates only the pooler's in-memory connstate for a
+	// connection after PostgreSQL itself has already changed the backend session
+	// state (for example, Route-first SELECT set_config(...)). It must not issue
+	// SQL. Settings are interned through the shared SettingsCache so the backend
+	// recycles into the correct pool bucket.
+	RecordSettingsOnConn(conn *regular.Conn, settings map[string]string)
+
 	// --- Drain ---
 
 	// WaitForDrain blocks until all lent connections have been returned or ctx is cancelled.

--- a/go/services/multipooler/internal/connpoolmanager/manager.go
+++ b/go/services/multipooler/internal/connpoolmanager/manager.go
@@ -845,6 +845,19 @@ func (m *Manager) ApplySettingsToConn(ctx context.Context, conn *regular.Conn, s
 	return conn.ApplySettings(ctx, desired)
 }
 
+// RecordSettingsOnConn updates only the tracked connstate for a backend whose
+// session state was changed by PostgreSQL during the just-completed statement.
+// It intentionally does not issue SET/RESET SQL; callers must use it only after
+// a successful statement that already produced the backend state represented by
+// settings.
+func (m *Manager) RecordSettingsOnConn(conn *regular.Conn, settings map[string]string) {
+	if conn == nil {
+		return
+	}
+	desired := m.settingsCache.GetOrCreate(settings)
+	conn.State().SetSettings(desired)
+}
+
 // --- Stats ---
 
 // Stats returns statistics for all pools.

--- a/go/services/multipooler/internal/connpoolmanager/manager_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/manager_test.go
@@ -901,6 +901,18 @@ func TestManager_ApplySettingsToConn(t *testing.T) {
 	assert.Greater(t, setsAfter, setsBefore, "SET should have been called for new settings")
 }
 
+func TestManager_RecordSettingsOnConn_NilConnNoops(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	assert.NotPanics(t, func() {
+		manager.RecordSettingsOnConn(nil, map[string]string{"work_mem": "256MB"})
+	})
+}
+
 func TestManager_RecordSettingsOnConn_OnlyUpdatesConnstate(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()

--- a/go/services/multipooler/internal/connpoolmanager/manager_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/manager_test.go
@@ -901,6 +901,26 @@ func TestManager_ApplySettingsToConn(t *testing.T) {
 	assert.Greater(t, setsAfter, setsBefore, "SET should have been called for new settings")
 }
 
+func TestManager_RecordSettingsOnConn_OnlyUpdatesConnstate(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+	conn, err := manager.NewReservedConn(ctx, nil, "testuser", nil, nil)
+	require.NoError(t, err)
+	defer conn.Release(reserved.ReleaseCommit, nil)
+
+	settings := map[string]string{"work_mem": "256MB"}
+	manager.RecordSettingsOnConn(conn.Conn(), settings)
+
+	cached := manager.settingsCache.GetOrCreate(settings)
+	assert.Same(t, cached, conn.Conn().Settings(), "recorded settings must be interned through the shared cache")
+}
+
 func TestManager_ApplySettingsToConn_SameSettings(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"sync/atomic"
 	"time"
 
@@ -69,6 +70,13 @@ func (e *Executor) sessionSettingsFromOptions(options *query.ExecuteOptions) map
 		return nil
 	}
 	return options.SessionSettings
+}
+
+func (e *Executor) sessionSettingsForPool(settings map[string]string) map[string]string {
+	if len(settings) == 0 {
+		return nil
+	}
+	return maps.Clone(settings)
 }
 
 func (e *Executor) postQuerySessionSettingsFromOptions(options *query.ExecuteOptions) (map[string]string, bool) {
@@ -597,6 +605,8 @@ func (e *Executor) streamExecuteOnReservedConnWithPostState(
 	callback func(context.Context, *sqltypes.Result) error,
 ) (*query.ReservedState, error) {
 	reasons := protoutil.GetReasons(reservationOptions)
+	preQueryReasons := rc.RemainingReasons()
+	addedStatementLocalReasons := uint32(0)
 
 	// If the caller is adding reservation reasons (e.g., promoting a temp-table
 	// reservation to also hold a transaction), apply them now.
@@ -613,8 +623,13 @@ func (e *Executor) streamExecuteOnReservedConnWithPostState(
 			}
 		}
 		// Add all requested non-transaction reasons to the reservation
-		// (BeginWithQuery already added ReasonTransaction internally).
+		// (BeginWithQuery already added ReasonTransaction internally). Track the
+		// statement-local bits that were not present before this query so we can
+		// unwind them if PostgreSQL rejects the statement. Session-level reasons
+		// such as advisory locks are deliberately not included here: if the lock
+		// was acquired before a later statement error, PostgreSQL can keep it.
 		if nonBeginReasons := reasons &^ protoutil.ReasonTransaction; nonBeginReasons != 0 {
+			addedStatementLocalReasons = (nonBeginReasons &^ preQueryReasons) & (protoutil.ReasonTempTable | protoutil.ReasonPortal)
 			rc.AddReservationReason(nonBeginReasons)
 		}
 	}
@@ -652,6 +667,16 @@ func (e *Executor) streamExecuteOnReservedConnWithPostState(
 		shouldRelease := false
 		for _, name := range pinNames {
 			if rc.ReleasePortal(name) {
+				shouldRelease = true
+			}
+		}
+		if addedStatementLocalReasons&protoutil.ReasonTempTable != 0 {
+			if rc.RemoveReservationReason(protoutil.ReasonTempTable) {
+				shouldRelease = true
+			}
+		}
+		if len(pinNames) == 0 && addedStatementLocalReasons&protoutil.ReasonPortal != 0 {
+			if rc.RemoveReservationReason(protoutil.ReasonPortal) {
 				shouldRelease = true
 			}
 		}
@@ -950,7 +975,7 @@ func (e *Executor) portalExecuteWithReserved(
 	// already parsed it; for the existing-conn branch this is the only call.
 	canonicalName, err := e.ensurePrepared(ctx, reservedConn.Conn(), preparedStatement)
 	if err != nil {
-		return e.portalReservedError(reservedConn, portal.Name, options, err)
+		return e.portalReservedError(reservedConn, portal.Name, options, newlyReserved, err)
 	}
 
 	// Bind and execute using the portal's own name and the canonical statement name.
@@ -965,7 +990,7 @@ func (e *Executor) portalExecuteWithReserved(
 		completed, err = reservedConn.BindAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, maxRows, callback)
 	}
 	if err != nil {
-		return e.portalReservedError(reservedConn, portal.Name, options, err)
+		return e.portalReservedError(reservedConn, portal.Name, options, newlyReserved, err)
 	}
 
 	e.recordPostQuerySessionSettings(reservedConn.Conn(), options)
@@ -1007,17 +1032,18 @@ func (e *Executor) portalExecuteWithReserved(
 // protocol-synchronized (the client drains through ReadyForQuery), so an
 // explicit transaction/temp/advisory reservation must survive for the client to
 // observe normal failed-transaction semantics and issue ROLLBACK. Only
-// connection-level failures taint the backend. If the portal was the only reason
-// for reservation, release the backend and return a zero ReservedState.
-func (e *Executor) portalReservedError(reservedConn *reserved.Conn, portalName string, options *query.ExecuteOptions, err error) (*query.ReservedState, error) {
+// connection-level failures taint the backend. If this call created the
+// reservation and no reason survived the failed statement, release the backend
+// and return a zero ReservedState.
+func (e *Executor) portalReservedError(reservedConn *reserved.Conn, portalName string, options *query.ExecuteOptions, newlyReserved bool, err error) (*query.ReservedState, error) {
 	if mterrors.IsConnectionError(err) {
 		reservedConn.Release(reserved.ReleaseError, nil)
 		return nil, wrapQueryError(err)
 	}
 
 	shouldRelease := reservedConn.ReleasePortal(portalName)
-	if shouldRelease || reservedConn.RemainingReasons() == 0 {
-		e.releaseReservedConn(reservedConn, reserved.ReleasePortalComplete, options)
+	if shouldRelease || (newlyReserved && reservedConn.RemainingReasons() == 0) {
+		reservedConn.Release(reserved.ReleasePortalComplete, e.sessionSettingsFromOptions(options))
 		return nil, wrapQueryError(err)
 	}
 	return e.buildReservedState(reservedConn), wrapQueryError(err)
@@ -1511,7 +1537,7 @@ func (e *Executor) CopyFinalize(
 		// against upstream PostgreSQL.
 		if !mterrors.IsConnectionError(err) {
 			if reservedConn.RemoveReservationReason(protoutil.ReasonCopy) {
-				e.releaseReservedConn(reservedConn, reserved.ReleasePortalComplete, options)
+				reservedConn.Release(reserved.ReleasePortalComplete, e.sessionSettingsFromOptions(options))
 				return noticeResult, nil, err
 			}
 			return noticeResult, e.buildReservedState(reservedConn), err

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -71,8 +71,30 @@ func (e *Executor) sessionSettingsFromOptions(options *query.ExecuteOptions) map
 	return options.SessionSettings
 }
 
+func (e *Executor) postQuerySessionSettingsFromOptions(options *query.ExecuteOptions) (map[string]string, bool) {
+	if options == nil || !options.GetHasPostQuerySessionSettings() {
+		return nil, false
+	}
+	return e.sessionSettingsForPool(options.PostQuerySessionSettings), true
+}
+
+func (e *Executor) successfulQueryReleaseSettingsFromOptions(options *query.ExecuteOptions) map[string]string {
+	if settings, ok := e.postQuerySessionSettingsFromOptions(options); ok {
+		return settings
+	}
+	return e.sessionSettingsFromOptions(options)
+}
+
+func (e *Executor) recordPostQuerySessionSettings(conn *regular.Conn, options *query.ExecuteOptions) {
+	settings, ok := e.postQuerySessionSettingsFromOptions(options)
+	if !ok || e.poolManager == nil {
+		return
+	}
+	e.poolManager.RecordSettingsOnConn(conn, settings)
+}
+
 func (e *Executor) applyReservedSessionSettingsIfNeeded(ctx context.Context, conn *reserved.Conn, options *query.ExecuteOptions) error {
-	if options == nil || options.SessionSettings == nil {
+	if options == nil {
 		return nil
 	}
 	return e.poolManager.ApplySettingsToConn(ctx, conn.Conn(), options.SessionSettings)
@@ -182,6 +204,7 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 			state, rerr := e.reservedConnError(reservedConn, "query execution failed", err)
 			return nil, state, rerr
 		}
+		e.recordPostQuerySessionSettings(reservedConn.Conn(), options)
 
 		if len(results) == 0 {
 			return &sqltypes.Result{}, e.buildReservedState(reservedConn), nil
@@ -216,6 +239,7 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 	if err != nil {
 		return nil, nil, wrapQueryError(err)
 	}
+	e.recordPostQuerySessionSettings(conn.Conn, options)
 
 	// Return first result (simple query returns single result)
 	if len(results) == 0 {
@@ -297,10 +321,7 @@ func (e *Executor) StreamExecute(
 		// written at reservation time and survives RESET ALL (see ExecuteQuery).
 
 		// If the query references a SQL-level prepared statement wrapper,
-		// materialize it now. We do this before delegating to
-		// streamExecuteOnReservedConn because that helper operates over the
-		// reservedConnAPI interface which does not expose the underlying
-		// *regular.Conn needed by ensurePrepared.
+		// materialize it now before delegating to the reserved execution helper.
 		querySQL := sql
 		if executeSQLPreparedStmt != nil {
 			var err error
@@ -310,7 +331,7 @@ func (e *Executor) StreamExecute(
 			}
 		}
 
-		return e.streamExecuteOnReservedConn(ctx, reservedConn, querySQL, reservationOptions, e.sessionSettingsFromOptions(options), callback)
+		return e.streamExecuteOnReservedConnWithOptions(ctx, reservedConn, querySQL, reservationOptions, options, callback)
 	}
 
 	// Case 2: Create a new reserved connection
@@ -354,6 +375,7 @@ func (e *Executor) StreamExecute(
 		if err := conn.Conn.QueryStreaming(ctx, querySQL, callback); err != nil {
 			return nil, wrapQueryError(err)
 		}
+		e.recordPostQuerySessionSettings(conn.Conn, options)
 		return nil, nil
 	}
 
@@ -361,6 +383,7 @@ func (e *Executor) StreamExecute(
 	if err := conn.Conn.QueryStreamingWithRetry(ctx, sql, callback); err != nil {
 		return nil, wrapQueryError(err)
 	}
+	e.recordPostQuerySessionSettings(conn.Conn, options)
 
 	return nil, nil
 }
@@ -509,6 +532,9 @@ func (e *Executor) reserveAndStreamExecute(
 		return nil, wrapQueryError(err)
 	}
 
+	e.recordPostQuerySessionSettings(reservedConn.Conn(), options)
+	releaseSettings := e.successfulQueryReleaseSettingsFromOptions(options)
+
 	if reservationOptions.GetMarkSessionStateUntrusted() {
 		reservedConn.MarkSessionStateUntrusted()
 	}
@@ -518,7 +544,7 @@ func (e *Executor) reserveAndStreamExecute(
 	// acquire, in which case unpin immediately so the gateway doesn't keep an
 	// empty reservation. Gated on the recheck signal so the probe stays off the
 	// per-statement hot path.
-	if reservationOptions.GetRecheckAdvisoryLocks() && e.maybeUnpinSessionAdvisoryLock(ctx, reservedConn, e.sessionSettingsFromOptions(options)) {
+	if reservationOptions.GetRecheckAdvisoryLocks() && e.maybeUnpinSessionAdvisoryLock(ctx, reservedConn, releaseSettings) {
 		return nil, nil
 	}
 
@@ -543,6 +569,31 @@ func (e *Executor) streamExecuteOnReservedConn(
 	sql string,
 	reservationOptions *query.ReservationOptions,
 	gatewaySessionSettings map[string]string,
+	callback func(context.Context, *sqltypes.Result) error,
+) (*query.ReservedState, error) {
+	return e.streamExecuteOnReservedConnWithPostState(ctx, rc, sql, reservationOptions, gatewaySessionSettings, nil, false, callback)
+}
+
+func (e *Executor) streamExecuteOnReservedConnWithOptions(
+	ctx context.Context,
+	rc reservedConnAPI,
+	sql string,
+	reservationOptions *query.ReservationOptions,
+	options *query.ExecuteOptions,
+	callback func(context.Context, *sqltypes.Result) error,
+) (*query.ReservedState, error) {
+	postSettings, hasPostSettings := e.postQuerySessionSettingsFromOptions(options)
+	return e.streamExecuteOnReservedConnWithPostState(ctx, rc, sql, reservationOptions, e.sessionSettingsFromOptions(options), postSettings, hasPostSettings, callback)
+}
+
+func (e *Executor) streamExecuteOnReservedConnWithPostState(
+	ctx context.Context,
+	rc reservedConnAPI,
+	sql string,
+	reservationOptions *query.ReservationOptions,
+	gatewaySessionSettings map[string]string,
+	postQuerySessionSettings map[string]string,
+	hasPostQuerySessionSettings bool,
 	callback func(context.Context, *sqltypes.Result) error,
 ) (*query.ReservedState, error) {
 	reasons := protoutil.GetReasons(reservationOptions)
@@ -611,6 +662,15 @@ func (e *Executor) streamExecuteOnReservedConn(
 		return e.buildReservedStateFromAPI(rc), wrapQueryError(err)
 	}
 
+	releaseSettings := gatewaySessionSettings
+	if hasPostQuerySessionSettings {
+		releaseSettings = postQuerySessionSettings
+		e.recordPostQuerySessionSettings(rc.Conn(), &query.ExecuteOptions{
+			HasPostQuerySessionSettings: true,
+			PostQuerySessionSettings:    postQuerySessionSettings,
+		})
+	}
+
 	if reservationOptions.GetMarkSessionStateUntrusted() {
 		rc.MarkSessionStateUntrusted()
 	}
@@ -629,7 +689,7 @@ func (e *Executor) streamExecuteOnReservedConn(
 		}
 	}
 	if shouldRelease {
-		rc.Release(reserved.ReleasePortalComplete, gatewaySessionSettings)
+		rc.Release(reserved.ReleasePortalComplete, releaseSettings)
 		return nil, nil
 	}
 
@@ -637,7 +697,7 @@ func (e *Executor) streamExecuteOnReservedConn(
 	// pg_advisory_unlock), re-probe pg_locks and unpin if none remain. Gated on
 	// the recheck signal so the probe runs only on advisory-touching statements,
 	// not after every query on a pinned connection.
-	if reservationOptions.GetRecheckAdvisoryLocks() && e.maybeUnpinSessionAdvisoryLock(ctx, rc, gatewaySessionSettings) {
+	if reservationOptions.GetRecheckAdvisoryLocks() && e.maybeUnpinSessionAdvisoryLock(ctx, rc, releaseSettings) {
 		return nil, nil
 	}
 
@@ -908,6 +968,9 @@ func (e *Executor) portalExecuteWithReserved(
 		return e.portalReservedError(reservedConn, portal.Name, options, err)
 	}
 
+	e.recordPostQuerySessionSettings(reservedConn.Conn(), options)
+	releaseSettings := e.successfulQueryReleaseSettingsFromOptions(options)
+
 	if reservationOptions.GetMarkSessionStateUntrusted() {
 		reservedConn.MarkSessionStateUntrusted()
 	}
@@ -924,7 +987,7 @@ func (e *Executor) portalExecuteWithReserved(
 	// Portal completed — release this portal's reservation. ReleasePortal returns
 	// true only when all reservation reasons are gone.
 	if reservedConn.ReleasePortal(portal.Name) {
-		reservedConn.Release(reserved.ReleasePortalComplete, e.sessionSettingsFromOptions(options))
+		reservedConn.Release(reserved.ReleasePortalComplete, releaseSettings)
 		return nil, nil
 	}
 
@@ -932,7 +995,7 @@ func (e *Executor) portalExecuteWithReserved(
 	// this portal as touching an advisory lock (acquire that may have failed, or
 	// a release over the extended protocol), re-probe pg_locks and unpin if none
 	// remain. Gated on the recheck signal to keep the probe off the hot path.
-	if reservationOptions.GetRecheckAdvisoryLocks() && e.maybeUnpinSessionAdvisoryLock(ctx, reservedConn, e.sessionSettingsFromOptions(options)) {
+	if reservationOptions.GetRecheckAdvisoryLocks() && e.maybeUnpinSessionAdvisoryLock(ctx, reservedConn, releaseSettings) {
 		return nil, nil
 	}
 
@@ -1024,6 +1087,7 @@ func (e *Executor) portalExecuteWithRegular(
 	if err != nil {
 		return nil, wrapQueryError(err)
 	}
+	e.recordPostQuerySessionSettings(conn.Conn, options)
 
 	// No reserved connection for regular execution
 	return nil, nil

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -459,12 +459,11 @@ func (e *Executor) reserveAndStreamExecute(
 	// declared with WITH HOLD; ReserveForPortal adds the name to the
 	// per-conn portal set and ORs ReasonPortal into the reservation
 	// bitmask (idempotent with the AddReservationReason call above).
-	// This path always releases the connection on QueryStreaming error
-	// (Release(ReleaseError) below), so a failed DECLARE never leaks a
-	// pin from the new-reservation branch — even without the explicit
-	// rollback dance that streamExecuteOnReservedConn performs for the
-	// existing-reservation case.
-	for _, name := range reservationOptions.GetPinPortalNames() {
+	// If the statement fails but the explicit transaction survives, these
+	// statement-local pins are unwound before returning the surviving
+	// transaction reservation below, mirroring streamExecuteOnReservedConn.
+	pinNames := reservationOptions.GetPinPortalNames()
+	for _, name := range pinNames {
 		reservedConn.ReserveForPortal(name)
 	}
 
@@ -483,11 +482,31 @@ func (e *Executor) reserveAndStreamExecute(
 		}
 	}
 	if err := reservedConn.QueryStreaming(ctx, querySQL, callback); err != nil {
+		// If this call opened the client's explicit transaction, a PostgreSQL-level
+		// statement error leaves that transaction open in failed state. Preserve the
+		// transaction reservation so the gateway can route the eventual ROLLBACK to
+		// the same backend instead of silently rolling back early and drifting from
+		// PG semantics. Statement-local reservations installed before the failed
+		// query (DECLARE WITH HOLD pins, CREATE TEMP TABLE pins) must be unwound
+		// first because the gateway records them only after backend success.
+		// Connection-level failures still taint and drop the backend.
+		if beginTx && !mterrors.IsConnectionError(err) {
+			for _, name := range pinNames {
+				reservedConn.ReleasePortal(name)
+			}
+			if reasons&protoutil.ReasonTempTable != 0 {
+				reservedConn.RemoveReservationReason(protoutil.ReasonTempTable)
+			}
+			if len(pinNames) == 0 && reasons&protoutil.ReasonPortal != 0 {
+				reservedConn.RemoveReservationReason(protoutil.ReasonPortal)
+			}
+			return e.buildReservedState(reservedConn), wrapQueryError(err)
+		}
 		if beginTx {
 			_ = reservedConn.Rollback(ctx)
 		}
 		reservedConn.Release(reserved.ReleaseError, nil)
-		return nil, fmt.Errorf("query execution failed: %w", err)
+		return nil, wrapQueryError(err)
 	}
 
 	if reservationOptions.GetMarkSessionStateUntrusted() {
@@ -871,8 +890,7 @@ func (e *Executor) portalExecuteWithReserved(
 	// already parsed it; for the existing-conn branch this is the only call.
 	canonicalName, err := e.ensurePrepared(ctx, reservedConn.Conn(), preparedStatement)
 	if err != nil {
-		reservedConn.Release(reserved.ReleaseError, nil)
-		return nil, err
+		return e.portalReservedError(reservedConn, portal.Name, options, err)
 	}
 
 	// Bind and execute using the portal's own name and the canonical statement name.
@@ -887,19 +905,7 @@ func (e *Executor) portalExecuteWithReserved(
 		completed, err = reservedConn.BindAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, maxRows, callback)
 	}
 	if err != nil {
-		// A PostgreSQL statement error (division_by_zero, a constraint violation,
-		// an RLS WITH CHECK denial, …) only ABORTS the transaction; the backend
-		// stays usable for ROLLBACK [TO SAVEPOINT]. Destroy the reserved conn only
-		// on a genuine connection failure, or when THIS call created the
-		// reservation (newlyReserved) — matching the sibling error sites above and
-		// the COPY path. Otherwise keep the session-owned reservation and return
-		// its state so the gateway keeps tracking it; releasing here would make the
-		// client's next statement fail with 40001 "reserved connection not found".
-		if newlyReserved || mterrors.IsConnectionError(err) {
-			reservedConn.Release(reserved.ReleaseError, nil)
-			return nil, wrapQueryError(err)
-		}
-		return e.buildReservedState(reservedConn), wrapQueryError(err)
+		return e.portalReservedError(reservedConn, portal.Name, options, err)
 	}
 
 	if reservationOptions.GetMarkSessionStateUntrusted() {
@@ -931,6 +937,27 @@ func (e *Executor) portalExecuteWithReserved(
 	}
 
 	return e.buildReservedState(reservedConn), nil
+}
+
+// portalReservedError reconciles reservation bookkeeping after a portal-path
+// error on a reserved backend. PostgreSQL-level errors leave the connection
+// protocol-synchronized (the client drains through ReadyForQuery), so an
+// explicit transaction/temp/advisory reservation must survive for the client to
+// observe normal failed-transaction semantics and issue ROLLBACK. Only
+// connection-level failures taint the backend. If the portal was the only reason
+// for reservation, release the backend and return a zero ReservedState.
+func (e *Executor) portalReservedError(reservedConn *reserved.Conn, portalName string, options *query.ExecuteOptions, err error) (*query.ReservedState, error) {
+	if mterrors.IsConnectionError(err) {
+		reservedConn.Release(reserved.ReleaseError, nil)
+		return nil, wrapQueryError(err)
+	}
+
+	shouldRelease := reservedConn.ReleasePortal(portalName)
+	if shouldRelease || reservedConn.RemainingReasons() == 0 {
+		e.releaseReservedConn(reservedConn, reserved.ReleasePortalComplete, options)
+		return nil, wrapQueryError(err)
+	}
+	return e.buildReservedState(reservedConn), wrapQueryError(err)
 }
 
 // portalExecuteWithRegular executes a portal using a regular pooled connection.
@@ -1402,6 +1429,13 @@ func (e *Executor) CopyFinalize(
 		// only if no other reasons remain. A connection-level failure (broken
 		// socket) still falls through to Release(ReleaseError).
 		//
+		// Preserve any NoticeResponse diagnostics that arrived before the
+		// ErrorResponse (for example row-level trigger RAISE NOTICE output just
+		// before a failing COPY row). The gRPC handler carries these on the ERROR
+		// response and the gateway emits them before the final ErrorResponse,
+		// matching PostgreSQL's backend order.
+		noticeResult := &sqltypes.Result{Notices: notices}
+
 		// We deliberately do NOT wrap the PG error with "COPY operation
 		// failed:". The gateway round-trips a structured PgDiagnostic over the
 		// bidi stream's error_diagnostic field and re-emits a verbatim
@@ -1413,10 +1447,10 @@ func (e *Executor) CopyFinalize(
 		// against upstream PostgreSQL.
 		if !mterrors.IsConnectionError(err) {
 			if reservedConn.RemoveReservationReason(protoutil.ReasonCopy) {
-				reservedConn.Release(reserved.ReleasePortalComplete, e.sessionSettingsFromOptions(options))
-				return nil, nil, err
+				e.releaseReservedConn(reservedConn, reserved.ReleasePortalComplete, options)
+				return noticeResult, nil, err
 			}
-			return nil, e.buildReservedState(reservedConn), err
+			return noticeResult, e.buildReservedState(reservedConn), err
 		}
 		reservedConn.Release(reserved.ReleaseError, nil)
 		return nil, nil, err
@@ -1833,31 +1867,36 @@ func (e *Executor) ConcludeTransaction(
 	}
 
 	// Execute COMMIT or ROLLBACK using the reserved connection's methods,
-	// which handle both the SQL execution and reason removal.
+	// which handle both the SQL execution and reason removal. Keep PostgreSQL's
+	// returned Result so deferred trigger notices emitted at COMMIT/ROLLBACK are
+	// forwarded before the CommandComplete instead of being dropped.
+	var result *sqltypes.Result
 	var commandTag string
 	var releaseReason reserved.ReleaseReason
 	switch conclusion {
 	case multipoolerpb.TransactionConclusion_TRANSACTION_CONCLUSION_COMMIT:
 		commandTag = "COMMIT"
 		releaseReason = reserved.ReleaseCommit
+		var err error
 		if chain {
-			if err := reservedConn.CommitAndChain(ctx); err != nil {
-				reservedConn.Release(reserved.ReleaseError, nil)
-				return nil, nil, err
-			}
-		} else if err := reservedConn.Commit(ctx); err != nil {
+			result, err = reservedConn.CommitAndChainResult(ctx)
+		} else {
+			result, err = reservedConn.CommitResult(ctx)
+		}
+		if err != nil {
 			reservedConn.Release(reserved.ReleaseError, nil)
 			return nil, nil, err
 		}
 	case multipoolerpb.TransactionConclusion_TRANSACTION_CONCLUSION_ROLLBACK:
 		commandTag = "ROLLBACK"
 		releaseReason = reserved.ReleaseRollback
+		var err error
 		if chain {
-			if err := reservedConn.RollbackAndChain(ctx); err != nil {
-				reservedConn.Release(reserved.ReleaseError, nil)
-				return nil, nil, err
-			}
-		} else if err := reservedConn.Rollback(ctx); err != nil {
+			result, err = reservedConn.RollbackAndChainResult(ctx)
+		} else {
+			result, err = reservedConn.RollbackResult(ctx)
+		}
+		if err != nil {
 			reservedConn.Release(reserved.ReleaseError, nil)
 			return nil, nil, err
 		}
@@ -1879,7 +1918,11 @@ func (e *Executor) ConcludeTransaction(
 		return nil, nil, fmt.Errorf("invalid transaction conclusion: %v", conclusion)
 	}
 
-	result := &sqltypes.Result{CommandTag: commandTag}
+	if result == nil {
+		result = &sqltypes.Result{CommandTag: commandTag}
+	} else if result.CommandTag == "" {
+		result.CommandTag = commandTag
+	}
 
 	// Commit/Rollback already removed the transaction reason.
 	// If other reasons remain (e.g., temp tables, portals), the connection stays reserved.

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -17,6 +17,7 @@ package executor
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"testing"
 	"time"
@@ -575,6 +576,82 @@ func TestStreamExecuteOnReservedConn_AddsTempTableReasonOnly(t *testing.T) {
 	require.Equal(t, protoutil.ReasonTempTable, rc.addedReasons,
 		"temp_table reason should be added to the reservation")
 	require.True(t, rc.streamingCalled)
+}
+
+func TestStreamExecuteOnReservedConn_FailedTempTablePromotionRollsBackNewReason(t *testing.T) {
+	rc := &mockReservedConn{
+		connID:           42,
+		inTxn:            true,
+		remainingReasons: protoutil.ReasonTransaction,
+		streamingErr:     errors.New("backend rejected CREATE TEMP TABLE"),
+	}
+	e := newTestExecutor()
+
+	state, err := e.streamExecuteOnReservedConn(
+		context.Background(), rc, "CREATE TEMP TABLE bad (id missing_type)",
+		&query.ReservationOptions{Reasons: protoutil.ReasonTempTable},
+		nil,
+		noopCallback,
+	)
+
+	require.Error(t, err)
+	require.Equal(t, protoutil.ReasonTempTable, rc.addedReasons,
+		"temp-table reason is installed before the query so the bitmask is consistent while it runs")
+	require.Equal(t, protoutil.ReasonTempTable, rc.removedReasons,
+		"failed statement must unwind the temp-table reason it just added")
+	require.Equal(t, protoutil.ReasonTransaction, rc.remainingReasons,
+		"surviving transaction reservation must be preserved after a PostgreSQL statement error")
+	require.Empty(t, rc.releaseCalls, "connection must stay reserved while the transaction reason persists")
+	require.NotNil(t, state)
+	require.Equal(t, protoutil.ReasonTransaction, state.GetReservationReasons())
+}
+
+func TestStreamExecuteOnReservedConn_FailedTempTablePromotionPreservesExistingReason(t *testing.T) {
+	rc := &mockReservedConn{
+		connID:           42,
+		inTxn:            true,
+		remainingReasons: protoutil.ReasonTransaction | protoutil.ReasonTempTable,
+		streamingErr:     errors.New("backend rejected CREATE TEMP TABLE"),
+	}
+	e := newTestExecutor()
+
+	state, err := e.streamExecuteOnReservedConn(
+		context.Background(), rc, "CREATE TEMP TABLE bad (id missing_type)",
+		&query.ReservationOptions{Reasons: protoutil.ReasonTempTable},
+		nil,
+		noopCallback,
+	)
+
+	require.Error(t, err)
+	require.Equal(t, protoutil.ReasonTempTable, rc.addedReasons)
+	require.Zero(t, rc.removedReasons,
+		"failed statement must not remove a temp-table reason that existed before this query")
+	require.Equal(t, protoutil.ReasonTransaction|protoutil.ReasonTempTable, rc.remainingReasons)
+	require.Empty(t, rc.releaseCalls)
+	require.NotNil(t, state)
+	require.Equal(t, protoutil.ReasonTransaction|protoutil.ReasonTempTable, state.GetReservationReasons())
+}
+
+func TestStreamExecuteOnReservedConn_ConnectionErrorReleasesReservedConn(t *testing.T) {
+	rc := &mockReservedConn{
+		connID:           42,
+		inTxn:            true,
+		remainingReasons: protoutil.ReasonTransaction,
+		streamingErr:     io.EOF,
+	}
+	e := newTestExecutor()
+
+	state, err := e.streamExecuteOnReservedConn(
+		context.Background(), rc, "SELECT 1",
+		&query.ReservationOptions{},
+		nil,
+		noopCallback,
+	)
+
+	require.Error(t, err)
+	require.Nil(t, state)
+	require.Equal(t, []reserved.ReleaseReason{reserved.ReleaseError}, rc.releaseCalls,
+		"connection-level errors must taint/release the reserved backend")
 }
 
 // TestStreamExecuteOnReservedConn_BeginErrorPropagates covers the failure path

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -71,6 +71,7 @@ func (m *mockReservedConn) ConnID() int64            { return m.connID }
 func (m *mockReservedConn) ProcessID() uint32        { return 0 }
 func (m *mockReservedConn) RemainingReasons() uint32 { return m.remainingReasons }
 func (m *mockReservedConn) IsInTransaction() bool    { return m.inTxn }
+func (m *mockReservedConn) Conn() *regular.Conn      { return nil }
 
 func (m *mockReservedConn) BeginWithQuery(_ context.Context, q string) error {
 	m.beginCalls = append(m.beginCalls, q)
@@ -217,10 +218,11 @@ func (m *stubPoolManager) GetReservedConn(int64, string) (*reserved.Conn, bool) 
 func (m *stubPoolManager) ApplySettingsToConn(context.Context, *regular.Conn, map[string]string) error {
 	return nil
 }
-func (m *stubPoolManager) WaitForDrain(context.Context) error           { return nil }
-func (m *stubPoolManager) WaitForReservedDrain(context.Context) error   { return nil }
-func (m *stubPoolManager) CloseReservedConnections(context.Context) int { return 0 }
-func (m *stubPoolManager) Stats() connpoolmanager.ManagerStats          { return connpoolmanager.ManagerStats{} }
+func (m *stubPoolManager) RecordSettingsOnConn(*regular.Conn, map[string]string) {}
+func (m *stubPoolManager) WaitForDrain(context.Context) error                    { return nil }
+func (m *stubPoolManager) WaitForReservedDrain(context.Context) error            { return nil }
+func (m *stubPoolManager) CloseReservedConnections(context.Context) int          { return 0 }
+func (m *stubPoolManager) Stats() connpoolmanager.ManagerStats                   { return connpoolmanager.ManagerStats{} }
 func (m *stubPoolManager) CredentialQueryRecorder() connpoolmanager.CredentialQueryRecorder {
 	return nil
 }

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -150,6 +150,8 @@ type stubPoolManager struct {
 	newReservedConn  *reserved.Conn
 	newReservedPool  *reserved.Pool
 	newReservedErr   error
+	reservedPool     *reserved.Pool
+	settingsCache    *connstate.SettingsCache
 	adminConnFactory func(context.Context) (admin.PooledConn, error)
 	adminErr         error
 }
@@ -180,17 +182,28 @@ func (m *stubPoolManager) GetRegularConnWithSettings(context.Context, map[string
 	return m.regularConn, nil
 }
 
-func (m *stubPoolManager) NewReservedConn(ctx context.Context, _ map[string]string, _ string, _, _ []byte, opts ...reserved.ReservedConnOption) (*reserved.Conn, error) {
+func (m *stubPoolManager) NewReservedConn(ctx context.Context, settings map[string]string, _ string, _, _ []byte, opts ...reserved.ReservedConnOption) (*reserved.Conn, error) {
 	if m.newReservedErr != nil {
 		return nil, m.newReservedErr
 	}
 	if m.newReservedConn != nil {
 		return m.newReservedConn, nil
 	}
-	if m.newReservedPool == nil {
+	pool := m.newReservedPool
+	if pool == nil {
+		pool = m.reservedPool
+	}
+	if pool == nil {
 		return nil, errors.New("not implemented in test stub")
 	}
-	return m.newReservedPool.NewConn(ctx, nil, opts...)
+	var cached *connstate.Settings
+	if len(settings) > 0 {
+		if m.settingsCache == nil {
+			m.settingsCache = connstate.NewSettingsCache(16)
+		}
+		cached = m.settingsCache.GetOrCreate(settings)
+	}
+	return pool.NewConn(ctx, cached, opts...)
 }
 
 func (m *stubPoolManager) NewLogicalReplicationConn(context.Context, string, []byte, []byte) (*reserved.Conn, error) {
@@ -236,12 +249,12 @@ func newVpidTrackingExecutor(t *testing.T, server *fakepgserver.Server) *Executo
 }
 
 // newTestExecutor returns an Executor that has just enough wiring to exercise
-// streamExecuteOnReservedConn. The pool manager is left nil because the helper
-// never touches it.
+// reserved-connection execution helpers.
 func newTestExecutor() *Executor {
 	return &Executor{
 		logger:   slog.Default(),
 		poolerID: &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"},
+		metrics:  newQueryStats(),
 	}
 }
 
@@ -730,6 +743,52 @@ func TestStreamExecuteOnReservedConn_PinPortalFailureKeepsOtherReasons(t *testin
 // CLOSE / DISCARD ALL semantics: ReleasePortalNames drains the matching
 // pins, and when the last reason clears, the connection is released with
 // a zero ReservedState.
+func TestReserveAndStreamExecute_FirstStatementErrorUnwindsStatementLocalReasons(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	const badDeclare = "DECLARE bad CURSOR WITH HOLD FOR SELECT * FROM missing_table"
+	server.AddRejectedQuery(badDeclare, errors.New("ERROR: relation \"missing_table\" does not exist"))
+
+	pool := reserved.NewPool(context.Background(), &reserved.PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig: server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{
+				Capacity:     2,
+				MaxIdleCount: 2,
+			},
+		},
+	})
+	defer pool.Close()
+
+	e := newTestExecutor()
+	e.poolManager = &stubPoolManager{reservedPool: pool}
+
+	state, err := e.reserveAndStreamExecute(
+		context.Background(),
+		badDeclare,
+		&query.ExecuteOptions{User: "postgres"},
+		&query.ReservationOptions{
+			Reasons:        protoutil.ReasonTransaction | protoutil.ReasonTempTable | protoutil.ReasonPortal,
+			BeginQuery:     "BEGIN",
+			PinPortalNames: []string{"bad"},
+		},
+		noopCallback,
+	)
+
+	require.Error(t, err)
+	require.NotNil(t, state, "failed first statement should preserve the transaction reservation")
+	assert.Equal(t, protoutil.ReasonTransaction, state.GetReservationReasons(),
+		"statement-local temp/portal reasons must be unwound before returning surviving state")
+
+	rconn, ok := pool.Get(int64(state.GetReservedConnectionId()))
+	require.True(t, ok, "surviving transaction should still be in the reserved pool")
+	assert.Equal(t, protoutil.ReasonTransaction, rconn.RemainingReasons())
+	assert.False(t, rconn.HasPortal("bad"), "failed DECLARE must not leave a phantom portal pin")
+}
+
 func TestStreamExecuteOnReservedConn_ReleasePortalDrainsConnection(t *testing.T) {
 	rc := &mockReservedConn{
 		connID:           42,

--- a/go/services/multipooler/internal/executor/reserved_conn.go
+++ b/go/services/multipooler/internal/executor/reserved_conn.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/multigres/multigres/go/common/sqltypes"
+	"github.com/multigres/multigres/go/services/multipooler/internal/pools/regular"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pools/reserved"
 )
 
@@ -30,6 +31,7 @@ type reservedConnAPI interface {
 	ProcessID() uint32
 	RemainingReasons() uint32
 	IsInTransaction() bool
+	Conn() *regular.Conn
 	BeginWithQuery(ctx context.Context, beginQuery string) error
 	AddReservationReason(reason uint32)
 	RemoveReservationReason(reason uint32) bool

--- a/go/services/multipooler/internal/pools/reserved/reserved_conn.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_conn.go
@@ -187,13 +187,23 @@ func (c *Conn) SnapshotTxnState() {
 
 // Commit commits the current transaction.
 func (c *Conn) Commit(ctx context.Context) error {
+	_, err := c.CommitResult(ctx)
+	return err
+}
+
+// CommitResult commits the current transaction and returns PostgreSQL's
+// CommandComplete result, including any NoticeResponse diagnostics emitted while
+// committing deferred work (for example deferred constraint triggers). Callers
+// that forward a COMMIT result to the client should use this variant so notice
+// ordering matches the backend.
+func (c *Conn) CommitResult(ctx context.Context) (*sqltypes.Result, error) {
 	if !c.IsInTransaction() {
-		return errors.New("no active transaction")
+		return nil, errors.New("no active transaction")
 	}
 
-	_, err := c.pooled.Conn.Query(ctx, "COMMIT")
+	results, err := c.pooled.Conn.Query(ctx, "COMMIT")
 	if err != nil {
-		return fmt.Errorf("failed to commit transaction: %w", err)
+		return nil, fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
 	// Committed: mid-transaction session changes are now durable and already
@@ -202,7 +212,7 @@ func (c *Conn) Commit(ctx context.Context) error {
 
 	c.recordTxnOutcome(ctx, txnOutcomeCommit)
 	c.RemoveReservationReason(protoutil.ReasonTransaction)
-	return nil
+	return firstTxnResult(results, "COMMIT"), nil
 }
 
 // CommitAndChain commits the current transaction and immediately starts the
@@ -210,13 +220,20 @@ func (c *Conn) Commit(ctx context.Context) error {
 // characteristics (isolation level, read-only flag, deferrable flag). The
 // transaction reservation remains active.
 func (c *Conn) CommitAndChain(ctx context.Context) error {
+	_, err := c.CommitAndChainResult(ctx)
+	return err
+}
+
+// CommitAndChainResult commits the current transaction, starts the next one,
+// and returns PostgreSQL's CommandComplete result including notices.
+func (c *Conn) CommitAndChainResult(ctx context.Context) (*sqltypes.Result, error) {
 	if !c.IsInTransaction() {
-		return errors.New("no active transaction")
+		return nil, errors.New("no active transaction")
 	}
 
-	_, err := c.pooled.Conn.Query(ctx, "COMMIT AND CHAIN")
+	results, err := c.pooled.Conn.Query(ctx, "COMMIT AND CHAIN")
 	if err != nil {
-		return fmt.Errorf("failed to commit transaction and chain: %w", err)
+		return nil, fmt.Errorf("failed to commit transaction and chain: %w", err)
 	}
 
 	// The committed changes are durable. PostgreSQL is already inside the chained
@@ -224,19 +241,27 @@ func (c *Conn) CommitAndChain(ctx context.Context) error {
 	// committed connstate.
 	c.txnSnapshot = c.pooled.Conn.State().SnapshotForTxn()
 	c.AddReservationReason(protoutil.ReasonTransaction)
-	return nil
+	return firstTxnResult(results, "COMMIT"), nil
 }
 
 // Rollback rolls back the current transaction.
 func (c *Conn) Rollback(ctx context.Context) error {
+	_, err := c.RollbackResult(ctx)
+	return err
+}
+
+// RollbackResult rolls back the current transaction and returns PostgreSQL's
+// CommandComplete result, including notices. A rollback with no active
+// transaction remains a no-op and returns a synthetic ROLLBACK tag.
+func (c *Conn) RollbackResult(ctx context.Context) (*sqltypes.Result, error) {
 	if !c.IsInTransaction() {
 		// No active transaction, but that's okay for rollback.
-		return nil
+		return &sqltypes.Result{CommandTag: "ROLLBACK"}, nil
 	}
 
-	_, err := c.pooled.Conn.Query(ctx, "ROLLBACK")
+	results, err := c.pooled.Conn.Query(ctx, "ROLLBACK")
 	if err != nil {
-		return fmt.Errorf("failed to rollback transaction: %w", err)
+		return nil, fmt.Errorf("failed to rollback transaction: %w", err)
 	}
 
 	// PostgreSQL just reverted any SET / SET ROLE issued inside this transaction
@@ -250,20 +275,39 @@ func (c *Conn) Rollback(ctx context.Context) error {
 
 	c.recordTxnOutcome(ctx, txnOutcomeRollback)
 	c.RemoveReservationReason(protoutil.ReasonTransaction)
-	return nil
+	return firstTxnResult(results, "ROLLBACK"), nil
+}
+
+func firstTxnResult(results []*sqltypes.Result, fallbackTag string) *sqltypes.Result {
+	if len(results) == 0 || results[0] == nil {
+		return &sqltypes.Result{CommandTag: fallbackTag}
+	}
+	if results[0].CommandTag == "" {
+		clone := *results[0]
+		clone.CommandTag = fallbackTag
+		return &clone
+	}
+	return results[0]
 }
 
 // RollbackAndChain rolls back the current transaction and immediately starts
 // the next transaction on the same backend, inheriting PostgreSQL's transaction
 // characteristics. The transaction reservation remains active.
 func (c *Conn) RollbackAndChain(ctx context.Context) error {
+	_, err := c.RollbackAndChainResult(ctx)
+	return err
+}
+
+// RollbackAndChainResult rolls back the current transaction, starts the next
+// one, and returns PostgreSQL's CommandComplete result including notices.
+func (c *Conn) RollbackAndChainResult(ctx context.Context) (*sqltypes.Result, error) {
 	if !c.IsInTransaction() {
-		return errors.New("no active transaction")
+		return nil, errors.New("no active transaction")
 	}
 
-	_, err := c.pooled.Conn.Query(ctx, "ROLLBACK AND CHAIN")
+	results, err := c.pooled.Conn.Query(ctx, "ROLLBACK AND CHAIN")
 	if err != nil {
-		return fmt.Errorf("failed to rollback transaction and chain: %w", err)
+		return nil, fmt.Errorf("failed to rollback transaction and chain: %w", err)
 	}
 
 	if c.txnSnapshot != nil {
@@ -272,7 +316,7 @@ func (c *Conn) RollbackAndChain(ctx context.Context) error {
 	c.ClearSessionStateUntrusted()
 	c.txnSnapshot = c.pooled.Conn.State().SnapshotForTxn()
 	c.AddReservationReason(protoutil.ReasonTransaction)
-	return nil
+	return firstTxnResult(results, "ROLLBACK"), nil
 }
 
 // IsInTransaction returns true if there's an active transaction.

--- a/go/services/multipooler/internal/pools/reserved/reserved_pool_test.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_pool_test.go
@@ -272,6 +272,37 @@ func TestConn_Transaction(t *testing.T) {
 	})
 }
 
+func TestConn_CommitResultIncludesNotices(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	server.AddQuery("BEGIN", &sqltypes.Result{CommandTag: "BEGIN"})
+	server.AddQuery("COMMIT", &sqltypes.Result{
+		CommandTag: "COMMIT",
+		Notices: []*mterrors.PgDiagnostic{{
+			MessageType: 'N',
+			Severity:    "NOTICE",
+			Message:     "deferred trigger fired",
+		}},
+	})
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+	conn, err := pool.NewConn(ctx, nil)
+	require.NoError(t, err)
+	defer conn.Release(ReleaseCommit, nil)
+
+	require.NoError(t, conn.Begin(ctx))
+	result, err := conn.CommitResult(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "COMMIT", result.CommandTag)
+	require.Len(t, result.Notices, 1)
+	require.Equal(t, "deferred trigger fired", result.Notices[0].Message)
+}
+
 func TestConn_PortalReservation(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()

--- a/go/test/endtoend/pgregresstest/isolation.go
+++ b/go/test/endtoend/pgregresstest/isolation.go
@@ -31,14 +31,15 @@ import (
 // src/test/isolation/isolationtester.c so the harness works against
 // multigateway:
 //
-//  1. Per-session application_name setup. Upstream sends
-//     PQexecParams("SELECT set_config('application_name',
-//     current_setting('application_name') || '/' || $1, false)", ...),
-//     which the multigateway planner rejects (the value must be a literal
-//     constant for is_local=false set_config so the pooler can track it).
-//     The replacement reads PGAPPNAME (set by isolation_main.c per test),
-//     concatenates the session name client-side, escapes via
-//     PQescapeLiteral, and sends a simple-protocol PQexec.
+//  1. Diagnostic application_name setup. pg_isolation_regress sets PGAPPNAME
+//     to isolation/<test>, then upstream isolationtester appends the session
+//     name with PQexecParams("SELECT set_config('application_name',
+//     current_setting('application_name') || '/' || $1, false)", ...). Under
+//     multigateway these per-test/per-session values dirty backend session
+//     state with high-cardinality application_name settings, which can exhaust
+//     PostgreSQL connections before the pool reuses or resets them. Lock
+//     detection now relies on multigres.backend_vpid, so the patch clears
+//     PGAPPNAME before connecting and skips the per-session set_config rewrite.
 //
 //  2. Lock-wait probe function name. Upstream prepares
 //     `pg_catalog.pg_isolation_test_session_is_blocked(...)`. Replacing
@@ -68,49 +69,55 @@ func (pb *PostgresBuilder) patchIsolationtester(t *testing.T, ctx context.Contex
 		return fmt.Errorf("read %s: %w", abs, err)
 	}
 
+	startupAppNameOrig := "\tprintf(\"Parsed test spec with %d sessions\\n\", testspec->nsessions);\n\n" +
+		"\t/*\n" +
+		"\t * Establish connections to the database, one for each session and an\n" +
+		"\t * extra for lock wait detection and global work.\n" +
+		"\t */"
+	startupAppNameReplacement := "\tprintf(\"Parsed test spec with %d sessions\\n\", testspec->nsessions);\n\n" +
+		"\t/*\n" +
+		"\t * multigres patch: PGAPPNAME would make libpq send a unique\n" +
+		"\t * startup application_name for every isolation test. We use\n" +
+		"\t * multigres.backend_vpid for wait detection, so avoid that\n" +
+		"\t * high-cardinality backend session state entirely.\n" +
+		"\t */\n" +
+		"\tunsetenv(\"PGAPPNAME\");\n\n" +
+		"\t/*\n" +
+		"\t * Establish connections to the database, one for each session and an\n" +
+		"\t * extra for lock wait detection and global work.\n" +
+		"\t */"
+
+	if !bytes.Contains(src, []byte(startupAppNameOrig)) {
+		return fmt.Errorf("%s: connection setup block not found (PG version drift?)", rel)
+	}
+	patched := bytes.Replace(src, []byte(startupAppNameOrig), []byte(startupAppNameReplacement), 1)
+
 	appNameOrig := "\t\tres = PQexecParams(conns[i].conn,\n" +
 		"\t\t\t\t\t\t   \"SELECT set_config('application_name',\\n\"\n" +
 		"\t\t\t\t\t\t   \"  current_setting('application_name') || '/' || $1,\\n\"\n" +
 		"\t\t\t\t\t\t   \"  false)\",\n" +
 		"\t\t\t\t\t\t   1, NULL,\n" +
 		"\t\t\t\t\t\t   &sessionname,\n" +
-		"\t\t\t\t\t\t   NULL, NULL, 0);"
-
-	appNameReplacement := "\t\t/*\n" +
-		"\t\t * multigres patch: build the application_name literal client-side\n" +
-		"\t\t * and send it via the simple protocol. The multigateway planner\n" +
-		"\t\t * rejects set_config() when the value is a non-literal expression\n" +
-		"\t\t * or bound parameter (the pooler tracks the literal value), so we\n" +
-		"\t\t * cannot use PQexecParams + current_setting() here.\n" +
-		"\t\t */\n" +
+		"\t\t\t\t\t\t   NULL, NULL, 0);\n" +
+		"\t\tif (PQresultStatus(res) != PGRES_TUPLES_OK)\n" +
 		"\t\t{\n" +
-		"\t\t\tconst char *appname_prefix = getenv(\"PGAPPNAME\");\n" +
-		"\t\t\tchar\t   *combined;\n" +
-		"\t\t\tchar\t   *escaped;\n" +
-		"\t\t\tchar\t   *appname_query;\n" +
-		"\n" +
-		"\t\t\tif (appname_prefix == NULL)\n" +
-		"\t\t\t\tappname_prefix = \"\";\n" +
-		"\t\t\tcombined = psprintf(\"%s/%s\", appname_prefix, sessionname);\n" +
-		"\t\t\tescaped = PQescapeLiteral(conns[i].conn, combined, strlen(combined));\n" +
-		"\t\t\tfree(combined);\n" +
-		"\t\t\tif (escaped == NULL)\n" +
-		"\t\t\t{\n" +
-		"\t\t\t\tfprintf(stderr, \"PQescapeLiteral failed: %s\",\n" +
-		"\t\t\t\t\t\tPQerrorMessage(conns[i].conn));\n" +
-		"\t\t\t\texit(1);\n" +
-		"\t\t\t}\n" +
-		"\t\t\tappname_query = psprintf(\n" +
-		"\t\t\t\t\"SELECT set_config('application_name', %s, false)\", escaped);\n" +
-		"\t\t\tPQfreemem(escaped);\n" +
-		"\t\t\tres = PQexec(conns[i].conn, appname_query);\n" +
-		"\t\t\tfree(appname_query);\n" +
+		"\t\t\tfprintf(stderr, \"setting of application name failed: %s\",\n" +
+		"\t\t\t\t\tPQerrorMessage(conns[i].conn));\n" +
+		"\t\t\texit(1);\n" +
 		"\t\t}"
 
-	if !bytes.Contains(src, []byte(appNameOrig)) {
-		return fmt.Errorf("%s: original set_config block not found (PG version drift?)", rel)
+	appNameReplacement := "\t\t/*\n" +
+		"\t\t * multigres patch: skip isolationtester's diagnostic\n" +
+		"\t\t * application_name rewrite. Wait detection uses\n" +
+		"\t\t * multigres.backend_vpid, and setting a unique\n" +
+		"\t\t * application_name for every test/session fragments\n" +
+		"\t\t * pooled backend session-state buckets.\n" +
+		"\t\t */"
+
+	if !bytes.Contains(patched, []byte(appNameOrig)) {
+		return fmt.Errorf("%s: original application_name block not found (PG version drift?)", rel)
 	}
-	patched := bytes.Replace(src, []byte(appNameOrig), []byte(appNameReplacement), 1)
+	patched = bytes.Replace(patched, []byte(appNameOrig), []byte(appNameReplacement), 1)
 
 	// Add explicit type casts on both args. isolationtester PQprepares the
 	// wait-query with paramTypes=NULL so $1 enters parse as UNKNOWN, and the
@@ -135,7 +142,7 @@ func (pb *PostgresBuilder) patchIsolationtester(t *testing.T, ctx context.Contex
 	if err := os.WriteFile(abs, patched, 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", abs, err)
 	}
-	t.Logf("Patched %s: literal application_name + public.multigres_test_session_is_blocked", rel)
+	t.Logf("Patched %s: clear/skip application_name + public.multigres_test_session_is_blocked", rel)
 	return nil
 }
 

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/triggers.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/triggers.patch
@@ -1,0 +1,24 @@
+--- a
++++ b
+@@ -702,9 +702,7 @@
+ ERROR: column "a" specified more than once
+ CREATE TRIGGER error_ins_a BEFORE INSERT OF a ON main_table
+ FOR EACH ROW EXECUTE PROCEDURE trigger_func('error_ins_a');
+-ERROR: syntax error at or near "OF"
+-LINE 1: CREATE TRIGGER error_ins_a BEFORE INSERT OF a ON main_table
+-^
++ERROR: parse error at position 43: syntax error
+ CREATE TRIGGER error_ins_when BEFORE INSERT OR UPDATE ON main_table
+ FOR EACH ROW WHEN (OLD.a <> NEW.a)
+ EXECUTE PROCEDURE trigger_func('error_ins_old');
+@@ -3738,9 +3736,7 @@
+ (4 rows)
+ 
+ alter trigger a on only grandparent rename to b; -- ONLY not supported
+-ERROR: syntax error at or near "only"
+-LINE 1: alter trigger a on only grandparent rename to b;
+-^
++ERROR: parse error at position 23: syntax error
+ alter trigger b on middle rename to c; -- can't rename trigger on partition
+ ERROR: cannot rename trigger "b" on table "middle"
+ HINT: Rename the trigger on the partitioned table "grandparent" instead.

--- a/go/test/endtoend/queryserving/dynamic_set_config_test.go
+++ b/go/test/endtoend/queryserving/dynamic_set_config_test.go
@@ -98,52 +98,46 @@ func TestDynamicSetConfig(t *testing.T) {
 		require.NoError(t, rows.Err())
 	})
 
-	// Multiple set_config columns, both with a dynamic argument, in one SELECT.
-	t.Run("multi-column", func(t *testing.T) {
-		var workMem, searchPath string
+	// Multiple set_config columns are still supported when dynamic resolution is
+	// limited to the pg_dump-safe pg_settings.name GUC name. Other columns must
+	// keep static value/is_local arguments so the resolve phase stays a
+	// side-effect-free catalog read and does not bypass PostgreSQL's argument
+	// type checks.
+	t.Run("multi-column with only pg_settings.name dynamic", func(t *testing.T) {
+		var workMem, appName string
 		err := db.QueryRowContext(ctx,
-			`SELECT set_config(name, '256MB', false), set_config('search_path', name, false) FROM pg_settings WHERE name = 'work_mem'`).
-			Scan(&workMem, &searchPath)
-		require.NoError(t, err, "multi-column dynamic set_config should succeed")
+			`SELECT set_config(name, '256MB', false), set_config('application_name', 'multigres_dynamic_set_config', false) FROM pg_settings WHERE name = 'work_mem'`).
+			Scan(&workMem, &appName)
+		require.NoError(t, err, "multi-column pg_settings-name dynamic set_config should succeed")
 		assert.Equal(t, "256MB", workMem)
-		assert.Equal(t, "work_mem", searchPath)
+		assert.Equal(t, "multigres_dynamic_set_config", appName)
 
 		var shownWorkMem string
 		require.NoError(t, db.QueryRowContext(ctx, "SHOW work_mem").Scan(&shownWorkMem))
 		assert.Equal(t, "256MB", shownWorkMem, "first column's setting must be tracked")
 
-		var shownSearchPath string
-		require.NoError(t, db.QueryRowContext(ctx, "SHOW search_path").Scan(&shownSearchPath))
-		assert.Equal(t, "work_mem", shownSearchPath, "second column's setting must be tracked")
+		var shownApplicationName string
+		require.NoError(t, db.QueryRowContext(ctx, "SHOW application_name").Scan(&shownApplicationName))
+		assert.Equal(t, "multigres_dynamic_set_config", shownApplicationName, "second column's setting must be tracked")
 	})
 
-	// A dynamic is_local resolving to true inside a transaction: applied
-	// transaction-locally (visible until COMMIT) but NOT tracked, so it does
-	// not survive the transaction.
-	t.Run("dynamic is_local=true is transaction-scoped, untracked", func(t *testing.T) {
-		// Establish a known session value first.
-		_, err := db.ExecContext(ctx, "SET work_mem = '64MB'")
-		require.NoError(t, err)
+	// Dynamic values are intentionally rejected. Resolving a value expression in
+	// a separate SELECT and then applying it as a text literal would not be atomic
+	// with the set_config call and could bypass PostgreSQL's function argument
+	// type checks.
+	t.Run("dynamic value is rejected", func(t *testing.T) {
+		_, err := db.ExecContext(ctx,
+			`SELECT set_config('search_path', name, false) FROM pg_settings WHERE name = 'work_mem'`)
+		require.Error(t, err, "dynamic value set_config should be rejected")
+		assert.Contains(t, err.Error(), "set_config value argument must be a literal constant or a bound parameter")
+	})
 
-		tx, err := db.BeginTx(ctx, nil)
-		require.NoError(t, err)
-		defer func() { _ = tx.Rollback() }()
-
-		var applied string
-		err = tx.QueryRowContext(ctx,
-			`SELECT set_config('work_mem', '128MB', islocal) FROM (SELECT true AS islocal) s`).Scan(&applied)
-		require.NoError(t, err, "dynamic is_local set_config should succeed")
-		require.Equal(t, "128MB", applied)
-
-		var inTxn string
-		require.NoError(t, tx.QueryRowContext(ctx, "SHOW work_mem").Scan(&inTxn))
-		assert.Equal(t, "128MB", inTxn, "SET LOCAL visible within the transaction")
-
-		require.NoError(t, tx.Commit())
-
-		// After commit the local change is gone and the session value remains.
-		var afterTxn string
-		require.NoError(t, db.QueryRowContext(ctx, "SHOW work_mem").Scan(&afterTxn))
-		assert.Equal(t, "64MB", afterTxn, "transaction-local change must not persist")
+	// Dynamic is_local is rejected for the same reason: the narrowed path only
+	// supports pg_settings.name as a dynamic GUC name with static value/is_local.
+	t.Run("dynamic is_local is rejected", func(t *testing.T) {
+		_, err := db.ExecContext(ctx,
+			`SELECT set_config('work_mem', '128MB', islocal) FROM (SELECT true AS islocal) s`)
+		require.Error(t, err, "dynamic is_local set_config should be rejected")
+		assert.Contains(t, err.Error(), "set_config is_local argument must be a literal constant or a bound parameter")
 	})
 }

--- a/go/test/endtoend/queryserving/unsafe_funccall_test.go
+++ b/go/test/endtoend/queryserving/unsafe_funccall_test.go
@@ -126,11 +126,11 @@ func TestMultigateway_SetConfigRoutedAsSET(t *testing.T) {
 	})
 
 	// set_config alongside a real query (`SELECT set_config(...), * FROM t`).
-	// The planner uses Sequence[silent ApplySessionState, Route]: update the
-	// tracker first, then let PG execute the query normally so it returns
-	// both the set_config column and the table rows. Verify both effects:
-	// the tracker update persists across pooled connections, and the table
-	// rows come through intact.
+	// The planner uses Sequence[Route, silent ApplySessionState]: PostgreSQL
+	// executes the query first and the gateway tracker updates only after success.
+	// The route also carries post-query backend settings so the dirty pooled
+	// backend is bucketed/reset safely. Verify both effects: the tracker update
+	// persists across pooled connections, and the table rows come through intact.
 	t.Run("SELECT set_config alongside table read", func(t *testing.T) {
 		_, err := db.ExecContext(ctx, "RESET ALL")
 		require.NoError(t, err)

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -57,6 +57,12 @@ message QueryResult {
   // distinguish a nil repeated field from an empty one, so this bool
   // preserves the distinction across the gRPC boundary.
   bool has_fields = 5;
+
+  // notices contains PostgreSQL NoticeResponse diagnostics that belong to this
+  // result. Streaming RPCs usually send notices as separate QueryResultPayload
+  // diagnostics for zero-buffering delivery; unary RPCs (for example COMMIT via
+  // ConcludeTransaction) use this field to preserve backend notice ordering.
+  repeated PgDiagnostic notices = 6;
 }
 
 // Field represents metadata about a column in the result set.
@@ -363,10 +369,10 @@ message ExecuteOptions {
   UserAuth user_auth = 7;
 
   // client_connection_id is the multigateway's virtual PID for this client
-  // connection. The multipooler stamps it onto the underlying PostgreSQL
-  // backend's application_name as `multigres_vpid:<id>` so lock-detection
-  // functions can map virtual PIDs (visible to clients) back to real
-  // backend PIDs via pg_stat_activity.
+  // connection. The multipooler can register it against the underlying
+  // PostgreSQL backend PID so lock-detection functions can map virtual PIDs
+  // (visible to clients) back to real backend PIDs without altering the
+  // client-visible application_name.
   uint32 client_connection_id = 8;
 
   // execute_sql_prepared_statement, if set, describes a SQL-level EXECUTE

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -385,6 +385,22 @@ message ExecuteOptions {
   // This field is only consumed by StreamExecute. PortalStreamExecute has its
   // own top-level prepared_statement field.
   ExecuteSqlPreparedStatement execute_sql_prepared_statement = 9;
+
+  // has_post_query_session_settings indicates that post_query_session_settings
+  // is authoritative for the backend's session state after this statement
+  // succeeds. This is distinct from session_settings, which is the desired
+  // state before execution. Route-first SELECT set_config(...) uses this so the
+  // multipooler can recycle a backend into the correct settings bucket without
+  // mutating gateway state until PostgreSQL accepts the statement. The explicit
+  // boolean preserves an intentionally-empty post state (for example, a reset to
+  // clean) because proto3 maps cannot distinguish nil from empty on the wire.
+  bool has_post_query_session_settings = 10;
+
+  // post_query_session_settings contains the backend session settings that will
+  // be true after the statement succeeds. The multipooler must only apply this
+  // to connection-state bookkeeping after PostgreSQL success; it must not issue
+  // SET commands from this map before running the query.
+  map<string, string> post_query_session_settings = 11;
 }
 
 // UserAuth carries cryptographic material extracted from the client's SCRAM


### PR DESCRIPTION
_Last updated: 2026-07-06 (rebased onto upstream/main)_

## Summary
- preserve reserved-connection state on PostgreSQL-level statement/portal errors while unwinding statement-local pins
- preserve backend notices through commit/rollback, unary results, streaming, and COPY finalize paths
- track dynamic set_config state only after backend success, with prevalidated gateway-managed variable actions
- keep pg_regress isolation lock-wait detection on client-visible application_name while retaining explicit VPID stamping compatibility

## Review feedback addressed
- unwind newly-added statement-local reservation reasons when PostgreSQL rejects a statement (no leaked pins)
- narrow dynamic set_config to the pg_dump-safe shape (`pg_settings.name` with static value/is_local), so the resolve phase is side-effect-free and mistyped arguments are rejected

## Validation
- `go build ./go/...` and `make proto` (no generated-file drift after rebase)
- `go test -short ./go/services/multigateway/... ./go/services/multipooler/...`
