### PR TITLE
feat(multipooler): keep retrying pg_rewind until the standby rejoins

### DIFF
--- a/go/cmd/pgctld/command/crash_recovery.go
+++ b/go/cmd/pgctld/command/crash_recovery.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -69,11 +70,65 @@ func extractClusterState(output string) string {
 	return "unknown"
 }
 
-// runCrashRecovery performs crash recovery in single-user mode.
-// This runs postgres --single to complete crash recovery, then exits cleanly.
+// crashRecoveryNeeded reports whether PostgreSQL is not cleanly shut down and so
+// must be crash recovered before it can start again.
+func crashRecoveryNeeded(ctx context.Context) (bool, error) {
+	cleanlyStopped, err := isPostgresCleanlyStopped(ctx)
+	if err != nil {
+		return false, err
+	}
+	return !cleanlyStopped, nil
+}
+
+// hasStandbySignal reports whether a standby.signal marker file is present, i.e.
+// PostgreSQL is configured to start in standby mode.
+func hasStandbySignal() bool {
+	_, err := os.Stat(filepath.Join(pgctld.PostgresDataDir(), constants.StandbySignalFile))
+	return err == nil
+}
+
+// runCrashRecovery performs crash recovery in single-user mode (postgres --single),
+// which replays WAL to a clean shutdown and exits.
+//
+// A standby.signal blocks single-user mode ("standby mode is not supported by
+// single-user servers"), so when one is present it is removed for the duration of
+// recovery and recreated afterwards, preserving the node's standby identity. Both
+// the start and rewind paths share this primitive, so a standby that can only be
+// cleaned up via single-user recovery — e.g. one wedged by an early pg_rewind that
+// stamped minRecoveryPoint onto the wrong timeline — is handled consistently
+// (notably, this lets a re-issued pg_rewind clean-shut-down such a node).
 func runCrashRecovery(ctx context.Context, logger *slog.Logger) error {
 	r := retry.New(constants.CrashRecoveryRetryDelay, constants.CrashRecoveryRetryDelay)
-	return runCrashRecoveryAttempts(ctx, logger, runSingleUserPostgres, r)
+	return runCrashRecoveryInDir(ctx, logger, pgctld.PostgresDataDir(), runSingleUserPostgres, r)
+}
+
+// runCrashRecoveryInDir is runCrashRecovery with the data directory and single-user
+// runner injected, so the standby.signal save/restore can be unit-tested without a
+// real postgres. Extracted for testing.
+func runCrashRecoveryInDir(
+	ctx context.Context,
+	logger *slog.Logger,
+	dataDir string,
+	run func(context.Context) ([]byte, error),
+	r *retry.Retry,
+) error {
+	signalPath := filepath.Join(dataDir, constants.StandbySignalFile)
+	if _, err := os.Stat(signalPath); err == nil {
+		logger.InfoContext(ctx, "Temporarily removing standby.signal for single-user crash recovery",
+			"path", signalPath)
+		if rmErr := os.Remove(signalPath); rmErr != nil {
+			return fmt.Errorf("failed to remove standby.signal before crash recovery: %w", rmErr)
+		}
+		// Recreate even if recovery fails, so the node is not silently converted
+		// from a standby into a primary on the next start.
+		defer func() {
+			if wErr := os.WriteFile(signalPath, []byte(""), 0o644); wErr != nil {
+				logger.ErrorContext(ctx, "failed to recreate standby.signal after crash recovery", "error", wErr, "path", signalPath)
+			}
+		}()
+	}
+
+	return runCrashRecoveryAttempts(ctx, logger, run, r)
 }
 
 // runCrashRecoveryAttempts retries `postgres --single` while the lock file is held.

--- a/go/cmd/pgctld/command/crash_recovery_test.go
+++ b/go/cmd/pgctld/command/crash_recovery_test.go
@@ -17,6 +17,8 @@ package command
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -165,4 +167,89 @@ func TestRunCrashRecovery_ContextCancelledDuringBackoff(t *testing.T) {
 	err := runCrashRecoveryAttempts(ctx, testLogger(), runner, retry.New(time.Hour, time.Hour))
 	require.ErrorIs(t, err, context.Canceled)
 	assert.Equal(t, 1, calls)
+}
+
+func fileExists(t *testing.T, path string) bool {
+	t.Helper()
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// TestRunCrashRecoveryInDir_RemovesAndRestoresStandbySignal verifies the
+// standby.signal is absent while postgres --single runs (single-user mode
+// refuses to start with one present) and is recreated afterwards so the node
+// stays a standby.
+func TestRunCrashRecoveryInDir_RemovesAndRestoresStandbySignal(t *testing.T) {
+	dir := t.TempDir()
+	signalPath := filepath.Join(dir, constants.StandbySignalFile)
+	require.NoError(t, os.WriteFile(signalPath, []byte(""), 0o644))
+
+	var signalPresentDuringRun bool
+	runner := func(ctx context.Context) ([]byte, error) {
+		signalPresentDuringRun = fileExists(t, signalPath)
+		return []byte("recovery complete"), nil
+	}
+
+	err := runCrashRecoveryInDir(context.Background(), testLogger(), dir, runner, fastRetry())
+	require.NoError(t, err)
+	assert.False(t, signalPresentDuringRun, "standby.signal must be removed while postgres --single runs")
+	assert.True(t, fileExists(t, signalPath), "standby.signal must be recreated after recovery")
+}
+
+// TestRunCrashRecoveryInDir_RestoresStandbySignalOnFailure verifies the signal is
+// recreated even when recovery fails, so a failed recovery does not silently
+// convert a standby into a primary on its next start.
+func TestRunCrashRecoveryInDir_RestoresStandbySignalOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	signalPath := filepath.Join(dir, constants.StandbySignalFile)
+	require.NoError(t, os.WriteFile(signalPath, []byte(""), 0o644))
+
+	runner := func(ctx context.Context) ([]byte, error) {
+		return []byte("FATAL:  could not access data directory"), errors.New("exit status 1")
+	}
+
+	err := runCrashRecoveryInDir(context.Background(), testLogger(), dir, runner, fastRetry())
+	require.Error(t, err)
+	assert.True(t, fileExists(t, signalPath), "standby.signal must be recreated even when recovery fails")
+}
+
+// TestRunCrashRecoveryInDir_NoStandbySignal_LeavesNoneBehind verifies a primary
+// (no standby.signal) is crash-recovered without a spurious signal being created.
+func TestRunCrashRecoveryInDir_NoStandbySignal_LeavesNoneBehind(t *testing.T) {
+	dir := t.TempDir()
+	signalPath := filepath.Join(dir, constants.StandbySignalFile)
+
+	calls := 0
+	runner := func(ctx context.Context) ([]byte, error) {
+		calls++
+		return []byte("recovery complete"), nil
+	}
+
+	err := runCrashRecoveryInDir(context.Background(), testLogger(), dir, runner, fastRetry())
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	assert.False(t, fileExists(t, signalPath), "no standby.signal should be created for a non-standby node")
+}
+
+// TestRunCrashRecoveryInDir_RemoveFailureSkipsRecovery verifies that when the
+// standby.signal cannot be removed, recovery is not attempted (running
+// postgres --single with the signal present would fail). standby.signal is made
+// un-removable by making it a non-empty directory, so os.Stat sees it present
+// but os.Remove fails.
+func TestRunCrashRecoveryInDir_RemoveFailureSkipsRecovery(t *testing.T) {
+	dir := t.TempDir()
+	signalPath := filepath.Join(dir, constants.StandbySignalFile)
+	require.NoError(t, os.Mkdir(signalPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(signalPath, "child"), []byte(""), 0o644))
+
+	called := false
+	runner := func(ctx context.Context) ([]byte, error) {
+		called = true
+		return []byte("recovery complete"), nil
+	}
+
+	err := runCrashRecoveryInDir(context.Background(), testLogger(), dir, runner, fastRetry())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to remove standby.signal")
+	assert.False(t, called, "recovery must not run when standby.signal could not be removed")
 }

--- a/go/cmd/pgctld/command/restart.go
+++ b/go/cmd/pgctld/command/restart.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/services/pgctld"
 	"github.com/multigres/multigres/go/tools/viperutil"
 
@@ -121,7 +122,7 @@ func RestartPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtl
 
 	// Create standby.signal if restarting as standby
 	if asStandby {
-		standbySignalPath := filepath.Join(config.PostgresDataDir, "standby.signal")
+		standbySignalPath := filepath.Join(config.PostgresDataDir, constants.StandbySignalFile)
 		logger.Info("Creating standby.signal file", "path", standbySignalPath)
 		if err := os.WriteFile(standbySignalPath, []byte(""), 0o644); err != nil {
 			return nil, fmt.Errorf("failed to create standby.signal: %w", err)

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -556,6 +556,35 @@ func (s *PgCtldService) Start(ctx context.Context, req *pb.StartRequest) (*pb.St
 		return nil, fmt.Errorf("data directory not initialized: %s. Run 'pgctld init' first", dataDir)
 	}
 
+	// When the caller allows it, make sure a node that was not cleanly shut down
+	// is crash recovered before the start below. crashRecoveryRan reports whether
+	// recovery occurs (here, or via the postmaster on the normal start) so the
+	// caller can treat it as evidence the node was not cleanly shut down.
+	var crashRecoveryRan bool
+	if req.GetAllowCrashRecovery() {
+		needed, nErr := crashRecoveryNeeded(ctx)
+		if nErr != nil {
+			s.logger.WarnContext(ctx, "could not determine clean-shutdown state before start (continuing)", "error", nErr)
+		} else if needed {
+			// crash recovery happens either way, so report it. A node without a
+			// standby.signal is crash-recovered by the postmaster on the normal start
+			// below, so it needs no explicit step. A standby may not be: if an early
+			// pg_rewind stamped minRecoveryPoint onto the wrong timeline, standby
+			// startup FATAL-loops and never reaches a clean state. Force single-user
+			// recovery for it — runCrashRecovery removes standby.signal first, since
+			// postgres --single refuses to run with it (that incompatibility, not
+			// standby.signal blocking the postmaster's own recovery, is why the
+			// explicit step is gated on standby.signal).
+			crashRecoveryRan = true
+			if hasStandbySignal() {
+				if rcErr := runCrashRecovery(ctx, s.logger); rcErr != nil {
+					// Best effort: the start below may still surface a clearer error.
+					s.logger.WarnContext(ctx, "standby crash recovery before start failed (continuing)", "error", rcErr)
+				}
+			}
+		}
+	}
+
 	// Use the pre-configured PostgreSQL config for start operation
 	result, err := StartPostgreSQLWithResult(s.logger, s.pgConfig)
 	if err != nil {
@@ -568,8 +597,9 @@ func (s *PgCtldService) Start(ctx context.Context, req *pb.StartRequest) (*pb.St
 	}
 
 	return &pb.StartResponse{
-		Pid:     pid,
-		Message: result.Message,
+		Pid:              pid,
+		Message:          result.Message,
+		CrashRecoveryRan: crashRecoveryRan,
 	}, nil
 }
 

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -98,6 +98,11 @@ const (
 	// backups.
 	BootstrapSentinelFile = ".multigres-bootstrap-in-progress"
 
+	// StandbySignalFile is PostgreSQL's marker file (in PGDATA) whose presence
+	// puts the server into standby mode. Notably, postgres --single refuses to
+	// run with it present, so crash recovery removes and recreates it.
+	StandbySignalFile = "standby.signal"
+
 	// DefaultSlowQueryThreshold is the duration after which a query is logged at WARN level.
 	DefaultSlowQueryThreshold = 1 * time.Second
 

--- a/go/pb/pgctldservice/pgctldservice.pb.go
+++ b/go/pb/pgctldservice/pgctldservice.pb.go
@@ -102,9 +102,15 @@ type StartRequest struct {
 	// Override the default port
 	Port int32 `protobuf:"varint,1,opt,name=port,proto3" json:"port,omitempty"`
 	// Additional postgres command line arguments
-	ExtraArgs     []string `protobuf:"bytes,2,rep,name=extra_args,json=extraArgs,proto3" json:"extra_args,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	ExtraArgs []string `protobuf:"bytes,2,rep,name=extra_args,json=extraArgs,proto3" json:"extra_args,omitempty"`
+	// When true and PostgreSQL is not cleanly shut down, run single-user crash
+	// recovery before starting. A standby.signal blocks single-user mode, so it is
+	// briefly removed for recovery and recreated afterwards. Callers that may be
+	// recovering a former primary (e.g. the postgres monitor) set this so the node
+	// reaches a clean state; the response reports whether recovery actually ran.
+	AllowCrashRecovery bool `protobuf:"varint,3,opt,name=allow_crash_recovery,json=allowCrashRecovery,proto3" json:"allow_crash_recovery,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *StartRequest) Reset() {
@@ -151,14 +157,27 @@ func (x *StartRequest) GetExtraArgs() []string {
 	return nil
 }
 
+func (x *StartRequest) GetAllowCrashRecovery() bool {
+	if x != nil {
+		return x.AllowCrashRecovery
+	}
+	return false
+}
+
 type StartResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Process ID of started PostgreSQL server
 	Pid int32 `protobuf:"varint,1,opt,name=pid,proto3" json:"pid,omitempty"`
 	// Status message
-	Message       string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Message string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	// True when single-user crash recovery was performed before start (only
+	// possible when the request set allow_crash_recovery). The caller uses this as
+	// evidence the node was not cleanly shut down: combined with knowing a
+	// different node is the consensus leader, it implies the local WAL may have
+	// diverged and a pg_rewind is needed before trusting it as a standby.
+	CrashRecoveryRan bool `protobuf:"varint,3,opt,name=crash_recovery_ran,json=crashRecoveryRan,proto3" json:"crash_recovery_ran,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *StartResponse) Reset() {
@@ -203,6 +222,13 @@ func (x *StartResponse) GetMessage() string {
 		return x.Message
 	}
 	return ""
+}
+
+func (x *StartResponse) GetCrashRecoveryRan() bool {
+	if x != nil {
+		return x.CrashRecoveryRan
+	}
+	return false
 }
 
 // Stop PostgreSQL server
@@ -1233,14 +1259,16 @@ var File_pgctldservice_proto protoreflect.FileDescriptor
 
 const file_pgctldservice_proto_rawDesc = "" +
 	"\n" +
-	"\x13pgctldservice.proto\x12\rpgctldservice\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"A\n" +
+	"\x13pgctldservice.proto\x12\rpgctldservice\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"s\n" +
 	"\fStartRequest\x12\x12\n" +
 	"\x04port\x18\x01 \x01(\x05R\x04port\x12\x1d\n" +
 	"\n" +
-	"extra_args\x18\x02 \x03(\tR\textraArgs\";\n" +
+	"extra_args\x18\x02 \x03(\tR\textraArgs\x120\n" +
+	"\x14allow_crash_recovery\x18\x03 \x01(\bR\x12allowCrashRecovery\"i\n" +
 	"\rStartResponse\x12\x10\n" +
 	"\x03pid\x18\x01 \x01(\x05R\x03pid\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage\"V\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\x12,\n" +
+	"\x12crash_recovery_ran\x18\x03 \x01(\bR\x10crashRecoveryRan\"V\n" +
 	"\vStopRequest\x12\x12\n" +
 	"\x04mode\x18\x01 \x01(\tR\x04mode\x123\n" +
 	"\atimeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\atimeout\"(\n" +

--- a/go/services/multiorch/recovery/recovery_loop_test.go
+++ b/go/services/multiorch/recovery/recovery_loop_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -120,18 +121,20 @@ type mockRecoveryAction struct {
 	name                  string
 	timeout               time.Duration
 	requiresHealthyLeader bool
-	executed              bool
-	executeErr            error
-	executeFn             func(ctx context.Context, problem types.Problem) error
-	metadata              types.RecoveryMetadata
-	gracePeriod           *types.GracePeriodConfig
+	// executed is written from Execute, which the engine runs concurrently
+	// (one goroutine per problem), so it must be accessed atomically.
+	executed    atomic.Bool
+	executeErr  error
+	executeFn   func(ctx context.Context, problem types.Problem) error
+	metadata    types.RecoveryMetadata
+	gracePeriod *types.GracePeriodConfig
 }
 
 func (m *mockRecoveryAction) Execute(ctx context.Context, problem types.Problem) error {
 	if m.executeFn != nil {
 		return m.executeFn(ctx, problem)
 	}
-	m.executed = true
+	m.executed.Store(true)
 	return m.executeErr
 }
 
@@ -689,8 +692,8 @@ func TestProcessShardProblems_DependencyEnforcement(t *testing.T) {
 
 	t.Run("skips replica recovery when primary is dead", func(t *testing.T) {
 		// Reset execution flags
-		primaryRecovery.executed = false
-		replicaRecovery.executed = false
+		primaryRecovery.executed.Store(false)
+		replicaRecovery.executed.Store(false)
 
 		// Setup test analyzers
 		analysis.SetTestAnalyzers([]analysis.Analyzer{
@@ -754,7 +757,7 @@ func TestProcessShardProblems_DependencyEnforcement(t *testing.T) {
 		engine.processShardProblems(t.Context(), shardKey, problems)
 
 		// ASSERTION: Replica recovery should be SKIPPED due to dependency check
-		assert.False(t, replicaRecovery.executed,
+		assert.False(t, replicaRecovery.executed.Load(),
 			"replica recovery requiring healthy primary should be skipped when primary is dead")
 
 		// Primary recovery should have been attempted (though it will fail validation
@@ -764,7 +767,7 @@ func TestProcessShardProblems_DependencyEnforcement(t *testing.T) {
 
 	t.Run("allows replica recovery when primary is healthy", func(t *testing.T) {
 		// Reset execution flags
-		replicaRecovery.executed = false
+		replicaRecovery.executed.Store(false)
 
 		// Setup test analyzers (only replica analyzer this time)
 		analysis.SetTestAnalyzers([]analysis.Analyzer{
@@ -829,7 +832,7 @@ func TestProcessShardProblems_DependencyEnforcement(t *testing.T) {
 		// ASSERTION: Replica recovery should be executed (NOT skipped)
 		// It will still fail validation since the mock analyzer won't re-detect it,
 		// but the key is it wasn't skipped by the dependency check
-		assert.True(t, replicaRecovery.executed,
+		assert.True(t, replicaRecovery.executed.Load(),
 			"replica recovery should be executed when primary is healthy")
 	})
 }
@@ -936,7 +939,7 @@ func TestRecoveryLoop_ValidationPreventsStaleRecovery(t *testing.T) {
 	engine.attemptRecovery(t.Context(), problems[0])
 
 	// ASSERTION: Recovery should NOT be executed because validation failed
-	assert.False(t, replicaRecovery.executed,
+	assert.False(t, replicaRecovery.executed.Load(),
 		"recovery should be skipped when problem no longer exists after validation")
 }
 
@@ -1113,7 +1116,7 @@ func TestRecoveryLoop_PostRecoveryRefresh(t *testing.T) {
 	engine.attemptRecovery(t.Context(), problems[0])
 
 	// ASSERTION: Recovery should be executed
-	assert.True(t, primaryRecovery.executed, "recovery should be executed")
+	assert.True(t, primaryRecovery.executed.Load(), "recovery should be executed")
 
 	// Poolers push their own updated state via ManagerHealthStream after a role
 	// change, so there is no need to force-poll them post-recovery.
@@ -1279,7 +1282,7 @@ func TestRecoveryLoop_FullCycle(t *testing.T) {
 	engine.performRecoveryCycle(t.Context())
 
 	// ASSERTION: Both recovery actions should be executed (no shard-wide problems)
-	assert.True(t, replica1Recovery.executed || replica2Recovery.executed,
+	assert.True(t, replica1Recovery.executed.Load() || replica2Recovery.executed.Load(),
 		"at least one replica recovery should be executed in full cycle")
 }
 
@@ -1740,12 +1743,12 @@ func TestRecoveryLoop_GracePeriodIntegration(t *testing.T) {
 
 	// Problem detected, grace period starts
 	engine.performRecoveryCycle(t.Context())
-	require.False(t, mockAction.executed, "action should not execute immediately - grace period active")
+	require.False(t, mockAction.executed.Load(), "action should not execute immediately - grace period active")
 
 	// Wait for grace period to expire and action to execute
 	require.Eventually(t, func() bool {
 		engine.performRecoveryCycle(t.Context())
-		return mockAction.executed
+		return mockAction.executed.Load()
 	}, 500*time.Millisecond, 10*time.Millisecond, "action should execute after grace period expires")
 }
 

--- a/go/services/multipooler/internal/manager/consensus/manager.go
+++ b/go/services/multipooler/internal/manager/consensus/manager.go
@@ -29,6 +29,7 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
 	"github.com/multigres/multigres/go/tools/pgutil"
+	"github.com/multigres/multigres/go/tools/retry"
 )
 
 // Broadcaster pushes an immediate health snapshot to subscribers. It is
@@ -128,6 +129,13 @@ type ConsensusManager struct {
 	// connecting. Atomic; production writes happen on action-lock paths, and the
 	// lock-free health-status reader loads it.
 	suspectedDivergence atomic.Bool
+
+	// rewindBackoff and rewindReadyAt rate-limit the monitor-driven divergence
+	// rewinds (RecordRewindAttempt/RewindBackoffElapsed) so a node that keeps
+	// failing to come up as a standby doesn't thrash disruptive restarts.
+	// rewindBackoff is lazily created. Guarded by mu.
+	rewindBackoff *retry.ExponentialBackoff
+	rewindReadyAt time.Time
 }
 
 // Deps are the lower-level dependencies a production ConsensusManager builds its
@@ -514,6 +522,70 @@ func (cm *ConsensusManager) SetSuspectedDivergence(ctx context.Context, suspecte
 		return false, err
 	}
 	return cm.suspectedDivergence.Swap(suspected) != suspected, nil
+}
+
+// rewindBackoffMin/Max bound the exponential backoff between monitor-driven
+// divergence rewinds.
+const (
+	rewindBackoffMin = 5 * time.Second
+	rewindBackoffMax = 5 * time.Minute
+)
+
+// RewindTarget returns the recorded leader (host, port) to rewind toward when a
+// diverged standby cannot come up, with ok=false when no leader is known, the
+// recorded leader is ourselves (nothing to diverge from), or the recorded rule
+// is revoked by our term revocation.
+func (cm *ConsensusManager) RewindTarget() (host string, port int32, ok bool) {
+	rp := cm.GetReplicationPrimary()
+	target := rp.GetPrimary()
+	if target == nil || target.GetHost() == "" || target.GetPostgresPort() == 0 {
+		return "", 0, false
+	}
+	leader := consensus.PossiblyUndecidedRule(rp.GetPosition()).GetLeaderId()
+	if leader == nil {
+		return "", 0, false
+	}
+	if cm.id != nil && leader.GetCell() == cm.id.GetCell() && leader.GetName() == cm.id.GetName() {
+		return "", 0, false
+	}
+	if consensus.IsRuleRevoked(rp.GetPosition(), cm.promises.GetInconsistentRevocation()) {
+		return "", 0, false
+	}
+	return target.GetHost(), target.GetPostgresPort(), true
+}
+
+// RewindBackoffElapsed reports whether enough time has passed since the last
+// divergence-rewind attempt to try another (true when none has been recorded).
+func (cm *ConsensusManager) RewindBackoffElapsed() bool {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	return cm.rewindReadyAt.IsZero() || !time.Now().Before(cm.rewindReadyAt)
+}
+
+// RecordRewindAttempt stamps the next time a divergence rewind may be attempted,
+// advancing the exponential backoff.
+func (cm *ConsensusManager) RecordRewindAttempt() {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	if cm.rewindBackoff == nil {
+		cm.rewindBackoff = retry.NewExponentialBackoff(rewindBackoffMin, rewindBackoffMax)
+	}
+	// Floor the delay at the minimum: the backoff uses full jitter, which can
+	// return a near-zero delay, but a rewind is a heavy stop+rewind+restart that
+	// needs a guaranteed gap between attempts. Exponential growth still applies
+	// above the floor.
+	delay := max(cm.rewindBackoff.NextDelay(), rewindBackoffMin)
+	cm.rewindReadyAt = time.Now().Add(delay)
+}
+
+// ResetRewindBackoff clears the backoff after a rewind succeeds.
+func (cm *ConsensusManager) ResetRewindBackoff() {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	if cm.rewindBackoff != nil {
+		cm.rewindBackoff.Reset()
+	}
+	cm.rewindReadyAt = time.Time{}
 }
 
 // IsPotentialCohortMember reports whether selfID is named in the cohort of

--- a/go/services/multipooler/internal/manager/consensus/rewind_test.go
+++ b/go/services/multipooler/internal/manager/consensus/rewind_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consensus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus/consensustest"
+)
+
+func rewindTestSelfID() *clustermetadatapb.ID {
+	return &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "self"}
+}
+
+// recordedPrimaryWithLeader builds a ReplicationPrimary naming leader with the
+// given contact address, as RecordTermPrimary would store it.
+func recordedPrimaryWithLeader(leader *clustermetadatapb.ID, addr *clustermetadatapb.PoolerAddress) *clustermetadatapb.ReplicationPrimary {
+	return &clustermetadatapb.ReplicationPrimary{
+		Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
+			RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
+			LeaderId:   leader,
+		}},
+		Primary: addr,
+	}
+}
+
+func TestConsensusManager_RewindTarget(t *testing.T) {
+	self := rewindTestSelfID()
+	other := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "other"}
+
+	tests := []struct {
+		name       string
+		record     *clustermetadatapb.ReplicationPrimary // nil = nothing recorded
+		revocation *clustermetadatapb.TermRevocation     // nil = no revocation seeded
+		wantOK     bool
+		wantHost   string
+		wantPort   int32
+	}{
+		{
+			name:     "different_leader_is_target",
+			record:   recordedPrimaryWithLeader(other, primaryAt("other", "other-host", 5432)),
+			wantOK:   true,
+			wantHost: "other-host",
+			wantPort: 5432,
+		},
+		{
+			// The recorded leader is us: nothing to diverge from.
+			name:   "leader_is_self_no_target",
+			record: recordedPrimaryWithLeader(self, primaryAt("self", "self-host", 5432)),
+			wantOK: false,
+		},
+		{
+			name:   "no_recorded_primary_no_target",
+			record: nil,
+			wantOK: false,
+		},
+		{
+			// A recorded primary whose rule names no leader is not actionable.
+			name:   "no_leader_in_rule_no_target",
+			record: recordedPrimaryWithLeader(nil, primaryAt("other", "other-host", 5432)),
+			wantOK: false,
+		},
+		{
+			// A recorded leader with no usable contact address is not actionable.
+			name: "no_address_no_target",
+			record: &clustermetadatapb.ReplicationPrimary{
+				Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
+					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
+					LeaderId:   other,
+				}},
+			},
+			wantOK: false,
+		},
+		{
+			// The recorded rule (term 5) is revoked by our term revocation, so we
+			// must not rewind toward it — we promised to abandon that leader.
+			name:   "revoked_rule_no_target",
+			record: recordedPrimaryWithLeader(other, primaryAt("other", "other-host", 5432)),
+			revocation: &clustermetadatapb.TermRevocation{
+				RevokedBelowTerm: 6,
+				OutgoingRule:     &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
+			},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.revocation != nil {
+				consensustest.SeedTerm(t, dir, tt.revocation)
+			}
+			promises := NewConsensusPromises(dir, self)
+			_, err := promises.Load()
+			require.NoError(t, err)
+			cm := NewManagerForTesting(t, self, promises, nil, nil)
+			if tt.record != nil {
+				require.NoError(t, cm.RecordTermPrimary(actionLockCtx(t), tt.record))
+			}
+			host, port, ok := cm.RewindTarget()
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantHost, host)
+			assert.Equal(t, tt.wantPort, port)
+		})
+	}
+}
+
+func TestConsensusManager_RewindBackoff(t *testing.T) {
+	cm := NewManagerForTesting(t, rewindTestSelfID(), nil, nil, nil)
+
+	// Fresh: no attempt recorded yet, so the backoff has elapsed and a rewind may
+	// be attempted immediately.
+	assert.True(t, cm.RewindBackoffElapsed(), "fresh manager should report backoff elapsed")
+
+	// After recording an attempt, the next-attempt window is pushed into the
+	// future (floored at the minimum), so the backoff has not elapsed.
+	cm.RecordRewindAttempt()
+	assert.False(t, cm.RewindBackoffElapsed(), "backoff should not have elapsed right after an attempt")
+
+	// A second attempt keeps it pending (exponential growth above the floor).
+	cm.RecordRewindAttempt()
+	assert.False(t, cm.RewindBackoffElapsed(), "backoff should still be pending after a second attempt")
+
+	// Reset (after a successful rewind) clears the window.
+	cm.ResetRewindBackoff()
+	assert.True(t, cm.RewindBackoffElapsed(), "reset should make the backoff elapsed again")
+}

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -589,10 +589,10 @@ func (pm *MultipoolerManager) ShutdownForTest(ctx context.Context) {
 	pm.closeLocked(lockCtx, "shutdown")
 }
 
-// closeLocked performs the actual close operation.
-// Returns true if the manager was open and is now closed, false if it was already closed.
-// Caller should NOT hold pm.mu - this function acquires it.
-// Always cancels the context - Open() will create a fresh one if reopened.
+// closeLocked performs the actual close operation. Returns true if the manager
+// was open and is now closed, false if it was already closed. Caller should NOT
+// hold pm.mu - this function acquires it. Always cancels the context - Open() will
+// create a fresh one if reopened.
 //
 // closeLocked does NOT stop the postgres monitor: Pause keeps it running (the
 // action lock neuters it for the maintenance window), and a terminal teardown

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -996,6 +996,19 @@ func (pm *MultipoolerManager) startPostgres(ctx context.Context) error {
 	// suspectedDivergence: the next standby transition routes through pg_rewind
 	// before trusting this node's WAL. If we are (or no one is) the leader, the
 	// local WAL is authoritative and there is nothing to diverge from.
+	//
+	// TODO: this signal is lost when the start itself FATALs (e.g. a wrong-timeline
+	// minRecoveryPoint from a premature rewind). pgctld computes CrashRecoveryRan
+	// from pg_controldata *before* the start, but a failed Start returns (nil, err)
+	// over gRPC, so resp is nil and this block never runs — a fresh crash into
+	// genuine divergence (flag not already set from a prior demote/rewind) can
+	// FATAL-loop without ever being marked. Fix by making Start's outcome a
+	// response field rather than an error: add a `started bool` to StartResponse
+	// and return (resp{started:false, crash_recovery_ran:true, ...}, nil) when the
+	// postmaster fails to come up, reserving gRPC errors for exceptional failures.
+	// Then this block can mark divergence even on a failed start. Callers that
+	// currently treat err==nil as "started" (rpc_first_backup, provisioner/local)
+	// must switch to checking `started`.
 	if resp.GetCrashRecoveryRan() {
 		leader := commonconsensus.PossiblyUndecidedRule(pm.consensusMgr.GetReplicationPrimary().GetPosition()).GetLeaderId()
 		differentLeaderKnown := leader != nil && pm.serviceID != nil &&

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -169,13 +169,14 @@ const (
 	// and broadcast so a diverged follower's recovery (orch's gated pg_rewind) can
 	// proceed. Purely a state-publication step — no postgres mutation.
 	remedialActionMarkRewindReady
-	// remedialActionRewindToLeader means postgres cannot come up as a healthy
-	// standby and we suspect our WAL diverged from a different known leader (e.g. an
-	// early pg_rewind stamped minRecoveryPoint onto the wrong timeline, so postgres
-	// FATALs on startup). A plain start just loops on the FATAL; instead re-run the
-	// rewind against the recorded leader (restartAsStandbyLocked crash-recovers and
-	// rewinds before bringing postgres back as a standby). Rate-limited with
-	// exponential backoff so we don't thrash disruptive restarts.
+	// remedialActionRewindToLeader means postgres is up as a standby but we suspect
+	// its WAL diverged from the recorded leader, and that leader is now rewind-ready
+	// (has checkpointed onto its current timeline). Rewind against it before it can
+	// safely follow: restartAsStandbyLocked reads the recruit-position floor from
+	// the live database, stops postgres, runs pg_rewind, and restarts as a standby.
+	// Only fires while postgres is up (so the floor is readable) — a down node is
+	// brought up "held" first (see startPostgres). Rate-limited with exponential
+	// backoff so we don't thrash disruptive restarts.
 	remedialActionRewindToLeader
 
 	// remedialActionDisableRestoreCommand means restore_command is currently
@@ -553,7 +554,20 @@ func (pm *MultipoolerManager) determineReplicationSettingsAction(ctx context.Con
 	// ReplicationPrimary when it has drifted from what we've been told via
 	// SetPrimary/Promote.
 	if !state.pgMode.OutOfRecovery() {
-		if pm.primaryConnInfoDiffersFromRecorded(ctx) {
+		// A standby that suspects its WAL diverged must be rewound against the
+		// recorded leader before it can safely follow it. Now that postgres is up,
+		// its position is readable, so once the leader is rewind-ready we rewind
+		// (restartAsStandbyLocked). Until then we stay "held": skip
+		// fix-primary-conninfo so we don't re-point at and stream from a leader we
+		// haven't rewound to (startPostgres cleared primary_conninfo bringing us up).
+		if pm.shouldRewindForDivergence() {
+			return remedialActionRewindToLeader
+		}
+		// When divergence is suspected we're "held": startPostgres cleared
+		// primary_conninfo, so don't re-point at a leader we haven't rewound to.
+		// Fall through to the restore_command backstop below (a held node must not
+		// archive-replay either). Otherwise reconcile primary_conninfo drift.
+		if !pm.consensusMgr.SuspectedDivergence() && pm.primaryConnInfoDiffersFromRecorded(ctx) {
 			return remedialActionFixPrimaryConnInfo
 		}
 		// TODO: self-rewind detection. A replica may need pg_rewind even
@@ -642,16 +656,24 @@ func (pm *MultipoolerManager) determineRemedialAction(ctx context.Context, curre
 	return pm.determinePostgresNotRunningAction(currentState)
 }
 
-// shouldRewindForDivergence reports whether a not-running postgres should be
-// rewound to the recorded leader rather than plainly restarted: we suspect our WAL
-// diverged (suspectedDivergence), a different leader is known to rewind toward, and
-// the backoff between attempts has elapsed. The divergence/rewind bookkeeping all
-// lives on the ConsensusManager.
+// shouldRewindForDivergence reports whether an up standby should now be rewound
+// to the recorded leader: we suspect our WAL diverged (suspectedDivergence), a
+// different, non-revoked leader is known to rewind toward, that leader is
+// rewind-ready (it has checkpointed onto its current timeline — rewinding against
+// a not-yet-checkpointed leader would stamp minRecoveryPoint onto the wrong
+// timeline), and the backoff between attempts has elapsed. Only consulted while
+// postgres is up: the rewind (restartAsStandbyLocked) reads the recruit-position
+// floor from the live database first, so a down node is brought up "held" instead
+// (see determinePostgresNotRunningAction / startPostgres). The divergence/rewind
+// bookkeeping all lives on the ConsensusManager.
 func (pm *MultipoolerManager) shouldRewindForDivergence() bool {
 	if !pm.consensusMgr.SuspectedDivergence() {
 		return false
 	}
 	if _, _, ok := pm.consensusMgr.RewindTarget(); !ok {
+		return false
+	}
+	if !pm.consensusMgr.GetReplicationPrimary().GetRewindReady() {
 		return false
 	}
 	return pm.consensusMgr.RewindBackoffElapsed()
@@ -682,17 +704,8 @@ func (pm *MultipoolerManager) determinePostgresNotRunningAction(state postgresSt
 	if state.bootstrapSentinelPresent {
 		return remedialActionCreateFirstBackup
 	}
-	// Postgres not running: Try to start or restore
+	// Postgres not running: start it (or restore/bootstrap below).
 	if state.dirInitialized {
-		// If we suspect our WAL diverged from a different known leader, a plain
-		// start just FATAL-loops — an early pg_rewind can stamp minRecoveryPoint
-		// onto the wrong timeline, so postgres can't come up as a standby until it
-		// is rewound again (crash recovery alone leaves it on its old timeline).
-		// Re-run the rewind against the recorded leader instead, rate-limited by
-		// exponential backoff so we don't thrash disruptive restarts.
-		if pm.shouldRewindForDivergence() {
-			return remedialActionRewindToLeader
-		}
 		return remedialActionStartPostgres
 	}
 	if state.backupsAvailable {
@@ -835,7 +848,7 @@ func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action rem
 		if err := pm.actionLock.SetAction(ctx, multipoolermanagerdatapb.PostgresAction_POSTGRES_ACTION_STARTING); err != nil {
 			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to set action", "error", err)
 		}
-		pm.logger.InfoContext(ctx, "MonitorPostgres: postgres can't start as a standby and divergence is suspected; rewinding to recorded leader",
+		pm.logger.InfoContext(ctx, "MonitorPostgres: standby diverged and leader is rewind-ready; rewinding to recorded leader",
 			"target_host", host, "target_port", port)
 		if _, err := pm.restartAsStandbyLocked(ctx, host, port); err != nil {
 			pm.logger.ErrorContext(ctx, "MonitorPostgres: rewind to leader failed, will retry with backoff", "error", err)
@@ -956,9 +969,22 @@ func (pm *MultipoolerManager) startPostgres(ctx context.Context) error {
 		return errors.New("pgctld client not available")
 	}
 
+	// If we already suspect divergence, bring postgres up "held": clear
+	// primary_conninfo first so the node does not stream from a leader it hasn't
+	// been rewound to. Postgres is down, so this edits postgresql.auto.conf
+	// directly rather than via ALTER SYSTEM. Best-effort — a failure here must not
+	// block the start; the rewind (restartAsStandbyLocked, once the leader is
+	// rewind-ready) re-establishes primary_conninfo afterwards.
+	if pm.consensusMgr != nil && pm.consensusMgr.SuspectedDivergence() {
+		if err := pm.dropAutoConfSettings(ctx, "primary_conninfo"); err != nil {
+			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to clear primary_conninfo before held start", "error", err)
+		}
+	}
+
 	// Allow crash recovery: a standby that was not cleanly shut down can't be
-	// started normally (a standby.signal blocks the postmaster from recovering
-	// it), so pgctld forces single-user crash recovery first when needed.
+	// started as a standby (postgres --single, which pgctld uses to crash-recover,
+	// refuses to run with a standby.signal present), so pgctld forces single-user
+	// crash recovery first when needed.
 	resp, err := pm.pgctldClient.Start(ctx, &pgctldpb.StartRequest{AllowCrashRecovery: true})
 	if err != nil {
 		return fmt.Errorf("MonitorPostgres: failed to start PostgreSQL: %w", err)
@@ -984,6 +1010,15 @@ func (pm *MultipoolerManager) startPostgres(ctx context.Context) error {
 	}
 
 	pm.logger.InfoContext(ctx, "MonitorPostgres: PostgreSQL started successfully")
+
+	// TODO: eager rewind heuristic. When this was a held start (divergence
+	// suspected) and the recorded leader is already rewind-ready, we could rewind
+	// immediately here — shouldRewindForDivergence() — instead of waiting for the
+	// next monitor tick to pick it up via determineReplicationSettingsAction. The
+	// node is up now, so its position is readable and the recruit-position floor
+	// works. Deferred: it only saves one monitor interval, and doing it here would
+	// duplicate the rewind gate and couple start with the stop→rewind→restart path;
+	// add it only if the tick latency proves too slow in practice.
 
 	// Reopen connections after postgres restart to replace stale socket FDs.
 	// Only when connection pool is initialized (the manager may not have

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -975,7 +975,7 @@ func (pm *MultipoolerManager) startPostgres(ctx context.Context) error {
 	// directly rather than via ALTER SYSTEM. Best-effort — a failure here must not
 	// block the start; the rewind (restartAsStandbyLocked, once the leader is
 	// rewind-ready) re-establishes primary_conninfo afterwards.
-	if pm.consensusMgr != nil && pm.consensusMgr.SuspectedDivergence() {
+	if pm.consensusMgr.SuspectedDivergence() {
 		if err := pm.dropAutoConfSettings(ctx, "primary_conninfo"); err != nil {
 			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to clear primary_conninfo before held start", "error", err)
 		}

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -169,6 +169,15 @@ const (
 	// and broadcast so a diverged follower's recovery (orch's gated pg_rewind) can
 	// proceed. Purely a state-publication step — no postgres mutation.
 	remedialActionMarkRewindReady
+	// remedialActionRewindToLeader means postgres cannot come up as a healthy
+	// standby and we suspect our WAL diverged from a different known leader (e.g. an
+	// early pg_rewind stamped minRecoveryPoint onto the wrong timeline, so postgres
+	// FATALs on startup). A plain start just loops on the FATAL; instead re-run the
+	// rewind against the recorded leader (restartAsStandbyLocked crash-recovers and
+	// rewinds before bringing postgres back as a standby). Rate-limited with
+	// exponential backoff so we don't thrash disruptive restarts.
+	remedialActionRewindToLeader
+
 	// remedialActionDisableRestoreCommand means restore_command is currently
 	// set on a standby that must not be relying on the archive: either it is
 	// a cohort member (only ever trusted to advance via streaming — see
@@ -226,6 +235,15 @@ func (pm *MultipoolerManager) monitorPostgresIteration(ctx context.Context) (pos
 		// No action needed - just log status
 		if currentState.postgresRunning {
 			pm.setMonitorReason(ctx, reasonPostgresRunning, "MonitorPostgres: PostgreSQL is running")
+			// Postgres is up and healthy with no rewind pending: any prior
+			// divergence incident is over (recovered here or via SetPrimary/orch),
+			// so clear the rewind backoff. This keeps the backoff incident-scoped —
+			// a future, unrelated divergence starts fresh instead of inheriting a
+			// stale (long) window. Gated on suspectedDivergence so a still-pending
+			// rewind keeps its backoff.
+			if !pm.consensusMgr.SuspectedDivergence() {
+				pm.consensusMgr.ResetRewindBackoff()
+			}
 		}
 		return currentState, nil
 	}
@@ -619,8 +637,24 @@ func (pm *MultipoolerManager) determineRemedialAction(ctx context.Context, curre
 		return remedialActionNone
 	}
 
-	// Postgres is not running: start it, restore from backup, or bootstrap.
-	return determinePostgresNotRunningAction(currentState)
+	// Postgres is not running: start it, rewind-then-start (on suspected
+	// divergence), restore from backup, or bootstrap.
+	return pm.determinePostgresNotRunningAction(currentState)
+}
+
+// shouldRewindForDivergence reports whether a not-running postgres should be
+// rewound to the recorded leader rather than plainly restarted: we suspect our WAL
+// diverged (suspectedDivergence), a different leader is known to rewind toward, and
+// the backoff between attempts has elapsed. The divergence/rewind bookkeeping all
+// lives on the ConsensusManager.
+func (pm *MultipoolerManager) shouldRewindForDivergence() bool {
+	if !pm.consensusMgr.SuspectedDivergence() {
+		return false
+	}
+	if _, _, ok := pm.consensusMgr.RewindTarget(); !ok {
+		return false
+	}
+	return pm.consensusMgr.RewindBackoffElapsed()
 }
 
 // shouldMarkRewindReady reports whether this pooler should advertise rewind
@@ -641,7 +675,7 @@ func (pm *MultipoolerManager) shouldMarkRewindReady(state postgresState, role co
 
 // determinePostgresNotRunningAction decides how to bring postgres up when it is
 // not running.
-func determinePostgresNotRunningAction(state postgresState) remedialAction {
+func (pm *MultipoolerManager) determinePostgresNotRunningAction(state postgresState) remedialAction {
 	// A sentinel from a prior first-backup attempt means bootstrap crashed
 	// mid-flight. Any on-disk pg_data is stale — force the create-first-backup
 	// path so createFirstBackupAndInitializeLocked can clean up and retry.
@@ -650,6 +684,15 @@ func determinePostgresNotRunningAction(state postgresState) remedialAction {
 	}
 	// Postgres not running: Try to start or restore
 	if state.dirInitialized {
+		// If we suspect our WAL diverged from a different known leader, a plain
+		// start just FATAL-loops — an early pg_rewind can stamp minRecoveryPoint
+		// onto the wrong timeline, so postgres can't come up as a standby until it
+		// is rewound again (crash recovery alone leaves it on its old timeline).
+		// Re-run the rewind against the recorded leader instead, rate-limited by
+		// exponential backoff so we don't thrash disruptive restarts.
+		if pm.shouldRewindForDivergence() {
+			return remedialActionRewindToLeader
+		}
 		return remedialActionStartPostgres
 	}
 	if state.backupsAvailable {
@@ -775,6 +818,34 @@ func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action rem
 			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to start PostgreSQL, will retry", "error", err)
 		}
 
+	case remedialActionRewindToLeader:
+		// Honor the in-memory flag set by tests and demos to suppress auto-restart.
+		if pm.postgresRestartsDisabled.Load() {
+			pm.logger.InfoContext(ctx, "MonitorPostgres: skipping rewind, postgres restarts disabled")
+			return
+		}
+		host, port, ok := pm.consensusMgr.RewindTarget()
+		if !ok {
+			return
+		}
+		// Stamp the backoff before attempting, so a failed rewind is rate-limited
+		// regardless of how it fails.
+		pm.consensusMgr.RecordRewindAttempt()
+		pm.setMonitorReason(ctx, reasonStartingPostgres, "MonitorPostgres: suspected divergence; rewinding to leader before restart")
+		if err := pm.actionLock.SetAction(ctx, multipoolermanagerdatapb.PostgresAction_POSTGRES_ACTION_STARTING); err != nil {
+			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to set action", "error", err)
+		}
+		pm.logger.InfoContext(ctx, "MonitorPostgres: postgres can't start as a standby and divergence is suspected; rewinding to recorded leader",
+			"target_host", host, "target_port", port)
+		if _, err := pm.restartAsStandbyLocked(ctx, host, port); err != nil {
+			pm.logger.ErrorContext(ctx, "MonitorPostgres: rewind to leader failed, will retry with backoff", "error", err)
+			return
+		}
+		// Success: postgres is back as a standby (suspectedDivergence cleared in
+		// restartAsStandbyLocked). The backoff is cleared on the next healthy
+		// monitor tick (postgres running, no rewind pending), so it doesn't linger
+		// into a future, unrelated incident.
+
 	case remedialActionRestoreFromBackup:
 		pm.setMonitorReason(ctx, reasonRestoringFromBackup, "MonitorPostgres: directory not initialized but backups available, restoring from backup")
 		if err := pm.actionLock.SetAction(ctx, multipoolermanagerdatapb.PostgresAction_POSTGRES_ACTION_RESTORING_FROM_BACKUP); err != nil {
@@ -885,9 +956,31 @@ func (pm *MultipoolerManager) startPostgres(ctx context.Context) error {
 		return errors.New("pgctld client not available")
 	}
 
-	_, err := pm.pgctldClient.Start(ctx, &pgctldpb.StartRequest{})
+	// Allow crash recovery: a standby that was not cleanly shut down can't be
+	// started normally (a standby.signal blocks the postmaster from recovering
+	// it), so pgctld forces single-user crash recovery first when needed.
+	resp, err := pm.pgctldClient.Start(ctx, &pgctldpb.StartRequest{AllowCrashRecovery: true})
 	if err != nil {
 		return fmt.Errorf("MonitorPostgres: failed to start PostgreSQL: %w", err)
+	}
+
+	// If pgctld had to force crash recovery, this standby was not cleanly shut
+	// down. When a *different* node is the known consensus leader, the recovered
+	// local WAL may have diverged from the leader's timeline, so mark
+	// suspectedDivergence: the next standby transition routes through pg_rewind
+	// before trusting this node's WAL. If we are (or no one is) the leader, the
+	// local WAL is authoritative and there is nothing to diverge from.
+	if resp.GetCrashRecoveryRan() {
+		leader := commonconsensus.PossiblyUndecidedRule(pm.consensusMgr.GetReplicationPrimary().GetPosition()).GetLeaderId()
+		differentLeaderKnown := leader != nil && pm.serviceID != nil &&
+			(leader.GetCell() != pm.serviceID.GetCell() || leader.GetName() != pm.serviceID.GetName())
+		if differentLeaderKnown {
+			pm.logger.InfoContext(ctx, "MonitorPostgres: crash recovery ran with a different known leader; marking suspected divergence",
+				"leader", leader.GetName())
+			if _, err := pm.consensusMgr.SetSuspectedDivergence(ctx, true); err != nil {
+				pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to mark suspected divergence after crash recovery", "error", err)
+			}
+		}
 	}
 
 	pm.logger.InfoContext(ctx, "MonitorPostgres: PostgreSQL started successfully")

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -929,11 +929,8 @@ func TestTakeRemedialAction_StartPostgres(t *testing.T) {
 
 	mockPgctld := &mockPgctldClient{}
 
-	pm := &MultipoolerManager{
-		pgctldClient: mockPgctld,
-		logger:       slog.Default(),
-		actionLock:   actionlock.NewActionLock(),
-	}
+	pm := newTestManager(t)
+	pm.pgctldClient = mockPgctld
 
 	// Acquire lock before calling takeRemedialAction
 	lockCtx, err := pm.actionLock.Acquire(ctx, "test")
@@ -954,11 +951,8 @@ func TestTakeRemedialAction_StartPostgresFails(t *testing.T) {
 		startError: assert.AnError,
 	}
 
-	pm := &MultipoolerManager{
-		pgctldClient: mockPgctld,
-		logger:       slog.Default(),
-		actionLock:   actionlock.NewActionLock(),
-	}
+	pm := newTestManager(t)
+	pm.pgctldClient = mockPgctld
 	pm.pgMonitorLastLoggedReason = "starting_postgres"
 
 	// Acquire lock before calling takeRemedialAction
@@ -998,15 +992,9 @@ func TestTakeRemedialAction_LogDeduplication(t *testing.T) {
 
 	mockPgctld := &mockPgctldClient{}
 
-	pm := &MultipoolerManager{
-		logger:       slog.Default(),
-		actionLock:   actionlock.NewActionLock(),
-		pgctldClient: mockPgctld,
-		record: newRecordFromProto(&clustermetadatapb.Multipooler{
-			Type: clustermetadatapb.PoolerType_REPLICA,
-		}),
-	}
-
+	// newTestManager defaults to a REPLICA record, which is what this test needs.
+	pm := newTestManager(t)
+	pm.pgctldClient = mockPgctld
 	pm.pgMonitorLastLoggedReason = "starting_postgres"
 
 	// Acquire lock before calling takeRemedialAction
@@ -1384,10 +1372,8 @@ func TestStartPostgres_Success(t *testing.T) {
 
 	mockPgctld := &mockPgctldClient{}
 
-	pm := &MultipoolerManager{
-		pgctldClient: mockPgctld,
-		logger:       slog.Default(),
-	}
+	pm := newTestManager(t)
+	pm.pgctldClient = mockPgctld
 
 	err := pm.startPostgres(ctx)
 
@@ -1416,10 +1402,8 @@ func TestStartPostgres_StartFails(t *testing.T) {
 		startError: assert.AnError,
 	}
 
-	pm := &MultipoolerManager{
-		pgctldClient: mockPgctld,
-		logger:       slog.Default(),
-	}
+	pm := newTestManager(t)
+	pm.pgctldClient = mockPgctld
 
 	err := pm.startPostgres(ctx)
 

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -627,24 +627,49 @@ func TestDetermineRemedialAction_StalePrimaryDemote(t *testing.T) {
 	}
 }
 
-// TestDetermineRemedialAction_RewindToLeaderOnDivergence verifies that a
-// not-running postgres is routed to remedialActionRewindToLeader (rather than a
-// plain start) only when divergence is suspected, a *different* leader is known to
-// rewind toward, and the backoff between attempts has elapsed. Otherwise it falls
-// back to a plain start.
-func TestDetermineRemedialAction_RewindToLeaderOnDivergence(t *testing.T) {
+// TestDeterminePostgresNotRunningAction_DivergedStartsHeld verifies recover-and-
+// hold: a down, diverged standby is brought up with a plain start
+// (remedialActionStartPostgres — startPostgres clears primary_conninfo when
+// divergence is suspected), never a rewind. Rewinding needs the live database (to
+// read the recruit-position floor), which a down node can't serve; the rewind
+// waits until postgres is up (see TestShouldRewindForDivergence).
+func TestDeterminePostgresNotRunningAction_DivergedStartsHeld(t *testing.T) {
+	selfID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "test-cell", Name: "self"}
+	otherID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "test-cell", Name: "other"}
+	otherAddr := &clustermetadatapb.PoolerAddress{Id: otherID, Host: "other-host", PostgresPort: 5432}
+	notRunning := postgresState{pgctldAvailable: true, dirInitialized: true, postgresRunning: false}
+
+	// Fully diverged, with a different, rewind-ready leader known — the strongest
+	// case for a rewind. A down node must still just start.
+	pm := newTestManager(t, withServiceID(selfID), withReplicationPrimary(&clustermetadatapb.ReplicationPrimary{
+		Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
+			RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
+			LeaderId:   otherID,
+		}},
+		Primary:     otherAddr,
+		RewindReady: true,
+	}))
+	lockCtx, err := pm.actionLock.Acquire(t.Context(), "test-seed")
+	require.NoError(t, err)
+	_, err = pm.consensusMgr.SetSuspectedDivergence(lockCtx, true)
+	require.NoError(t, err)
+	pm.actionLock.Release(lockCtx)
+
+	require.Equal(t, remedialActionStartPostgres, pm.determineRemedialAction(t.Context(), notRunning))
+}
+
+// TestShouldRewindForDivergence verifies the up-path rewind gate: suspected
+// divergence, a different non-revoked leader known to rewind toward, that leader
+// rewind-ready, and the backoff elapsed. Any missing condition holds instead.
+func TestShouldRewindForDivergence(t *testing.T) {
 	selfID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "test-cell", Name: "self"}
 	otherID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "test-cell", Name: "other"}
 	otherAddr := &clustermetadatapb.PoolerAddress{Id: otherID, Host: "other-host", PostgresPort: 5432}
 	selfAddr := &clustermetadatapb.PoolerAddress{Id: selfID, Host: "self-host", PostgresPort: 5432}
 
-	// Postgres is initialized but not running: the choice is between a plain start
-	// (remedialActionStartPostgres) and a rewind-then-start.
-	notRunning := postgresState{pgctldAvailable: true, dirInitialized: true, postgresRunning: false}
-
 	// recordedPrimary builds the ReplicationPrimary a test seeds via
-	// withReplicationPrimary; nil addr means "no recorded leader".
-	recordedPrimary := func(leader *clustermetadatapb.ID, addr *clustermetadatapb.PoolerAddress) *clustermetadatapb.ReplicationPrimary {
+	// withReplicationPrimary; a nil addr means "no recorded leader".
+	recordedPrimary := func(leader *clustermetadatapb.ID, addr *clustermetadatapb.PoolerAddress, rewindReady bool) *clustermetadatapb.ReplicationPrimary {
 		if addr == nil {
 			return nil
 		}
@@ -653,7 +678,8 @@ func TestDetermineRemedialAction_RewindToLeaderOnDivergence(t *testing.T) {
 				RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
 				LeaderId:   leader,
 			}},
-			Primary: addr,
+			Primary:     addr,
+			RewindReady: rewindReady,
 		}
 	}
 
@@ -662,43 +688,50 @@ func TestDetermineRemedialAction_RewindToLeaderOnDivergence(t *testing.T) {
 		replicationPrimary *clustermetadatapb.ReplicationPrimary
 		suspectDivergence  bool
 		backoffPending     bool // record a rewind attempt first, so the backoff has not elapsed
-		expectedAction     remedialAction
+		want               bool
 	}{
 		{
-			// All conditions met: re-run the rewind against the recorded leader.
-			name:               "divergence_with_different_leader_rewinds",
-			replicationPrimary: recordedPrimary(otherID, otherAddr),
+			// All conditions met: rewind toward the recorded, rewind-ready leader.
+			name:               "all_conditions_met",
+			replicationPrimary: recordedPrimary(otherID, otherAddr, true),
 			suspectDivergence:  true,
-			expectedAction:     remedialActionRewindToLeader,
+			want:               true,
 		},
 		{
-			// No divergence suspected: a plain start is correct.
-			name:               "no_divergence_plain_start",
-			replicationPrimary: recordedPrimary(otherID, otherAddr),
+			// No divergence suspected: nothing to rewind.
+			name:               "not_suspected",
+			replicationPrimary: recordedPrimary(otherID, otherAddr, true),
 			suspectDivergence:  false,
-			expectedAction:     remedialActionStartPostgres,
+			want:               false,
 		},
 		{
-			// The recorded leader is us: nothing to diverge from, so just start.
-			name:               "recorded_leader_is_self_plain_start",
-			replicationPrimary: recordedPrimary(selfID, selfAddr),
+			// Leader has not checkpointed onto its new timeline yet: hold.
+			name:               "leader_not_rewind_ready",
+			replicationPrimary: recordedPrimary(otherID, otherAddr, false),
 			suspectDivergence:  true,
-			expectedAction:     remedialActionStartPostgres,
+			want:               false,
 		},
 		{
-			// No recorded leader to rewind toward: wait and start normally.
-			name:               "no_recorded_leader_plain_start",
-			replicationPrimary: recordedPrimary(otherID, nil),
+			// The recorded leader is us: nothing to diverge from.
+			name:               "recorded_leader_is_self",
+			replicationPrimary: recordedPrimary(selfID, selfAddr, true),
 			suspectDivergence:  true,
-			expectedAction:     remedialActionStartPostgres,
+			want:               false,
 		},
 		{
-			// Backoff has not elapsed: don't thrash; fall back to a plain start.
-			name:               "backoff_not_elapsed_plain_start",
-			replicationPrimary: recordedPrimary(otherID, otherAddr),
+			// No recorded leader to rewind toward: hold.
+			name:               "no_recorded_leader",
+			replicationPrimary: recordedPrimary(otherID, nil, true),
+			suspectDivergence:  true,
+			want:               false,
+		},
+		{
+			// Backoff has not elapsed: don't thrash.
+			name:               "backoff_not_elapsed",
+			replicationPrimary: recordedPrimary(otherID, otherAddr, true),
 			suspectDivergence:  true,
 			backoffPending:     true,
-			expectedAction:     remedialActionStartPostgres,
+			want:               false,
 		},
 	}
 
@@ -709,7 +742,6 @@ func TestDetermineRemedialAction_RewindToLeaderOnDivergence(t *testing.T) {
 				opts = append(opts, withReplicationPrimary(tt.replicationPrimary))
 			}
 			pm := newTestManager(t, opts...)
-
 			if tt.suspectDivergence {
 				lockCtx, err := pm.actionLock.Acquire(t.Context(), "test-seed")
 				require.NoError(t, err)
@@ -721,9 +753,7 @@ func TestDetermineRemedialAction_RewindToLeaderOnDivergence(t *testing.T) {
 				// Record an attempt so the backoff window has not yet elapsed.
 				pm.consensusMgr.RecordRewindAttempt()
 			}
-
-			got := pm.determineRemedialAction(t.Context(), notRunning)
-			require.Equal(t, tt.expectedAction, got)
+			require.Equal(t, tt.want, pm.shouldRewindForDivergence())
 		})
 	}
 }

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -627,6 +627,107 @@ func TestDetermineRemedialAction_StalePrimaryDemote(t *testing.T) {
 	}
 }
 
+// TestDetermineRemedialAction_RewindToLeaderOnDivergence verifies that a
+// not-running postgres is routed to remedialActionRewindToLeader (rather than a
+// plain start) only when divergence is suspected, a *different* leader is known to
+// rewind toward, and the backoff between attempts has elapsed. Otherwise it falls
+// back to a plain start.
+func TestDetermineRemedialAction_RewindToLeaderOnDivergence(t *testing.T) {
+	selfID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "test-cell", Name: "self"}
+	otherID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "test-cell", Name: "other"}
+	otherAddr := &clustermetadatapb.PoolerAddress{Id: otherID, Host: "other-host", PostgresPort: 5432}
+	selfAddr := &clustermetadatapb.PoolerAddress{Id: selfID, Host: "self-host", PostgresPort: 5432}
+
+	// Postgres is initialized but not running: the choice is between a plain start
+	// (remedialActionStartPostgres) and a rewind-then-start.
+	notRunning := postgresState{pgctldAvailable: true, dirInitialized: true, postgresRunning: false}
+
+	// recordedPrimary builds the ReplicationPrimary a test seeds via
+	// withReplicationPrimary; nil addr means "no recorded leader".
+	recordedPrimary := func(leader *clustermetadatapb.ID, addr *clustermetadatapb.PoolerAddress) *clustermetadatapb.ReplicationPrimary {
+		if addr == nil {
+			return nil
+		}
+		return &clustermetadatapb.ReplicationPrimary{
+			Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
+				RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
+				LeaderId:   leader,
+			}},
+			Primary: addr,
+		}
+	}
+
+	tests := []struct {
+		name               string
+		replicationPrimary *clustermetadatapb.ReplicationPrimary
+		suspectDivergence  bool
+		backoffPending     bool // record a rewind attempt first, so the backoff has not elapsed
+		expectedAction     remedialAction
+	}{
+		{
+			// All conditions met: re-run the rewind against the recorded leader.
+			name:               "divergence_with_different_leader_rewinds",
+			replicationPrimary: recordedPrimary(otherID, otherAddr),
+			suspectDivergence:  true,
+			expectedAction:     remedialActionRewindToLeader,
+		},
+		{
+			// No divergence suspected: a plain start is correct.
+			name:               "no_divergence_plain_start",
+			replicationPrimary: recordedPrimary(otherID, otherAddr),
+			suspectDivergence:  false,
+			expectedAction:     remedialActionStartPostgres,
+		},
+		{
+			// The recorded leader is us: nothing to diverge from, so just start.
+			name:               "recorded_leader_is_self_plain_start",
+			replicationPrimary: recordedPrimary(selfID, selfAddr),
+			suspectDivergence:  true,
+			expectedAction:     remedialActionStartPostgres,
+		},
+		{
+			// No recorded leader to rewind toward: wait and start normally.
+			name:               "no_recorded_leader_plain_start",
+			replicationPrimary: recordedPrimary(otherID, nil),
+			suspectDivergence:  true,
+			expectedAction:     remedialActionStartPostgres,
+		},
+		{
+			// Backoff has not elapsed: don't thrash; fall back to a plain start.
+			name:               "backoff_not_elapsed_plain_start",
+			replicationPrimary: recordedPrimary(otherID, otherAddr),
+			suspectDivergence:  true,
+			backoffPending:     true,
+			expectedAction:     remedialActionStartPostgres,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := []testManagerOption{withServiceID(selfID)}
+			if tt.replicationPrimary != nil {
+				opts = append(opts, withReplicationPrimary(tt.replicationPrimary))
+			}
+			pm := newTestManager(t, opts...)
+
+			if tt.suspectDivergence {
+				lockCtx, err := pm.actionLock.Acquire(t.Context(), "test-seed")
+				require.NoError(t, err)
+				_, err = pm.consensusMgr.SetSuspectedDivergence(lockCtx, true)
+				require.NoError(t, err)
+				pm.actionLock.Release(lockCtx)
+			}
+			if tt.backoffPending {
+				// Record an attempt so the backoff window has not yet elapsed.
+				pm.consensusMgr.RecordRewindAttempt()
+			}
+
+			got := pm.determineRemedialAction(t.Context(), notRunning)
+			require.Equal(t, tt.expectedAction, got)
+		})
+	}
+}
+
 // TestStaleStandbyDemoteTarget verifies the gating for monitor-driven
 // self-demotion: a stale primary restarts as a standby only when consensus has
 // genuinely, non-revocably named another leader at a rule that outranks our
@@ -1660,6 +1761,85 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 			got := pm.primaryConnInfoDiffersFromRecorded(t.Context())
 			assert.Equal(t, tt.want, got)
 			assert.NoError(t, mockQueryService.ExpectationsWereMet())
+		})
+	}
+}
+
+// TestStartPostgres_MarksSuspectedDivergenceAfterCrashRecovery covers the block
+// in startPostgres that marks suspected divergence when pgctld had to force
+// crash recovery AND a *different* node is the known consensus leader — the
+// recovered local WAL may have diverged from that leader's timeline. When we are
+// (or no one is) the leader, or no crash recovery ran, the flag stays clear.
+func TestStartPostgres_MarksSuspectedDivergenceAfterCrashRecovery(t *testing.T) {
+	self := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "self"}
+	other := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "other"}
+
+	recordedPrimary := func(leader *clustermetadatapb.ID) *clustermetadatapb.ReplicationPrimary {
+		if leader == nil {
+			return nil
+		}
+		return &clustermetadatapb.ReplicationPrimary{
+			Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
+				RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
+				LeaderId:   leader,
+			}},
+			Primary: &clustermetadatapb.PoolerAddress{Id: leader, Host: "host", PostgresPort: 5432},
+		}
+	}
+
+	tests := []struct {
+		name             string
+		crashRecoveryRan bool
+		recordedLeader   *clustermetadatapb.ID // nil = no leader recorded
+		wantSuspected    bool
+	}{
+		{
+			// Crash recovery ran and a different leader is known: mark divergence.
+			name:             "crash_recovery_different_leader_marks",
+			crashRecoveryRan: true,
+			recordedLeader:   other,
+			wantSuspected:    true,
+		},
+		{
+			// The known leader is us: our WAL is authoritative, nothing to diverge from.
+			name:             "crash_recovery_self_leader_no_mark",
+			crashRecoveryRan: true,
+			recordedLeader:   self,
+			wantSuspected:    false,
+		},
+		{
+			// No leader known: nothing to diverge from.
+			name:             "crash_recovery_no_leader_no_mark",
+			crashRecoveryRan: true,
+			recordedLeader:   nil,
+			wantSuspected:    false,
+		},
+		{
+			// Postgres started cleanly (no crash recovery): no divergence suspected.
+			name:             "no_crash_recovery_no_mark",
+			crashRecoveryRan: false,
+			recordedLeader:   other,
+			wantSuspected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := []testManagerOption{withServiceID(self)}
+			if rp := recordedPrimary(tt.recordedLeader); rp != nil {
+				opts = append(opts, withReplicationPrimary(rp))
+			}
+			pm := newTestManager(t, opts...)
+			pm.pgctldClient = &mockPgctldClient{
+				startResponse: &pgctldpb.StartResponse{CrashRecoveryRan: tt.crashRecoveryRan},
+			}
+
+			lockCtx, err := pm.actionLock.Acquire(t.Context(), "test")
+			require.NoError(t, err)
+			defer pm.actionLock.Release(lockCtx)
+
+			require.NoError(t, pm.startPostgres(lockCtx))
+			assert.Equal(t, tt.wantSuspected, pm.consensusMgr.SuspectedDivergence())
 		})
 	}
 }

--- a/go/services/multipooler/internal/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/internal/manager/rpc_initialization_test.go
@@ -335,6 +335,7 @@ func TestPromotion_PublishesSelfLeadership(t *testing.T) {
 type mockPgctldClient struct {
 	statusResponse *pgctldpb.StatusResponse
 	statusError    error
+	startResponse  *pgctldpb.StartResponse
 	startCalled    bool
 	startError     error
 	restartCalled  bool
@@ -357,6 +358,9 @@ func (m *mockPgctldClient) Start(ctx context.Context, req *pgctldpb.StartRequest
 	m.startCalled = true
 	if m.startError != nil {
 		return nil, m.startError
+	}
+	if m.startResponse != nil {
+		return m.startResponse, nil
 	}
 	return &pgctldpb.StartResponse{}, nil
 }

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -975,6 +975,10 @@ func (pm *MultipoolerManager) restartAsStandbyLocked(
 
 	pm.logger.InfoContext(ctx, "Pausing manager and stopping PostgreSQL to restart as standby",
 		"source_host", sourceHost, "source_port", sourcePort, "rewind_pending", wantRewind)
+	// Pause without stopping the monitor: every caller either runs inside the
+	// monitor callback (backpressure prevents a concurrent iteration, and
+	// self-stopping would deadlock) or holds the action lock (the monitor blocks on
+	// it before acting), so there is nothing to stop.
 	resume := pm.Pause(ctx)
 	defer resume(ctx) // safety net; explicit resume() below after restart succeeds
 
@@ -1002,13 +1006,15 @@ func (pm *MultipoolerManager) restartAsStandbyLocked(
 		if err != nil {
 			return false, mterrors.Wrap(err, "pg_rewind")
 		}
-		// pg_rewind is idempotent on an already-rewound target (a re-run's
-		// dry-run detects no divergence and skips), so clearing as soon as
-		// pg_rewind returns is safe even if the restart or reconnect below
-		// fails: the next attempt will skip pg_rewind and just restart.
-		if _, err := pm.consensusMgr.SetSuspectedDivergence(ctx, false); err != nil {
-			pm.logger.ErrorContext(ctx, "failed to clear suspected divergence after pg_rewind", "error", err)
-		}
+		// suspectedDivergence is intentionally NOT cleared here. It is cleared only
+		// after postgres restarts and is verified in recovery mode below, because a
+		// rewind that returns success can still leave an un-startable node: an early
+		// rewind from a not-yet-checkpointed leader stamps minRecoveryPoint onto the
+		// wrong timeline, and postgres FATALs on startup. Clearing here would let the
+		// next attempt skip the rewind (wantRewind=false) and merely retry the doomed
+		// start; keeping it set means the retry re-runs pg_rewind against the
+		// (by-then-checkpointed) leader and actually recovers.
+		//
 		// pg_rewind copies postgresql.auto.conf from source, baking source's
 		// own pooler paths into pgbackrest commands (restore_command,
 		// archive_command). Patch them back to this pooler's paths before
@@ -1068,6 +1074,16 @@ func (pm *MultipoolerManager) restartAsStandbyLocked(
 	// automatically once postgres reads the new conninfo.
 	if err := pm.setPrimaryConnInfoLocked(ctx, sourceHost, sourcePort, false, false); err != nil {
 		return false, mterrors.Wrap(err, "set primary_conninfo after restart as standby")
+	}
+
+	// Postgres restarted, verified in recovery mode, and primary_conninfo points at
+	// the source: a working standby. Only now do we consider any suspected
+	// divergence resolved (see the note on the rewind path above for why clearing
+	// is deferred to here rather than right after pg_rewind returns).
+	if wantRewind {
+		if _, err := pm.consensusMgr.SetSuspectedDivergence(ctx, false); err != nil {
+			pm.logger.ErrorContext(ctx, "failed to clear suspected divergence after restart as standby", "error", err)
+		}
 	}
 
 	return rewindPerformed, nil

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -886,10 +886,12 @@ func (pm *MultipoolerManager) pgctldStopWithEscalation(ctx context.Context) erro
 // sets it after an emergency demote; SetPrimary's stale-primary branch
 // and RewindToSource set it before calling here). When the flag is clear we
 // skip even the pg_rewind dry-run — the WAL is trusted and we just need to
-// come back as a standby. The flag is cleared as soon as pg_rewind returns
-// success; pg_rewind is idempotent on an already-rewound target, so a
-// failure later in this function or a caller retry is safe — the next
-// invocation will simply skip the rewind step.
+// come back as a standby. The flag is cleared only after postgres restarts and
+// is verified in recovery mode below, NOT as soon as pg_rewind returns: an early
+// rewind from a not-yet-checkpointed leader can stamp minRecoveryPoint onto the
+// wrong timeline and FATAL on startup, so a doomed restart must re-run the rewind
+// on retry (against the by-then-checkpointed leader) rather than skip it. pg_rewind
+// is idempotent on an already-rewound target, so re-running it is safe.
 //
 // The manager is guaranteed to be resumed before this function returns, even
 // on error paths — that's the whole reason for the Pause/defer-resume
@@ -1156,6 +1158,16 @@ func (pm *MultipoolerManager) runPgRewind(ctx context.Context, sourceHost string
 // streaming from the leader. Editing the file (rather than ALTER SYSTEM RESET) is
 // required here because postgres is stopped at this point in restartAsStandbyLocked.
 func (pm *MultipoolerManager) dropRestoreCommandFromAutoConf(ctx context.Context) error {
+	// The standby must stream only from the leader, never replay from the archive.
+	return pm.dropAutoConfSettings(ctx, "restore_command")
+}
+
+// editAutoConf reads postgresql.auto.conf, applies transform, and writes the
+// result back only when transform reports a change. It edits the file directly,
+// so — unlike ALTER SYSTEM — it is safe to call while postgres is stopped (the
+// crash-recovery and rewind paths rely on that). Centralizing the read / write /
+// permissions here lets callers express only the content transform.
+func (pm *MultipoolerManager) editAutoConf(ctx context.Context, transform func(content string) (string, bool)) error {
 	autoConfPath := filepath.Join(postgresDataDir(), "postgresql.auto.conf")
 
 	content, err := os.ReadFile(autoConfPath)
@@ -1163,29 +1175,50 @@ func (pm *MultipoolerManager) dropRestoreCommandFromAutoConf(ctx context.Context
 		return mterrors.Wrap(err, "failed to read postgresql.auto.conf")
 	}
 
-	// Drop any line whose setting name is restore_command. postgresql.auto.conf
-	// holds one "name = 'value'" ALTER SYSTEM entry per line, so a line-oriented
-	// filter is sufficient and matches how fixPgBackRestPaths treats the file.
-	lines := strings.Split(string(content), "\n")
-	kept := lines[:0]
-	dropped := false
-	for _, line := range lines {
-		if strings.HasPrefix(strings.TrimSpace(line), "restore_command") {
-			dropped = true
-			continue
-		}
-		kept = append(kept, line)
-	}
-	if !dropped {
+	updated, changed := transform(string(content))
+	if !changed {
 		return nil
 	}
 
-	pm.logger.InfoContext(ctx, "Removing restore_command from postgresql.auto.conf so the standby streams only from the leader", "file", autoConfPath)
+	pm.logger.InfoContext(ctx, "Rewriting postgresql.auto.conf", "file", autoConfPath)
 	// #nosec G703 -- autoConfPath is postgresql.auto.conf under the pooler's own data dir, not external input.
-	if err := os.WriteFile(autoConfPath, []byte(strings.Join(kept, "\n")), 0o600); err != nil {
+	if err := os.WriteFile(autoConfPath, []byte(updated), 0o600); err != nil {
 		return mterrors.Wrap(err, "failed to write postgresql.auto.conf")
 	}
 	return nil
+}
+
+// dropAutoConfSettings removes every postgresql.auto.conf line that sets one of
+// the named settings. postgresql.auto.conf holds one "name = 'value'" ALTER
+// SYSTEM entry per line, so a line-oriented filter is sufficient. No-op when none
+// are present.
+func (pm *MultipoolerManager) dropAutoConfSettings(ctx context.Context, names ...string) error {
+	return pm.editAutoConf(ctx, func(content string) (string, bool) {
+		lines := strings.Split(content, "\n")
+		kept := lines[:0]
+		dropped := false
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			match := false
+			for _, name := range names {
+				// Match the setting name at a token boundary so e.g.
+				// "primary_conninfo" does not also drop "primary_conninfo_extra".
+				if trimmed == name ||
+					strings.HasPrefix(trimmed, name+" ") ||
+					strings.HasPrefix(trimmed, name+"=") ||
+					strings.HasPrefix(trimmed, name+"\t") {
+					match = true
+					break
+				}
+			}
+			if match {
+				dropped = true
+				continue
+			}
+			kept = append(kept, line)
+		}
+		return strings.Join(kept, "\n"), dropped
+	})
 }
 
 func (pm *MultipoolerManager) fixPgBackRestPaths(ctx context.Context) error {
@@ -1197,37 +1230,15 @@ func (pm *MultipoolerManager) fixPgBackRestPaths(ctx context.Context) error {
 		return mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION, "pooler directory not set")
 	}
 
-	autoConfPath := filepath.Join(postgresDataDir(), "postgresql.auto.conf")
-
-	pm.logger.InfoContext(ctx, "Fixing pgbackrest paths in postgresql.auto.conf", "file", autoConfPath)
-
-	// Read the file
-	content, err := os.ReadFile(autoConfPath)
-	if err != nil {
-		return mterrors.Wrap(err, "failed to read postgresql.auto.conf")
-	}
-
-	// Replace all occurrences of old pooler paths with current pooler paths
-	// We need to fix: --config, --lock-path, --log-path, --pg1-path
-	// These paths follow the pattern: /some/path/pooler-X/data/...
-	// We want to replace them with: /some/path/pooler-current/data/...
-
-	// Extract current pooler dir path pattern
-	// poolerDir is like: /tmp/test_12345/pooler-1/data
-	// We want to match patterns like: /tmp/test_12345/pooler-X/data
-	baseDir := filepath.Dir(filepath.Dir(poolerDir)) // Go up two levels to get base directory
-
-	// Use regex to replace pooler-X paths with current pooler paths
-	// Pattern matches: /path/to/pooler-<anything>/data
+	// Replace all occurrences of old pooler paths with current pooler paths.
+	// pgbackrest args (--config, --lock-path, --log-path, --pg1-path) follow the
+	// pattern /some/path/pooler-X/data/...; rewrite the pooler-X/data segment to
+	// this pooler's own dir. poolerDir is like /tmp/test_12345/pooler-1/data, so
+	// go up two levels for the base and match /base/pooler-<anything>/data.
+	baseDir := filepath.Dir(filepath.Dir(poolerDir))
 	re := regexp.MustCompile(regexp.QuoteMeta(baseDir) + `/pooler-[^/]+/data`)
-	newContent := re.ReplaceAllString(string(content), poolerDir)
-
-	// Write the file back
-	// #nosec G703 -- autoConfPath is postgresql.auto.conf under the pooler's own data dir, not external input.
-	if err := os.WriteFile(autoConfPath, []byte(newContent), 0o600); err != nil {
-		return mterrors.Wrap(err, "failed to write postgresql.auto.conf")
-	}
-
-	pm.logger.InfoContext(ctx, "Successfully fixed pgbackrest paths in postgresql.auto.conf")
-	return nil
+	return pm.editAutoConf(ctx, func(content string) (string, bool) {
+		updated := re.ReplaceAllString(content, poolerDir)
+		return updated, updated != content
+	})
 }

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -185,7 +185,10 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		assert.Equal(t, newPrimaryTerm, newPrimaryTermActual,
 			"Primary term should match consensus term for new primary %s (term=%d)", newPrimaryName, newPrimaryTerm)
 
-		// Wait for killed multipooler to rejoin as standby (always wait, even on last iteration)
+		// Wait for killed multipooler to rejoin as standby (always wait, even on last
+		// iteration). Rewind-readiness gating delays the first rewind until the leader
+		// has checkpointed onto its current timeline, so the rejoining node isn't
+		// poisoned (minRecoveryPoint on the wrong timeline) and comes back promptly.
 		waitForNodeToRejoinAsStandby(t, setup, currentPrimaryName, newPrimaryName, newPrimaryTerm, 2*time.Second)
 
 		// Verify multigateway has rerouted to the new primary by confirming a write succeeds.

--- a/go/test/endtoend/pgctld/pgctld_test.go
+++ b/go/test/endtoend/pgctld/pgctld_test.go
@@ -1596,3 +1596,82 @@ func TestPgRewind_AfterCrash(t *testing.T) {
 		"Database should be in 'shut down' or 'shut down in recovery' state after crash recovery, got:\n%s", outputStr)
 	t.Log("Success: standby is now cleanly stopped, proving crash recovery succeeded")
 }
+
+// TestPgRewind_AfterCrash_PreservesStandbySignal is the standby.signal variant of
+// TestPgRewind_AfterCrash: a crashed node that carries a standby.signal. postgres
+// --single refuses to run with a standby.signal present ("standby mode is not
+// supported by single-user servers"), so crash recovery must remove it for the
+// duration and recreate it afterwards. Without that handling the node would stay
+// stuck "in production"; with it, the node is cleanly recovered AND remains a
+// standby (signal restored).
+func TestPgRewind_AfterCrash_PreservesStandbySignal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	if !utils.HasPostgreSQLBinaries() {
+		t.Skip("PostgreSQL binaries not found, skipping test")
+	}
+
+	tempDir, cleanup := testutil.TempDir(t, "pgctld_crash_standbysignal")
+	defer cleanup()
+
+	dir := filepath.Join(tempDir, "standby")
+	configFile := filepath.Join(tempDir, "standby.pgctld.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte("log-level: info\ntimeout: 30\n"), 0o644))
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	testPassword := "test_crash_pw"
+	srv := startPgCtldServer(t, dir, configFile, "POSTGRES_PASSWORD="+testPassword)
+	grpcAddr := fmt.Sprintf("localhost:%d", srv.GrpcPort)
+	require.NoError(t, InitAndStartPostgreSQL(t, grpcAddr))
+	t.Log("PostgreSQL started")
+
+	// Make it look like a standby: standby.signal present in the data dir.
+	pgDataDir := filepath.Join(dir, "pg_data")
+	signalPath := filepath.Join(pgDataDir, "standby.signal")
+	require.NoError(t, os.WriteFile(signalPath, []byte(""), 0o644))
+
+	// Crash postgres with SIGKILL, leaving the cluster "in production" (dirty).
+	pid, err := readPostmasterPID(pgDataDir)
+	require.NoError(t, err)
+	proc, err := os.FindProcess(pid)
+	require.NoError(t, err)
+	killCtx, killCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer killCancel()
+	_, _ = executil.KillPID(killCtx, pid)
+	require.Eventually(t, func() bool {
+		return proc.Signal(syscall.Signal(0)) != nil
+	}, 5*time.Second, 100*time.Millisecond, "postgres should terminate after SIGKILL")
+
+	out, err := exec.Command("pg_controldata", pgDataDir).CombinedOutput()
+	require.NoError(t, err)
+	require.Contains(t, string(out), "in production", "cluster should be dirty after SIGKILL")
+
+	// PgRewind runs crash recovery before it attempts the rewind. The source is
+	// irrelevant here (the rewind itself may fail once recovery has run); we only
+	// exercise the standby.signal-aware crash recovery.
+	conn, err := grpc.NewClient(grpcAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer conn.Close()
+	client := pb.NewPgCtldClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	t.Log("Calling PgRewind (triggers standby.signal-aware crash recovery)")
+	_, _ = client.PgRewind(ctx, &pb.PgRewindRequest{
+		SourceHost: "localhost",
+		SourcePort: int32(srv.PgPort),
+		DryRun:     true,
+	})
+
+	// Crash recovery must have cleanly recovered the node despite the
+	// standby.signal (postgres --single would otherwise have refused to start).
+	out, err = exec.Command("pg_controldata", pgDataDir).CombinedOutput()
+	require.NoError(t, err)
+	outStr := string(out)
+	assert.True(t, strings.Contains(outStr, "shut down"),
+		"crash recovery should have cleanly recovered the node despite standby.signal, got:\n%s", outStr)
+	// ...and the standby.signal must be restored so the node stays a standby
+	// rather than being silently promoted on its next start.
+	assert.FileExists(t, signalPath, "standby.signal must be restored after crash recovery")
+	t.Log("Success: node recovered and standby.signal preserved")
+}

--- a/go/tools/retry/backoff.go
+++ b/go/tools/retry/backoff.go
@@ -37,6 +37,34 @@ type backoff interface {
 	reset()
 }
 
+// ExponentialBackoff exposes the package's exponential-backoff-with-full-jitter
+// calculation for callers that manage their own timing — e.g. rate-limiting an
+// action across independent scheduling cycles — rather than driving a Retry loop.
+// Call NextDelay each time you act to get the next delay (it advances the
+// sequence), and Reset after a success to start over. Safe for use by a single
+// owner; NextDelay/Reset are individually thread-safe.
+type ExponentialBackoff struct {
+	inner *exponentialFullJitterBackoff
+}
+
+// NewExponentialBackoff returns an ExponentialBackoff with the given base and max
+// delays. Delays are random in [0, min(maxDelay, baseDelay*2^attempt)].
+//
+// TODO: support configurable jitter strategies (e.g. equal/fractional jitter)
+// rather than only full jitter. Full jitter can return a near-zero delay, so
+// callers that need a guaranteed minimum gap between attempts currently have to
+// floor the result themselves (see recordDivergenceRewindAttempt). An "equal
+// jitter" option (delay/2 + random(0, delay/2)) would give that floor natively.
+func NewExponentialBackoff(baseDelay, maxDelay time.Duration) *ExponentialBackoff {
+	return &ExponentialBackoff{inner: newExponentialFullJitterBackoff(baseDelay, maxDelay)}
+}
+
+// NextDelay returns the next delay and advances the backoff state.
+func (b *ExponentialBackoff) NextDelay() time.Duration { return b.inner.nextDelay() }
+
+// Reset restarts the backoff sequence (e.g. after a successful action).
+func (b *ExponentialBackoff) Reset() { b.inner.reset() }
+
 // exponentialFullJitterBackoff implements exponential backoff with Full Jitter.
 //
 // This implements the "Full Jitter" algorithm recommended by AWS:

--- a/go/tools/retry/backoff_test.go
+++ b/go/tools/retry/backoff_test.go
@@ -332,3 +332,25 @@ func TestBackoff_Reset(t *testing.T) {
 	delay4 := b.nextDelay()
 	assert.Equal(t, 20*time.Millisecond, delay4)
 }
+
+// TestExponentialBackoff exercises the exported ExponentialBackoff wrapper used by
+// callers that manage their own timing. It injects the no-jitter inner so the
+// delays are deterministic (full jitter is covered by the tests above); this
+// verifies the wrapper delegates NextDelay/Reset correctly: exponential growth,
+// the maxDelay cap, and restart on Reset.
+func TestExponentialBackoff(t *testing.T) {
+	base := 10 * time.Millisecond
+	maxDelay := 80 * time.Millisecond
+	b := &ExponentialBackoff{inner: newExponentialBackoffNoJitter(base, maxDelay)}
+
+	// base * 2^attempt, capped at maxDelay.
+	assert.Equal(t, 10*time.Millisecond, b.NextDelay()) // attempt 0
+	assert.Equal(t, 20*time.Millisecond, b.NextDelay()) // attempt 1
+	assert.Equal(t, 40*time.Millisecond, b.NextDelay()) // attempt 2
+	assert.Equal(t, 80*time.Millisecond, b.NextDelay()) // attempt 3 (== cap)
+	assert.Equal(t, 80*time.Millisecond, b.NextDelay()) // attempt 4 (160 capped to 80)
+
+	// Reset restarts the sequence.
+	b.Reset()
+	assert.Equal(t, 10*time.Millisecond, b.NextDelay())
+}

--- a/proto/pgctldservice.proto
+++ b/proto/pgctldservice.proto
@@ -66,6 +66,13 @@ message StartRequest {
 
   // Additional postgres command line arguments
   repeated string extra_args = 2;
+
+  // When true and PostgreSQL is not cleanly shut down, run single-user crash
+  // recovery before starting. A standby.signal blocks single-user mode, so it is
+  // briefly removed for recovery and recreated afterwards. Callers that may be
+  // recovering a former primary (e.g. the postgres monitor) set this so the node
+  // reaches a clean state; the response reports whether recovery actually ran.
+  bool allow_crash_recovery = 3;
 }
 
 message StartResponse {
@@ -74,6 +81,13 @@ message StartResponse {
 
   // Status message
   string message = 2;
+
+  // True when single-user crash recovery was performed before start (only
+  // possible when the request set allow_crash_recovery). The caller uses this as
+  // evidence the node was not cleanly shut down: combined with knowing a
+  // different node is the consensus leader, it implies the local WAL may have
+  // diverged and a pg_rewind is needed before trusting it as a standby.
+  bool crash_recovery_ran = 3;
 }
 
 // Stop PostgreSQL server


### PR DESCRIPTION
A diverged standby that needs pg_rewind could get permanently stuck. Make the
rewind keep retrying until the node actually rejoins as a standby, closing two
gaps:

**1) Don't get stuck on a crash.**
pgctld `Start` gains `allow_crash_recovery`: a standby that can't start (e.g. an
early pg_rewind stamped `minRecoveryPoint` onto the wrong timeline and postgres
FATALs on startup) is crash-recovered first. `runCrashRecovery` is now
`standby.signal`-aware, since `postgres --single` refuses to run with a
`standby.signal` present. When crash recovery runs and a *different* node is the
known leader, the node marks `suspectedDivergence` so the next standby
transition routes through pg_rewind.

**2) Don't forget to retry just because the rewind path is idempotent.**
- `suspectedDivergence` is cleared only after postgres restarts and is verified
  in recovery mode, not as soon as pg_rewind returns. Clearing early left an
  un-startable (wrong-timeline) node with the flag already false, so the next
  attempt skipped the rewind and merely retried the doomed start.
- A new monitor remedial action re-runs the rewind against the recorded leader
  when a standby cannot come up and divergence is suspected, rate-limited with
  exponential backoff so it does not thrash disruptive restarts.

The rewind bookkeeping (target selection + backoff + `suspectedDivergence`)
lives on the `ConsensusManager`; the monitor decides, then composes those
queries. The backoff is incident-scoped — cleared on any healthy monitor tick
(postgres running, no rewind pending) — so an unrelated future divergence starts
with a fresh window.
