### PR TITLE
refactor(multipooler): consolidate consensus state onto ConsensusManager

### DIFF
--- a/go/services/multipooler/internal/manager/actionlock/action_lock.go
+++ b/go/services/multipooler/internal/manager/actionlock/action_lock.go
@@ -162,6 +162,15 @@ func (al *ActionLock) ActiveAction() (multipoolermanagerdatapb.PostgresAction, t
 // AssertActionLockHeld returns an error if the provided context does not hold
 // an action lock or if the lock has been released. This is a global function
 // that doesn't require a reference to the ActionLock.
+//
+// TODO: build this on a shared assertion helper in go/tools (e.g. tools/assert)
+// for "can't happen" invariants. That helper would (a) increment a metric when
+// an assertion fires so we can alert on logic errors that are supposed to be
+// impossible, and (b) panic by default under test builds — except for the unit
+// tests that explicitly opt out to exercise the lock-not-held path — while
+// returning an error in production. AssertActionLockHeld would then be one such
+// assertion, giving us loud failures in tests and observable-but-non-fatal
+// behavior in production.
 func AssertActionLockHeld(ctx context.Context) error {
 	val, ok := ctx.Value(actionLockKey{}).(*actionLockValue)
 	if !ok {

--- a/go/services/multipooler/internal/manager/consensus/consensus_promises.go
+++ b/go/services/multipooler/internal/manager/consensus/consensus_promises.go
@@ -28,10 +28,10 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
 )
 
-// ConsensusState manages the in-memory and on-disk consensus state for this node.
+// ConsensusPromises manages the in-memory and on-disk consensus state for this node.
 // It provides thread-safe access to consensus state and ensures that memory is only
 // updated after successful disk writes (pessimistic approach).
-type ConsensusState struct {
+type ConsensusPromises struct {
 	poolerDir string
 	serviceID *clustermetadatapb.ID
 
@@ -52,10 +52,10 @@ type ConsensusState struct {
 	leaderObservedAt time.Time
 }
 
-// NewConsensusState creates a new ConsensusState manager.
+// NewConsensusPromises creates a new ConsensusPromises manager.
 // It does not load state from disk - call Load() to initialize.
-func NewConsensusState(poolerDir string, serviceID *clustermetadatapb.ID) *ConsensusState {
-	return &ConsensusState{
+func NewConsensusPromises(poolerDir string, serviceID *clustermetadatapb.ID) *ConsensusPromises {
+	return &ConsensusPromises{
 		poolerDir:  poolerDir,
 		serviceID:  serviceID,
 		revocation: nil,
@@ -82,7 +82,7 @@ func NewConsensusState(poolerDir string, serviceID *clustermetadatapb.ID) *Conse
 // Safe to call on no-op SetPrimary paths so the recorded values reflect
 // everything the pooler has been told, regardless of whether postgres-side
 // changes were applied.
-func (cs *ConsensusState) RecordTermPrimary(rp *clustermetadatapb.ReplicationPrimary) {
+func (cs *ConsensusPromises) RecordTermPrimary(rp *clustermetadatapb.ReplicationPrimary) {
 	rule := rp.GetRule()
 	if rule == nil {
 		return
@@ -128,7 +128,7 @@ func (cs *ConsensusState) RecordTermPrimary(rp *clustermetadatapb.ReplicationPri
 
 // LeaderObservedAt returns when RecordTermPrimary last recorded a change of leader
 // identity, or the zero time if no leader has been recorded yet.
-func (cs *ConsensusState) LeaderObservedAt() time.Time {
+func (cs *ConsensusPromises) LeaderObservedAt() time.Time {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 	return cs.leaderObservedAt
@@ -137,7 +137,7 @@ func (cs *ConsensusState) LeaderObservedAt() time.Time {
 // GetReplicationPrimary returns a copy of the primary + rule this pooler has
 // been told to use, or nil if it has never been informed. The returned message
 // is the same one exposed in ConsensusStatus.
-func (cs *ConsensusState) GetReplicationPrimary() *clustermetadatapb.ReplicationPrimary {
+func (cs *ConsensusPromises) GetReplicationPrimary() *clustermetadatapb.ReplicationPrimary {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 	if cs.replicationPrimary == nil {
@@ -165,7 +165,7 @@ func (cs *ConsensusState) GetReplicationPrimary() *clustermetadatapb.Replication
 // pooler currently holds non-resigned leadership is the caller's concern —
 // resignation state lives in the manager, not here.) No-op if no
 // ReplicationPrimary has been recorded yet.
-func (cs *ConsensusState) MarkSelfRewindReady(selfID *clustermetadatapb.ID, expectedCoordinatorTerm int64) bool {
+func (cs *ConsensusPromises) MarkSelfRewindReady(selfID *clustermetadatapb.ID, expectedCoordinatorTerm int64) bool {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 	if cs.replicationPrimary == nil || cs.replicationPrimary.GetRewindReady() {
@@ -186,7 +186,7 @@ func (cs *ConsensusState) MarkSelfRewindReady(selfID *clustermetadatapb.ID, expe
 // Load loads consensus state from disk into memory.
 // If the file doesn't exist, initializes with default values (term 0, no accepted coordinator).
 // This method is idempotent - subsequent calls will reload from disk.
-func (cs *ConsensusState) Load() (int64, error) {
+func (cs *ConsensusPromises) Load() (int64, error) {
 	revocation, err := cs.getRevocation()
 	if err != nil {
 		return 0, fmt.Errorf("failed to load consensus term: %w", err)
@@ -201,7 +201,7 @@ func (cs *ConsensusState) Load() (int64, error) {
 
 // GetCurrentTermNumber returns the current term.
 // Returns 0 if state has not been loaded.
-func (cs *ConsensusState) GetCurrentTermNumber(ctx context.Context) (int64, error) {
+func (cs *ConsensusPromises) GetCurrentTermNumber(ctx context.Context) (int64, error) {
 	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
 		return 0, err
 	}
@@ -213,7 +213,7 @@ func (cs *ConsensusState) GetCurrentTermNumber(ctx context.Context) (int64, erro
 // be outdated by the time it's used. Use GetCurrentTermNumber() as part of
 // any action workflow to protect against race conditions.
 // Returns 0 if state has not been loaded.
-func (cs *ConsensusState) GetInconsistentCurrentTermNumber() (int64, error) {
+func (cs *ConsensusPromises) GetInconsistentCurrentTermNumber() (int64, error) {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 
@@ -228,7 +228,7 @@ func (cs *ConsensusState) GetInconsistentCurrentTermNumber() (int64, error) {
 // be outdated by the time it's used. Use GetRevocation() as part of any action
 // workflow to protect against race conditions.
 // Returns nil if state has not been loaded.
-func (cs *ConsensusState) GetInconsistentRevocation() *clustermetadatapb.TermRevocation {
+func (cs *ConsensusPromises) GetInconsistentRevocation() *clustermetadatapb.TermRevocation {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 
@@ -242,7 +242,7 @@ func (cs *ConsensusState) GetInconsistentRevocation() *clustermetadatapb.TermRev
 
 // GetAcceptedLeader returns the coordinator ID this pooler accepted the term from.
 // Returns empty string if no coordinator was accepted.
-func (cs *ConsensusState) GetAcceptedLeader(ctx context.Context) (string, error) {
+func (cs *ConsensusPromises) GetAcceptedLeader(ctx context.Context) (string, error) {
 	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
 		return "", err
 	}
@@ -257,7 +257,7 @@ func (cs *ConsensusState) GetAcceptedLeader(ctx context.Context) (string, error)
 
 // GetRevocation returns a copy of the current term revocation.
 // Returns nil if state has not been loaded.
-func (cs *ConsensusState) GetRevocation(ctx context.Context) (*clustermetadatapb.TermRevocation, error) {
+func (cs *ConsensusPromises) GetRevocation(ctx context.Context) (*clustermetadatapb.TermRevocation, error) {
 	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
 		return nil, err
 	}
@@ -276,7 +276,7 @@ func (cs *ConsensusState) GetRevocation(ctx context.Context) (*clustermetadatapb
 // It builds the validation status from the observed position in status combined
 // with the current in-memory revocation (read under the mutex), so the check
 // reflects the actual locked state rather than a potentially stale snapshot.
-func (cs *ConsensusState) AcceptRevocation(ctx context.Context, status *clustermetadatapb.ConsensusStatus, revocation *clustermetadatapb.TermRevocation) error {
+func (cs *ConsensusPromises) AcceptRevocation(ctx context.Context, status *clustermetadatapb.ConsensusStatus, revocation *clustermetadatapb.TermRevocation) error {
 	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
 		return err
 	}
@@ -298,7 +298,7 @@ func (cs *ConsensusState) AcceptRevocation(ctx context.Context, status *clusterm
 // This is called when discovering a newer term from another node.
 // Returns error if newTerm < currentTerm.
 // Idempotent: succeeds without changes if newTerm == currentTerm.
-func (cs *ConsensusState) UpdateTermAndSave(ctx context.Context, newTerm int64) error {
+func (cs *ConsensusPromises) UpdateTermAndSave(ctx context.Context, newTerm int64) error {
 	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
 		return err
 	}
@@ -334,7 +334,7 @@ func (cs *ConsensusState) UpdateTermAndSave(ctx context.Context, newTerm int64) 
 // MUST be called with cs.mu held.
 // This is the key method that ensures memory never diverges from disk.
 // If the save fails, memory remains unchanged and the error is returned.
-func (cs *ConsensusState) saveAndUpdateLocked(newRevocation *clustermetadatapb.TermRevocation) error {
+func (cs *ConsensusPromises) saveAndUpdateLocked(newRevocation *clustermetadatapb.TermRevocation) error {
 	// Save to disk (lock still held)
 	if err := cs.setRevocation(newRevocation); err != nil {
 		// Save failed - don't update memory, propagate error

--- a/go/services/multipooler/internal/manager/consensus/consensus_promises.go
+++ b/go/services/multipooler/internal/manager/consensus/consensus_promises.go
@@ -199,30 +199,6 @@ func (cs *ConsensusPromises) Load() (int64, error) {
 	return revocation.RevokedBelowTerm, nil
 }
 
-// GetCurrentTermNumber returns the current term.
-// Returns 0 if state has not been loaded.
-func (cs *ConsensusPromises) GetCurrentTermNumber(ctx context.Context) (int64, error) {
-	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
-		return 0, err
-	}
-	return cs.GetInconsistentCurrentTermNumber()
-}
-
-// GetInconsistentCurrentTermNumber returns the current term for monitoring.
-// It doesn't require the action lock to be held, so the value returned may
-// be outdated by the time it's used. Use GetCurrentTermNumber() as part of
-// any action workflow to protect against race conditions.
-// Returns 0 if state has not been loaded.
-func (cs *ConsensusPromises) GetInconsistentCurrentTermNumber() (int64, error) {
-	cs.mu.Lock()
-	defer cs.mu.Unlock()
-
-	if cs.revocation == nil {
-		return 0, nil
-	}
-	return cs.revocation.GetRevokedBelowTerm(), nil
-}
-
 // GetInconsistentRevocation returns a copy of the current term revocation for monitoring.
 // It doesn't require the action lock to be held, so the value returned may
 // be outdated by the time it's used. Use GetRevocation() as part of any action
@@ -238,21 +214,6 @@ func (cs *ConsensusPromises) GetInconsistentRevocation() *clustermetadatapb.Term
 
 	// Return a copy to prevent external modifications
 	return cloneRevocation(cs.revocation)
-}
-
-// GetAcceptedLeader returns the coordinator ID this pooler accepted the term from.
-// Returns empty string if no coordinator was accepted.
-func (cs *ConsensusPromises) GetAcceptedLeader(ctx context.Context) (string, error) {
-	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
-		return "", err
-	}
-	cs.mu.Lock()
-	defer cs.mu.Unlock()
-
-	if cs.revocation == nil || cs.revocation.AcceptedCoordinatorId == nil {
-		return "", nil
-	}
-	return cs.revocation.AcceptedCoordinatorId.GetName(), nil
 }
 
 // GetRevocation returns a copy of the current term revocation.
@@ -292,42 +253,6 @@ func (cs *ConsensusPromises) AcceptRevocation(ctx context.Context, status *clust
 	}
 
 	return cs.saveAndUpdateLocked(cloneRevocation(revocation))
-}
-
-// UpdateTermAndSave atomically updates the term number, resetting accepted coordinator.
-// This is called when discovering a newer term from another node.
-// Returns error if newTerm < currentTerm.
-// Idempotent: succeeds without changes if newTerm == currentTerm.
-func (cs *ConsensusPromises) UpdateTermAndSave(ctx context.Context, newTerm int64) error {
-	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
-		return err
-	}
-	cs.mu.Lock()
-	defer cs.mu.Unlock()
-
-	currentTerm := int64(0)
-	if cs.revocation != nil {
-		currentTerm = cs.revocation.GetRevokedBelowTerm()
-	}
-
-	if newTerm < currentTerm {
-		return fmt.Errorf("cannot update to older term: current=%d, new=%d", currentTerm, newTerm)
-	}
-
-	// If same term, nothing to do (idempotent success)
-	if newTerm == currentTerm {
-		return nil
-	}
-
-	// Only if newTerm > currentTerm: create new revocation with reset acceptance
-	newRevocation := &clustermetadatapb.TermRevocation{
-		RevokedBelowTerm:       newTerm,
-		AcceptedCoordinatorId:  nil,
-		CoordinatorInitiatedAt: nil,
-	}
-
-	// Save and update under lock
-	return cs.saveAndUpdateLocked(newRevocation)
 }
 
 // saveAndUpdateLocked saves the revocation to disk and updates memory.

--- a/go/services/multipooler/internal/manager/consensus/consensus_promises.go
+++ b/go/services/multipooler/internal/manager/consensus/consensus_promises.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"google.golang.org/protobuf/proto"
 
@@ -38,18 +37,6 @@ type ConsensusPromises struct {
 	mu sync.Mutex
 	// revocation is persisted to disk; see term_storage.go.
 	revocation *clustermetadatapb.TermRevocation
-	// replicationPrimary is held in memory only — see HighestKnownRule's proto
-	// comment. Populated by RPCs that inform this pooler about the cluster
-	// state (SetPrimary today; Promote can be wired in via the same RecordTermPrimary
-	// entry point). Restarts reset it to nil; coordinators re-inform the
-	// pooler.
-	replicationPrimary *clustermetadatapb.ReplicationPrimary
-	// leaderObservedAt is when RecordTermPrimary last saw the leader ID change
-	// (a new primary was recorded). Zero until the first leader is recorded. Used
-	// to measure how long a diverged follower's pg_rewind waited for that leader
-	// to become rewind-ready: the delay is (rewind start) - leaderObservedAt, which
-	// is ~0 when the same SetPrimary that learned the new leader could also rewind.
-	leaderObservedAt time.Time
 }
 
 // NewConsensusPromises creates a new ConsensusPromises manager.
@@ -60,127 +47,6 @@ func NewConsensusPromises(poolerDir string, serviceID *clustermetadatapb.ID) *Co
 		serviceID:  serviceID,
 		revocation: nil,
 	}
-}
-
-// RecordTermPrimary updates the highest-known (rule, primary, rewind_ready)
-// based on what this pooler has been told. A nil argument (or nil rule) is a
-// no-op. Bump semantics:
-//
-//   - rule: updated only when strictly greater than the current value
-//     (comparison by RuleNumber: coordinator_term then leader_subterm).
-//
-//   - primary: updated when the rule advances, OR when the supplied rule
-//     equals the current rule but the primary's contact info has changed.
-//     The same-rule-different-contact case covers a primary pooler being
-//     re-homed (host or port changes) without a new election.
-//
-//   - rewind_ready: recorded alongside, and a change to it is itself enough to
-//     record even at the same rule and contact — the leader completing its
-//     post-promotion checkpoint flips rewind_ready false->true without a new
-//     election, and a diverged follower gates its pg_rewind on that flip.
-//
-// Safe to call on no-op SetPrimary paths so the recorded values reflect
-// everything the pooler has been told, regardless of whether postgres-side
-// changes were applied.
-func (cs *ConsensusPromises) RecordTermPrimary(rp *clustermetadatapb.ReplicationPrimary) {
-	rule := rp.GetRule()
-	if rule == nil {
-		return
-	}
-	primary := rp.GetPrimary()
-	rewindReady := rp.GetRewindReady()
-	cs.mu.Lock()
-	defer cs.mu.Unlock()
-	cmp := consensus.CompareRuleNumbers(rule.GetRuleNumber(), cs.replicationPrimary.GetRule().GetRuleNumber())
-	if cmp < 0 {
-		return
-	}
-	if cmp == 0 &&
-		(primary == nil || proto.Equal(primary, cs.replicationPrimary.GetPrimary())) &&
-		rewindReady == cs.replicationPrimary.GetRewindReady() {
-		return
-	}
-	// Build the next value by starting from the existing fields (via getters,
-	// which are nil-safe) and overlaying the updates we want to apply.
-	next := &clustermetadatapb.ReplicationPrimary{
-		Rule:        cs.replicationPrimary.GetRule(),
-		Primary:     cs.replicationPrimary.GetPrimary(),
-		RewindReady: rewindReady,
-	}
-	if cmp > 0 {
-		next.Rule = proto.Clone(rule).(*clustermetadatapb.ShardRule)
-	}
-	// Update primary only when one is supplied; an RPC that advances the rule
-	// without re-stating the primary (or a future WAL-observation path) leaves
-	// the previously-recorded contact info in place.
-	if primary != nil {
-		next.Primary = proto.Clone(primary).(*clustermetadatapb.PoolerAddress)
-	}
-	// Stamp the time the leader identity changed, so a subsequent rewind toward
-	// this leader can report how long it waited for the leader to become
-	// rewind-ready (~0 when this same call already advances to a rewind-ready
-	// leader).
-	if !proto.Equal(cs.replicationPrimary.GetPrimary().GetId(), next.GetPrimary().GetId()) {
-		cs.leaderObservedAt = time.Now()
-	}
-	cs.replicationPrimary = next
-}
-
-// LeaderObservedAt returns when RecordTermPrimary last recorded a change of leader
-// identity, or the zero time if no leader has been recorded yet.
-func (cs *ConsensusPromises) LeaderObservedAt() time.Time {
-	cs.mu.Lock()
-	defer cs.mu.Unlock()
-	return cs.leaderObservedAt
-}
-
-// GetReplicationPrimary returns a copy of the primary + rule this pooler has
-// been told to use, or nil if it has never been informed. The returned message
-// is the same one exposed in ConsensusStatus.
-func (cs *ConsensusPromises) GetReplicationPrimary() *clustermetadatapb.ReplicationPrimary {
-	cs.mu.Lock()
-	defer cs.mu.Unlock()
-	if cs.replicationPrimary == nil {
-		return nil
-	}
-	return proto.Clone(cs.replicationPrimary).(*clustermetadatapb.ReplicationPrimary)
-}
-
-// MarkSelfRewindReady records that this pooler is safe to pg_rewind from: it has
-// checkpointed onto its current timeline. The postgres monitor calls this once it
-// observes the condition (and the async post-promotion checkpoint can flip it as
-// soon as it completes). It is one-way: the flag auto-clears whenever
-// RecordTermPrimary installs a fresh ReplicationPrimary — a new coordinator term,
-// or a SetPrimary naming a different leader (resignation / restart-as-replica) —
-// since the new record defaults rewind_ready to false. Returns true if the value
-// changed, so callers can broadcast the new health promptly.
-//
-// selfID and expectedCoordinatorTerm guard against marking the wrong record:
-// only the pooler the record names as primary may declare itself rewind-ready,
-// and only at the coordinator term it expects. The term check matters for the
-// async post-promotion checkpoint — by the time it completes a newer term (a
-// re-promotion or a different leader) may have replaced the record, and we must
-// not stamp rewind_ready onto that newer term whose checkpoint hasn't completed.
-// Both checks happen under the lock so the decision is atomic. (Whether this
-// pooler currently holds non-resigned leadership is the caller's concern —
-// resignation state lives in the manager, not here.) No-op if no
-// ReplicationPrimary has been recorded yet.
-func (cs *ConsensusPromises) MarkSelfRewindReady(selfID *clustermetadatapb.ID, expectedCoordinatorTerm int64) bool {
-	cs.mu.Lock()
-	defer cs.mu.Unlock()
-	if cs.replicationPrimary == nil || cs.replicationPrimary.GetRewindReady() {
-		return false
-	}
-	if !proto.Equal(cs.replicationPrimary.GetPrimary().GetId(), selfID) {
-		return false
-	}
-	if cs.replicationPrimary.GetRule().GetRuleNumber().GetCoordinatorTerm() != expectedCoordinatorTerm {
-		return false
-	}
-	next := proto.Clone(cs.replicationPrimary).(*clustermetadatapb.ReplicationPrimary)
-	next.RewindReady = true
-	cs.replicationPrimary = next
-	return true
 }
 
 // Load loads consensus state from disk into memory.

--- a/go/services/multipooler/internal/manager/consensus/consensus_promises_test.go
+++ b/go/services/multipooler/internal/manager/consensus/consensus_promises_test.go
@@ -140,7 +140,7 @@ func TestRecordTermPrimary(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cs := NewConsensusState(t.TempDir(), nil)
+			cs := NewConsensusPromises(t.TempDir(), nil)
 			if tt.seedRule != nil {
 				cs.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: tt.seedRule, Primary: tt.seedPrimary})
 			}
@@ -174,7 +174,7 @@ func TestRecordTermPrimary(t *testing.T) {
 // TestRecordTermPrimary_ReturnsCopies guards against callers mutating internal state
 // by holding the returned pointer.
 func TestRecordTermPrimary_ReturnsCopies(t *testing.T) {
-	cs := NewConsensusState(t.TempDir(), nil)
+	cs := NewConsensusPromises(t.TempDir(), nil)
 	cs.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: ruleAt(5, 0), Primary: primaryAt("p1", "hostA", 5432)})
 
 	got := cs.GetReplicationPrimary()

--- a/go/services/multipooler/internal/manager/consensus/consensustest/consensustest.go
+++ b/go/services/multipooler/internal/manager/consensus/consensustest/consensustest.go
@@ -28,7 +28,7 @@ import (
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
 
-// SeedTerm writes the consensus term file into poolerDir so a ConsensusState
+// SeedTerm writes the consensus term file into poolerDir so a ConsensusPromises
 // rooted at that directory will load the given revocation. It writes the file
 // directly, bypassing any in-memory cache, so tests can prime persisted state
 // before exercising Load() or an operation that reads it.

--- a/go/services/multipooler/internal/manager/consensus/manager.go
+++ b/go/services/multipooler/internal/manager/consensus/manager.go
@@ -78,6 +78,9 @@ type Broadcaster interface {
 // broadcast through the injected Broadcaster on a real change (the coordinator
 // must see those promptly); nothing holds mu or any lock across that broadcast.
 type ConsensusManager struct {
+	// id is this pooler's identity, stamped into the ConsensusStatus this manager
+	// builds. Immutable after construction.
+	id *clustermetadatapb.ID
 	// promises and rules are immutable after construction (see Concurrency above).
 	promises *ConsensusPromises
 	rules    RuleStorer
@@ -153,15 +156,15 @@ func NewConsensusManager(deps Deps) (*ConsensusManager, error) {
 		}
 	}
 	rules := NewRuleStore(deps.Logger, deps.QueryService, NewSyncStandbyManager(deps.Logger, deps.QueryService, deps.ID))
-	return newConsensusManager(promises, rules, deps.Broadcaster), nil
+	return newConsensusManager(deps.ID, promises, rules, deps.Broadcaster), nil
 }
 
 // newConsensusManager wires a ConsensusManager over already-constructed
 // components. Shared by NewConsensusManager (production) and NewManagerForTesting
 // (tests, which inject fakes). broadcaster may be nil, in which case broadcasts
 // are skipped.
-func newConsensusManager(promises *ConsensusPromises, rules RuleStorer, broadcaster Broadcaster) *ConsensusManager {
-	cm := &ConsensusManager{promises: promises, rules: rules, broadcaster: broadcaster}
+func newConsensusManager(id *clustermetadatapb.ID, promises *ConsensusPromises, rules RuleStorer, broadcaster Broadcaster) *ConsensusManager {
+	cm := &ConsensusManager{id: id, promises: promises, rules: rules, broadcaster: broadcaster}
 	// Default to ELIGIBLE — a fresh node is willing to join the cohort. (The
 	// atomic's zero value is the proto's UNSPECIFIED, so set it explicitly.)
 	cm.cohortEligibility.Store(int32(clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE))
@@ -181,6 +184,120 @@ func (cm *ConsensusManager) Promises() *ConsensusPromises { return cm.promises }
 
 // Rules returns the rule store.
 func (cm *ConsensusManager) Rules() RuleStorer { return cm.rules }
+
+// ConsensusStatus builds a ConsensusStatus snapshot using a consistent disk read
+// of the term and a fresh postgres read of the current rule position. The caller
+// must hold the action lock (GetRevocation asserts it). Returns an error if
+// postgres is unreachable, since a partial status (term without position) could
+// mislead callers about this pooler's rule position.
+func (cm *ConsensusManager) ConsensusStatus(ctx context.Context) (*clustermetadatapb.ConsensusStatus, error) {
+	revocation, err := cm.promises.GetRevocation(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read consensus term: %w", err)
+	}
+	pos, err := cm.rules.ObservePosition(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read current rule position: %w", err)
+	}
+	return cm.buildStatus(revocation, pos), nil
+}
+
+// CachedConsensusStatus builds a ConsensusStatus from the in-memory term cache and
+// the rule store's cached position; it never queries postgres or disk. The action
+// lock must be held by the caller (it prevents concurrent term updates). Returns
+// nil if no position has been cached yet.
+func (cm *ConsensusManager) CachedConsensusStatus() *clustermetadatapb.ConsensusStatus {
+	pos := cm.rules.CachedPosition()
+	if pos == nil {
+		return nil
+	}
+	return cm.buildStatus(cm.promises.GetInconsistentRevocation(), pos)
+}
+
+// InconsistentConsensusStatus builds a ConsensusStatus from a fresh postgres
+// position read without holding the action lock; it may observe partially-updated
+// state during a concurrent Recruit, so it is suitable for observability only.
+// Returns an error if postgres is unreachable.
+func (cm *ConsensusManager) InconsistentConsensusStatus(ctx context.Context) (*clustermetadatapb.ConsensusStatus, error) {
+	pos, err := cm.rules.ObservePosition(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return cm.buildStatus(cm.promises.GetInconsistentRevocation(), pos), nil
+}
+
+// buildStatus assembles a ConsensusStatus from a pre-resolved revocation and
+// position plus the recorded replication primary. Any input may be nil; the
+// corresponding field is left unset. Never performs I/O.
+//
+// The published HighestKnownRule reflects best knowledge from any source: the
+// rule is the max of the observed position's rule and the rule from the most
+// recent SetPrimary/Promote RPC, and the primary is the contact info from that
+// RPC (ObservePosition cannot carry it).
+func (cm *ConsensusManager) buildStatus(revocation *clustermetadatapb.TermRevocation, pos *clustermetadatapb.PoolerPosition) *clustermetadatapb.ConsensusStatus {
+	status := &clustermetadatapb.ConsensusStatus{Id: cm.id}
+	if revocation != nil {
+		status.TermRevocation = revocation
+	}
+	if pos != nil {
+		status.CurrentPosition = pos
+	}
+	if highest := statusReplicationPrimary(pos, cm.GetReplicationPrimary()); highest != nil {
+		status.ReplicationPrimary = highest
+	}
+	return status
+}
+
+// statusReplicationPrimary returns the HighestKnownRule to publish given the most
+// recent observed position and the most recent rule+primary heard via RPC.
+func statusReplicationPrimary(pos *clustermetadatapb.PoolerPosition, replicationPrimary *clustermetadatapb.ReplicationPrimary) *clustermetadatapb.ReplicationPrimary {
+	// ruleStoreRule is read fresh from the rule store (the current_rule row in
+	// postgres, replicated through WAL). highestKnownRule is the rule last recorded
+	// via a SetPrimary/Promote RPC, which can lead the rule store before the write
+	// has been observed locally.
+	ruleStoreRule := pos.GetRule()
+	highestKnownRule := replicationPrimary.GetRule()
+	rpcPrimary := replicationPrimary.GetPrimary()
+	if ruleStoreRule == nil && highestKnownRule == nil && rpcPrimary == nil {
+		return nil
+	}
+	rule := ruleStoreRule
+	// rewind_ready is recorded alongside the rpc (rule, primary): on the primary
+	// it is the self-report ("checkpointed onto my current timeline"); on a
+	// follower it is the value last relayed via SetPrimary about its leader.
+	// Republishing a relayed value is harmless — the leader's own status is the
+	// authority orch reads.
+	//
+	// Use the recorded rule and rewind_ready whenever it is at least as high as the
+	// rule-store observation — including a tie, the steady state for a leader. Only
+	// a strictly-higher rule-store rule means the recorded rewind_ready no longer
+	// describes the rule we publish, so we fall back to false there.
+	rewindReady := false
+	if consensus.CompareRuleNumbers(highestKnownRule.GetRuleNumber(), ruleStoreRule.GetRuleNumber()) >= 0 {
+		rule = highestKnownRule
+		rewindReady = replicationPrimary.GetRewindReady()
+	}
+	return &clustermetadatapb.ReplicationPrimary{
+		Rule:        rule,
+		Primary:     rpcPrimary,
+		RewindReady: rewindReady,
+	}
+}
+
+// LeadershipStatus returns the LeadershipStatus for this node. Non-nil only when
+// the node has resigned leadership (after a Recruit-driven emergency demotion or
+// graceful shutdown of a leader). Nil means it has not recently held or resigned
+// from primary leadership.
+func (cm *ConsensusManager) LeadershipStatus() *clustermetadatapb.LeadershipStatus {
+	resignedTerm := cm.ResignedLeaderAtTerm()
+	if resignedTerm == 0 {
+		return nil
+	}
+	return &clustermetadatapb.LeadershipStatus{
+		LeaderTerm: resignedTerm,
+		Signal:     clustermetadatapb.LeadershipSignal_LEADERSHIP_SIGNAL_REQUESTING_DEMOTION,
+	}
+}
 
 // RecordTermPrimary updates the highest-known (rule, primary, rewind_ready)
 // based on what this pooler has been told. A nil argument (or nil rule) is a

--- a/go/services/multipooler/internal/manager/consensus/manager.go
+++ b/go/services/multipooler/internal/manager/consensus/manager.go
@@ -69,11 +69,11 @@ type Broadcaster interface {
 //     safe; the action lock orders the writers. They are independent scalars and
 //     never need to be read consistently with each other or with mu's fields.
 //
-// Nothing here holds mu (or any lock) across a health broadcast: the Set* methods
-// return whether the value changed and the manager broadcasts afterward.
-//
-// Later steps fold the remaining consensus state still scattered across the
-// manager (suspected divergence and the rewind backoff) into this type.
+// The mutating methods assert the action lock is held (writes are serialized by
+// it), with one exception documented on MarkSelfRewindReady.
+// SetResignedLeaderAtTerm and SetCohortEligibility push an immediate health
+// broadcast through the injected Broadcaster on a real change (the coordinator
+// must see those promptly); nothing holds mu or any lock across that broadcast.
 type ConsensusManager struct {
 	// promises and rules are immutable after construction (see Concurrency above).
 	promises *ConsensusPromises

--- a/go/services/multipooler/internal/manager/consensus/manager.go
+++ b/go/services/multipooler/internal/manager/consensus/manager.go
@@ -169,10 +169,13 @@ func (cm *ConsensusManager) Rules() RuleStorer { return cm.rules }
 // Safe to call on no-op SetPrimary paths so the recorded values reflect
 // everything the pooler has been told, regardless of whether postgres-side
 // changes were applied.
-func (cm *ConsensusManager) RecordTermPrimary(rp *clustermetadatapb.ReplicationPrimary) {
+func (cm *ConsensusManager) RecordTermPrimary(ctx context.Context, rp *clustermetadatapb.ReplicationPrimary) error {
+	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
+		return err
+	}
 	rule := rp.GetRule()
 	if rule == nil {
-		return
+		return nil
 	}
 	primary := rp.GetPrimary()
 	rewindReady := rp.GetRewindReady()
@@ -180,12 +183,12 @@ func (cm *ConsensusManager) RecordTermPrimary(rp *clustermetadatapb.ReplicationP
 	defer cm.mu.Unlock()
 	cmp := consensus.CompareRuleNumbers(rule.GetRuleNumber(), cm.replicationPrimary.GetRule().GetRuleNumber())
 	if cmp < 0 {
-		return
+		return nil
 	}
 	if cmp == 0 &&
 		(primary == nil || proto.Equal(primary, cm.replicationPrimary.GetPrimary())) &&
 		rewindReady == cm.replicationPrimary.GetRewindReady() {
-		return
+		return nil
 	}
 	// Build the next value by starting from the existing fields (via getters,
 	// which are nil-safe) and overlaying the updates we want to apply.
@@ -211,6 +214,7 @@ func (cm *ConsensusManager) RecordTermPrimary(rp *clustermetadatapb.ReplicationP
 		cm.leaderObservedAt = time.Now()
 	}
 	cm.replicationPrimary = next
+	return nil
 }
 
 // LeaderObservedAt returns when RecordTermPrimary last recorded a change of leader
@@ -252,6 +256,12 @@ func (cm *ConsensusManager) GetReplicationPrimary() *clustermetadatapb.Replicati
 // pooler currently holds non-resigned leadership is the caller's concern —
 // resignation state lives in the manager, not here.) No-op if no
 // ReplicationPrimary has been recorded yet.
+// Unlike the other mutators, MarkSelfRewindReady does NOT assert the action
+// lock: the async post-promotion checkpoint goroutine (see promoteStandbyToPrimary)
+// calls it without holding the lock. Its safety comes from mu plus the selfID /
+// expectedCoordinatorTerm guards, which ensure it only stamps the record it still
+// owns. This lock-free writer is also why replicationPrimary needs mu, not just
+// action-lock serialization.
 func (cm *ConsensusManager) MarkSelfRewindReady(selfID *clustermetadatapb.ID, expectedCoordinatorTerm int64) bool {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
@@ -329,8 +339,12 @@ func (cm *ConsensusManager) SuspectedDivergence() bool {
 
 // SetSuspectedDivergence sets or clears the suspected-divergence flag, returning
 // whether the value changed (so a caller clearing it can log the transition).
-func (cm *ConsensusManager) SetSuspectedDivergence(suspected bool) (changed bool) {
-	return cm.suspectedDivergence.Swap(suspected) != suspected
+// Requires the action lock (ctx must be an action-lock context).
+func (cm *ConsensusManager) SetSuspectedDivergence(ctx context.Context, suspected bool) (changed bool, err error) {
+	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
+		return false, err
+	}
+	return cm.suspectedDivergence.Swap(suspected) != suspected, nil
 }
 
 // RewindWaitEmittedFor returns the leaderObservedAt value the rewind-wait metric

--- a/go/services/multipooler/internal/manager/consensus/manager.go
+++ b/go/services/multipooler/internal/manager/consensus/manager.go
@@ -16,6 +16,8 @@ package consensus
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -24,6 +26,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/consensus"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
 )
 
@@ -123,11 +126,41 @@ type ConsensusManager struct {
 	suspectedDivergence atomic.Bool
 }
 
-// NewConsensusManager builds a ConsensusManager over an already-constructed
-// durable-promise store and rule store. broadcaster (the manager's health
-// streamer) is notified after a change the coordinator should see promptly; it
-// may be nil, in which case broadcasts are skipped.
-func NewConsensusManager(promises *ConsensusPromises, rules RuleStorer, broadcaster Broadcaster) *ConsensusManager {
+// Deps are the lower-level dependencies a production ConsensusManager builds its
+// components from. ID is this pooler's identity (used to root the durable promise
+// store and the sync-standby manager). LoadPromises asks the constructor to load
+// the persisted term from disk (the consensus-enabled path). Broadcaster — the
+// manager's health streamer — may be nil, in which case broadcasts are skipped.
+type Deps struct {
+	Logger       *slog.Logger
+	QueryService executor.InternalQueryService
+	PoolerDir    string
+	ID           *clustermetadatapb.ID
+	Broadcaster  Broadcaster
+	LoadPromises bool
+}
+
+// NewConsensusManager builds a ConsensusManager and the components it owns — the
+// durable promise store and the rule store (with its sync-standby manager) — from
+// deps, so the consensus package owns its own wiring. When deps.LoadPromises is
+// set it loads the persisted term from disk, returning an error on a read/parse
+// failure. Tests that need to inject fakes use NewManagerForTesting.
+func NewConsensusManager(deps Deps) (*ConsensusManager, error) {
+	promises := NewConsensusPromises(deps.PoolerDir, deps.ID)
+	if deps.LoadPromises {
+		if _, err := promises.Load(); err != nil {
+			return nil, fmt.Errorf("failed to load consensus state from disk: %w", err)
+		}
+	}
+	rules := NewRuleStore(deps.Logger, deps.QueryService, NewSyncStandbyManager(deps.Logger, deps.QueryService, deps.ID))
+	return newConsensusManager(promises, rules, deps.Broadcaster), nil
+}
+
+// newConsensusManager wires a ConsensusManager over already-constructed
+// components. Shared by NewConsensusManager (production) and NewManagerForTesting
+// (tests, which inject fakes). broadcaster may be nil, in which case broadcasts
+// are skipped.
+func newConsensusManager(promises *ConsensusPromises, rules RuleStorer, broadcaster Broadcaster) *ConsensusManager {
 	cm := &ConsensusManager{promises: promises, rules: rules, broadcaster: broadcaster}
 	// Default to ELIGIBLE — a fresh node is willing to join the cohort. (The
 	// atomic's zero value is the proto's UNSPECIFIED, so set it explicitly.)

--- a/go/services/multipooler/internal/manager/consensus/manager.go
+++ b/go/services/multipooler/internal/manager/consensus/manager.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consensus
+
+// ConsensusManager owns the pooler's consensus state. It composes the two
+// lower-level pieces in this package:
+//
+//   - promises: the durable term revocation (ConsensusPromises), persisted to
+//     disk via pessimistic save-then-update.
+//   - rules: the rule store (RuleStorer), which observes and writes the
+//     current_rule row replicated through postgres WAL.
+//
+// The fields are unexported and reached through Promises()/Rules(); callers
+// build a manager with NewConsensusManager. Tests construct it the same way
+// (via the manager package's test builder), so neither the fields nor a setter
+// need to be exported.
+//
+// Later steps fold the consensus state currently scattered across the manager
+// (the recorded replication primary and leader-observed-at, leader resignation,
+// cohort eligibility, suspected divergence, and the rewind backoff) into this
+// type so consensus state lives in one place.
+type ConsensusManager struct {
+	promises *ConsensusPromises
+	rules    RuleStorer
+}
+
+// NewConsensusManager builds a ConsensusManager over an already-constructed
+// durable-promise store and rule store.
+func NewConsensusManager(promises *ConsensusPromises, rules RuleStorer) *ConsensusManager {
+	return &ConsensusManager{promises: promises, rules: rules}
+}
+
+// Promises returns the durable term-revocation store.
+func (cm *ConsensusManager) Promises() *ConsensusPromises { return cm.promises }
+
+// Rules returns the rule store.
+func (cm *ConsensusManager) Rules() RuleStorer { return cm.rules }

--- a/go/services/multipooler/internal/manager/consensus/manager.go
+++ b/go/services/multipooler/internal/manager/consensus/manager.go
@@ -15,14 +15,25 @@
 package consensus
 
 import (
+	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"google.golang.org/protobuf/proto"
 
 	"github.com/multigres/multigres/go/common/consensus"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
 )
+
+// Broadcaster pushes an immediate health snapshot to subscribers. It is
+// satisfied by the manager's health streamer. ConsensusManager calls it after a
+// change the coordinator should see without waiting for the next heartbeat
+// (e.g. a resignation or cohort-eligibility flip).
+type Broadcaster interface {
+	Broadcast()
+}
 
 // ConsensusManager owns the pooler's consensus state. It composes the two
 // lower-level pieces in this package:
@@ -42,36 +53,81 @@ import (
 // way (via the manager package's test builder), so neither the fields nor a
 // setter need to be exported.
 //
-// Locking: the observational fields use mu, which is deliberately separate from
-// ConsensusPromises's own lock. ConsensusPromises's lock wraps disk writes, and
-// GetReplicationPrimary is read on nearly every monitor tick; sharing one lock
-// would serialize the latency-sensitive monitor loop behind term persistence.
+// Concurrency — each field documents its own access rule; in summary:
+//
+//   - promises, rules: set once at construction, immutable thereafter. Each has
+//     its own internal synchronization (ConsensusPromises wraps a disk lock;
+//     RuleStorer guards its cache), so callers just use the returned value.
+//   - replicationPrimary, leaderObservedAt: guarded by mu. mu is deliberately
+//     NOT shared with ConsensusPromises's lock: that lock wraps disk writes, and
+//     GetReplicationPrimary is read on nearly every monitor tick — sharing would
+//     serialize the latency-sensitive monitor loop behind term persistence.
+//   - resignedLeaderAtTerm, cohortEligibility: atomics, NOT under mu. Production
+//     writes go through the manager under the action lock (so writers are
+//     serialized there); the lock-free readers (Status/health snapshot, monitor
+//     decision phase) load them without any lock. The atomic makes those reads
+//     safe; the action lock orders the writers. They are independent scalars and
+//     never need to be read consistently with each other or with mu's fields.
+//
+// Nothing here holds mu (or any lock) across a health broadcast: the Set* methods
+// return whether the value changed and the manager broadcasts afterward.
 //
 // Later steps fold the remaining consensus state still scattered across the
-// manager (leader resignation, cohort eligibility, suspected divergence, and
-// the rewind backoff) into this type.
+// manager (suspected divergence and the rewind backoff) into this type.
 type ConsensusManager struct {
+	// promises and rules are immutable after construction (see Concurrency above).
 	promises *ConsensusPromises
 	rules    RuleStorer
+	// broadcaster pushes an immediate health snapshot after a change the
+	// coordinator should see promptly. Immutable after construction; may be nil
+	// (then broadcasts are skipped — used by unit tests with no health stream).
+	broadcaster Broadcaster
 
+	// mu guards replicationPrimary and leaderObservedAt only.
 	mu sync.Mutex
 	// replicationPrimary is held in memory only — see HighestKnownRule's proto
 	// comment. Populated by RPCs that inform this pooler about the cluster state
 	// (SetPrimary today; Promote via the same RecordTermPrimary entry point).
-	// Restarts reset it to nil; coordinators re-inform the pooler.
+	// Restarts reset it to nil; coordinators re-inform the pooler. Guarded by mu.
 	replicationPrimary *clustermetadatapb.ReplicationPrimary
 	// leaderObservedAt is when RecordTermPrimary last saw the leader ID change (a
 	// new primary was recorded). Zero until the first leader is recorded. Used to
 	// measure how long a diverged follower's pg_rewind waited for that leader to
 	// become rewind-ready: the delay is (rewind start) - leaderObservedAt, which
 	// is ~0 when the same SetPrimary that learned the new leader could also rewind.
+	// Guarded by mu.
 	leaderObservedAt time.Time
+
+	// resignedLeaderAtTerm is the consensus term at which this node voluntarily
+	// resigned as primary (via emergency-demote or graceful shutdown), or 0 if it
+	// has not resigned. A non-zero value tells the coordinator to trigger an
+	// immediate election. Cleared when this node is elected primary again. Atomic;
+	// production writes are serialized by the action lock (see Concurrency above).
+	resignedLeaderAtTerm atomic.Int64
+	// cohortEligibility is this node's self-reported willingness to be a member of
+	// the consensus cohort, holding a clustermetadatapb.CohortEligibilitySignal.
+	// Atomic; production writes are serialized by the action lock.
+	cohortEligibility atomic.Int32
 }
 
 // NewConsensusManager builds a ConsensusManager over an already-constructed
-// durable-promise store and rule store.
-func NewConsensusManager(promises *ConsensusPromises, rules RuleStorer) *ConsensusManager {
-	return &ConsensusManager{promises: promises, rules: rules}
+// durable-promise store and rule store. broadcaster (the manager's health
+// streamer) is notified after a change the coordinator should see promptly; it
+// may be nil, in which case broadcasts are skipped.
+func NewConsensusManager(promises *ConsensusPromises, rules RuleStorer, broadcaster Broadcaster) *ConsensusManager {
+	cm := &ConsensusManager{promises: promises, rules: rules, broadcaster: broadcaster}
+	// Default to ELIGIBLE — a fresh node is willing to join the cohort. (The
+	// atomic's zero value is the proto's UNSPECIFIED, so set it explicitly.)
+	cm.cohortEligibility.Store(int32(clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE))
+	return cm
+}
+
+// broadcast pushes an immediate health snapshot, if a broadcaster is wired.
+// Never call while holding cm.mu: the snapshot build reads mu-guarded fields.
+func (cm *ConsensusManager) broadcast() {
+	if cm.broadcaster != nil {
+		cm.broadcaster.Broadcast()
+	}
 }
 
 // Promises returns the durable term-revocation store.
@@ -199,4 +255,55 @@ func (cm *ConsensusManager) MarkSelfRewindReady(selfID *clustermetadatapb.ID, ex
 	next.RewindReady = true
 	cm.replicationPrimary = next
 	return true
+}
+
+// ResignedLeaderAtTerm returns the term at which this node requested demotion as
+// primary, or 0 if it has not resigned.
+func (cm *ConsensusManager) ResignedLeaderAtTerm() int64 {
+	return cm.resignedLeaderAtTerm.Load()
+}
+
+// SetResignedLeaderAtTerm records that this node is requesting demotion as
+// primary for the given term. When the value changes it pushes an immediate
+// health broadcast so the coordinator can trigger an election without waiting
+// for the next heartbeat. Requires the action lock (ctx must be an action-lock
+// context), which serializes writers.
+func (cm *ConsensusManager) SetResignedLeaderAtTerm(ctx context.Context, term int64) error {
+	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
+		return err
+	}
+	if cm.resignedLeaderAtTerm.Swap(term) != term {
+		cm.broadcast()
+	}
+	return nil
+}
+
+// ClearResignedLeaderAtTerm clears the leadership-demotion request (sets it to
+// 0). Called when this node is appointed primary at a new term; that promotion
+// flow broadcasts, so this does not. Requires the action lock.
+func (cm *ConsensusManager) ClearResignedLeaderAtTerm(ctx context.Context) error {
+	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
+		return err
+	}
+	cm.resignedLeaderAtTerm.Store(0)
+	return nil
+}
+
+// CohortEligibility returns this node's self-reported cohort eligibility.
+func (cm *ConsensusManager) CohortEligibility() clustermetadatapb.CohortEligibilitySignal {
+	return clustermetadatapb.CohortEligibilitySignal(cm.cohortEligibility.Load())
+}
+
+// SetCohortEligibility records this node's cohort eligibility. When the value
+// changes it pushes an immediate health broadcast so the coordinator sees the
+// new value without waiting for the next heartbeat. Requires the action lock
+// (ctx must be an action-lock context), which serializes writers.
+func (cm *ConsensusManager) SetCohortEligibility(ctx context.Context, signal clustermetadatapb.CohortEligibilitySignal) error {
+	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
+		return err
+	}
+	if cm.cohortEligibility.Swap(int32(signal)) != int32(signal) {
+		cm.broadcast()
+	}
+	return nil
 }

--- a/go/services/multipooler/internal/manager/consensus/manager.go
+++ b/go/services/multipooler/internal/manager/consensus/manager.go
@@ -14,6 +14,16 @@
 
 package consensus
 
+import (
+	"sync"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/multigres/multigres/go/common/consensus"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+)
+
 // ConsensusManager owns the pooler's consensus state. It composes the two
 // lower-level pieces in this package:
 //
@@ -22,18 +32,40 @@ package consensus
 //   - rules: the rule store (RuleStorer), which observes and writes the
 //     current_rule row replicated through postgres WAL.
 //
-// The fields are unexported and reached through Promises()/Rules(); callers
-// build a manager with NewConsensusManager. Tests construct it the same way
-// (via the manager package's test builder), so neither the fields nor a setter
-// need to be exported.
+// and holds the in-memory, observational consensus state that is not durable:
+// the recorded replication primary (what a coordinator last told this pooler
+// via SetPrimary/Promote) and the time that leader was first observed. These
+// live here rather than in ConsensusPromises, whose name promises durability.
 //
-// Later steps fold the consensus state currently scattered across the manager
-// (the recorded replication primary and leader-observed-at, leader resignation,
-// cohort eligibility, suspected divergence, and the rewind backoff) into this
-// type so consensus state lives in one place.
+// The promises/rules fields are unexported and reached through Promises()/Rules();
+// callers build a manager with NewConsensusManager. Tests construct it the same
+// way (via the manager package's test builder), so neither the fields nor a
+// setter need to be exported.
+//
+// Locking: the observational fields use mu, which is deliberately separate from
+// ConsensusPromises's own lock. ConsensusPromises's lock wraps disk writes, and
+// GetReplicationPrimary is read on nearly every monitor tick; sharing one lock
+// would serialize the latency-sensitive monitor loop behind term persistence.
+//
+// Later steps fold the remaining consensus state still scattered across the
+// manager (leader resignation, cohort eligibility, suspected divergence, and
+// the rewind backoff) into this type.
 type ConsensusManager struct {
 	promises *ConsensusPromises
 	rules    RuleStorer
+
+	mu sync.Mutex
+	// replicationPrimary is held in memory only — see HighestKnownRule's proto
+	// comment. Populated by RPCs that inform this pooler about the cluster state
+	// (SetPrimary today; Promote via the same RecordTermPrimary entry point).
+	// Restarts reset it to nil; coordinators re-inform the pooler.
+	replicationPrimary *clustermetadatapb.ReplicationPrimary
+	// leaderObservedAt is when RecordTermPrimary last saw the leader ID change (a
+	// new primary was recorded). Zero until the first leader is recorded. Used to
+	// measure how long a diverged follower's pg_rewind waited for that leader to
+	// become rewind-ready: the delay is (rewind start) - leaderObservedAt, which
+	// is ~0 when the same SetPrimary that learned the new leader could also rewind.
+	leaderObservedAt time.Time
 }
 
 // NewConsensusManager builds a ConsensusManager over an already-constructed
@@ -47,3 +79,124 @@ func (cm *ConsensusManager) Promises() *ConsensusPromises { return cm.promises }
 
 // Rules returns the rule store.
 func (cm *ConsensusManager) Rules() RuleStorer { return cm.rules }
+
+// RecordTermPrimary updates the highest-known (rule, primary, rewind_ready)
+// based on what this pooler has been told. A nil argument (or nil rule) is a
+// no-op. Bump semantics:
+//
+//   - rule: updated only when strictly greater than the current value
+//     (comparison by RuleNumber: coordinator_term then leader_subterm).
+//
+//   - primary: updated when the rule advances, OR when the supplied rule
+//     equals the current rule but the primary's contact info has changed.
+//     The same-rule-different-contact case covers a primary pooler being
+//     re-homed (host or port changes) without a new election.
+//
+//   - rewind_ready: recorded alongside, and a change to it is itself enough to
+//     record even at the same rule and contact — the leader completing its
+//     post-promotion checkpoint flips rewind_ready false->true without a new
+//     election, and a diverged follower gates its pg_rewind on that flip.
+//
+// Safe to call on no-op SetPrimary paths so the recorded values reflect
+// everything the pooler has been told, regardless of whether postgres-side
+// changes were applied.
+func (cm *ConsensusManager) RecordTermPrimary(rp *clustermetadatapb.ReplicationPrimary) {
+	rule := rp.GetRule()
+	if rule == nil {
+		return
+	}
+	primary := rp.GetPrimary()
+	rewindReady := rp.GetRewindReady()
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	cmp := consensus.CompareRuleNumbers(rule.GetRuleNumber(), cm.replicationPrimary.GetRule().GetRuleNumber())
+	if cmp < 0 {
+		return
+	}
+	if cmp == 0 &&
+		(primary == nil || proto.Equal(primary, cm.replicationPrimary.GetPrimary())) &&
+		rewindReady == cm.replicationPrimary.GetRewindReady() {
+		return
+	}
+	// Build the next value by starting from the existing fields (via getters,
+	// which are nil-safe) and overlaying the updates we want to apply.
+	next := &clustermetadatapb.ReplicationPrimary{
+		Rule:        cm.replicationPrimary.GetRule(),
+		Primary:     cm.replicationPrimary.GetPrimary(),
+		RewindReady: rewindReady,
+	}
+	if cmp > 0 {
+		next.Rule = proto.Clone(rule).(*clustermetadatapb.ShardRule)
+	}
+	// Update primary only when one is supplied; an RPC that advances the rule
+	// without re-stating the primary (or a future WAL-observation path) leaves
+	// the previously-recorded contact info in place.
+	if primary != nil {
+		next.Primary = proto.Clone(primary).(*clustermetadatapb.PoolerAddress)
+	}
+	// Stamp the time the leader identity changed, so a subsequent rewind toward
+	// this leader can report how long it waited for the leader to become
+	// rewind-ready (~0 when this same call already advances to a rewind-ready
+	// leader).
+	if !proto.Equal(cm.replicationPrimary.GetPrimary().GetId(), next.GetPrimary().GetId()) {
+		cm.leaderObservedAt = time.Now()
+	}
+	cm.replicationPrimary = next
+}
+
+// LeaderObservedAt returns when RecordTermPrimary last recorded a change of leader
+// identity, or the zero time if no leader has been recorded yet.
+func (cm *ConsensusManager) LeaderObservedAt() time.Time {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	return cm.leaderObservedAt
+}
+
+// GetReplicationPrimary returns a copy of the primary + rule this pooler has
+// been told to use, or nil if it has never been informed. The returned message
+// is the same one exposed in ConsensusStatus.
+func (cm *ConsensusManager) GetReplicationPrimary() *clustermetadatapb.ReplicationPrimary {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	if cm.replicationPrimary == nil {
+		return nil
+	}
+	return proto.Clone(cm.replicationPrimary).(*clustermetadatapb.ReplicationPrimary)
+}
+
+// MarkSelfRewindReady records that this pooler is safe to pg_rewind from: it has
+// checkpointed onto its current timeline. The postgres monitor calls this once it
+// observes the condition (and the async post-promotion checkpoint can flip it as
+// soon as it completes). It is one-way: the flag auto-clears whenever
+// RecordTermPrimary installs a fresh ReplicationPrimary — a new coordinator term,
+// or a SetPrimary naming a different leader (resignation / restart-as-replica) —
+// since the new record defaults rewind_ready to false. Returns true if the value
+// changed, so callers can broadcast the new health promptly.
+//
+// selfID and expectedCoordinatorTerm guard against marking the wrong record:
+// only the pooler the record names as primary may declare itself rewind-ready,
+// and only at the coordinator term it expects. The term check matters for the
+// async post-promotion checkpoint — by the time it completes a newer term (a
+// re-promotion or a different leader) may have replaced the record, and we must
+// not stamp rewind_ready onto that newer term whose checkpoint hasn't completed.
+// Both checks happen under the lock so the decision is atomic. (Whether this
+// pooler currently holds non-resigned leadership is the caller's concern —
+// resignation state lives in the manager, not here.) No-op if no
+// ReplicationPrimary has been recorded yet.
+func (cm *ConsensusManager) MarkSelfRewindReady(selfID *clustermetadatapb.ID, expectedCoordinatorTerm int64) bool {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	if cm.replicationPrimary == nil || cm.replicationPrimary.GetRewindReady() {
+		return false
+	}
+	if !proto.Equal(cm.replicationPrimary.GetPrimary().GetId(), selfID) {
+		return false
+	}
+	if cm.replicationPrimary.GetRule().GetRuleNumber().GetCoordinatorTerm() != expectedCoordinatorTerm {
+		return false
+	}
+	next := proto.Clone(cm.replicationPrimary).(*clustermetadatapb.ReplicationPrimary)
+	next.RewindReady = true
+	cm.replicationPrimary = next
+	return true
+}

--- a/go/services/multipooler/internal/manager/consensus/manager.go
+++ b/go/services/multipooler/internal/manager/consensus/manager.go
@@ -97,6 +97,12 @@ type ConsensusManager struct {
 	// is ~0 when the same SetPrimary that learned the new leader could also rewind.
 	// Guarded by mu.
 	leaderObservedAt time.Time
+	// rewindWaitEmittedFor is the leaderObservedAt value the rewind-wait metric
+	// was last emitted for, so a rewind that fails and is re-attempted against the
+	// same leader is counted once. Touched only on the restart-as-standby path
+	// under the action lock; guarded by mu for safe publication alongside
+	// leaderObservedAt.
+	rewindWaitEmittedFor time.Time
 
 	// resignedLeaderAtTerm is the consensus term at which this node voluntarily
 	// resigned as primary (via emergency-demote or graceful shutdown), or 0 if it
@@ -108,6 +114,13 @@ type ConsensusManager struct {
 	// the consensus cohort, holding a clustermetadatapb.CohortEligibilitySignal.
 	// Atomic; production writes are serialized by the action lock.
 	cohortEligibility atomic.Int32
+	// suspectedDivergence marks that this node's WAL may have diverged from the
+	// cluster's chosen history, so the next restart-as-standby should run
+	// pg_rewind to drop potential phantom / non-durable WAL. Set when consensus
+	// ends this node's term (failover) or a replica can't replicate despite
+	// connecting. Atomic; production writes happen on action-lock paths, and the
+	// lock-free health-status reader loads it.
+	suspectedDivergence atomic.Bool
 }
 
 // NewConsensusManager builds a ConsensusManager over an already-constructed
@@ -306,4 +319,32 @@ func (cm *ConsensusManager) SetCohortEligibility(ctx context.Context, signal clu
 		cm.broadcast()
 	}
 	return nil
+}
+
+// SuspectedDivergence reports whether this node's WAL may have diverged from the
+// cluster's chosen history (so the next restart-as-standby should pg_rewind).
+func (cm *ConsensusManager) SuspectedDivergence() bool {
+	return cm.suspectedDivergence.Load()
+}
+
+// SetSuspectedDivergence sets or clears the suspected-divergence flag, returning
+// whether the value changed (so a caller clearing it can log the transition).
+func (cm *ConsensusManager) SetSuspectedDivergence(suspected bool) (changed bool) {
+	return cm.suspectedDivergence.Swap(suspected) != suspected
+}
+
+// RewindWaitEmittedFor returns the leaderObservedAt value the rewind-wait metric
+// was last emitted for.
+func (cm *ConsensusManager) RewindWaitEmittedFor() time.Time {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	return cm.rewindWaitEmittedFor
+}
+
+// SetRewindWaitEmittedFor records the leaderObservedAt value the rewind-wait
+// metric was just emitted for, so the same leader is not double-counted.
+func (cm *ConsensusManager) SetRewindWaitEmittedFor(t time.Time) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	cm.rewindWaitEmittedFor = t
 }

--- a/go/services/multipooler/internal/manager/consensus/manager_test.go
+++ b/go/services/multipooler/internal/manager/consensus/manager_test.go
@@ -15,6 +15,7 @@
 package consensus
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,7 +23,19 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
 )
+
+// actionLockCtx returns a context holding a freshly-acquired action lock, for
+// tests that exercise ConsensusManager mutators (which assert the lock is held).
+func actionLockCtx(t *testing.T) context.Context {
+	t.Helper()
+	al := actionlock.NewActionLock()
+	ctx, err := al.Acquire(t.Context(), "test")
+	require.NoError(t, err)
+	t.Cleanup(func() { al.Release(ctx) })
+	return ctx
+}
 
 func ruleAt(term, subterm int64) *clustermetadatapb.ShardRule {
 	return &clustermetadatapb.ShardRule{
@@ -140,11 +153,12 @@ func TestRecordTermPrimary(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := actionLockCtx(t)
 			cm := NewConsensusManager(nil, nil, nil)
 			if tt.seedRule != nil {
-				cm.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: tt.seedRule, Primary: tt.seedPrimary})
+				require.NoError(t, cm.RecordTermPrimary(ctx, &clustermetadatapb.ReplicationPrimary{Rule: tt.seedRule, Primary: tt.seedPrimary}))
 			}
-			cm.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: tt.callRule, Primary: tt.callPrimary})
+			require.NoError(t, cm.RecordTermPrimary(ctx, &clustermetadatapb.ReplicationPrimary{Rule: tt.callRule, Primary: tt.callPrimary}))
 
 			got := cm.GetReplicationPrimary()
 			if tt.wantRule == nil && tt.wantPrimary == nil {
@@ -175,7 +189,7 @@ func TestRecordTermPrimary(t *testing.T) {
 // by holding the returned pointer.
 func TestRecordTermPrimary_ReturnsCopies(t *testing.T) {
 	cm := NewConsensusManager(nil, nil, nil)
-	cm.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: ruleAt(5, 0), Primary: primaryAt("p1", "hostA", 5432)})
+	require.NoError(t, cm.RecordTermPrimary(actionLockCtx(t), &clustermetadatapb.ReplicationPrimary{Rule: ruleAt(5, 0), Primary: primaryAt("p1", "hostA", 5432)}))
 
 	got := cm.GetReplicationPrimary()
 	require.NotNil(t, got)

--- a/go/services/multipooler/internal/manager/consensus/manager_test.go
+++ b/go/services/multipooler/internal/manager/consensus/manager_test.go
@@ -140,13 +140,13 @@ func TestRecordTermPrimary(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cs := NewConsensusPromises(t.TempDir(), nil)
+			cm := NewConsensusManager(nil, nil)
 			if tt.seedRule != nil {
-				cs.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: tt.seedRule, Primary: tt.seedPrimary})
+				cm.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: tt.seedRule, Primary: tt.seedPrimary})
 			}
-			cs.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: tt.callRule, Primary: tt.callPrimary})
+			cm.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: tt.callRule, Primary: tt.callPrimary})
 
-			got := cs.GetReplicationPrimary()
+			got := cm.GetReplicationPrimary()
 			if tt.wantRule == nil && tt.wantPrimary == nil {
 				assert.Nil(t, got)
 				return
@@ -174,15 +174,15 @@ func TestRecordTermPrimary(t *testing.T) {
 // TestRecordTermPrimary_ReturnsCopies guards against callers mutating internal state
 // by holding the returned pointer.
 func TestRecordTermPrimary_ReturnsCopies(t *testing.T) {
-	cs := NewConsensusPromises(t.TempDir(), nil)
-	cs.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: ruleAt(5, 0), Primary: primaryAt("p1", "hostA", 5432)})
+	cm := NewConsensusManager(nil, nil)
+	cm.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: ruleAt(5, 0), Primary: primaryAt("p1", "hostA", 5432)})
 
-	got := cs.GetReplicationPrimary()
+	got := cm.GetReplicationPrimary()
 	require.NotNil(t, got)
 	require.NotNil(t, got.GetPrimary())
 	got.Primary.Host = "tampered"
 
-	got2 := cs.GetReplicationPrimary()
+	got2 := cm.GetReplicationPrimary()
 	require.NotNil(t, got2)
 	require.NotNil(t, got2.GetPrimary())
 	assert.Equal(t, "hostA", got2.GetPrimary().GetHost(),

--- a/go/services/multipooler/internal/manager/consensus/manager_test.go
+++ b/go/services/multipooler/internal/manager/consensus/manager_test.go
@@ -140,7 +140,7 @@ func TestRecordTermPrimary(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cm := NewConsensusManager(nil, nil)
+			cm := NewConsensusManager(nil, nil, nil)
 			if tt.seedRule != nil {
 				cm.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: tt.seedRule, Primary: tt.seedPrimary})
 			}
@@ -174,7 +174,7 @@ func TestRecordTermPrimary(t *testing.T) {
 // TestRecordTermPrimary_ReturnsCopies guards against callers mutating internal state
 // by holding the returned pointer.
 func TestRecordTermPrimary_ReturnsCopies(t *testing.T) {
-	cm := NewConsensusManager(nil, nil)
+	cm := NewConsensusManager(nil, nil, nil)
 	cm.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: ruleAt(5, 0), Primary: primaryAt("p1", "hostA", 5432)})
 
 	got := cm.GetReplicationPrimary()

--- a/go/services/multipooler/internal/manager/consensus/manager_test.go
+++ b/go/services/multipooler/internal/manager/consensus/manager_test.go
@@ -154,7 +154,7 @@ func TestRecordTermPrimary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := actionLockCtx(t)
-			cm := NewManagerForTesting(t, nil, nil, nil)
+			cm := NewManagerForTesting(t, nil, nil, nil, nil)
 			if tt.seedRule != nil {
 				require.NoError(t, cm.RecordTermPrimary(ctx, &clustermetadatapb.ReplicationPrimary{Rule: tt.seedRule, Primary: tt.seedPrimary}))
 			}
@@ -188,7 +188,7 @@ func TestRecordTermPrimary(t *testing.T) {
 // TestRecordTermPrimary_ReturnsCopies guards against callers mutating internal state
 // by holding the returned pointer.
 func TestRecordTermPrimary_ReturnsCopies(t *testing.T) {
-	cm := NewManagerForTesting(t, nil, nil, nil)
+	cm := NewManagerForTesting(t, nil, nil, nil, nil)
 	require.NoError(t, cm.RecordTermPrimary(actionLockCtx(t), &clustermetadatapb.ReplicationPrimary{Rule: ruleAt(5, 0), Primary: primaryAt("p1", "hostA", 5432)}))
 
 	got := cm.GetReplicationPrimary()

--- a/go/services/multipooler/internal/manager/consensus/manager_test.go
+++ b/go/services/multipooler/internal/manager/consensus/manager_test.go
@@ -154,7 +154,7 @@ func TestRecordTermPrimary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := actionLockCtx(t)
-			cm := NewConsensusManager(nil, nil, nil)
+			cm := NewManagerForTesting(t, nil, nil, nil)
 			if tt.seedRule != nil {
 				require.NoError(t, cm.RecordTermPrimary(ctx, &clustermetadatapb.ReplicationPrimary{Rule: tt.seedRule, Primary: tt.seedPrimary}))
 			}
@@ -188,7 +188,7 @@ func TestRecordTermPrimary(t *testing.T) {
 // TestRecordTermPrimary_ReturnsCopies guards against callers mutating internal state
 // by holding the returned pointer.
 func TestRecordTermPrimary_ReturnsCopies(t *testing.T) {
-	cm := NewConsensusManager(nil, nil, nil)
+	cm := NewManagerForTesting(t, nil, nil, nil)
 	require.NoError(t, cm.RecordTermPrimary(actionLockCtx(t), &clustermetadatapb.ReplicationPrimary{Rule: ruleAt(5, 0), Primary: primaryAt("p1", "hostA", 5432)}))
 
 	got := cm.GetReplicationPrimary()

--- a/go/services/multipooler/internal/manager/consensus/term_storage.go
+++ b/go/services/multipooler/internal/manager/consensus/term_storage.go
@@ -26,12 +26,12 @@ import (
 )
 
 // consensusTermPath returns the path to the consensus term file
-func (cs *ConsensusState) consensusTermPath() string {
+func (cs *ConsensusPromises) consensusTermPath() string {
 	return filepath.Join(cs.poolerDir, constants.ConsensusTermFile)
 }
 
 // getRevocation retrieves the current term revocation from disk.
-func (cs *ConsensusState) getRevocation() (*clustermetadatapb.TermRevocation, error) {
+func (cs *ConsensusPromises) getRevocation() (*clustermetadatapb.TermRevocation, error) {
 	termPath := cs.consensusTermPath()
 
 	// Check if consensus term file exists
@@ -56,7 +56,7 @@ func (cs *ConsensusState) getRevocation() (*clustermetadatapb.TermRevocation, er
 }
 
 // setRevocation saves the term revocation to disk atomically.
-func (cs *ConsensusState) setRevocation(revocation *clustermetadatapb.TermRevocation) error {
+func (cs *ConsensusPromises) setRevocation(revocation *clustermetadatapb.TermRevocation) error {
 	termPath := cs.consensusTermPath()
 
 	// Marshal protobuf to JSON

--- a/go/services/multipooler/internal/manager/consensus/testing.go
+++ b/go/services/multipooler/internal/manager/consensus/testing.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consensus
+
+import "testing"
+
+// NewManagerForTesting builds a ConsensusManager over already-constructed
+// components, for tests that inject fakes (a fake RuleStorer, an in-memory
+// ConsensusPromises). Production code uses NewConsensusManager, which builds the
+// real components from its dependencies.
+//
+// It takes a testing.TB to mark it test-only — it must live in this package (not
+// a _test.go file) because the manager package's tests, in a different package,
+// construct a ConsensusManager with a fake RuleStorer, and only this package can
+// set the unexported fields.
+func NewManagerForTesting(t testing.TB, promises *ConsensusPromises, rules RuleStorer, broadcaster Broadcaster) *ConsensusManager {
+	t.Helper()
+	return newConsensusManager(promises, rules, broadcaster)
+}

--- a/go/services/multipooler/internal/manager/consensus/testing.go
+++ b/go/services/multipooler/internal/manager/consensus/testing.go
@@ -14,18 +14,23 @@
 
 package consensus
 
-import "testing"
+import (
+	"testing"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+)
 
 // NewManagerForTesting builds a ConsensusManager over already-constructed
 // components, for tests that inject fakes (a fake RuleStorer, an in-memory
 // ConsensusPromises). Production code uses NewConsensusManager, which builds the
-// real components from its dependencies.
+// real components from its dependencies. id is the pooler identity stamped into
+// the ConsensusStatus this manager builds.
 //
 // It takes a testing.TB to mark it test-only — it must live in this package (not
 // a _test.go file) because the manager package's tests, in a different package,
 // construct a ConsensusManager with a fake RuleStorer, and only this package can
 // set the unexported fields.
-func NewManagerForTesting(t testing.TB, promises *ConsensusPromises, rules RuleStorer, broadcaster Broadcaster) *ConsensusManager {
+func NewManagerForTesting(t testing.TB, id *clustermetadatapb.ID, promises *ConsensusPromises, rules RuleStorer, broadcaster Broadcaster) *ConsensusManager {
 	t.Helper()
-	return newConsensusManager(promises, rules, broadcaster)
+	return newConsensusManager(id, promises, rules, broadcaster)
 }

--- a/go/services/multipooler/internal/manager/consensus_manager_test.go
+++ b/go/services/multipooler/internal/manager/consensus_manager_test.go
@@ -66,7 +66,7 @@ func NewMultiPoolerManagerForTesting(t *testing.T, logger *slog.Logger, mp *clus
 		// Build the ConsensusManager with the fake rule store. Promises is rooted
 		// at the pooler dir; no broadcaster (these tests don't assert broadcasts).
 		promises := consensus.NewConsensusPromises(mp.GetPoolerDir(), mp.GetId())
-		ov.consensusMgr = consensus.NewManagerForTesting(t, promises, c.rules, nil)
+		ov.consensusMgr = consensus.NewManagerForTesting(t, mp.GetId(), promises, c.rules, nil)
 	}
 	return newMultiPoolerManager(logger, mp, config, 5*time.Minute, ov)
 }
@@ -111,10 +111,6 @@ func withReplicationPrimary(rp *clustermetadatapb.ReplicationPrimary) testManage
 	return func(c *testManagerConfig) { c.replicationPrimary = rp }
 }
 
-func withCohortEligibility(signal clustermetadatapb.CohortEligibilitySignal) testManagerOption {
-	return func(c *testManagerConfig) { c.cohortEligibility = signal }
-}
-
 func withResignedLeaderAtTerm(term int64) testManagerOption {
 	return func(c *testManagerConfig) { c.resignedLeaderAtTerm = term }
 }
@@ -144,7 +140,7 @@ func resolveTestManagerConfig(t *testing.T, opts ...testManagerOption) *testMana
 // eligibility are seeded separately under the action lock by seedLockedState,
 // since those setters assert the action lock.
 func (cfg *testManagerConfig) consensusManager(t *testing.T) *consensus.ConsensusManager {
-	return consensus.NewManagerForTesting(t, cfg.promises, cfg.rules, nil)
+	return consensus.NewManagerForTesting(t, cfg.serviceID, cfg.promises, cfg.rules, nil)
 }
 
 // seedLockedState applies the replication-primary / resignation / eligibility

--- a/go/services/multipooler/internal/manager/consensus_manager_test.go
+++ b/go/services/multipooler/internal/manager/consensus_manager_test.go
@@ -31,6 +31,7 @@ type testManagerConfig struct {
 	record               *poolerRecord
 	promises             *consensus.ConsensusPromises
 	rules                consensus.RuleStorer
+	replicationPrimary   *clustermetadatapb.ReplicationPrimary
 	cohortEligibility    clustermetadatapb.CohortEligibilitySignal
 	resignedLeaderAtTerm int64
 }
@@ -53,6 +54,13 @@ func withPromises(promises *consensus.ConsensusPromises) testManagerOption {
 
 func withRuleStore(rules consensus.RuleStorer) testManagerOption {
 	return func(c *testManagerConfig) { c.rules = rules }
+}
+
+// withReplicationPrimary records a ReplicationPrimary on the manager at
+// construction (via RecordTermPrimary), seeding the recorded primary/leader the
+// consensus decision paths read.
+func withReplicationPrimary(rp *clustermetadatapb.ReplicationPrimary) testManagerOption {
+	return func(c *testManagerConfig) { c.replicationPrimary = rp }
 }
 
 func withCohortEligibility(signal clustermetadatapb.CohortEligibilitySignal) testManagerOption {
@@ -84,7 +92,11 @@ func resolveTestManagerConfig(t *testing.T, opts ...testManagerOption) *testMana
 }
 
 func (cfg *testManagerConfig) consensusManager() *consensus.ConsensusManager {
-	return consensus.NewConsensusManager(cfg.promises, cfg.rules)
+	cm := consensus.NewConsensusManager(cfg.promises, cfg.rules)
+	if cfg.replicationPrimary != nil {
+		cm.RecordTermPrimary(cfg.replicationPrimary)
+	}
+	return cm
 }
 
 // newTestManager builds a MultiPoolerManager for unit tests of the consensus

--- a/go/services/multipooler/internal/manager/consensus_manager_test.go
+++ b/go/services/multipooler/internal/manager/consensus_manager_test.go
@@ -18,6 +18,8 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
@@ -91,12 +93,36 @@ func resolveTestManagerConfig(t *testing.T, opts ...testManagerOption) *testMana
 	return cfg
 }
 
+// consensusManager builds the ConsensusManager and seeds the lock-free state
+// (the recorded replication primary). A nil broadcaster means health broadcasts
+// are skipped in tests. Resignation/eligibility are seeded separately under the
+// action lock by seedLockedState, since their setters assert the action lock.
 func (cfg *testManagerConfig) consensusManager() *consensus.ConsensusManager {
-	cm := consensus.NewConsensusManager(cfg.promises, cfg.rules)
+	cm := consensus.NewConsensusManager(cfg.promises, cfg.rules, nil)
 	if cfg.replicationPrimary != nil {
 		cm.RecordTermPrimary(cfg.replicationPrimary)
 	}
 	return cm
+}
+
+// seedLockedState applies the resignation/eligibility overrides through the
+// action-lock-asserting setters, briefly acquiring the manager's action lock.
+// No-op when both are at their defaults.
+func (cfg *testManagerConfig) seedLockedState(t *testing.T, pm *MultiPoolerManager) {
+	t.Helper()
+	eligibleDefault := clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE
+	if cfg.resignedLeaderAtTerm == 0 && cfg.cohortEligibility == eligibleDefault {
+		return
+	}
+	lockCtx, err := pm.actionLock.Acquire(t.Context(), "test-seed")
+	require.NoError(t, err)
+	defer pm.actionLock.Release(lockCtx)
+	if cfg.resignedLeaderAtTerm != 0 {
+		require.NoError(t, pm.consensusMgr.SetResignedLeaderAtTerm(lockCtx, cfg.resignedLeaderAtTerm))
+	}
+	if cfg.cohortEligibility != eligibleDefault {
+		require.NoError(t, pm.consensusMgr.SetCohortEligibility(lockCtx, cfg.cohortEligibility))
+	}
 }
 
 // newTestManager builds a MultiPoolerManager for unit tests of the consensus
@@ -107,26 +133,29 @@ func (cfg *testManagerConfig) consensusManager() *consensus.ConsensusManager {
 func newTestManager(t *testing.T, opts ...testManagerOption) *MultiPoolerManager {
 	t.Helper()
 	cfg := resolveTestManagerConfig(t, opts...)
-	return &MultiPoolerManager{
-		logger:               slog.Default(),
-		actionLock:           actionlock.NewActionLock(),
-		serviceID:            cfg.serviceID,
-		record:               cfg.record,
-		cohortEligibility:    cfg.cohortEligibility,
-		resignedLeaderAtTerm: cfg.resignedLeaderAtTerm,
-		consensusMgr:         cfg.consensusManager(),
+	pm := &MultiPoolerManager{
+		logger:       slog.Default(),
+		actionLock:   actionlock.NewActionLock(),
+		serviceID:    cfg.serviceID,
+		record:       cfg.record,
+		consensusMgr: cfg.consensusManager(),
 	}
+	cfg.seedLockedState(t, pm)
+	return pm
 }
 
 // setTestRuleStore swaps the rule store of an already-constructed manager,
 // preserving its promises. Used by tests that build a manager via the real
 // NewMultiPoolerManager and then point the rule store at a mock query service.
+// (The rebuilt manager drops the broadcaster — acceptable since these tests
+// don't assert health broadcasts; this bridge goes away with the deferred
+// dependency-injection refactor.)
 func setTestRuleStore(pm *MultiPoolerManager, rules consensus.RuleStorer) {
-	pm.consensusMgr = consensus.NewConsensusManager(pm.consensusMgr.Promises(), rules)
+	pm.consensusMgr = consensus.NewConsensusManager(pm.consensusMgr.Promises(), rules, nil)
 }
 
 // setTestPromises swaps the durable-promise store of an already-constructed
 // manager, preserving its rule store.
 func setTestPromises(pm *MultiPoolerManager, promises *consensus.ConsensusPromises) {
-	pm.consensusMgr = consensus.NewConsensusManager(promises, pm.consensusMgr.Rules())
+	pm.consensusMgr = consensus.NewConsensusManager(promises, pm.consensusMgr.Rules(), nil)
 }

--- a/go/services/multipooler/internal/manager/consensus_manager_test.go
+++ b/go/services/multipooler/internal/manager/consensus_manager_test.go
@@ -17,13 +17,59 @@ package manager
 import (
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
+	"github.com/multigres/multigres/go/services/multipooler/internal/poolerserver"
 )
+
+// forTestOption configures NewMultiPoolerManagerForTesting.
+type forTestOption func(*forTestConfig)
+
+type forTestConfig struct {
+	qsc   poolerserver.PoolerController
+	rules consensus.RuleStorer
+}
+
+// withMockController injects a query-pooler controller (a mock query service)
+// instead of the one the constructor would build. The consensus rule store is
+// built over its InternalQueryService(), so this also points the rule store at
+// the mock.
+func withMockController(qsc poolerserver.PoolerController) forTestOption {
+	return func(c *forTestConfig) { c.qsc = qsc }
+}
+
+// withFakeRules injects a fake rule store: the manager is built through the real
+// constructor but its ConsensusManager uses this RuleStorer instead of a real
+// store over postgres.
+func withFakeRules(rules consensus.RuleStorer) forTestOption {
+	return func(c *forTestConfig) { c.rules = rules }
+}
+
+// NewMultiPoolerManagerForTesting builds a MultiPoolerManager through the real
+// constructor path (topology record, health streamer, lifecycle, etc.) while
+// letting a test inject a mock query-pooler controller and/or a fake rule store.
+// It replaces the old build-then-swap pattern (a manual pm.qsc assignment plus
+// setTestRuleStore/setTestPromises).
+func NewMultiPoolerManagerForTesting(t *testing.T, logger *slog.Logger, mp *clustermetadatapb.MultiPooler, config *Config, opts ...forTestOption) (*MultiPoolerManager, error) {
+	t.Helper()
+	var c forTestConfig
+	for _, o := range opts {
+		o(&c)
+	}
+	ov := overrides{qsc: c.qsc}
+	if c.rules != nil {
+		// Build the ConsensusManager with the fake rule store. Promises is rooted
+		// at the pooler dir; no broadcaster (these tests don't assert broadcasts).
+		promises := consensus.NewConsensusPromises(mp.GetPoolerDir(), mp.GetId())
+		ov.consensusMgr = consensus.NewManagerForTesting(t, promises, c.rules, nil)
+	}
+	return newMultiPoolerManager(logger, mp, config, 5*time.Minute, ov)
+}
 
 // testManagerConfig collects the consensus-related inputs a test wants to inject
 // into a MultiPoolerManager. Defaults are filled in by newTestManager, so a test
@@ -141,20 +187,4 @@ func newTestManager(t *testing.T, opts ...testManagerOption) *MultiPoolerManager
 	}
 	cfg.seedLockedState(t, pm)
 	return pm
-}
-
-// setTestRuleStore swaps the rule store of an already-constructed manager,
-// preserving its promises. Used by tests that build a manager via the real
-// NewMultiPoolerManager and then point the rule store at a mock query service.
-// (The rebuilt manager drops the broadcaster — acceptable since these tests
-// don't assert health broadcasts; this bridge goes away with the deferred
-// dependency-injection refactor.)
-func setTestRuleStore(t *testing.T, pm *MultiPoolerManager, rules consensus.RuleStorer) {
-	pm.consensusMgr = consensus.NewManagerForTesting(t, pm.consensusMgr.Promises(), rules, nil)
-}
-
-// setTestPromises swaps the durable-promise store of an already-constructed
-// manager, preserving its rule store.
-func setTestPromises(t *testing.T, pm *MultiPoolerManager, promises *consensus.ConsensusPromises) {
-	pm.consensusMgr = consensus.NewManagerForTesting(t, promises, pm.consensusMgr.Rules(), nil)
 }

--- a/go/services/multipooler/internal/manager/consensus_manager_test.go
+++ b/go/services/multipooler/internal/manager/consensus_manager_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"log/slog"
+	"testing"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
+	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
+)
+
+// testManagerConfig collects the consensus-related inputs a test wants to inject
+// into a MultiPoolerManager. Defaults are filled in by newTestManager, so a test
+// only sets what it cares about via the with* options.
+type testManagerConfig struct {
+	serviceID            *clustermetadatapb.ID
+	record               *poolerRecord
+	promises             *consensus.ConsensusPromises
+	rules                consensus.RuleStorer
+	cohortEligibility    clustermetadatapb.CohortEligibilitySignal
+	resignedLeaderAtTerm int64
+}
+
+type testManagerOption func(*testManagerConfig)
+
+func withServiceID(id *clustermetadatapb.ID) testManagerOption {
+	return func(c *testManagerConfig) { c.serviceID = id }
+}
+
+func withRecord(record *poolerRecord) testManagerOption {
+	return func(c *testManagerConfig) { c.record = record }
+}
+
+// withPromises injects an already-constructed ConsensusPromises (e.g. one that a
+// test has seeded via consensustest.SeedTerm or RecordTermPrimary).
+func withPromises(promises *consensus.ConsensusPromises) testManagerOption {
+	return func(c *testManagerConfig) { c.promises = promises }
+}
+
+func withRuleStore(rules consensus.RuleStorer) testManagerOption {
+	return func(c *testManagerConfig) { c.rules = rules }
+}
+
+func withCohortEligibility(signal clustermetadatapb.CohortEligibilitySignal) testManagerOption {
+	return func(c *testManagerConfig) { c.cohortEligibility = signal }
+}
+
+func withResignedLeaderAtTerm(term int64) testManagerOption {
+	return func(c *testManagerConfig) { c.resignedLeaderAtTerm = term }
+}
+
+// resolveTestManagerConfig applies the options and fills in defaults: a fake
+// rule store and an empty in-memory ConsensusPromises (rooted at a temp dir).
+// Shared by the test constructors so they install a non-nil ConsensusManager.
+func resolveTestManagerConfig(t *testing.T, opts ...testManagerOption) *testManagerConfig {
+	t.Helper()
+	cfg := &testManagerConfig{
+		cohortEligibility: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE,
+	}
+	for _, o := range opts {
+		o(cfg)
+	}
+	if cfg.promises == nil {
+		cfg.promises = consensus.NewConsensusPromises(t.TempDir(), cfg.serviceID)
+	}
+	if cfg.rules == nil {
+		cfg.rules = &fakeRuleStore{}
+	}
+	return cfg
+}
+
+func (cfg *testManagerConfig) consensusManager() *consensus.ConsensusManager {
+	return consensus.NewConsensusManager(cfg.promises, cfg.rules)
+}
+
+// newTestManager builds a MultiPoolerManager for unit tests of the consensus
+// decision paths (remedial-action selection, stale-standby detection, etc.)
+// without going through the full NewMultiPoolerManager bootstrap. It always
+// installs a non-nil ConsensusManager: a fake rule store and an empty in-memory
+// ConsensusPromises by default, each overridable via with* options.
+func newTestManager(t *testing.T, opts ...testManagerOption) *MultiPoolerManager {
+	t.Helper()
+	cfg := resolveTestManagerConfig(t, opts...)
+	return &MultiPoolerManager{
+		logger:               slog.Default(),
+		actionLock:           actionlock.NewActionLock(),
+		serviceID:            cfg.serviceID,
+		record:               cfg.record,
+		cohortEligibility:    cfg.cohortEligibility,
+		resignedLeaderAtTerm: cfg.resignedLeaderAtTerm,
+		consensusMgr:         cfg.consensusManager(),
+	}
+}
+
+// setTestRuleStore swaps the rule store of an already-constructed manager,
+// preserving its promises. Used by tests that build a manager via the real
+// NewMultiPoolerManager and then point the rule store at a mock query service.
+func setTestRuleStore(pm *MultiPoolerManager, rules consensus.RuleStorer) {
+	pm.consensusMgr = consensus.NewConsensusManager(pm.consensusMgr.Promises(), rules)
+}
+
+// setTestPromises swaps the durable-promise store of an already-constructed
+// manager, preserving its rule store.
+func setTestPromises(pm *MultiPoolerManager, promises *consensus.ConsensusPromises) {
+	pm.consensusMgr = consensus.NewConsensusManager(promises, pm.consensusMgr.Rules())
+}

--- a/go/services/multipooler/internal/manager/consensus_manager_test.go
+++ b/go/services/multipooler/internal/manager/consensus_manager_test.go
@@ -93,30 +93,29 @@ func resolveTestManagerConfig(t *testing.T, opts ...testManagerOption) *testMana
 	return cfg
 }
 
-// consensusManager builds the ConsensusManager and seeds the lock-free state
-// (the recorded replication primary). A nil broadcaster means health broadcasts
-// are skipped in tests. Resignation/eligibility are seeded separately under the
-// action lock by seedLockedState, since their setters assert the action lock.
+// consensusManager builds the ConsensusManager. A nil broadcaster means health
+// broadcasts are skipped in tests. The recorded primary, resignation, and
+// eligibility are seeded separately under the action lock by seedLockedState,
+// since those setters assert the action lock.
 func (cfg *testManagerConfig) consensusManager() *consensus.ConsensusManager {
-	cm := consensus.NewConsensusManager(cfg.promises, cfg.rules, nil)
-	if cfg.replicationPrimary != nil {
-		cm.RecordTermPrimary(cfg.replicationPrimary)
-	}
-	return cm
+	return consensus.NewConsensusManager(cfg.promises, cfg.rules, nil)
 }
 
-// seedLockedState applies the resignation/eligibility overrides through the
-// action-lock-asserting setters, briefly acquiring the manager's action lock.
-// No-op when both are at their defaults.
+// seedLockedState applies the replication-primary / resignation / eligibility
+// overrides through the action-lock-asserting setters, briefly acquiring the
+// manager's action lock. No-op when all are at their defaults.
 func (cfg *testManagerConfig) seedLockedState(t *testing.T, pm *MultiPoolerManager) {
 	t.Helper()
 	eligibleDefault := clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE
-	if cfg.resignedLeaderAtTerm == 0 && cfg.cohortEligibility == eligibleDefault {
+	if cfg.replicationPrimary == nil && cfg.resignedLeaderAtTerm == 0 && cfg.cohortEligibility == eligibleDefault {
 		return
 	}
 	lockCtx, err := pm.actionLock.Acquire(t.Context(), "test-seed")
 	require.NoError(t, err)
 	defer pm.actionLock.Release(lockCtx)
+	if cfg.replicationPrimary != nil {
+		require.NoError(t, pm.consensusMgr.RecordTermPrimary(lockCtx, cfg.replicationPrimary))
+	}
 	if cfg.resignedLeaderAtTerm != 0 {
 		require.NoError(t, pm.consensusMgr.SetResignedLeaderAtTerm(lockCtx, cfg.resignedLeaderAtTerm))
 	}

--- a/go/services/multipooler/internal/manager/consensus_manager_test.go
+++ b/go/services/multipooler/internal/manager/consensus_manager_test.go
@@ -97,8 +97,8 @@ func resolveTestManagerConfig(t *testing.T, opts ...testManagerOption) *testMana
 // broadcasts are skipped in tests. The recorded primary, resignation, and
 // eligibility are seeded separately under the action lock by seedLockedState,
 // since those setters assert the action lock.
-func (cfg *testManagerConfig) consensusManager() *consensus.ConsensusManager {
-	return consensus.NewConsensusManager(cfg.promises, cfg.rules, nil)
+func (cfg *testManagerConfig) consensusManager(t *testing.T) *consensus.ConsensusManager {
+	return consensus.NewManagerForTesting(t, cfg.promises, cfg.rules, nil)
 }
 
 // seedLockedState applies the replication-primary / resignation / eligibility
@@ -137,7 +137,7 @@ func newTestManager(t *testing.T, opts ...testManagerOption) *MultiPoolerManager
 		actionLock:   actionlock.NewActionLock(),
 		serviceID:    cfg.serviceID,
 		record:       cfg.record,
-		consensusMgr: cfg.consensusManager(),
+		consensusMgr: cfg.consensusManager(t),
 	}
 	cfg.seedLockedState(t, pm)
 	return pm
@@ -149,12 +149,12 @@ func newTestManager(t *testing.T, opts ...testManagerOption) *MultiPoolerManager
 // (The rebuilt manager drops the broadcaster — acceptable since these tests
 // don't assert health broadcasts; this bridge goes away with the deferred
 // dependency-injection refactor.)
-func setTestRuleStore(pm *MultiPoolerManager, rules consensus.RuleStorer) {
-	pm.consensusMgr = consensus.NewConsensusManager(pm.consensusMgr.Promises(), rules, nil)
+func setTestRuleStore(t *testing.T, pm *MultiPoolerManager, rules consensus.RuleStorer) {
+	pm.consensusMgr = consensus.NewManagerForTesting(t, pm.consensusMgr.Promises(), rules, nil)
 }
 
 // setTestPromises swaps the durable-promise store of an already-constructed
 // manager, preserving its rule store.
-func setTestPromises(pm *MultiPoolerManager, promises *consensus.ConsensusPromises) {
-	pm.consensusMgr = consensus.NewConsensusManager(promises, pm.consensusMgr.Rules(), nil)
+func setTestPromises(t *testing.T, pm *MultiPoolerManager, promises *consensus.ConsensusPromises) {
+	pm.consensusMgr = consensus.NewManagerForTesting(t, promises, pm.consensusMgr.Rules(), nil)
 }

--- a/go/services/multipooler/internal/manager/graceful_shutdown.go
+++ b/go/services/multipooler/internal/manager/graceful_shutdown.go
@@ -106,7 +106,9 @@ func (pm *MultiPoolerManager) GracefulShutdown(ctx context.Context) {
 
 	// Advertise cohort ineligibility before stopping postgres just in case
 	// stopping is slow. We're favoring speed of failover rather than grace.
-	pm.setCohortEligibility(clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE)
+	if err := pm.consensusMgr.SetCohortEligibility(lockCtx, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE); err != nil {
+		pm.logger.WarnContext(lockCtx, "failed to set cohort ineligibility during shutdown", "error", err)
+	}
 
 	if err := pm.pgctldStopWithEscalation(lockCtx); err != nil {
 		pm.logger.ErrorContext(lockCtx, "pgctld.Stop failed during graceful shutdown", "error", err)

--- a/go/services/multipooler/internal/manager/graceful_shutdown_test.go
+++ b/go/services/multipooler/internal/manager/graceful_shutdown_test.go
@@ -101,7 +101,7 @@ func newGracefulShutdownTestManager(t *testing.T, pgctldClient pgctldpb.PgCtldCl
 		pgctldClient:   pgctldClient,
 		healthStreamer: hs,
 		actionLock:     actionlock.NewActionLock(),
-		consensusMgr:   consensus.NewManagerForTesting(t, consensus.NewConsensusPromises("", id), &fakeRuleStore{}, hs),
+		consensusMgr:   consensus.NewManagerForTesting(t, id, consensus.NewConsensusPromises("", id), &fakeRuleStore{}, hs),
 		// Match the production default set by topoclient.NewMultiPooler so
 		// the record's LifecycleStatus reads as STARTING from the start.
 		// (Real boot wires this in via NewMultiPoolerManager(multiPooler).)

--- a/go/services/multipooler/internal/manager/graceful_shutdown_test.go
+++ b/go/services/multipooler/internal/manager/graceful_shutdown_test.go
@@ -101,7 +101,7 @@ func newGracefulShutdownTestManager(t *testing.T, pgctldClient pgctldpb.PgCtldCl
 		pgctldClient:   pgctldClient,
 		healthStreamer: hs,
 		actionLock:     actionlock.NewActionLock(),
-		consensusMgr:   consensus.NewConsensusManager(consensus.NewConsensusPromises("", id), &fakeRuleStore{}, hs),
+		consensusMgr:   consensus.NewManagerForTesting(t, consensus.NewConsensusPromises("", id), &fakeRuleStore{}, hs),
 		// Match the production default set by topoclient.NewMultiPooler so
 		// the record's LifecycleStatus reads as STARTING from the start.
 		// (Real boot wires this in via NewMultiPoolerManager(multiPooler).)

--- a/go/services/multipooler/internal/manager/graceful_shutdown_test.go
+++ b/go/services/multipooler/internal/manager/graceful_shutdown_test.go
@@ -33,6 +33,7 @@ import (
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
+	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
 )
 
 // assertRecent fails the test if ts is nil or older than 5 seconds ago.
@@ -92,13 +93,15 @@ func newGracefulShutdownTestManager(t *testing.T, pgctldClient pgctldpb.PgCtldCl
 		Cell:      "zone1",
 		Name:      "test",
 	}
+	hs := newHealthStreamer(logger, id, "tg", "0")
 	return &MultiPoolerManager{
 		logger:         logger,
 		serviceID:      id,
 		config:         &Config{},
 		pgctldClient:   pgctldClient,
-		healthStreamer: newHealthStreamer(logger, id, "tg", "0"),
+		healthStreamer: hs,
 		actionLock:     actionlock.NewActionLock(),
+		consensusMgr:   consensus.NewConsensusManager(consensus.NewConsensusPromises("", id), &fakeRuleStore{}, hs),
 		// Match the production default set by topoclient.NewMultiPooler so
 		// the record's LifecycleStatus reads as STARTING from the start.
 		// (Real boot wires this in via NewMultiPoolerManager(multiPooler).)
@@ -367,9 +370,7 @@ func TestGracefulShutdown_AdvertisesCohortIneligibleBeforeStop(t *testing.T) {
 	var atStopSignal clustermetadatapb.CohortEligibilitySignal
 	pgctld := &recordingPgctldClient{
 		stopFn: func(string) error {
-			pm.mu.Lock()
-			atStopSignal = pm.cohortEligibility
-			pm.mu.Unlock()
+			atStopSignal = pm.consensusMgr.CohortEligibility()
 			return nil
 		},
 	}
@@ -386,9 +387,7 @@ func TestGracefulShutdown_AdvertisesCohortIneligibleBeforeStop(t *testing.T) {
 			"the default ELIGIBLE, the announce was sequenced AFTER stop and the "+
 			"broadcast races stream EOF")
 
-	pm.mu.Lock()
-	finalSignal := pm.cohortEligibility
-	pm.mu.Unlock()
+	finalSignal := pm.consensusMgr.CohortEligibility()
 	require.Equal(t,
 		clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE,
 		finalSignal,

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -148,17 +148,8 @@ type MultiPoolerManager struct {
 	// Once true, stays true for the lifetime of the manager.
 	initialized bool
 
-	// resignedLeaderAtTerm is set when this node voluntarily resigns as primary
-	// (via Recruit's emergency-demote path or graceful shutdown). The value is
-	// the consensus term at which the primary resigned. A non-zero value signals
-	// the coordinator to trigger an immediate election. Protected by mu. Cleared
-	// when this node is elected primary again.
-	resignedLeaderAtTerm int64
-
-	// cohortEligibility is this node's self-reported willingness to be a member
-	// of the consensus cohort. Defaults to ELIGIBLE; published in every health
-	// snapshot via AvailabilityStatus.CohortEligibilityStatus. Protected by mu.
-	cohortEligibility clustermetadatapb.CohortEligibilitySignal
+	// Leader-resignation and cohort-eligibility state now live on consensusMgr
+	// (consensus.ConsensusManager), alongside the term promises and rule store.
 
 	// pgMonitor manages the PostgreSQL monitoring loop.
 	pgMonitor *timer.PeriodicRunner
@@ -326,7 +317,6 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 		readyChan:              make(chan struct{}),
 		pgMonitor:              monitorRunner,
 		healthStreamer:         newHealthStreamer(logger, multiPooler.Id, multiPooler.GetShardKey().GetTableGroup(), multiPooler.GetShardKey().GetShard()),
-		cohortEligibility:      clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE,
 		// We create a dummy context because some unit tests need them.
 		// These will be overwritten when Open gets called.
 		ctx:    ctx,
@@ -358,7 +348,7 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 	}
 	pm.qsc = poolerserver.NewQueryPoolerServer(logger, connPoolMgr, multiPooler.Id, multiPooler.GetShardKey().GetTableGroup(), multiPooler.GetShardKey().GetShard(), pm, drainGracePeriod, config.VpidStampEnabled)
 	rules := consensus.NewRuleStore(pm.logger, pm.qsc.InternalQueryService(), consensus.NewSyncStandbyManager(pm.logger, pm.qsc.InternalQueryService(), multiPooler.Id))
-	pm.consensusMgr = consensus.NewConsensusManager(promises, rules)
+	pm.consensusMgr = consensus.NewConsensusManager(promises, rules, pm.healthStreamer)
 
 	// The health streamer must wait for the query server to update its type before
 	// broadcasting SERVING transitions, so the gateway doesn't discover the new

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -314,16 +314,6 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 	// long-lived stream subscribers can keep watching it.
 	pm.shutdownCtx, pm.shutdownCancel = context.WithCancel(ctxutil.Detach(ctx))
 
-	// Load consensus state from disk. Missing file means term=0 (new node), which is fine.
-	// Only actual read/parse errors fail the constructor.
-	promises := consensus.NewConsensusPromises(pm.record.PoolerDir(), pm.serviceID)
-	if config.ConsensusEnabled {
-		if _, err := promises.Load(); err != nil {
-			cancel()
-			return nil, fmt.Errorf("failed to load consensus state from disk: %w", err)
-		}
-	}
-
 	// Create the query service controller with the pool manager.
 	// Get the drain grace period from connpool config (0 means use default).
 	var drainGracePeriod time.Duration
@@ -331,8 +321,23 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 		drainGracePeriod = config.ConnPoolConfig.DrainGracePeriod()
 	}
 	pm.qsc = poolerserver.NewQueryPoolerServer(logger, connPoolMgr, multiPooler.Id, multiPooler.GetShardKey().GetTableGroup(), multiPooler.GetShardKey().GetShard(), pm, drainGracePeriod, config.VpidStampEnabled)
-	rules := consensus.NewRuleStore(pm.logger, pm.qsc.InternalQueryService(), consensus.NewSyncStandbyManager(pm.logger, pm.qsc.InternalQueryService(), multiPooler.Id))
-	pm.consensusMgr = consensus.NewConsensusManager(promises, rules, pm.healthStreamer)
+
+	// ConsensusManager owns its own wiring (durable promise store + rule store +
+	// sync-standby manager). LoadPromises loads the persisted term from disk on
+	// the consensus-enabled path; a missing file means term=0 (new node), and
+	// only an actual read/parse error fails the constructor.
+	pm.consensusMgr, err = consensus.NewConsensusManager(consensus.Deps{
+		Logger:       pm.logger,
+		QueryService: pm.qsc.InternalQueryService(),
+		PoolerDir:    pm.record.PoolerDir(),
+		ID:           multiPooler.Id,
+		Broadcaster:  pm.healthStreamer,
+		LoadPromises: config.ConsensusEnabled,
+	})
+	if err != nil {
+		cancel()
+		return nil, err
+	}
 
 	// The health streamer must wait for the query server to update its type before
 	// broadcasting SERVING transitions, so the gateway doesn't discover the new

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -112,15 +112,15 @@ type MultiPoolerManager struct {
 	// exclusively written through record.Mutate (today only by StateManager);
 	// the remaining fields are immutable after construction and exposed via
 	// typed accessors that read without locking.
-	record         *poolerRecord
-	state          ManagerState
-	stateError     error
-	consensusState *consensus.ConsensusState
-	topoLoaded     bool
-	rules          consensus.RuleStorer
-	ctx            context.Context
-	cancel         context.CancelFunc
-	loadTimeout    time.Duration
+	record            *poolerRecord
+	state             ManagerState
+	stateError        error
+	consensusPromises *consensus.ConsensusPromises
+	topoLoaded        bool
+	rules             consensus.RuleStorer
+	ctx               context.Context
+	cancel            context.CancelFunc
+	loadTimeout       time.Duration
 
 	// shutdownCtx is cancelled at the end of GracefulShutdown to signal
 	// long-lived subscribers (currently the health-stream gRPC handlers via
@@ -177,7 +177,7 @@ type MultiPoolerManager struct {
 	//     this, but in the future a pooler could self-detect it.
 	suspectedDivergence atomic.Bool
 
-	// rewindWaitEmittedFor is the ConsensusState.LeaderObservedAt() value the
+	// rewindWaitEmittedFor is the ConsensusPromises.LeaderObservedAt() value the
 	// rewind-wait metric was last emitted for, so a rewind that fails and is
 	// re-attempted against the same leader is counted once. Only read/written from
 	// restartAsStandbyLocked, which always holds the action lock, so it needs no
@@ -343,9 +343,9 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 
 	// Load consensus state from disk. Missing file means term=0 (new node), which is fine.
 	// Only actual read/parse errors fail the constructor.
-	pm.consensusState = consensus.NewConsensusState(pm.record.PoolerDir(), pm.serviceID)
+	pm.consensusPromises = consensus.NewConsensusPromises(pm.record.PoolerDir(), pm.serviceID)
 	if config.ConsensusEnabled {
-		if _, err := pm.consensusState.Load(); err != nil {
+		if _, err := pm.consensusPromises.Load(); err != nil {
 			cancel()
 			return nil, fmt.Errorf("failed to load consensus state from disk: %w", err)
 		}
@@ -878,7 +878,7 @@ func (pm *MultiPoolerManager) checkPoolerType(expectedType clustermetadatapb.Poo
 
 // getCurrentTermNumber returns the current consensus term number.
 func (pm *MultiPoolerManager) getCurrentTermNumber(ctx context.Context) (int64, error) {
-	return pm.consensusState.GetCurrentTermNumber(ctx)
+	return pm.consensusPromises.GetCurrentTermNumber(ctx)
 }
 
 // checkReplicaGuardrails verifies that the pooler is a REPLICA and PostgreSQL is in recovery mode
@@ -1127,7 +1127,7 @@ func (pm *MultiPoolerManager) validateAndUpdateTerm(ctx context.Context, request
 			"service_id", pm.serviceID.String())
 
 		// Update term atomically (resets accepted leader)
-		if err := pm.consensusState.UpdateTermAndSave(ctx, requestTerm); err != nil {
+		if err := pm.consensusPromises.UpdateTermAndSave(ctx, requestTerm); err != nil {
 			pm.logger.ErrorContext(ctx, "Failed to update term", "error", err)
 			return mterrors.Wrap(err, "failed to update consensus term")
 		}
@@ -1484,7 +1484,7 @@ func (pm *MultiPoolerManager) promoteStandbyToPrimary(ctx context.Context, state
 			pm.logger.WarnContext(checkpointCtx, "Async post-promotion checkpoint failed; rewind-readiness will be delayed until PostgreSQL's own checkpoint completes", "error", err)
 			return
 		}
-		if pm.consensusState.MarkSelfRewindReady(pm.serviceID, coordinatorTerm) {
+		if pm.consensusPromises.MarkSelfRewindReady(pm.serviceID, coordinatorTerm) {
 			pm.logger.InfoContext(checkpointCtx, "Post-promotion checkpoint complete; advertising rewind-ready", "coordinator_term", coordinatorTerm)
 			pm.broadcastHealth()
 		}

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -965,9 +965,9 @@ func (pm *MultiPoolerManager) checkAndSetReady() {
 		// commonconsensus.LeaderTerm returns 0 unless the rule names us as the
 		// leader, so publishing serviceID here is safe. Fall back to the cached
 		// position if postgres is unreachable.
-		cs, err := pm.getInconsistentConsensusStatus(pm.ctx)
+		cs, err := pm.consensusMgr.InconsistentConsensusStatus(pm.ctx)
 		if err != nil {
-			cs = pm.getCachedConsensusStatus()
+			cs = pm.consensusMgr.CachedConsensusStatus()
 		}
 		if primaryTerm := commonconsensus.LeaderTerm(cs); primaryTerm > 0 {
 			pm.healthStreamer.UpdateLeaderObservation(&poolerserver.LeaderObservation{

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -876,11 +876,6 @@ func (pm *MultiPoolerManager) checkPoolerType(expectedType clustermetadatapb.Poo
 	return nil
 }
 
-// getCurrentTermNumber returns the current consensus term number.
-func (pm *MultiPoolerManager) getCurrentTermNumber(ctx context.Context) (int64, error) {
-	return pm.consensusPromises.GetCurrentTermNumber(ctx)
-}
-
 // checkReplicaGuardrails verifies that the pooler is a REPLICA and PostgreSQL is in recovery mode
 // This is a common guardrail for replication-related operations on standby servers
 func (pm *MultiPoolerManager) checkReplicaGuardrails(ctx context.Context) error {
@@ -1091,51 +1086,6 @@ func (pm *MultiPoolerManager) loadShardConfigFromGlobalTopo() {
 		pm.checkAndSetReady()
 		return
 	}
-}
-
-// validateAndUpdateTerm validates the request term against the current term following Consensus rules.
-// Returns an error if the request term is stale (less than current term).
-// If the request term is higher, it updates the term in pgctld and the cache.
-// If force is true, validation is skipped.
-func (pm *MultiPoolerManager) validateAndUpdateTerm(ctx context.Context, requestTerm int64, force bool) error {
-	if force {
-		return nil // Skip validation if force is set
-	}
-
-	currentTerm, err := pm.getCurrentTermNumber(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get current term: %w", err)
-	}
-
-	// If request term == current term: ACCEPT (same term, execute)
-	// If request term < current term: REJECT (stale request)
-	// If request term > current term: UPDATE term and ACCEPT (new term discovered)
-	if requestTerm < currentTerm {
-		// Request has stale term, reject
-		pm.logger.ErrorContext(ctx, "Consensus term too old, rejecting request",
-			"request_term", requestTerm,
-			"current_term", currentTerm,
-			"service_id", pm.serviceID.String())
-		return mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION,
-			fmt.Sprintf("consensus term too old: request term %d is less than current term %d (use force=true to bypass)",
-				requestTerm, currentTerm))
-	} else if requestTerm > currentTerm {
-		// Request has newer term, update our term
-		pm.logger.InfoContext(ctx, "Discovered newer term, updating",
-			"request_term", requestTerm,
-			"old_term", currentTerm,
-			"service_id", pm.serviceID.String())
-
-		// Update term atomically (resets accepted leader)
-		if err := pm.consensusPromises.UpdateTermAndSave(ctx, requestTerm); err != nil {
-			pm.logger.ErrorContext(ctx, "Failed to update term", "error", err)
-			return mterrors.Wrap(err, "failed to update consensus term")
-		}
-
-		pm.logger.InfoContext(ctx, "Consensus term updated successfully", "new_term", requestTerm)
-	}
-	// If requestTerm == currentCachedTerm, just continue (same term is OK)
-	return nil
 }
 
 // checkDemotionState checks the current state to determine what steps remain

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -226,6 +226,25 @@ func NewMultiPoolerManager(logger *slog.Logger, multiPooler *clustermetadatapb.M
 
 // NewMultiPoolerManagerWithTimeout creates a new MultiPoolerManager instance with a custom load timeout
 func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clustermetadatapb.MultiPooler, config *Config, loadTimeout time.Duration) (*MultiPoolerManager, error) {
+	return newMultiPoolerManager(logger, multiPooler, config, loadTimeout, overrides{})
+}
+
+// overrides carries test-only injections for the constructor core. Its zero
+// value is the production path; tests populate it via NewMultiPoolerManagerForTesting.
+type overrides struct {
+	// qsc, when non-nil, replaces the query-pooler server the constructor would
+	// otherwise build (so tests can supply a mock query service). The consensus
+	// rule store is built over qsc.InternalQueryService(), so injecting a mock
+	// here also points the rule store at the mock.
+	qsc poolerserver.PoolerController
+	// consensusMgr, when non-nil, replaces the ConsensusManager the constructor
+	// would otherwise build (so tests can supply one with a fake rule store).
+	consensusMgr *consensus.ConsensusManager
+}
+
+// newMultiPoolerManager is the constructor core shared by the production
+// constructors and the test constructor. ov is the zero value in production.
+func newMultiPoolerManager(logger *slog.Logger, multiPooler *clustermetadatapb.MultiPooler, config *Config, loadTimeout time.Duration, ov overrides) (*MultiPoolerManager, error) {
 	// Validate required multiPooler fields
 	if multiPooler == nil {
 		return nil, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "multiPooler is required")
@@ -320,23 +339,32 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 	if config.ConnPoolConfig != nil {
 		drainGracePeriod = config.ConnPoolConfig.DrainGracePeriod()
 	}
-	pm.qsc = poolerserver.NewQueryPoolerServer(logger, connPoolMgr, multiPooler.Id, multiPooler.GetShardKey().GetTableGroup(), multiPooler.GetShardKey().GetShard(), pm, drainGracePeriod, config.VpidStampEnabled)
+	if ov.qsc != nil {
+		pm.qsc = ov.qsc
+	} else {
+		pm.qsc = poolerserver.NewQueryPoolerServer(logger, connPoolMgr, multiPooler.Id, multiPooler.GetShardKey().GetTableGroup(), multiPooler.GetShardKey().GetShard(), pm, drainGracePeriod, config.VpidStampEnabled)
+	}
 
 	// ConsensusManager owns its own wiring (durable promise store + rule store +
 	// sync-standby manager). LoadPromises loads the persisted term from disk on
 	// the consensus-enabled path; a missing file means term=0 (new node), and
-	// only an actual read/parse error fails the constructor.
-	pm.consensusMgr, err = consensus.NewConsensusManager(consensus.Deps{
-		Logger:       pm.logger,
-		QueryService: pm.qsc.InternalQueryService(),
-		PoolerDir:    pm.record.PoolerDir(),
-		ID:           multiPooler.Id,
-		Broadcaster:  pm.healthStreamer,
-		LoadPromises: config.ConsensusEnabled,
-	})
-	if err != nil {
-		cancel()
-		return nil, err
+	// only an actual read/parse error fails the constructor. A test may inject a
+	// pre-built ConsensusManager (e.g. with a fake rule store) instead.
+	if ov.consensusMgr != nil {
+		pm.consensusMgr = ov.consensusMgr
+	} else {
+		pm.consensusMgr, err = consensus.NewConsensusManager(consensus.Deps{
+			Logger:       pm.logger,
+			QueryService: pm.qsc.InternalQueryService(),
+			PoolerDir:    pm.record.PoolerDir(),
+			ID:           multiPooler.Id,
+			Broadcaster:  pm.healthStreamer,
+			LoadPromises: config.ConsensusEnabled,
+		})
+		if err != nil {
+			cancel()
+			return nil, err
+		}
 	}
 
 	// The health streamer must wait for the query server to update its type before

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -154,25 +154,9 @@ type MultiPoolerManager struct {
 	// pgMonitor manages the PostgreSQL monitoring loop.
 	pgMonitor *timer.PeriodicRunner
 
-	// suspectedDivergence marks that this node's WAL may have diverged from the
-	// cluster's chosen history, so the next restart-as-standby or SetPrimary should
-	// run pg_rewind to remove potential phantom / non-durable WAL entries.
-	//
-	// We suspect divergence when:
-	//   - a primary learns its term was ended by a failover — it may have local
-	//     WAL the new leader's history never adopted. Set by emergencyDemoteLocked,
-	//     SetPrimary's stale-primary branch, and the monitor's stale-primary demote.
-	//   - a replica cannot replicate despite successfully connecting to the leader,
-	//     implying its timeline diverged. Set via RewindToSource; today orch detects
-	//     this, but in the future a pooler could self-detect it.
-	suspectedDivergence atomic.Bool
-
-	// rewindWaitEmittedFor is the ConsensusPromises.LeaderObservedAt() value the
-	// rewind-wait metric was last emitted for, so a rewind that fails and is
-	// re-attempted against the same leader is counted once. Only read/written from
-	// restartAsStandbyLocked, which always holds the action lock, so it needs no
-	// separate synchronization.
-	rewindWaitEmittedFor time.Time
+	// Suspected-divergence and rewind-wait bookkeeping now live on consensusMgr
+	// (consensus.ConsensusManager). promotionInProgress stays here: it tracks
+	// pg_promote() transition mechanics, not consensus state.
 
 	// promotionInProgress is set while pg_promote() has been called but postgres has not yet
 	// transitioned to primary mode. Cleared when promotion completes (success or failure).
@@ -1434,7 +1418,7 @@ func (pm *MultiPoolerManager) promoteStandbyToPrimary(ctx context.Context, state
 	// the consensus protocol picked this node as the new leader at a higher
 	// term, so its WAL is by definition the rule going forward. Clear the
 	// flag so the postgres monitor and other operations resume.
-	if pm.suspectedDivergence.Swap(false) {
+	if pm.consensusMgr.SetSuspectedDivergence(false) {
 		pm.logger.InfoContext(ctx, "Cleared suspectedDivergence before promotion")
 	}
 

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -112,15 +112,14 @@ type MultiPoolerManager struct {
 	// exclusively written through record.Mutate (today only by StateManager);
 	// the remaining fields are immutable after construction and exposed via
 	// typed accessors that read without locking.
-	record            *poolerRecord
-	state             ManagerState
-	stateError        error
-	consensusPromises *consensus.ConsensusPromises
-	topoLoaded        bool
-	rules             consensus.RuleStorer
-	ctx               context.Context
-	cancel            context.CancelFunc
-	loadTimeout       time.Duration
+	record       *poolerRecord
+	state        ManagerState
+	stateError   error
+	consensusMgr *consensus.ConsensusManager
+	topoLoaded   bool
+	ctx          context.Context
+	cancel       context.CancelFunc
+	loadTimeout  time.Duration
 
 	// shutdownCtx is cancelled at the end of GracefulShutdown to signal
 	// long-lived subscribers (currently the health-stream gRPC handlers via
@@ -343,9 +342,9 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 
 	// Load consensus state from disk. Missing file means term=0 (new node), which is fine.
 	// Only actual read/parse errors fail the constructor.
-	pm.consensusPromises = consensus.NewConsensusPromises(pm.record.PoolerDir(), pm.serviceID)
+	promises := consensus.NewConsensusPromises(pm.record.PoolerDir(), pm.serviceID)
 	if config.ConsensusEnabled {
-		if _, err := pm.consensusPromises.Load(); err != nil {
+		if _, err := promises.Load(); err != nil {
 			cancel()
 			return nil, fmt.Errorf("failed to load consensus state from disk: %w", err)
 		}
@@ -358,7 +357,8 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 		drainGracePeriod = config.ConnPoolConfig.DrainGracePeriod()
 	}
 	pm.qsc = poolerserver.NewQueryPoolerServer(logger, connPoolMgr, multiPooler.Id, multiPooler.GetShardKey().GetTableGroup(), multiPooler.GetShardKey().GetShard(), pm, drainGracePeriod, config.VpidStampEnabled)
-	pm.rules = consensus.NewRuleStore(pm.logger, pm.qsc.InternalQueryService(), consensus.NewSyncStandbyManager(pm.logger, pm.qsc.InternalQueryService(), multiPooler.Id))
+	rules := consensus.NewRuleStore(pm.logger, pm.qsc.InternalQueryService(), consensus.NewSyncStandbyManager(pm.logger, pm.qsc.InternalQueryService(), multiPooler.Id))
+	pm.consensusMgr = consensus.NewConsensusManager(promises, rules)
 
 	// The health streamer must wait for the query server to update its type before
 	// broadcasting SERVING transitions, so the gateway doesn't discover the new
@@ -401,7 +401,7 @@ func (pm *MultiPoolerManager) internalQueryService() executor.InternalQueryServi
 func (pm *MultiPoolerManager) DoUpdateRule(ctx context.Context, update *consensus.RuleUpdateBuilder) (*clustermetadatapb.PoolerPosition, error) {
 	ruleWriteCtx, ruleWriteSpan := telemetry.Tracer().Start(ctx, "consensus/rule-write")
 	defer ruleWriteSpan.End()
-	return pm.rules.UpdateRule(ruleWriteCtx, update)
+	return pm.consensusMgr.Rules().UpdateRule(ruleWriteCtx, update)
 }
 
 // query executes a query using the internal query service and returns the result.
@@ -1434,7 +1434,7 @@ func (pm *MultiPoolerManager) promoteStandbyToPrimary(ctx context.Context, state
 			pm.logger.WarnContext(checkpointCtx, "Async post-promotion checkpoint failed; rewind-readiness will be delayed until PostgreSQL's own checkpoint completes", "error", err)
 			return
 		}
-		if pm.consensusPromises.MarkSelfRewindReady(pm.serviceID, coordinatorTerm) {
+		if pm.consensusMgr.Promises().MarkSelfRewindReady(pm.serviceID, coordinatorTerm) {
 			pm.logger.InfoContext(checkpointCtx, "Post-promotion checkpoint complete; advertising rewind-ready", "coordinator_term", coordinatorTerm)
 			pm.broadcastHealth()
 		}

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -1434,7 +1434,7 @@ func (pm *MultiPoolerManager) promoteStandbyToPrimary(ctx context.Context, state
 			pm.logger.WarnContext(checkpointCtx, "Async post-promotion checkpoint failed; rewind-readiness will be delayed until PostgreSQL's own checkpoint completes", "error", err)
 			return
 		}
-		if pm.consensusMgr.Promises().MarkSelfRewindReady(pm.serviceID, coordinatorTerm) {
+		if pm.consensusMgr.MarkSelfRewindReady(pm.serviceID, coordinatorTerm) {
 			pm.logger.InfoContext(checkpointCtx, "Post-promotion checkpoint complete; advertising rewind-ready", "coordinator_term", coordinatorTerm)
 			pm.broadcastHealth()
 		}

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -1418,7 +1418,9 @@ func (pm *MultiPoolerManager) promoteStandbyToPrimary(ctx context.Context, state
 	// the consensus protocol picked this node as the new leader at a higher
 	// term, so its WAL is by definition the rule going forward. Clear the
 	// flag so the postgres monitor and other operations resume.
-	if pm.consensusMgr.SetSuspectedDivergence(false) {
+	if changed, err := pm.consensusMgr.SetSuspectedDivergence(ctx, false); err != nil {
+		pm.logger.ErrorContext(ctx, "failed to clear suspected divergence before promotion", "error", err)
+	} else if changed {
 		pm.logger.InfoContext(ctx, "Cleared suspectedDivergence before promotion")
 	}
 

--- a/go/services/multipooler/internal/manager/manager_test.go
+++ b/go/services/multipooler/internal/manager/manager_test.go
@@ -27,18 +27,12 @@ import (
 
 	"github.com/multigres/multigres/go/common/backup"
 	"github.com/multigres/multigres/go/common/constants"
-	"github.com/multigres/multigres/go/common/mterrors"
-	"github.com/multigres/multigres/go/common/servenv"
 	"github.com/multigres/multigres/go/common/topoclient"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor/mock"
-	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
-	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus/consensustest"
 	"github.com/multigres/multigres/go/test/utils"
-	"github.com/multigres/multigres/go/tools/viperutil"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
-	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 )
 
 func TestManagerState_InitialState(t *testing.T) {
@@ -258,154 +252,6 @@ func TestManagerState_NilServiceID(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, manager)
 	assert.Contains(t, err.Error(), "MultiPooler.Id is required")
-}
-
-func TestValidateAndUpdateTerm(t *testing.T) {
-	ctx := t.Context()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-
-	serviceID := &clustermetadatapb.ID{
-		Component: clustermetadatapb.ID_MULTIPOOLER,
-		Cell:      "zone1",
-		Name:      "test-service",
-	}
-
-	tests := []struct {
-		name          string
-		currentTerm   int64
-		requestTerm   int64
-		force         bool
-		expectError   bool
-		expectedCode  mtrpcpb.Code
-		errorContains string
-	}{
-		{
-			name:        "Equal term should accept",
-			currentTerm: 5,
-			requestTerm: 5,
-			force:       false,
-			expectError: false,
-		},
-		{
-			name:        "Higher term should update and accept",
-			currentTerm: 5,
-			requestTerm: 10,
-			force:       false,
-			expectError: false,
-		},
-		{
-			name:          "Lower term should reject",
-			currentTerm:   10,
-			requestTerm:   5,
-			force:         false,
-			expectError:   true,
-			expectedCode:  mtrpcpb.Code_FAILED_PRECONDITION,
-			errorContains: "consensus term too old",
-		},
-		{
-			name:        "Force flag bypasses validation",
-			currentTerm: 10,
-			requestTerm: 5,
-			force:       true,
-			expectError: false,
-		},
-		{
-			// Term 0 means uninitialized (consensus_term.json not yet written, e.g. on a fresh
-			// standby after poolerDir was wiped by a restore). A positive request term is
-			// accepted and initializes the local term.
-			name:        "Zero cached term accepts higher request term (initializes standby)",
-			currentTerm: 0,
-			requestTerm: 5,
-			force:       false,
-			expectError: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
-			defer ts.Close()
-
-			// Create temp directory for pooler-dir
-			poolerDir := t.TempDir()
-
-			// Create a minimal data directory structure to satisfy IsDataDirInitialized check
-			dataDir := filepath.Join(poolerDir, "pg_data")
-			t.Setenv(constants.PgDataDirEnvVar, dataDir)
-			require.NoError(t, os.MkdirAll(dataDir, 0o755))
-			require.NoError(t, os.WriteFile(filepath.Join(dataDir, "PG_VERSION"), []byte("15\n"), 0o644))
-
-			// Set initial consensus term on disk if currentTerm > 0
-			if tt.currentTerm > 0 {
-				initialTerm := &clustermetadatapb.TermRevocation{
-					RevokedBelowTerm: tt.currentTerm,
-				}
-				consensustest.SeedTerm(t, poolerDir, initialTerm)
-			}
-
-			// Create the database in topology with backup location
-			database := "testdb"
-			addDatabaseToTopo(t, ts, database)
-
-			multipooler := &clustermetadatapb.MultiPooler{
-				Id:            serviceID,
-				Hostname:      "localhost",
-				PortMap:       map[string]int32{"grpc": 8080},
-				Type:          clustermetadatapb.PoolerType_PRIMARY,
-				ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
-				// A PRIMARY record must name itself as leader (the record invariant).
-				SelfLeadership: &clustermetadatapb.LeaderObservation{LeaderId: serviceID},
-				ShardKey: &clustermetadatapb.ShardKey{
-					Database:   database,
-					TableGroup: constants.DefaultTableGroup,
-					Shard:      constants.DefaultShard,
-				},
-				PoolerDir: poolerDir,
-			}
-			require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
-
-			config := &Config{
-				TopoClient:       ts,
-				ConsensusEnabled: true,
-			}
-			manager, err := NewMultiPoolerManager(logger, multipooler, config)
-			require.NoError(t, err)
-			defer manager.ShutdownForTest(t.Context())
-
-			// Set up mock query service for isInRecovery check during startup
-			mockQueryService := mock.NewQueryService()
-			mockQueryService.AddQueryPattern("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"f"}}))
-			manager.qsc = &mockPoolerController{queryService: mockQueryService}
-			manager.rules = consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{})
-
-			// Start and wait for ready
-			senv := servenv.NewServEnv(viperutil.NewRegistry())
-			go manager.Start(senv)
-			require.Eventually(t, func() bool {
-				return manager.GetState() == ManagerStateReady
-			}, 5*time.Second, 100*time.Millisecond, "Manager should reach Ready state")
-
-			// Acquire action lock before calling validateAndUpdateTerm
-			ctx, err := manager.actionLock.Acquire(ctx, "test")
-			require.NoError(t, err)
-			defer manager.actionLock.Release(ctx)
-
-			// Call validateAndUpdateTerm
-			err = manager.validateAndUpdateTerm(ctx, tt.requestTerm, tt.force)
-
-			if tt.expectError {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errorContains)
-
-				if tt.expectedCode != 0 {
-					code := mterrors.Code(err)
-					assert.Equal(t, tt.expectedCode, code)
-				}
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
 }
 
 func TestGetBackupLocation(t *testing.T) {

--- a/go/services/multipooler/internal/manager/pg_multischema.go
+++ b/go/services/multipooler/internal/manager/pg_multischema.go
@@ -55,7 +55,7 @@ func (pm *MultiPoolerManager) createSidecarSchema(ctx context.Context, policy *c
 		return err
 	}
 
-	if err := pm.rules.CreateRuleTables(ctx, policy, pm.serviceID); err != nil {
+	if err := pm.consensusMgr.Rules().CreateRuleTables(ctx, policy, pm.serviceID); err != nil {
 		return err
 	}
 

--- a/go/services/multipooler/internal/manager/pg_multischema_test.go
+++ b/go/services/multipooler/internal/manager/pg_multischema_test.go
@@ -93,8 +93,11 @@ func newTestManagerWithMock(tableGroup, shard string) (*MultiPoolerManager, *moc
 		record:          newRecordFromProto(multiPooler),
 		serviceID:       svcID,
 		servicePoolerID: svcPoolerID,
+		consensusMgr: consensus.NewConsensusManager(
+			consensus.NewConsensusPromises("", svcID),
+			consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}),
+		),
 	}
-	pm.rules = consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{})
 
 	return pm, mockQueryService
 }

--- a/go/services/multipooler/internal/manager/pg_multischema_test.go
+++ b/go/services/multipooler/internal/manager/pg_multischema_test.go
@@ -93,7 +93,7 @@ func newTestManagerWithMock(t *testing.T, tableGroup, shard string) (*MultiPoole
 		record:          newRecordFromProto(multiPooler),
 		serviceID:       svcID,
 		servicePoolerID: svcPoolerID,
-		consensusMgr: consensus.NewManagerForTesting(t,
+		consensusMgr: consensus.NewManagerForTesting(t, svcID,
 			consensus.NewConsensusPromises("", svcID),
 			consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}),
 			nil,

--- a/go/services/multipooler/internal/manager/pg_multischema_test.go
+++ b/go/services/multipooler/internal/manager/pg_multischema_test.go
@@ -64,7 +64,7 @@ func (m *mockPoolerController) PubSubListener() *pubsub.Listener     { return ni
 var _ poolerserver.PoolerController = (*mockPoolerController)(nil)
 
 // newTestManagerWithMock creates a test MultiPoolerManager with a mock query service
-func newTestManagerWithMock(tableGroup, shard string) (*MultiPoolerManager, *mock.QueryService) {
+func newTestManagerWithMock(t *testing.T, tableGroup, shard string) (*MultiPoolerManager, *mock.QueryService) {
 	logger := slog.New(slog.DiscardHandler)
 	mockQueryService := mock.NewQueryService()
 
@@ -93,7 +93,7 @@ func newTestManagerWithMock(tableGroup, shard string) (*MultiPoolerManager, *moc
 		record:          newRecordFromProto(multiPooler),
 		serviceID:       svcID,
 		servicePoolerID: svcPoolerID,
-		consensusMgr: consensus.NewConsensusManager(
+		consensusMgr: consensus.NewManagerForTesting(t,
 			consensus.NewConsensusPromises("", svcID),
 			consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}),
 			nil,
@@ -199,7 +199,7 @@ func TestCreateSidecarSchema(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pm, mockQueryService := newTestManagerWithMock(tt.tableGroup, constants.DefaultShard)
+			pm, mockQueryService := newTestManagerWithMock(t, tt.tableGroup, constants.DefaultShard)
 
 			tt.setupMock(mockQueryService)
 
@@ -293,7 +293,7 @@ func TestInitializeMultischemaData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pm, mockQueryService := newTestManagerWithMock(tt.tableGroup, tt.shard)
+			pm, mockQueryService := newTestManagerWithMock(t, tt.tableGroup, tt.shard)
 
 			tt.setupMock(mockQueryService)
 

--- a/go/services/multipooler/internal/manager/pg_multischema_test.go
+++ b/go/services/multipooler/internal/manager/pg_multischema_test.go
@@ -96,6 +96,7 @@ func newTestManagerWithMock(tableGroup, shard string) (*MultiPoolerManager, *moc
 		consensusMgr: consensus.NewConsensusManager(
 			consensus.NewConsensusPromises("", svcID),
 			consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}),
+			nil,
 		),
 	}
 

--- a/go/services/multipooler/internal/manager/pg_replication_test.go
+++ b/go/services/multipooler/internal/manager/pg_replication_test.go
@@ -648,7 +648,7 @@ func TestIsInRecovery(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pm, mockQueryService := newTestManagerWithMock("default", "0-inf")
+			pm, mockQueryService := newTestManagerWithMock(t, "default", "0-inf")
 
 			tt.setupMock(mockQueryService)
 
@@ -700,7 +700,7 @@ func TestGetPrimaryLSN(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pm, mockQueryService := newTestManagerWithMock("default", "0-inf")
+			pm, mockQueryService := newTestManagerWithMock(t, "default", "0-inf")
 
 			tt.setupMock(mockQueryService)
 
@@ -752,7 +752,7 @@ func TestGetStandbyReplayLSN(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pm, mockQueryService := newTestManagerWithMock("default", "0-inf")
+			pm, mockQueryService := newTestManagerWithMock(t, "default", "0-inf")
 
 			tt.setupMock(mockQueryService)
 
@@ -896,7 +896,7 @@ func TestSetSynchronousStandbyNames(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pm, mockQueryService := newTestManagerWithMock("default", "0-inf")
+			pm, mockQueryService := newTestManagerWithMock(t, "default", "0-inf")
 
 			tt.setupMock(mockQueryService)
 
@@ -971,7 +971,7 @@ func TestValidateExpectedLSN(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pm, mockQueryService := newTestManagerWithMock("default", "0-inf")
+			pm, mockQueryService := newTestManagerWithMock(t, "default", "0-inf")
 
 			tt.setupMock(mockQueryService)
 
@@ -1330,7 +1330,7 @@ func TestPauseReplication(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pm, mockQueryService := newTestManagerWithMock("default", "0-inf")
+			pm, mockQueryService := newTestManagerWithMock(t, "default", "0-inf")
 
 			tt.setupMock(mockQueryService)
 
@@ -1367,7 +1367,7 @@ func TestPauseReplication(t *testing.T) {
 // min-deadline semantics of context.WithTimeout.
 func TestWaitForReceiverDisconnect_Timeout(t *testing.T) {
 	t.Run("deadline already expired surfaces timeout before polling", func(t *testing.T) {
-		pm, _ := newTestManagerWithMock("default", "0-inf")
+		pm, _ := newTestManagerWithMock(t, "default", "0-inf")
 		// Deadline already in the past: the first retry attempt observes the
 		// expired context and returns the timeout without ever polling, so no
 		// query mock is needed.
@@ -1382,7 +1382,7 @@ func TestWaitForReceiverDisconnect_Timeout(t *testing.T) {
 	})
 
 	t.Run("deadline expires while polls keep returning still-streaming", func(t *testing.T) {
-		pm, mockQueryService := newTestManagerWithMock("default", "0-inf")
+		pm, mockQueryService := newTestManagerWithMock(t, "default", "0-inf")
 		// Persistent (non-consumeOnce) pattern: the function polls repeatedly
 		// (immediately, then with exponential backoff) until the deadline trips.
 		mockQueryService.AddQueryPattern("SELECT COUNT", mock.MakeQueryResult(
@@ -1400,7 +1400,7 @@ func TestWaitForReceiverDisconnect_Timeout(t *testing.T) {
 	})
 
 	t.Run("parent context cancelled surfaces cancellation, not timeout", func(t *testing.T) {
-		pm, _ := newTestManagerWithMock("default", "0-inf")
+		pm, _ := newTestManagerWithMock(t, "default", "0-inf")
 		ctx, cancel := context.WithCancel(t.Context())
 		cancel() // cancel immediately
 
@@ -1448,7 +1448,7 @@ func TestResetPrimaryConnInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pm, mockQueryService := newTestManagerWithMock("default", "0-inf")
+			pm, mockQueryService := newTestManagerWithMock(t, "default", "0-inf")
 
 			tt.setupMock(mockQueryService)
 
@@ -1504,7 +1504,7 @@ func TestClearSyncReplicationForDemotion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pm, mockQueryService := newTestManagerWithMock("default", "0-inf")
+			pm, mockQueryService := newTestManagerWithMock(t, "default", "0-inf")
 
 			tt.setupMock(mockQueryService)
 
@@ -1631,7 +1631,7 @@ func TestQueryReplicationStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pm, mockQueryService := newTestManagerWithMock("default", "0-inf")
+			pm, mockQueryService := newTestManagerWithMock(t, "default", "0-inf")
 
 			tt.setupMock(mockQueryService)
 

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -51,7 +51,7 @@ func deriveTypeAndObs(rule *clustermetadatapb.ShardRule, selfID *clustermetadata
 
 // latestRule returns the highest-numbered rule this pooler knows of, combining
 // the rule it has applied into its own position with the rule it was most
-// recently told to follow via SetPrimary/Promote (consensusState's recorded
+// recently told to follow via SetPrimary/Promote (consensusPromises's recorded
 // ReplicationPrimary). A standby told of a newer leader before its own position
 // advances still reads the newer rule. Returns nil if neither source carries a
 // rule.
@@ -87,7 +87,7 @@ func (pm *MultiPoolerManager) intendedRole() clustermetadatapb.PoolerType {
 // diverged primary as a standby of a not-yet-checkpointed leader would FATAL on
 // our own un-replicated WAL).
 func (pm *MultiPoolerManager) staleStandbyDemoteTarget() *clustermetadatapb.PoolerAddress {
-	rp := pm.consensusState.GetReplicationPrimary()
+	rp := pm.consensusPromises.GetReplicationPrimary()
 	if rp == nil {
 		return nil
 	}
@@ -115,7 +115,7 @@ func (pm *MultiPoolerManager) staleStandbyDemoteTarget() *clustermetadatapb.Pool
 		return nil
 	}
 	// Don't race a mid-flight Recruit/Propose: skip a revoked rule.
-	if commonconsensus.IsRuleRevoked(rp.GetRule(), pm.consensusState.GetInconsistentRevocation()) {
+	if commonconsensus.IsRuleRevoked(rp.GetRule(), pm.consensusPromises.GetInconsistentRevocation()) {
 		return nil
 	}
 	return target
@@ -162,7 +162,7 @@ const (
 	remedialActionReconcileGUC
 	// remedialActionFixPrimaryConnInfo means postgres is in recovery and the
 	// topology says REPLICA, but primary_conninfo doesn't match the primary
-	// recorded in consensus.ConsensusState.ReplicationPrimary (the most recent
+	// recorded in consensus.ConsensusPromises.ReplicationPrimary (the most recent
 	// SetPrimary/Promote). Reconciles the GUC so this replica points at the right
 	// primary regardless of how it got out of sync (failed SetPrimary apply,
 	// hand edit, snapshot restore, etc.).
@@ -385,7 +385,7 @@ func (pm *MultiPoolerManager) primaryConnInfoDiffersFromRecorded(_ postgresState
 	if pm.walReceiverManuallyStopped.Load() {
 		return false
 	}
-	rp := pm.consensusState.GetReplicationPrimary()
+	rp := pm.consensusPromises.GetReplicationPrimary()
 	if rp == nil {
 		return false
 	}
@@ -402,7 +402,7 @@ func (pm *MultiPoolerManager) primaryConnInfoDiffersFromRecorded(_ postgresState
 	// Skip if the recorded rule is revoked. The cached primary is from before
 	// the current revocation took effect; restoring conninfo to it would race
 	// the Recruit/Promote flow that's mid-flight (see function doc).
-	if commonconsensus.IsRuleRevoked(rp.GetRule(), pm.consensusState.GetInconsistentRevocation()) {
+	if commonconsensus.IsRuleRevoked(rp.GetRule(), pm.consensusPromises.GetInconsistentRevocation()) {
 		return false
 	}
 	targetHost := target.GetHost()
@@ -556,7 +556,7 @@ func (pm *MultiPoolerManager) shouldMarkRewindReady(state postgresState, intende
 	if pm.getResignedLeaderAtTerm() != 0 {
 		return false
 	}
-	return !pm.consensusState.GetReplicationPrimary().GetRewindReady()
+	return !pm.consensusPromises.GetReplicationPrimary().GetRewindReady()
 }
 
 // determinePostgresNotRunningAction decides how to bring postgres up when it is
@@ -662,7 +662,7 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 		}
 
 	case remedialActionFixPrimaryConnInfo:
-		rp := pm.consensusState.GetReplicationPrimary()
+		rp := pm.consensusPromises.GetReplicationPrimary()
 		target := rp.GetPrimary()
 		targetHost := target.GetHost()
 		targetPort := target.GetPostgresPort()
@@ -742,8 +742,8 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 		// record names us at the term we observed and that the flag was not already
 		// set; broadcast on the false->true edge so a diverged follower's recovery
 		// sees it without waiting for the next periodic snapshot.
-		term := pm.consensusState.GetReplicationPrimary().GetRule().GetRuleNumber().GetCoordinatorTerm()
-		if pm.consensusState.MarkSelfRewindReady(pm.serviceID, term) {
+		term := pm.consensusPromises.GetReplicationPrimary().GetRule().GetRuleNumber().GetCoordinatorTerm()
+		if pm.consensusPromises.MarkSelfRewindReady(pm.serviceID, term) {
 			pm.logger.InfoContext(ctx, "MonitorPostgres: checkpointed onto current timeline; advertising rewind-ready")
 			pm.broadcastHealth()
 		}
@@ -862,7 +862,7 @@ func (pm *MultiPoolerManager) restoreAndStartPostgres(ctx context.Context) error
 		return fmt.Errorf("failed to restore from backup: %w", err)
 	}
 
-	revokedBelowTerm, _ := pm.consensusState.GetInconsistentCurrentTermNumber()
+	revokedBelowTerm, _ := pm.consensusPromises.GetInconsistentCurrentTermNumber()
 	pm.logger.InfoContext(ctx, "MonitorPostgres: successfully restored from backup",
 		"backup_id", latestBackup.BackupId,
 		"shard", pm.getShardID(),

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -619,7 +619,7 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 		// diverged from the new leader; restartAsStandbyLocked runs pg_rewind
 		// (cheap when there's no divergence). The rewind-ready gate is enforced in
 		// staleStandbyDemoteTarget above, so by here it is safe to rewind.
-		pm.suspectedDivergence.Store(true)
+		pm.consensusMgr.SetSuspectedDivergence(true)
 		if _, err := pm.restartAsStandbyLocked(ctx, target.GetHost(), target.GetPostgresPort()); err != nil {
 			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to restart stale primary as standby", "error", err)
 			return

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -65,7 +65,7 @@ func deriveTypeAndObs(rule *clustermetadatapb.ShardRule, selfID *clustermetadata
 // differently.
 func (pm *MultiPoolerManager) latestRule() *clustermetadatapb.ShardRule {
 	return commonconsensus.HighestKnownRule([]*clustermetadatapb.ConsensusStatus{
-		pm.getCachedConsensusStatus(),
+		pm.consensusMgr.CachedConsensusStatus(),
 	})
 }
 
@@ -309,9 +309,9 @@ func (pm *MultiPoolerManager) discoverPostgresState(ctx context.Context) (postgr
 		// Lock-free first pass from the monitor: prefer a fresh read, fall back to
 		// the cached rule when postgres is unreachable so we keep the last-known
 		// primary term across postgres restarts and crashes.
-		cs, err := pm.getInconsistentConsensusStatus(ctx)
+		cs, err := pm.consensusMgr.InconsistentConsensusStatus(ctx)
 		if err != nil {
-			cs = pm.getCachedConsensusStatus()
+			cs = pm.consensusMgr.CachedConsensusStatus()
 		}
 		state.primaryTerm = commonconsensus.LeaderTerm(cs)
 	}
@@ -344,7 +344,7 @@ func (pm *MultiPoolerManager) discoverPostgresState(ctx context.Context) (postgr
 // getInconsistentConsensusStatus themselves and pass the result to
 // consensus.LeaderTerm.
 func (pm *MultiPoolerManager) primaryTermLocked(ctx context.Context) (int64, error) {
-	cs, err := pm.getConsensusStatus(ctx)
+	cs, err := pm.consensusMgr.ConsensusStatus(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to read consensus status: %w", err)
 	}

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -457,10 +457,7 @@ func (pm *MultiPoolerManager) determineRoleAction(intended clustermetadatapb.Poo
 	// postgres) from promote (newly elected). Embedding the leader host/port in the
 	// WAL rule would also let replicas reconcile without waiting for SetPrimary.
 	if intended == clustermetadatapb.PoolerType_PRIMARY && !state.isPrimary {
-		pm.mu.Lock()
-		resigned := pm.resignedLeaderAtTerm
-		pm.mu.Unlock()
-		if resigned == 0 {
+		if pm.getResignedLeaderAtTerm() == 0 {
 			return remedialActionResignLeadership
 		}
 		return remedialActionNone
@@ -556,10 +553,7 @@ func (pm *MultiPoolerManager) shouldMarkRewindReady(state postgresState, intende
 	if !state.rewindSourceReady || intended != clustermetadatapb.PoolerType_PRIMARY {
 		return false
 	}
-	pm.mu.Lock()
-	resigned := pm.resignedLeaderAtTerm != 0
-	pm.mu.Unlock()
-	if resigned {
+	if pm.getResignedLeaderAtTerm() != 0 {
 		return false
 	}
 	return !pm.consensusState.GetReplicationPrimary().GetRewindReady()

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -87,7 +87,7 @@ func (pm *MultiPoolerManager) intendedRole() clustermetadatapb.PoolerType {
 // diverged primary as a standby of a not-yet-checkpointed leader would FATAL on
 // our own un-replicated WAL).
 func (pm *MultiPoolerManager) staleStandbyDemoteTarget() *clustermetadatapb.PoolerAddress {
-	rp := pm.consensusPromises.GetReplicationPrimary()
+	rp := pm.consensusMgr.Promises().GetReplicationPrimary()
 	if rp == nil {
 		return nil
 	}
@@ -110,12 +110,12 @@ func (pm *MultiPoolerManager) staleStandbyDemoteTarget() *clustermetadatapb.Pool
 	}
 	// Only act when the recorded rule outranks our applied position. A lower or
 	// equal recorded rule is stale relative to us and must not trigger a demote.
-	selfRuleNum := pm.rules.CachedPosition().GetRule().GetRuleNumber()
+	selfRuleNum := pm.consensusMgr.Rules().CachedPosition().GetRule().GetRuleNumber()
 	if commonconsensus.CompareRuleNumbers(rp.GetRule().GetRuleNumber(), selfRuleNum) <= 0 {
 		return nil
 	}
 	// Don't race a mid-flight Recruit/Propose: skip a revoked rule.
-	if commonconsensus.IsRuleRevoked(rp.GetRule(), pm.consensusPromises.GetInconsistentRevocation()) {
+	if commonconsensus.IsRuleRevoked(rp.GetRule(), pm.consensusMgr.Promises().GetInconsistentRevocation()) {
 		return nil
 	}
 	return target
@@ -385,7 +385,7 @@ func (pm *MultiPoolerManager) primaryConnInfoDiffersFromRecorded(_ postgresState
 	if pm.walReceiverManuallyStopped.Load() {
 		return false
 	}
-	rp := pm.consensusPromises.GetReplicationPrimary()
+	rp := pm.consensusMgr.Promises().GetReplicationPrimary()
 	if rp == nil {
 		return false
 	}
@@ -402,7 +402,7 @@ func (pm *MultiPoolerManager) primaryConnInfoDiffersFromRecorded(_ postgresState
 	// Skip if the recorded rule is revoked. The cached primary is from before
 	// the current revocation took effect; restoring conninfo to it would race
 	// the Recruit/Promote flow that's mid-flight (see function doc).
-	if commonconsensus.IsRuleRevoked(rp.GetRule(), pm.consensusPromises.GetInconsistentRevocation()) {
+	if commonconsensus.IsRuleRevoked(rp.GetRule(), pm.consensusMgr.Promises().GetInconsistentRevocation()) {
 		return false
 	}
 	targetHost := target.GetHost()
@@ -502,7 +502,7 @@ func (pm *MultiPoolerManager) determineReplicationSettingsAction(ctx context.Con
 
 	// synchronous_standby_names is a primary concern: it has no effect on a
 	// standby, and setting it there leaks state.
-	if state.isPrimary && pm.rules.HasInconsistentGUC(ctx) {
+	if state.isPrimary && pm.consensusMgr.Rules().HasInconsistentGUC(ctx) {
 		return remedialActionReconcileGUC
 	}
 
@@ -556,7 +556,7 @@ func (pm *MultiPoolerManager) shouldMarkRewindReady(state postgresState, intende
 	if pm.getResignedLeaderAtTerm() != 0 {
 		return false
 	}
-	return !pm.consensusPromises.GetReplicationPrimary().GetRewindReady()
+	return !pm.consensusMgr.Promises().GetReplicationPrimary().GetRewindReady()
 }
 
 // determinePostgresNotRunningAction decides how to bring postgres up when it is
@@ -662,7 +662,7 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 		}
 
 	case remedialActionFixPrimaryConnInfo:
-		rp := pm.consensusPromises.GetReplicationPrimary()
+		rp := pm.consensusMgr.Promises().GetReplicationPrimary()
 		target := rp.GetPrimary()
 		targetHost := target.GetHost()
 		targetPort := target.GetPostgresPort()
@@ -732,7 +732,7 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 	case remedialActionReconcileGUC:
 		pm.setMonitorReason(ctx, reasonPostgresRunning, "MonitorPostgres: PostgreSQL is running")
 		pm.logger.InfoContext(ctx, "MonitorPostgres: re-applying stale GUC")
-		if err := pm.rules.ReconcileGUC(ctx, !state.isPrimary); err != nil {
+		if err := pm.consensusMgr.Rules().ReconcileGUC(ctx, !state.isPrimary); err != nil {
 			pm.logger.ErrorContext(ctx, "MonitorPostgres: GUC reconciliation failed", "error", err)
 		}
 
@@ -742,8 +742,8 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 		// record names us at the term we observed and that the flag was not already
 		// set; broadcast on the false->true edge so a diverged follower's recovery
 		// sees it without waiting for the next periodic snapshot.
-		term := pm.consensusPromises.GetReplicationPrimary().GetRule().GetRuleNumber().GetCoordinatorTerm()
-		if pm.consensusPromises.MarkSelfRewindReady(pm.serviceID, term) {
+		term := pm.consensusMgr.Promises().GetReplicationPrimary().GetRule().GetRuleNumber().GetCoordinatorTerm()
+		if pm.consensusMgr.Promises().MarkSelfRewindReady(pm.serviceID, term) {
 			pm.logger.InfoContext(ctx, "MonitorPostgres: checkpointed onto current timeline; advertising rewind-ready")
 			pm.broadcastHealth()
 		}
@@ -865,7 +865,7 @@ func (pm *MultiPoolerManager) restoreAndStartPostgres(ctx context.Context) error
 	pm.logger.InfoContext(ctx, "MonitorPostgres: successfully restored from backup",
 		"backup_id", latestBackup.BackupId,
 		"shard", pm.getShardID(),
-		"rule", commonconsensus.FormatRuleNumber(pm.rules.CachedPosition().GetRule().GetRuleNumber()))
+		"rule", commonconsensus.FormatRuleNumber(pm.consensusMgr.Rules().CachedPosition().GetRule().GetRuleNumber()))
 
 	return nil
 }

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -457,7 +457,7 @@ func (pm *MultiPoolerManager) determineRoleAction(intended clustermetadatapb.Poo
 	// postgres) from promote (newly elected). Embedding the leader host/port in the
 	// WAL rule would also let replicas reconcile without waiting for SetPrimary.
 	if intended == clustermetadatapb.PoolerType_PRIMARY && !state.isPrimary {
-		if pm.getResignedLeaderAtTerm() == 0 {
+		if pm.consensusMgr.ResignedLeaderAtTerm() == 0 {
 			return remedialActionResignLeadership
 		}
 		return remedialActionNone
@@ -553,7 +553,7 @@ func (pm *MultiPoolerManager) shouldMarkRewindReady(state postgresState, intende
 	if !state.rewindSourceReady || intended != clustermetadatapb.PoolerType_PRIMARY {
 		return false
 	}
-	if pm.getResignedLeaderAtTerm() != 0 {
+	if pm.consensusMgr.ResignedLeaderAtTerm() != 0 {
 		return false
 	}
 	return !pm.consensusMgr.GetReplicationPrimary().GetRewindReady()
@@ -656,7 +656,7 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 		pm.logger.InfoContext(ctx, "MonitorPostgres: rule names us leader but postgres is a standby; resigning",
 			"primary_term", state.primaryTerm)
 		if state.primaryTerm != 0 {
-			if err := pm.setResignedLeaderAtTerm(ctx, state.primaryTerm); err != nil {
+			if err := pm.consensusMgr.SetResignedLeaderAtTerm(ctx, state.primaryTerm); err != nil {
 				pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to set resigned primary term", "error", err)
 			}
 		}

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -87,7 +87,7 @@ func (pm *MultiPoolerManager) intendedRole() clustermetadatapb.PoolerType {
 // diverged primary as a standby of a not-yet-checkpointed leader would FATAL on
 // our own un-replicated WAL).
 func (pm *MultiPoolerManager) staleStandbyDemoteTarget() *clustermetadatapb.PoolerAddress {
-	rp := pm.consensusMgr.Promises().GetReplicationPrimary()
+	rp := pm.consensusMgr.GetReplicationPrimary()
 	if rp == nil {
 		return nil
 	}
@@ -385,7 +385,7 @@ func (pm *MultiPoolerManager) primaryConnInfoDiffersFromRecorded(_ postgresState
 	if pm.walReceiverManuallyStopped.Load() {
 		return false
 	}
-	rp := pm.consensusMgr.Promises().GetReplicationPrimary()
+	rp := pm.consensusMgr.GetReplicationPrimary()
 	if rp == nil {
 		return false
 	}
@@ -556,7 +556,7 @@ func (pm *MultiPoolerManager) shouldMarkRewindReady(state postgresState, intende
 	if pm.getResignedLeaderAtTerm() != 0 {
 		return false
 	}
-	return !pm.consensusMgr.Promises().GetReplicationPrimary().GetRewindReady()
+	return !pm.consensusMgr.GetReplicationPrimary().GetRewindReady()
 }
 
 // determinePostgresNotRunningAction decides how to bring postgres up when it is
@@ -662,7 +662,7 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 		}
 
 	case remedialActionFixPrimaryConnInfo:
-		rp := pm.consensusMgr.Promises().GetReplicationPrimary()
+		rp := pm.consensusMgr.GetReplicationPrimary()
 		target := rp.GetPrimary()
 		targetHost := target.GetHost()
 		targetPort := target.GetPostgresPort()
@@ -742,8 +742,8 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 		// record names us at the term we observed and that the flag was not already
 		// set; broadcast on the false->true edge so a diverged follower's recovery
 		// sees it without waiting for the next periodic snapshot.
-		term := pm.consensusMgr.Promises().GetReplicationPrimary().GetRule().GetRuleNumber().GetCoordinatorTerm()
-		if pm.consensusMgr.Promises().MarkSelfRewindReady(pm.serviceID, term) {
+		term := pm.consensusMgr.GetReplicationPrimary().GetRule().GetRuleNumber().GetCoordinatorTerm()
+		if pm.consensusMgr.MarkSelfRewindReady(pm.serviceID, term) {
 			pm.logger.InfoContext(ctx, "MonitorPostgres: checkpointed onto current timeline; advertising rewind-ready")
 			pm.broadcastHealth()
 		}

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -619,7 +619,9 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 		// diverged from the new leader; restartAsStandbyLocked runs pg_rewind
 		// (cheap when there's no divergence). The rewind-ready gate is enforced in
 		// staleStandbyDemoteTarget above, so by here it is safe to rewind.
-		pm.consensusMgr.SetSuspectedDivergence(true)
+		if _, err := pm.consensusMgr.SetSuspectedDivergence(ctx, true); err != nil {
+			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to set suspected divergence", "error", err)
+		}
 		if _, err := pm.restartAsStandbyLocked(ctx, target.GetHost(), target.GetPostgresPort()); err != nil {
 			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to restart stale primary as standby", "error", err)
 			return

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -862,11 +862,10 @@ func (pm *MultiPoolerManager) restoreAndStartPostgres(ctx context.Context) error
 		return fmt.Errorf("failed to restore from backup: %w", err)
 	}
 
-	revokedBelowTerm, _ := pm.consensusPromises.GetInconsistentCurrentTermNumber()
 	pm.logger.InfoContext(ctx, "MonitorPostgres: successfully restored from backup",
 		"backup_id", latestBackup.BackupId,
 		"shard", pm.getShardID(),
-		"term", revokedBelowTerm)
+		"rule", commonconsensus.FormatRuleNumber(pm.rules.CachedPosition().GetRule().GetRuleNumber()))
 
 	return nil
 }

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -429,17 +429,17 @@ func TestDetermineRemedialAction(t *testing.T) {
 				// observation that names itself.
 				seed.SelfLeadership = &clustermetadatapb.LeaderObservation{LeaderId: selfID}
 			}
-			pm := &MultiPoolerManager{
-				serviceID: selfID,
-				record:    newRecordFromProto(seed),
+			promises := tt.consensusPromises
+			if promises == nil {
+				promises = consensus.NewConsensusPromises("", selfID)
 			}
-			if tt.consensusPromises != nil {
-				pm.consensusPromises = tt.consensusPromises
-			} else {
-				pm.consensusPromises = consensus.NewConsensusPromises("", selfID)
-			}
-			pm.resignedLeaderAtTerm = tt.resignedLeaderTerm
-			pm.rules = &fakeRuleStore{pos: tt.cachedPos, inconsistentGUC: tt.inconsistentGUC}
+			pm := newTestManager(t,
+				withServiceID(selfID),
+				withRecord(newRecordFromProto(seed)),
+				withPromises(promises),
+				withResignedLeaderAtTerm(tt.resignedLeaderTerm),
+				withRuleStore(&fakeRuleStore{pos: tt.cachedPos, inconsistentGUC: tt.inconsistentGUC}),
+			)
 			tt.state.primaryTerm = tt.primaryTerm
 
 			got := pm.determineRemedialAction(t.Context(), tt.state)
@@ -534,16 +534,16 @@ func TestDetermineRemedialAction_StalePrimaryDemote(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pm := &MultiPoolerManager{
-				serviceID: selfID,
-				record: newRecordFromProto(&clustermetadatapb.MultiPooler{
+			pm := newTestManager(t,
+				withServiceID(selfID),
+				withRecord(newRecordFromProto(&clustermetadatapb.MultiPooler{
 					Id:             selfID,
 					Type:           clustermetadatapb.PoolerType_PRIMARY,
 					SelfLeadership: &clustermetadatapb.LeaderObservation{LeaderId: selfID},
-				}),
-			}
-			pm.consensusPromises = tt.consensusPromises
-			pm.rules = &fakeRuleStore{pos: tt.cachedPos}
+				})),
+				withPromises(tt.consensusPromises),
+				withRuleStore(&fakeRuleStore{pos: tt.cachedPos}),
+			)
 
 			got := pm.determineRemedialAction(t.Context(), runningPrimary)
 			require.Equal(t, tt.expectedAction, got)
@@ -572,11 +572,11 @@ func TestStaleStandbyDemoteTarget(t *testing.T) {
 			// nil do so for their own reason (not-ready is covered separately below).
 			cs.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: recordedRule, Primary: addr, RewindReady: true})
 		}
-		return &MultiPoolerManager{
-			serviceID:         selfID,
-			consensusPromises: cs,
-			rules:             &fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Rule: rule(selfTerm, selfID)}},
-		}
+		return newTestManager(t,
+			withServiceID(selfID),
+			withPromises(cs),
+			withRuleStore(&fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Rule: rule(selfTerm, selfID)}}),
+		)
 	}
 
 	t.Run("no recorded replication primary -> nil", func(t *testing.T) {
@@ -607,11 +607,11 @@ func TestStaleStandbyDemoteTarget(t *testing.T) {
 		_, err := cs.Load()
 		require.NoError(t, err)
 		cs.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: rule(5, otherID), Primary: otherAddr, RewindReady: true})
-		pm := &MultiPoolerManager{
-			serviceID:         selfID,
-			consensusPromises: cs,
-			rules:             &fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Rule: rule(4, selfID)}},
-		}
+		pm := newTestManager(t,
+			withServiceID(selfID),
+			withPromises(cs),
+			withRuleStore(&fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Rule: rule(4, selfID)}}),
+		)
 		require.Nil(t, pm.staleStandbyDemoteTarget())
 	})
 
@@ -629,11 +629,11 @@ func TestStaleStandbyDemoteTarget(t *testing.T) {
 		// FATAL against a not-yet-checkpointed source.
 		cs := consensus.NewConsensusPromises(t.TempDir(), selfID)
 		cs.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: rule(5, otherID), Primary: otherAddr, RewindReady: false})
-		pm := &MultiPoolerManager{
-			serviceID:         selfID,
-			consensusPromises: cs,
-			rules:             &fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Rule: rule(4, selfID)}},
-		}
+		pm := newTestManager(t,
+			withServiceID(selfID),
+			withPromises(cs),
+			withRuleStore(&fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Rule: rule(4, selfID)}}),
+		)
 		require.Nil(t, pm.staleStandbyDemoteTarget())
 	})
 }
@@ -868,16 +868,17 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 				// Record invariant: a PRIMARY record must carry a self-leadership obs.
 				multipooler.SelfLeadership = &clustermetadatapb.LeaderObservation{LeaderId: multipooler.Id}
 			}
-			pm := newRemedialActionTestManager(t, multipooler)
-			pm.rules = &fakeRuleStore{pos: tc.cachedPos}
-
 			dir := t.TempDir()
 			// Seed a revocation of everything below term 1 so the manager has a term.
 			consensustest.SeedTerm(t, dir, &clustermetadatapb.TermRevocation{RevokedBelowTerm: 1})
 			cs := consensus.NewConsensusPromises(dir, nil)
 			_, err := cs.Load()
 			require.NoError(t, err)
-			pm.consensusPromises = cs
+
+			pm := newRemedialActionTestManager(t, multipooler,
+				withRuleStore(&fakeRuleStore{pos: tc.cachedPos}),
+				withPromises(cs),
+			)
 
 			lockCtx, err := pm.actionLock.Acquire(ctx, "test")
 			require.NoError(t, err)
@@ -898,20 +899,13 @@ func TestTakeRemedialAction_ReconcileGUC(t *testing.T) {
 	ctx := t.Context()
 
 	frs := &fakeRuleStore{}
-	pm := &MultiPoolerManager{
-		logger:     slog.Default(),
-		actionLock: actionlock.NewActionLock(),
-		rules:      frs,
-		record: newRecordFromProto(&clustermetadatapb.MultiPooler{
-			Id:   &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "test-pooler"},
-			Type: clustermetadatapb.PoolerType_PRIMARY,
-			// A PRIMARY record must name itself as leader (the record invariant).
-			SelfLeadership: &clustermetadatapb.LeaderObservation{
-				LeaderId: &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "test-pooler"},
-			},
-		}),
-	}
-	pm.consensusPromises = consensus.NewConsensusPromises("", nil)
+	selfID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "test-pooler"}
+	pm := newRemedialActionTestManager(t, &clustermetadatapb.MultiPooler{
+		Id:   selfID,
+		Type: clustermetadatapb.PoolerType_PRIMARY,
+		// A PRIMARY record must name itself as leader (the record invariant).
+		SelfLeadership: &clustermetadatapb.LeaderObservation{LeaderId: selfID},
+	}, withRuleStore(frs))
 
 	lockCtx, err := pm.actionLock.Acquire(ctx, "test")
 	require.NoError(t, err)
@@ -932,15 +926,13 @@ func TestTakeRemedialAction_ReconcileRole_AppliesRuleDerivedRole(t *testing.T) {
 		Id:   &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "test-pooler"},
 		Type: clustermetadatapb.PoolerType_REPLICA,
 	}
-	pm := newRemedialActionTestManager(t, multipooler)
-	pm.consensusPromises = consensus.NewConsensusPromises("", multipooler.Id)
 	committed := &clustermetadatapb.RuleNumber{CoordinatorTerm: 4}
 	// The committed rule names this pooler leader, so the rule-derived role is
 	// PRIMARY — ReconcileRole must publish PRIMARY plus the self-leadership obs
 	// regardless of the stale REPLICA label on the record.
-	pm.rules = &fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{
+	pm := newRemedialActionTestManager(t, multipooler, withRuleStore(&fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{
 		Rule: &clustermetadatapb.ShardRule{RuleNumber: committed, LeaderId: multipooler.Id},
-	}}
+	}}))
 
 	lockCtx, err := pm.actionLock.Acquire(t.Context(), "test")
 	require.NoError(t, err)
@@ -1417,11 +1409,11 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 			pm, tmpDir := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(0)})
 
 			if tt.seedRP != nil {
-				pm.consensusPromises.RecordTermPrimary(tt.seedRP)
+				pm.consensusMgr.Promises().RecordTermPrimary(tt.seedRP)
 			}
 			if tt.seedRevocation != nil {
 				consensustest.SeedTerm(t, tmpDir, tt.seedRevocation)
-				_, err := pm.consensusPromises.Load()
+				_, err := pm.consensusMgr.Promises().Load()
 				require.NoError(t, err)
 			}
 			if tt.seedManualStop {

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -874,7 +874,7 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 			defer pm.actionLock.Release(lockCtx)
 
 			if tc.resignedBefore != 0 {
-				require.NoError(t, pm.setResignedLeaderAtTerm(lockCtx, tc.resignedBefore))
+				require.NoError(t, pm.consensusMgr.SetResignedLeaderAtTerm(lockCtx, tc.resignedBefore))
 			}
 
 			pm.takeRemedialAction(lockCtx, tc.action, postgresState{primaryTerm: tc.primaryTerm})

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -185,9 +185,8 @@ func TestDetermineRemedialAction(t *testing.T) {
 			},
 		}
 	}
-	recordedPrimary := func(term int64, leader *clustermetadatapb.ID, addr *clustermetadatapb.PoolerAddress) *consensus.ConsensusPromises {
-		cs := consensus.NewConsensusPromises("", selfID)
-		cs.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{
+	recordedPrimary := func(term int64, leader *clustermetadatapb.ID, addr *clustermetadatapb.PoolerAddress) *clustermetadatapb.ReplicationPrimary {
+		return &clustermetadatapb.ReplicationPrimary{
 			Rule: &clustermetadatapb.ShardRule{
 				RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: term},
 				LeaderId:   leader,
@@ -196,15 +195,14 @@ func TestDetermineRemedialAction(t *testing.T) {
 			// The recorded leader has advertised rewind-readiness, so the
 			// stale-primary demote is allowed to proceed.
 			RewindReady: true,
-		})
-		return cs
+		}
 	}
 
 	tests := []struct {
 		name               string
 		state              postgresState
 		poolerType         clustermetadatapb.PoolerType
-		consensusPromises  *consensus.ConsensusPromises
+		seedPrimary        *clustermetadatapb.ReplicationPrimary
 		cachedPos          *clustermetadatapb.PoolerPosition
 		primaryTerm        int64
 		resignedLeaderTerm int64
@@ -266,10 +264,10 @@ func TestDetermineRemedialAction(t *testing.T) {
 				postgresRunning: true,
 				isPrimary:       true,
 			},
-			poolerType:        clustermetadatapb.PoolerType_PRIMARY,
-			consensusPromises: recordedPrimary(5, otherID, otherAddr),
-			cachedPos:         selfPos(4, selfID),
-			expectedAction:    remedialActionDemoteStalePrimary,
+			poolerType:     clustermetadatapb.PoolerType_PRIMARY,
+			seedPrimary:    recordedPrimary(5, otherID, otherAddr),
+			cachedPos:      selfPos(4, selfID),
+			expectedAction: remedialActionDemoteStalePrimary,
 		},
 		{
 			// Intended PRIMARY (rule names self) but postgres is a standby and we
@@ -429,14 +427,10 @@ func TestDetermineRemedialAction(t *testing.T) {
 				// observation that names itself.
 				seed.SelfLeadership = &clustermetadatapb.LeaderObservation{LeaderId: selfID}
 			}
-			promises := tt.consensusPromises
-			if promises == nil {
-				promises = consensus.NewConsensusPromises("", selfID)
-			}
 			pm := newTestManager(t,
 				withServiceID(selfID),
 				withRecord(newRecordFromProto(seed)),
-				withPromises(promises),
+				withReplicationPrimary(tt.seedPrimary),
 				withResignedLeaderAtTerm(tt.resignedLeaderTerm),
 				withRuleStore(&fakeRuleStore{pos: tt.cachedPos, inconsistentGUC: tt.inconsistentGUC}),
 			)
@@ -470,9 +464,8 @@ func TestDetermineRemedialAction_StalePrimaryDemote(t *testing.T) {
 			},
 		}
 	}
-	recordedPrimary := func(term int64, leader *clustermetadatapb.ID, addr *clustermetadatapb.PoolerAddress) *consensus.ConsensusPromises {
-		cs := consensus.NewConsensusPromises("", selfID)
-		cs.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{
+	recordedPrimary := func(term int64, leader *clustermetadatapb.ID, addr *clustermetadatapb.PoolerAddress) *clustermetadatapb.ReplicationPrimary {
+		return &clustermetadatapb.ReplicationPrimary{
 			Rule: &clustermetadatapb.ShardRule{
 				RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: term},
 				LeaderId:   leader,
@@ -481,54 +474,53 @@ func TestDetermineRemedialAction_StalePrimaryDemote(t *testing.T) {
 			// The recorded leader has advertised rewind-readiness, so the
 			// stale-primary demote is allowed to proceed.
 			RewindReady: true,
-		})
-		return cs
+		}
 	}
 
 	tests := []struct {
-		name              string
-		consensusPromises *consensus.ConsensusPromises
-		cachedPos         *clustermetadatapb.PoolerPosition
-		expectedAction    remedialAction
+		name           string
+		seedPrimary    *clustermetadatapb.ReplicationPrimary
+		cachedPos      *clustermetadatapb.PoolerPosition
+		expectedAction remedialAction
 	}{
 		{
 			// Recorded rule outranks our applied position and names another
 			// leader with usable contact info: retry the demote.
-			name:              "higher_rule_names_other_leader_demotes",
-			consensusPromises: recordedPrimary(5, otherID, otherAddr),
-			cachedPos:         selfPos(4),
-			expectedAction:    remedialActionDemoteStalePrimary,
+			name:           "higher_rule_names_other_leader_demotes",
+			seedPrimary:    recordedPrimary(5, otherID, otherAddr),
+			cachedPos:      selfPos(4),
+			expectedAction: remedialActionDemoteStalePrimary,
 		},
 		{
 			// No recorded primary: we have nothing to rewind against or stream
 			// from, so wait rather than restart blind.
-			name:              "no_recorded_primary_waits",
-			consensusPromises: consensus.NewConsensusPromises("", selfID),
-			cachedPos:         selfPos(4),
-			expectedAction:    remedialActionNone,
+			name:           "no_recorded_primary_waits",
+			seedPrimary:    nil,
+			cachedPos:      selfPos(4),
+			expectedAction: remedialActionNone,
 		},
 		{
 			// Recorded rule advanced but carries no contact info: still no
 			// source to connect to, so wait.
-			name:              "recorded_primary_without_address_waits",
-			consensusPromises: recordedPrimary(5, otherID, nil),
-			cachedPos:         selfPos(4),
-			expectedAction:    remedialActionNone,
+			name:           "recorded_primary_without_address_waits",
+			seedPrimary:    recordedPrimary(5, otherID, nil),
+			cachedPos:      selfPos(4),
+			expectedAction: remedialActionNone,
 		},
 		{
 			// Recorded rule is not higher than our applied position: it is stale
 			// relative to us and must not trigger a demote.
-			name:              "recorded_rule_not_higher_waits",
-			consensusPromises: recordedPrimary(4, otherID, otherAddr),
-			cachedPos:         selfPos(4),
-			expectedAction:    remedialActionNone,
+			name:           "recorded_rule_not_higher_waits",
+			seedPrimary:    recordedPrimary(4, otherID, otherAddr),
+			cachedPos:      selfPos(4),
+			expectedAction: remedialActionNone,
 		},
 		{
 			// Recorded rule names us as the leader: not a "superseded" case.
-			name:              "recorded_rule_names_self_waits",
-			consensusPromises: recordedPrimary(5, selfID, &clustermetadatapb.PoolerAddress{Id: selfID, Host: "self-host", PostgresPort: 5432}),
-			cachedPos:         selfPos(4),
-			expectedAction:    remedialActionNone,
+			name:           "recorded_rule_names_self_waits",
+			seedPrimary:    recordedPrimary(5, selfID, &clustermetadatapb.PoolerAddress{Id: selfID, Host: "self-host", PostgresPort: 5432}),
+			cachedPos:      selfPos(4),
+			expectedAction: remedialActionNone,
 		},
 	}
 
@@ -541,7 +533,7 @@ func TestDetermineRemedialAction_StalePrimaryDemote(t *testing.T) {
 					Type:           clustermetadatapb.PoolerType_PRIMARY,
 					SelfLeadership: &clustermetadatapb.LeaderObservation{LeaderId: selfID},
 				})),
-				withPromises(tt.consensusPromises),
+				withReplicationPrimary(tt.seedPrimary),
 				withRuleStore(&fakeRuleStore{pos: tt.cachedPos}),
 			)
 
@@ -566,17 +558,16 @@ func TestStaleStandbyDemoteTarget(t *testing.T) {
 	// newPM builds a manager whose applied position is at selfTerm (naming self)
 	// and whose recorded replication primary is recordedRule/addr (nil = unset).
 	newPM := func(t *testing.T, recordedRule *clustermetadatapb.ShardRule, addr *clustermetadatapb.PoolerAddress, selfTerm int64) *MultiPoolerManager {
-		cs := consensus.NewConsensusPromises(t.TempDir(), selfID)
+		opts := []testManagerOption{
+			withServiceID(selfID),
+			withRuleStore(&fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Rule: rule(selfTerm, selfID)}}),
+		}
 		if recordedRule != nil {
 			// RewindReady so the rewind-ready gate is satisfied; cases that expect
 			// nil do so for their own reason (not-ready is covered separately below).
-			cs.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: recordedRule, Primary: addr, RewindReady: true})
+			opts = append(opts, withReplicationPrimary(&clustermetadatapb.ReplicationPrimary{Rule: recordedRule, Primary: addr, RewindReady: true}))
 		}
-		return newTestManager(t,
-			withServiceID(selfID),
-			withPromises(cs),
-			withRuleStore(&fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Rule: rule(selfTerm, selfID)}}),
-		)
+		return newTestManager(t, opts...)
 	}
 
 	t.Run("no recorded replication primary -> nil", func(t *testing.T) {
@@ -606,10 +597,10 @@ func TestStaleStandbyDemoteTarget(t *testing.T) {
 		cs := consensus.NewConsensusPromises(dir, selfID)
 		_, err := cs.Load()
 		require.NoError(t, err)
-		cs.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: rule(5, otherID), Primary: otherAddr, RewindReady: true})
 		pm := newTestManager(t,
 			withServiceID(selfID),
 			withPromises(cs),
+			withReplicationPrimary(&clustermetadatapb.ReplicationPrimary{Rule: rule(5, otherID), Primary: otherAddr, RewindReady: true}),
 			withRuleStore(&fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Rule: rule(4, selfID)}}),
 		)
 		require.Nil(t, pm.staleStandbyDemoteTarget())
@@ -627,11 +618,9 @@ func TestStaleStandbyDemoteTarget(t *testing.T) {
 		// Same as the returns-target case, but the recorded leader has not advertised
 		// rewind-readiness, so we defer rather than restart into a rewind that would
 		// FATAL against a not-yet-checkpointed source.
-		cs := consensus.NewConsensusPromises(t.TempDir(), selfID)
-		cs.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: rule(5, otherID), Primary: otherAddr, RewindReady: false})
 		pm := newTestManager(t,
 			withServiceID(selfID),
-			withPromises(cs),
+			withReplicationPrimary(&clustermetadatapb.ReplicationPrimary{Rule: rule(5, otherID), Primary: otherAddr, RewindReady: false}),
 			withRuleStore(&fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Rule: rule(4, selfID)}}),
 		)
 		require.Nil(t, pm.staleStandbyDemoteTarget())
@@ -1409,7 +1398,7 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 			pm, tmpDir := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(0)})
 
 			if tt.seedRP != nil {
-				pm.consensusMgr.Promises().RecordTermPrimary(tt.seedRP)
+				pm.consensusMgr.RecordTermPrimary(tt.seedRP)
 			}
 			if tt.seedRevocation != nil {
 				consensustest.SeedTerm(t, tmpDir, tt.seedRevocation)

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -599,11 +599,19 @@ func TestStaleStandbyDemoteTarget(t *testing.T) {
 	})
 
 	t.Run("recorded rule is revoked -> nil", func(t *testing.T) {
-		pm := newPM(t, rule(5, otherID), otherAddr, 4)
-		lockCtx, err := actionlock.NewActionLock().Acquire(t.Context(), "test")
+		dir := t.TempDir()
+		// Seed a revocation of everything below term 6, which revokes the recorded
+		// rule at term 5.
+		consensustest.SeedTerm(t, dir, &clustermetadatapb.TermRevocation{RevokedBelowTerm: 6})
+		cs := consensus.NewConsensusPromises(dir, selfID)
+		_, err := cs.Load()
 		require.NoError(t, err)
-		// Revoke everything below term 6, which revokes the recorded rule at term 5.
-		require.NoError(t, pm.consensusPromises.UpdateTermAndSave(lockCtx, 6))
+		cs.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: rule(5, otherID), Primary: otherAddr, RewindReady: true})
+		pm := &MultiPoolerManager{
+			serviceID:         selfID,
+			consensusPromises: cs,
+			rules:             &fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Rule: rule(4, selfID)}},
+		}
 		require.Nil(t, pm.staleStandbyDemoteTarget())
 	})
 
@@ -863,14 +871,17 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 			pm := newRemedialActionTestManager(t, multipooler)
 			pm.rules = &fakeRuleStore{pos: tc.cachedPos}
 
-			cs := consensus.NewConsensusPromises(t.TempDir(), nil)
+			dir := t.TempDir()
+			// Seed a revocation of everything below term 1 so the manager has a term.
+			consensustest.SeedTerm(t, dir, &clustermetadatapb.TermRevocation{RevokedBelowTerm: 1})
+			cs := consensus.NewConsensusPromises(dir, nil)
+			_, err := cs.Load()
+			require.NoError(t, err)
 			pm.consensusPromises = cs
 
 			lockCtx, err := pm.actionLock.Acquire(ctx, "test")
 			require.NoError(t, err)
 			defer pm.actionLock.Release(lockCtx)
-
-			require.NoError(t, cs.UpdateTermAndSave(lockCtx, 1))
 
 			if tc.resignedBefore != 0 {
 				require.NoError(t, pm.setResignedLeaderAtTerm(lockCtx, tc.resignedBefore))

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -1398,7 +1398,10 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 			pm, tmpDir := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(0)})
 
 			if tt.seedRP != nil {
-				pm.consensusMgr.RecordTermPrimary(tt.seedRP)
+				lockCtx, err := pm.actionLock.Acquire(t.Context(), "test-seed")
+				require.NoError(t, err)
+				require.NoError(t, pm.consensusMgr.RecordTermPrimary(lockCtx, tt.seedRP))
+				pm.actionLock.Release(lockCtx)
 			}
 			if tt.seedRevocation != nil {
 				consensustest.SeedTerm(t, tmpDir, tt.seedRevocation)

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -185,8 +185,8 @@ func TestDetermineRemedialAction(t *testing.T) {
 			},
 		}
 	}
-	recordedPrimary := func(term int64, leader *clustermetadatapb.ID, addr *clustermetadatapb.PoolerAddress) *consensus.ConsensusState {
-		cs := consensus.NewConsensusState("", selfID)
+	recordedPrimary := func(term int64, leader *clustermetadatapb.ID, addr *clustermetadatapb.PoolerAddress) *consensus.ConsensusPromises {
+		cs := consensus.NewConsensusPromises("", selfID)
 		cs.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{
 			Rule: &clustermetadatapb.ShardRule{
 				RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: term},
@@ -204,7 +204,7 @@ func TestDetermineRemedialAction(t *testing.T) {
 		name               string
 		state              postgresState
 		poolerType         clustermetadatapb.PoolerType
-		consensusState     *consensus.ConsensusState
+		consensusPromises  *consensus.ConsensusPromises
 		cachedPos          *clustermetadatapb.PoolerPosition
 		primaryTerm        int64
 		resignedLeaderTerm int64
@@ -266,10 +266,10 @@ func TestDetermineRemedialAction(t *testing.T) {
 				postgresRunning: true,
 				isPrimary:       true,
 			},
-			poolerType:     clustermetadatapb.PoolerType_PRIMARY,
-			consensusState: recordedPrimary(5, otherID, otherAddr),
-			cachedPos:      selfPos(4, selfID),
-			expectedAction: remedialActionDemoteStalePrimary,
+			poolerType:        clustermetadatapb.PoolerType_PRIMARY,
+			consensusPromises: recordedPrimary(5, otherID, otherAddr),
+			cachedPos:         selfPos(4, selfID),
+			expectedAction:    remedialActionDemoteStalePrimary,
 		},
 		{
 			// Intended PRIMARY (rule names self) but postgres is a standby and we
@@ -433,10 +433,10 @@ func TestDetermineRemedialAction(t *testing.T) {
 				serviceID: selfID,
 				record:    newRecordFromProto(seed),
 			}
-			if tt.consensusState != nil {
-				pm.consensusState = tt.consensusState
+			if tt.consensusPromises != nil {
+				pm.consensusPromises = tt.consensusPromises
 			} else {
-				pm.consensusState = consensus.NewConsensusState("", selfID)
+				pm.consensusPromises = consensus.NewConsensusPromises("", selfID)
 			}
 			pm.resignedLeaderAtTerm = tt.resignedLeaderTerm
 			pm.rules = &fakeRuleStore{pos: tt.cachedPos, inconsistentGUC: tt.inconsistentGUC}
@@ -470,8 +470,8 @@ func TestDetermineRemedialAction_StalePrimaryDemote(t *testing.T) {
 			},
 		}
 	}
-	recordedPrimary := func(term int64, leader *clustermetadatapb.ID, addr *clustermetadatapb.PoolerAddress) *consensus.ConsensusState {
-		cs := consensus.NewConsensusState("", selfID)
+	recordedPrimary := func(term int64, leader *clustermetadatapb.ID, addr *clustermetadatapb.PoolerAddress) *consensus.ConsensusPromises {
+		cs := consensus.NewConsensusPromises("", selfID)
 		cs.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{
 			Rule: &clustermetadatapb.ShardRule{
 				RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: term},
@@ -486,49 +486,49 @@ func TestDetermineRemedialAction_StalePrimaryDemote(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		consensusState *consensus.ConsensusState
-		cachedPos      *clustermetadatapb.PoolerPosition
-		expectedAction remedialAction
+		name              string
+		consensusPromises *consensus.ConsensusPromises
+		cachedPos         *clustermetadatapb.PoolerPosition
+		expectedAction    remedialAction
 	}{
 		{
 			// Recorded rule outranks our applied position and names another
 			// leader with usable contact info: retry the demote.
-			name:           "higher_rule_names_other_leader_demotes",
-			consensusState: recordedPrimary(5, otherID, otherAddr),
-			cachedPos:      selfPos(4),
-			expectedAction: remedialActionDemoteStalePrimary,
+			name:              "higher_rule_names_other_leader_demotes",
+			consensusPromises: recordedPrimary(5, otherID, otherAddr),
+			cachedPos:         selfPos(4),
+			expectedAction:    remedialActionDemoteStalePrimary,
 		},
 		{
 			// No recorded primary: we have nothing to rewind against or stream
 			// from, so wait rather than restart blind.
-			name:           "no_recorded_primary_waits",
-			consensusState: consensus.NewConsensusState("", selfID),
-			cachedPos:      selfPos(4),
-			expectedAction: remedialActionNone,
+			name:              "no_recorded_primary_waits",
+			consensusPromises: consensus.NewConsensusPromises("", selfID),
+			cachedPos:         selfPos(4),
+			expectedAction:    remedialActionNone,
 		},
 		{
 			// Recorded rule advanced but carries no contact info: still no
 			// source to connect to, so wait.
-			name:           "recorded_primary_without_address_waits",
-			consensusState: recordedPrimary(5, otherID, nil),
-			cachedPos:      selfPos(4),
-			expectedAction: remedialActionNone,
+			name:              "recorded_primary_without_address_waits",
+			consensusPromises: recordedPrimary(5, otherID, nil),
+			cachedPos:         selfPos(4),
+			expectedAction:    remedialActionNone,
 		},
 		{
 			// Recorded rule is not higher than our applied position: it is stale
 			// relative to us and must not trigger a demote.
-			name:           "recorded_rule_not_higher_waits",
-			consensusState: recordedPrimary(4, otherID, otherAddr),
-			cachedPos:      selfPos(4),
-			expectedAction: remedialActionNone,
+			name:              "recorded_rule_not_higher_waits",
+			consensusPromises: recordedPrimary(4, otherID, otherAddr),
+			cachedPos:         selfPos(4),
+			expectedAction:    remedialActionNone,
 		},
 		{
 			// Recorded rule names us as the leader: not a "superseded" case.
-			name:           "recorded_rule_names_self_waits",
-			consensusState: recordedPrimary(5, selfID, &clustermetadatapb.PoolerAddress{Id: selfID, Host: "self-host", PostgresPort: 5432}),
-			cachedPos:      selfPos(4),
-			expectedAction: remedialActionNone,
+			name:              "recorded_rule_names_self_waits",
+			consensusPromises: recordedPrimary(5, selfID, &clustermetadatapb.PoolerAddress{Id: selfID, Host: "self-host", PostgresPort: 5432}),
+			cachedPos:         selfPos(4),
+			expectedAction:    remedialActionNone,
 		},
 	}
 
@@ -542,7 +542,7 @@ func TestDetermineRemedialAction_StalePrimaryDemote(t *testing.T) {
 					SelfLeadership: &clustermetadatapb.LeaderObservation{LeaderId: selfID},
 				}),
 			}
-			pm.consensusState = tt.consensusState
+			pm.consensusPromises = tt.consensusPromises
 			pm.rules = &fakeRuleStore{pos: tt.cachedPos}
 
 			got := pm.determineRemedialAction(t.Context(), runningPrimary)
@@ -566,16 +566,16 @@ func TestStaleStandbyDemoteTarget(t *testing.T) {
 	// newPM builds a manager whose applied position is at selfTerm (naming self)
 	// and whose recorded replication primary is recordedRule/addr (nil = unset).
 	newPM := func(t *testing.T, recordedRule *clustermetadatapb.ShardRule, addr *clustermetadatapb.PoolerAddress, selfTerm int64) *MultiPoolerManager {
-		cs := consensus.NewConsensusState(t.TempDir(), selfID)
+		cs := consensus.NewConsensusPromises(t.TempDir(), selfID)
 		if recordedRule != nil {
 			// RewindReady so the rewind-ready gate is satisfied; cases that expect
 			// nil do so for their own reason (not-ready is covered separately below).
 			cs.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: recordedRule, Primary: addr, RewindReady: true})
 		}
 		return &MultiPoolerManager{
-			serviceID:      selfID,
-			consensusState: cs,
-			rules:          &fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Rule: rule(selfTerm, selfID)}},
+			serviceID:         selfID,
+			consensusPromises: cs,
+			rules:             &fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Rule: rule(selfTerm, selfID)}},
 		}
 	}
 
@@ -603,7 +603,7 @@ func TestStaleStandbyDemoteTarget(t *testing.T) {
 		lockCtx, err := actionlock.NewActionLock().Acquire(t.Context(), "test")
 		require.NoError(t, err)
 		// Revoke everything below term 6, which revokes the recorded rule at term 5.
-		require.NoError(t, pm.consensusState.UpdateTermAndSave(lockCtx, 6))
+		require.NoError(t, pm.consensusPromises.UpdateTermAndSave(lockCtx, 6))
 		require.Nil(t, pm.staleStandbyDemoteTarget())
 	})
 
@@ -619,12 +619,12 @@ func TestStaleStandbyDemoteTarget(t *testing.T) {
 		// Same as the returns-target case, but the recorded leader has not advertised
 		// rewind-readiness, so we defer rather than restart into a rewind that would
 		// FATAL against a not-yet-checkpointed source.
-		cs := consensus.NewConsensusState(t.TempDir(), selfID)
+		cs := consensus.NewConsensusPromises(t.TempDir(), selfID)
 		cs.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{Rule: rule(5, otherID), Primary: otherAddr, RewindReady: false})
 		pm := &MultiPoolerManager{
-			serviceID:      selfID,
-			consensusState: cs,
-			rules:          &fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Rule: rule(4, selfID)}},
+			serviceID:         selfID,
+			consensusPromises: cs,
+			rules:             &fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Rule: rule(4, selfID)}},
 		}
 		require.Nil(t, pm.staleStandbyDemoteTarget())
 	})
@@ -863,8 +863,8 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 			pm := newRemedialActionTestManager(t, multipooler)
 			pm.rules = &fakeRuleStore{pos: tc.cachedPos}
 
-			cs := consensus.NewConsensusState(t.TempDir(), nil)
-			pm.consensusState = cs
+			cs := consensus.NewConsensusPromises(t.TempDir(), nil)
+			pm.consensusPromises = cs
 
 			lockCtx, err := pm.actionLock.Acquire(ctx, "test")
 			require.NoError(t, err)
@@ -900,7 +900,7 @@ func TestTakeRemedialAction_ReconcileGUC(t *testing.T) {
 			},
 		}),
 	}
-	pm.consensusState = consensus.NewConsensusState("", nil)
+	pm.consensusPromises = consensus.NewConsensusPromises("", nil)
 
 	lockCtx, err := pm.actionLock.Acquire(ctx, "test")
 	require.NoError(t, err)
@@ -922,7 +922,7 @@ func TestTakeRemedialAction_ReconcileRole_AppliesRuleDerivedRole(t *testing.T) {
 		Type: clustermetadatapb.PoolerType_REPLICA,
 	}
 	pm := newRemedialActionTestManager(t, multipooler)
-	pm.consensusState = consensus.NewConsensusState("", multipooler.Id)
+	pm.consensusPromises = consensus.NewConsensusPromises("", multipooler.Id)
 	committed := &clustermetadatapb.RuleNumber{CoordinatorTerm: 4}
 	// The committed rule names this pooler leader, so the rule-derived role is
 	// PRIMARY — ReconcileRole must publish PRIMARY plus the self-leadership obs
@@ -1238,9 +1238,9 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 
 	tests := []struct {
 		name string
-		// seedRP, when non-nil, is recorded on consensusState before the call.
+		// seedRP, when non-nil, is recorded on consensusPromises before the call.
 		seedRP *clustermetadatapb.ReplicationPrimary
-		// seedRevocation, when non-nil, is written to consensusState before the call.
+		// seedRevocation, when non-nil, is written to consensusPromises before the call.
 		seedRevocation *clustermetadatapb.TermRevocation
 		// seedManualStop, when true, sets the walReceiverManuallyStopped flag
 		// before the call to simulate a prior StopReplication.
@@ -1406,11 +1406,11 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 			pm, tmpDir := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(0)})
 
 			if tt.seedRP != nil {
-				pm.consensusState.RecordTermPrimary(tt.seedRP)
+				pm.consensusPromises.RecordTermPrimary(tt.seedRP)
 			}
 			if tt.seedRevocation != nil {
 				consensustest.SeedTerm(t, tmpDir, tt.seedRevocation)
-				_, err := pm.consensusState.Load()
+				_, err := pm.consensusPromises.Load()
 				require.NoError(t, err)
 			}
 			if tt.seedManualStop {

--- a/go/services/multipooler/internal/manager/rpc_backup.go
+++ b/go/services/multipooler/internal/manager/rpc_backup.go
@@ -367,6 +367,15 @@ func (pm *MultiPoolerManager) restoreFromBackupLocked(ctx context.Context, backu
 		return err
 	}
 
+	// Best-effort refresh of the rule observation cache. The restore restarted
+	// postgres with the backup's current_rule row and reopenPoolerManager just
+	// re-established the query-service connection, so observe the position now
+	// rather than leaving the cache stale until the next monitor tick. A failure
+	// here is non-fatal — the next ObservePosition will refresh it.
+	if _, err := pm.rules.ObservePosition(ctx); err != nil {
+		pm.logger.WarnContext(ctx, "Could not refresh rule observation after restore", "error", err)
+	}
+
 	// Mark as initialized after successful restore
 	return telemetry.WithSpan(ctx, "restore/mark-initialized", func(_ context.Context) error {
 		if err := pm.setInitialized(); err != nil {

--- a/go/services/multipooler/internal/manager/rpc_backup.go
+++ b/go/services/multipooler/internal/manager/rpc_backup.go
@@ -177,7 +177,7 @@ func (pm *MultiPoolerManager) GetPrimaryAsPg2Args(
 	// canonical source is consensusPromises.ReplicationPrimary, populated by
 	// every RPC that informs this pooler of a primary (SetPrimary and
 	// Promote's leader path for the rare self-as-primary case).
-	primary := pm.consensusPromises.GetReplicationPrimary().GetPrimary()
+	primary := pm.consensusMgr.Promises().GetReplicationPrimary().GetPrimary()
 	primaryHost := primary.GetHost()
 	primaryPort := primary.GetPostgresPort()
 	primaryPoolerID := primary.GetId()
@@ -372,7 +372,7 @@ func (pm *MultiPoolerManager) restoreFromBackupLocked(ctx context.Context, backu
 	// re-established the query-service connection, so observe the position now
 	// rather than leaving the cache stale until the next monitor tick. A failure
 	// here is non-fatal — the next ObservePosition will refresh it.
-	if _, err := pm.rules.ObservePosition(ctx); err != nil {
+	if _, err := pm.consensusMgr.Rules().ObservePosition(ctx); err != nil {
 		pm.logger.WarnContext(ctx, "Could not refresh rule observation after restore", "error", err)
 	}
 

--- a/go/services/multipooler/internal/manager/rpc_backup.go
+++ b/go/services/multipooler/internal/manager/rpc_backup.go
@@ -177,7 +177,7 @@ func (pm *MultiPoolerManager) GetPrimaryAsPg2Args(
 	// canonical source is consensusPromises.ReplicationPrimary, populated by
 	// every RPC that informs this pooler of a primary (SetPrimary and
 	// Promote's leader path for the rare self-as-primary case).
-	primary := pm.consensusMgr.Promises().GetReplicationPrimary().GetPrimary()
+	primary := pm.consensusMgr.GetReplicationPrimary().GetPrimary()
 	primaryHost := primary.GetHost()
 	primaryPort := primary.GetPostgresPort()
 	primaryPoolerID := primary.GetId()

--- a/go/services/multipooler/internal/manager/rpc_backup.go
+++ b/go/services/multipooler/internal/manager/rpc_backup.go
@@ -174,10 +174,10 @@ func (pm *MultiPoolerManager) GetPrimaryAsPg2Args(
 	}
 
 	// Replica poolers MUST have primary info to backup from primary. The
-	// canonical source is consensusState.ReplicationPrimary, populated by
+	// canonical source is consensusPromises.ReplicationPrimary, populated by
 	// every RPC that informs this pooler of a primary (SetPrimary and
 	// Promote's leader path for the rare self-as-primary case).
-	primary := pm.consensusState.GetReplicationPrimary().GetPrimary()
+	primary := pm.consensusPromises.GetReplicationPrimary().GetPrimary()
 	primaryHost := primary.GetHost()
 	primaryPort := primary.GetPostgresPort()
 	primaryPoolerID := primary.GetId()

--- a/go/services/multipooler/internal/manager/rpc_backup_test.go
+++ b/go/services/multipooler/internal/manager/rpc_backup_test.go
@@ -135,19 +135,23 @@ func createTestManagerWithBackupLocation(poolerDir, tableGroup, shard string, po
 // backup paths that read pm.consensusMgr.GetReplicationPrimary() see a
 // configured primary. Synthetic rule at term 1 is sufficient — no consumer
 // of rp.Rule reads cohort_members or durability_policy.
-func setBackupPrimary(pm *MultiPoolerManager, primaryName, host string, port int32) {
+func setBackupPrimary(t *testing.T, pm *MultiPoolerManager, primaryName, host string, port int32) {
+	t.Helper()
 	id := &clustermetadatapb.ID{
 		Component: clustermetadatapb.ID_MULTIPOOLER,
 		Cell:      "zone1",
 		Name:      primaryName,
 	}
-	pm.consensusMgr.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{
+	lockCtx, err := pm.actionLock.Acquire(t.Context(), "test-seed")
+	require.NoError(t, err)
+	defer pm.actionLock.Release(lockCtx)
+	require.NoError(t, pm.consensusMgr.RecordTermPrimary(lockCtx, &clustermetadatapb.ReplicationPrimary{
 		Rule: &clustermetadatapb.ShardRule{
 			RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
 			LeaderId:   id,
 		},
 		Primary: &clustermetadatapb.PoolerAddress{Id: id, Host: host, PostgresPort: port},
-	})
+	}))
 }
 
 // setupMockPgBackRestConfig creates a mock pgbackrest.conf file and returns its path.
@@ -245,7 +249,7 @@ func TestBackup_Validation(t *testing.T) {
 
 			// Setup primary info for replica poolers (required for backup)
 			if tt.poolerType == clustermetadatapb.PoolerType_REPLICA {
-				setBackupPrimary(pm, "primary-pooler", "primary.local", 5432)
+				setBackupPrimary(t, pm, "primary-pooler", "primary.local", 5432)
 			}
 
 			_, err := pm.Backup(ctx, tt.forcePrimary, tt.backupType, "", nil)
@@ -571,7 +575,7 @@ pg1-path=/tmp/pg_data
 	pm.backup.SetConfigPath(pgctldConfigPath)
 
 	// Setup primary info (required for replica backups)
-	setBackupPrimary(pm, "primary-pooler", "primary.local", 5432)
+	setBackupPrimary(t, pm, "primary-pooler", "primary.local", 5432)
 
 	// Call Backup with pg2_path override for local mode
 	primaryDataPath := filepath.Join(poolerDir, "pg_data")
@@ -656,7 +660,7 @@ exit 0
 	configPath := setupMockPgBackRestConfig(t, poolerDir)
 	pm := createTestManagerWithBackupLocation(poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
 	pm.backup.SetConfigPath(configPath)
-	setBackupPrimary(pm, "primary-pooler", "primary.local", 5432)
+	setBackupPrimary(t, pm, "primary-pooler", "primary.local", 5432)
 	overrides := map[string]string{"pg2_path": filepath.Join(poolerDir, "pg_data")}
 
 	// First backup fails → streak 1, in-progress cleared.
@@ -702,7 +706,7 @@ exit 0
 	configPath := setupMockPgBackRestConfig(t, poolerDir)
 	pm := createTestManagerWithBackupLocation(poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
 	pm.backup.SetConfigPath(configPath)
-	setBackupPrimary(pm, "primary-pooler", "primary.local", 5432)
+	setBackupPrimary(t, pm, "primary-pooler", "primary.local", 5432)
 
 	// Gauges start empty before any backup.
 	require.Zero(t, pm.backup.Health().Snapshot().CompleteCount)
@@ -899,7 +903,7 @@ func TestGetPrimaryAsPg2Args(t *testing.T) {
 			// the "no primary info" case leaves ReplicationPrimary empty so
 			// GetPrimaryAsPg2Args returns FAILED_PRECONDITION.
 			if tt.primaryHost != "" && tt.primaryPort != 0 {
-				setBackupPrimary(pm, "test-primary", tt.primaryHost, tt.primaryPort)
+				setBackupPrimary(t, pm, "test-primary", tt.primaryHost, tt.primaryPort)
 			}
 
 			// Setup TLS certs if needed and create primary pooler in topology
@@ -987,7 +991,7 @@ func TestGetPrimaryAsPg2Args_WithOverrides(t *testing.T) {
 		pm.config.PgBackRestCAFile = "/path/to/ca.crt"
 		pm.config.PgBackRestCertFile = "/path/to/client.crt"
 		pm.config.PgBackRestKeyFile = "/path/to/client.key"
-		setBackupPrimary(pm, "test-primary-override", "primary.example.com", 5432)
+		setBackupPrimary(t, pm, "test-primary-override", "primary.example.com", 5432)
 
 		// Matching primary id for the topology entry below.
 		primaryID := &clustermetadatapb.ID{
@@ -1028,7 +1032,7 @@ func TestGetPrimaryAsPg2Args_WithOverrides(t *testing.T) {
 		pm.config.PgBackRestCAFile = "/path/to/ca.crt"
 		pm.config.PgBackRestCertFile = "/path/to/client.crt"
 		pm.config.PgBackRestKeyFile = "/path/to/client.key"
-		setBackupPrimary(pm, "test-primary-no-datadir", "primary.example.com", 5432)
+		setBackupPrimary(t, pm, "test-primary-no-datadir", "primary.example.com", 5432)
 
 		primaryID := &clustermetadatapb.ID{
 			Component: clustermetadatapb.ID_MULTIPOOLER,
@@ -1059,7 +1063,7 @@ func TestGetPrimaryAsPg2Args_WithOverrides(t *testing.T) {
 	t.Run("local mode requires pg2_path override", func(t *testing.T) {
 		// Create manager without TLS certs (local mode)
 		pm := createTestManager(poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA)
-		setBackupPrimary(pm, "test-primary-local", "localhost", 5432)
+		setBackupPrimary(t, pm, "test-primary-local", "localhost", 5432)
 
 		// Without override - should error
 		_, err := pm.GetPrimaryAsPg2Args(ctx, nil, false)
@@ -1081,7 +1085,7 @@ func TestGetPrimaryAsPg2Args_WithOverrides(t *testing.T) {
 		pm.config.PgBackRestCAFile = "/path/to/ca.crt"
 		pm.config.PgBackRestCertFile = "/path/to/client.crt"
 		pm.config.PgBackRestKeyFile = "/path/to/client.key"
-		setBackupPrimary(pm, "test-primary-override2", "primary.example.com", 5432)
+		setBackupPrimary(t, pm, "test-primary-override2", "primary.example.com", 5432)
 
 		primaryID := &clustermetadatapb.ID{
 			Component: clustermetadatapb.ID_MULTIPOOLER,

--- a/go/services/multipooler/internal/manager/rpc_backup_test.go
+++ b/go/services/multipooler/internal/manager/rpc_backup_test.go
@@ -115,7 +115,7 @@ func createTestManagerWithBackupLocation(t *testing.T, poolerDir, tableGroup, sh
 		// consensus.ConsensusPromises is the canonical home for the recorded primary
 		// (replacing the former pm.primaryHost/Port/PoolerID fields). Backup
 		// tests seed it via setBackupPrimary below.
-		consensusMgr: consensus.NewManagerForTesting(t,
+		consensusMgr: consensus.NewManagerForTesting(t, multipoolerID,
 			consensus.NewConsensusPromises(poolerDir, multipoolerID),
 			&fakeRuleStore{},
 			nil,

--- a/go/services/multipooler/internal/manager/rpc_backup_test.go
+++ b/go/services/multipooler/internal/manager/rpc_backup_test.go
@@ -112,10 +112,10 @@ func createTestManagerWithBackupLocation(poolerDir, tableGroup, shard string, po
 		actionLock: actionlock.NewActionLock(),
 		logger:     slog.Default(),
 		pgMonitor:  monitorRunner,
-		// consensus.ConsensusState is the canonical home for the recorded primary
+		// consensus.ConsensusPromises is the canonical home for the recorded primary
 		// (replacing the former pm.primaryHost/Port/PoolerID fields). Backup
 		// tests seed it via setBackupPrimary below.
-		consensusState: consensus.NewConsensusState(poolerDir, multipoolerID),
+		consensusPromises: consensus.NewConsensusPromises(poolerDir, multipoolerID),
 	}
 
 	// Build the backup engine the way the production constructor does, feeding
@@ -128,7 +128,7 @@ func createTestManagerWithBackupLocation(poolerDir, tableGroup, shard string, po
 }
 
 // setBackupPrimary seeds the ReplicationPrimary on the test manager so the
-// backup paths that read pm.consensusState.GetReplicationPrimary() see a
+// backup paths that read pm.consensusPromises.GetReplicationPrimary() see a
 // configured primary. Synthetic rule at term 1 is sufficient — no consumer
 // of rp.Rule reads cohort_members or durability_policy.
 func setBackupPrimary(pm *MultiPoolerManager, primaryName, host string, port int32) {
@@ -137,7 +137,7 @@ func setBackupPrimary(pm *MultiPoolerManager, primaryName, host string, port int
 		Cell:      "zone1",
 		Name:      primaryName,
 	}
-	pm.consensusState.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{
+	pm.consensusPromises.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{
 		Rule: &clustermetadatapb.ShardRule{
 			RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
 			LeaderId:   id,

--- a/go/services/multipooler/internal/manager/rpc_backup_test.go
+++ b/go/services/multipooler/internal/manager/rpc_backup_test.go
@@ -131,7 +131,7 @@ func createTestManagerWithBackupLocation(poolerDir, tableGroup, shard string, po
 }
 
 // setBackupPrimary seeds the ReplicationPrimary on the test manager so the
-// backup paths that read pm.consensusMgr.Promises().GetReplicationPrimary() see a
+// backup paths that read pm.consensusMgr.GetReplicationPrimary() see a
 // configured primary. Synthetic rule at term 1 is sufficient — no consumer
 // of rp.Rule reads cohort_members or durability_policy.
 func setBackupPrimary(pm *MultiPoolerManager, primaryName, host string, port int32) {
@@ -140,7 +140,7 @@ func setBackupPrimary(pm *MultiPoolerManager, primaryName, host string, port int
 		Cell:      "zone1",
 		Name:      primaryName,
 	}
-	pm.consensusMgr.Promises().RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{
+	pm.consensusMgr.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{
 		Rule: &clustermetadatapb.ShardRule{
 			RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
 			LeaderId:   id,

--- a/go/services/multipooler/internal/manager/rpc_backup_test.go
+++ b/go/services/multipooler/internal/manager/rpc_backup_test.go
@@ -115,7 +115,10 @@ func createTestManagerWithBackupLocation(poolerDir, tableGroup, shard string, po
 		// consensus.ConsensusPromises is the canonical home for the recorded primary
 		// (replacing the former pm.primaryHost/Port/PoolerID fields). Backup
 		// tests seed it via setBackupPrimary below.
-		consensusPromises: consensus.NewConsensusPromises(poolerDir, multipoolerID),
+		consensusMgr: consensus.NewConsensusManager(
+			consensus.NewConsensusPromises(poolerDir, multipoolerID),
+			&fakeRuleStore{},
+		),
 	}
 
 	// Build the backup engine the way the production constructor does, feeding
@@ -128,7 +131,7 @@ func createTestManagerWithBackupLocation(poolerDir, tableGroup, shard string, po
 }
 
 // setBackupPrimary seeds the ReplicationPrimary on the test manager so the
-// backup paths that read pm.consensusPromises.GetReplicationPrimary() see a
+// backup paths that read pm.consensusMgr.Promises().GetReplicationPrimary() see a
 // configured primary. Synthetic rule at term 1 is sufficient — no consumer
 // of rp.Rule reads cohort_members or durability_policy.
 func setBackupPrimary(pm *MultiPoolerManager, primaryName, host string, port int32) {
@@ -137,7 +140,7 @@ func setBackupPrimary(pm *MultiPoolerManager, primaryName, host string, port int
 		Cell:      "zone1",
 		Name:      primaryName,
 	}
-	pm.consensusPromises.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{
+	pm.consensusMgr.Promises().RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{
 		Rule: &clustermetadatapb.ShardRule{
 			RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
 			LeaderId:   id,

--- a/go/services/multipooler/internal/manager/rpc_backup_test.go
+++ b/go/services/multipooler/internal/manager/rpc_backup_test.go
@@ -118,6 +118,7 @@ func createTestManagerWithBackupLocation(poolerDir, tableGroup, shard string, po
 		consensusMgr: consensus.NewConsensusManager(
 			consensus.NewConsensusPromises(poolerDir, multipoolerID),
 			&fakeRuleStore{},
+			nil,
 		),
 	}
 

--- a/go/services/multipooler/internal/manager/rpc_backup_test.go
+++ b/go/services/multipooler/internal/manager/rpc_backup_test.go
@@ -42,13 +42,13 @@ import (
 )
 
 // createTestManager creates a minimal MultiPoolerManager for testing
-func createTestManager(poolerDir, tableGroup, shard string, poolerType clustermetadatapb.PoolerType) *MultiPoolerManager {
-	return createTestManagerWithBackupLocation(poolerDir, tableGroup, shard, poolerType, "/tmp/backups")
+func createTestManager(t *testing.T, poolerDir, tableGroup, shard string, poolerType clustermetadatapb.PoolerType) *MultiPoolerManager {
+	return createTestManagerWithBackupLocation(t, poolerDir, tableGroup, shard, poolerType, "/tmp/backups")
 }
 
 // createTestManagerWithBackupLocation creates a minimal MultiPoolerManager for testing with backup_location.
 // backupLocation is the base path; the full path (with database/tablegroup/shard) is computed internally.
-func createTestManagerWithBackupLocation(poolerDir, tableGroup, shard string, poolerType clustermetadatapb.PoolerType, backupLocation string) *MultiPoolerManager {
+func createTestManagerWithBackupLocation(t *testing.T, poolerDir, tableGroup, shard string, poolerType clustermetadatapb.PoolerType, backupLocation string) *MultiPoolerManager {
 	database := "test-database"
 
 	// Use defaults if not provided
@@ -115,7 +115,7 @@ func createTestManagerWithBackupLocation(poolerDir, tableGroup, shard string, po
 		// consensus.ConsensusPromises is the canonical home for the recorded primary
 		// (replacing the former pm.primaryHost/Port/PoolerID fields). Backup
 		// tests seed it via setBackupPrimary below.
-		consensusMgr: consensus.NewConsensusManager(
+		consensusMgr: consensus.NewManagerForTesting(t,
 			consensus.NewConsensusPromises(poolerDir, multipoolerID),
 			&fakeRuleStore{},
 			nil,
@@ -244,7 +244,7 @@ func TestBackup_Validation(t *testing.T) {
 			// Provide backup location for tests that need to reach pgbackrest execution or validation
 			backupLocation := "/tmp/test-backups"
 			configPath := setupMockPgBackRestConfig(t, tt.poolerDir)
-			pm := createTestManagerWithBackupLocation(tt.poolerDir, "", "", tt.poolerType, backupLocation)
+			pm := createTestManagerWithBackupLocation(t, tt.poolerDir, "", "", tt.poolerType, backupLocation)
 			pm.backup.SetConfigPath(configPath)
 
 			// Setup primary info for replica poolers (required for backup)
@@ -297,7 +297,7 @@ func TestGetBackups_Validation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			configPath := setupMockPgBackRestConfig(t, tt.poolerDir)
-			pm := createTestManager(tt.poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA)
+			pm := createTestManager(t, tt.poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA)
 			pm.backup.SetConfigPath(configPath)
 
 			result, err := pm.GetBackups(ctx, tt.limit)
@@ -353,7 +353,7 @@ func TestBackup_ActionLock(t *testing.T) {
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 
-	pm := createTestManagerWithBackupLocation(tmpDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
+	pm := createTestManagerWithBackupLocation(t, tmpDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
 
 	// Hold the lock in another goroutine
 	lockCtx, err := pm.actionLock.Acquire(ctx, "test-holder")
@@ -376,7 +376,7 @@ func TestGetBackups_ActionLock(t *testing.T) {
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 
-	pm := createTestManagerWithBackupLocation(tmpDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
+	pm := createTestManagerWithBackupLocation(t, tmpDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
 
 	// Hold the lock in another goroutine
 	lockCtx, err := pm.actionLock.Acquire(ctx, "test-holder")
@@ -399,7 +399,7 @@ func TestRestoreFromBackup_ActionLock(t *testing.T) {
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 
-	pm := createTestManagerWithBackupLocation(tmpDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
+	pm := createTestManagerWithBackupLocation(t, tmpDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
 
 	// Hold the lock in another goroutine
 	lockCtx, err := pm.actionLock.Acquire(ctx, "test-holder")
@@ -422,7 +422,7 @@ func TestBackup_ActionLockReleased(t *testing.T) {
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 
-	pm := createTestManagerWithBackupLocation(tmpDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
+	pm := createTestManagerWithBackupLocation(t, tmpDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
 
 	// Call Backup - it will fail (no pgbackrest), but should release the lock
 	_, _ = pm.Backup(ctx, false, "full", "", nil)
@@ -440,7 +440,7 @@ func TestGetBackups_ActionLockReleased(t *testing.T) {
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 
-	pm := createTestManagerWithBackupLocation(tmpDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
+	pm := createTestManagerWithBackupLocation(t, tmpDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
 
 	// Call GetBackups - it may fail or succeed, but should release the lock
 	_, _ = pm.GetBackups(ctx, 10)
@@ -458,7 +458,7 @@ func TestRestoreFromBackup_ActionLockReleased(t *testing.T) {
 	ctx := t.Context()
 	tmpDir := t.TempDir()
 
-	pm := createTestManagerWithBackupLocation(tmpDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
+	pm := createTestManagerWithBackupLocation(t, tmpDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
 
 	// Call RestoreFromBackup - it will fail (precondition), but should release the lock
 	_ = pm.RestoreFromBackup(ctx, "test-backup-id")
@@ -571,7 +571,7 @@ pg1-path=/tmp/pg_data
 	require.NoError(t, err)
 
 	// Create test manager with the pooler directory
-	pm := createTestManagerWithBackupLocation(poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
+	pm := createTestManagerWithBackupLocation(t, poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
 	pm.backup.SetConfigPath(pgctldConfigPath)
 
 	// Setup primary info (required for replica backups)
@@ -610,7 +610,7 @@ pg1-path=/tmp/pg_data
 
 func TestRecordLeaseLossIfApplicable(t *testing.T) {
 	poolerDir := t.TempDir()
-	pm := createTestManagerWithBackupLocation(poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA, t.TempDir())
+	pm := createTestManagerWithBackupLocation(t, poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA, t.TempDir())
 
 	t.Run("no error → not recorded", func(t *testing.T) {
 		assert.False(t, pm.recordLeaseLossIfApplicable(t.Context(), nil))
@@ -658,7 +658,7 @@ exit 0
 	poolerDir := filepath.Join(tmpDir, "pooler")
 	require.NoError(t, os.MkdirAll(poolerDir, 0o755))
 	configPath := setupMockPgBackRestConfig(t, poolerDir)
-	pm := createTestManagerWithBackupLocation(poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
+	pm := createTestManagerWithBackupLocation(t, poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
 	pm.backup.SetConfigPath(configPath)
 	setBackupPrimary(t, pm, "primary-pooler", "primary.local", 5432)
 	overrides := map[string]string{"pg2_path": filepath.Join(poolerDir, "pg_data")}
@@ -704,7 +704,7 @@ exit 0
 	poolerDir := filepath.Join(tmpDir, "pooler")
 	require.NoError(t, os.MkdirAll(poolerDir, 0o755))
 	configPath := setupMockPgBackRestConfig(t, poolerDir)
-	pm := createTestManagerWithBackupLocation(poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
+	pm := createTestManagerWithBackupLocation(t, poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
 	pm.backup.SetConfigPath(configPath)
 	setBackupPrimary(t, pm, "primary-pooler", "primary.local", 5432)
 
@@ -898,7 +898,7 @@ func TestGetPrimaryAsPg2Args(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create test manager
 			poolerDir := t.TempDir()
-			pm := createTestManager(poolerDir, "", "", tt.poolerType)
+			pm := createTestManager(t, poolerDir, "", "", tt.poolerType)
 			// Only seed a recorded primary when the test case supplies one;
 			// the "no primary info" case leaves ReplicationPrimary empty so
 			// GetPrimaryAsPg2Args returns FAILED_PRECONDITION.
@@ -987,7 +987,7 @@ func TestGetPrimaryAsPg2Args_WithOverrides(t *testing.T) {
 
 	t.Run("TLS mode pg2_path override replaces topology value", func(t *testing.T) {
 		// Create manager with TLS certs
-		pm := createTestManager(poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA)
+		pm := createTestManager(t, poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA)
 		pm.config.PgBackRestCAFile = "/path/to/ca.crt"
 		pm.config.PgBackRestCertFile = "/path/to/client.crt"
 		pm.config.PgBackRestKeyFile = "/path/to/client.key"
@@ -1028,7 +1028,7 @@ func TestGetPrimaryAsPg2Args_WithOverrides(t *testing.T) {
 	})
 
 	t.Run("TLS mode errors when pg_data_dir missing from topology", func(t *testing.T) {
-		pm := createTestManager(poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA)
+		pm := createTestManager(t, poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA)
 		pm.config.PgBackRestCAFile = "/path/to/ca.crt"
 		pm.config.PgBackRestCertFile = "/path/to/client.crt"
 		pm.config.PgBackRestKeyFile = "/path/to/client.key"
@@ -1062,7 +1062,7 @@ func TestGetPrimaryAsPg2Args_WithOverrides(t *testing.T) {
 
 	t.Run("local mode requires pg2_path override", func(t *testing.T) {
 		// Create manager without TLS certs (local mode)
-		pm := createTestManager(poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA)
+		pm := createTestManager(t, poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA)
 		setBackupPrimary(t, pm, "test-primary-local", "localhost", 5432)
 
 		// Without override - should error
@@ -1081,7 +1081,7 @@ func TestGetPrimaryAsPg2Args_WithOverrides(t *testing.T) {
 	})
 
 	t.Run("override replaces existing arg", func(t *testing.T) {
-		pm := createTestManager(poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA)
+		pm := createTestManager(t, poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA)
 		pm.config.PgBackRestCAFile = "/path/to/ca.crt"
 		pm.config.PgBackRestCertFile = "/path/to/client.crt"
 		pm.config.PgBackRestKeyFile = "/path/to/client.key"
@@ -1146,7 +1146,7 @@ func TestVerifyBackups(t *testing.T) {
 
 	t.Run("fails when config not yet generated", func(t *testing.T) {
 		// Ready, but topology hasn't been loaded so no config path exists.
-		pm := createTestManager(t.TempDir(), "", "", clustermetadatapb.PoolerType_REPLICA)
+		pm := createTestManager(t, t.TempDir(), "", "", clustermetadatapb.PoolerType_REPLICA)
 		_, err := pm.VerifyBackups(context.Background())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "pgbackrest config not found")

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -568,10 +568,12 @@ func (pm *MultiPoolerManager) promoteLocked(ctx context.Context, req *consensusd
 	// Record the (rule, primary) — this pooler IS now the primary. Stamping
 	// the published ReplicationPrimary lets the health stream advertise the
 	// new leadership immediately.
-	pm.consensusMgr.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{
+	if err := pm.consensusMgr.RecordTermPrimary(ctx, &clustermetadatapb.ReplicationPrimary{
 		Rule:    proposedRule,
 		Primary: proposalLeader,
-	})
+	}); err != nil {
+		pm.logger.ErrorContext(ctx, "failed to record replication primary after promote", "error", err)
+	}
 
 	pm.logger.InfoContext(ctx, "Promote complete",
 		"rule", commonconsensus.FormatRuleNumber(proposedRule.GetRuleNumber()),
@@ -682,7 +684,9 @@ func (pm *MultiPoolerManager) SetPrimary(ctx context.Context, req *consensusdata
 	//   - Pooler-side reconciliation: reads last-known-primary to retry
 	//     ALTER SYSTEM SET primary_conninfo if this SetPrimary arrived while
 	//     postgres was unavailable.
-	pm.consensusMgr.RecordTermPrimary(rp)
+	if err := pm.consensusMgr.RecordTermPrimary(ctx, rp); err != nil {
+		pm.logger.ErrorContext(ctx, "failed to record replication primary in SetPrimary", "error", err)
+	}
 
 	// Observe the freshest view of our rule. SetPrimary is the staleness gate,
 	// so we want authoritative state — not the cached snapshot.
@@ -736,7 +740,9 @@ func (pm *MultiPoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 	consensusTerm := rule.GetRuleNumber().GetCoordinatorTerm()
 
 	if isPrimary {
-		pm.consensusMgr.SetSuspectedDivergence(true)
+		if _, err := pm.consensusMgr.SetSuspectedDivergence(ctx, true); err != nil {
+			pm.logger.ErrorContext(ctx, "failed to set suspected divergence in SetPrimary", "error", err)
+		}
 	}
 
 	if pm.consensusMgr.SuspectedDivergence() {

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -107,16 +107,16 @@ func buildStatusReplicationPrimary(pos *clustermetadatapb.PoolerPosition, replic
 // Returns an error if postgres is unreachable, since a partial status (term revocation
 // without current_position) could mislead callers about this pooler's rule position.
 func (pm *MultiPoolerManager) getConsensusStatus(ctx context.Context) (*clustermetadatapb.ConsensusStatus, error) {
-	revocation, err := pm.consensusPromises.GetRevocation(ctx)
+	revocation, err := pm.consensusMgr.Promises().GetRevocation(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read consensus term: %w", err)
 	}
 
-	pos, err := pm.rules.ObservePosition(ctx)
+	pos, err := pm.consensusMgr.Rules().ObservePosition(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read current rule position: %w", err)
 	}
-	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusPromises.GetReplicationPrimary()), nil
+	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusMgr.Promises().GetReplicationPrimary()), nil
 }
 
 // getCachedConsensusStatus builds a ConsensusStatus using the in-memory term cache and
@@ -126,12 +126,12 @@ func (pm *MultiPoolerManager) getConsensusStatus(ctx context.Context) (*clusterm
 // Returns nil if no position has been cached yet (i.e. ObservePosition or UpdateRule
 // has never been called).
 func (pm *MultiPoolerManager) getCachedConsensusStatus() *clustermetadatapb.ConsensusStatus {
-	pos := pm.rules.CachedPosition()
+	pos := pm.consensusMgr.Rules().CachedPosition()
 	if pos == nil {
 		return nil
 	}
-	revocation := pm.consensusPromises.GetInconsistentRevocation()
-	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusPromises.GetReplicationPrimary())
+	revocation := pm.consensusMgr.Promises().GetInconsistentRevocation()
+	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusMgr.Promises().GetReplicationPrimary())
 }
 
 // getInconsistentConsensusStatus builds a ConsensusStatus from a fresh postgres
@@ -145,12 +145,12 @@ func (pm *MultiPoolerManager) getCachedConsensusStatus() *clustermetadatapb.Cons
 // to derive the last-known position — rather than this returning stale data
 // silently.
 func (pm *MultiPoolerManager) getInconsistentConsensusStatus(ctx context.Context) (*clustermetadatapb.ConsensusStatus, error) {
-	pos, err := pm.rules.ObservePosition(ctx)
+	pos, err := pm.consensusMgr.Rules().ObservePosition(ctx)
 	if err != nil {
 		return nil, err
 	}
-	revocation := pm.consensusPromises.GetInconsistentRevocation()
-	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusPromises.GetReplicationPrimary()), nil
+	revocation := pm.consensusMgr.Promises().GetInconsistentRevocation()
+	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusMgr.Promises().GetReplicationPrimary()), nil
 }
 
 // buildAvailabilityStatus returns the current AvailabilityStatus for this node.
@@ -401,7 +401,7 @@ func (pm *MultiPoolerManager) Recruit(ctx context.Context, req *consensusdatapb.
 	}
 	{
 		acceptCtx, acceptSpan := telemetry.Tracer().Start(ctx, "consensus/accept-revocation")
-		err = pm.consensusPromises.AcceptRevocation(acceptCtx, stableStatus, revocation)
+		err = pm.consensusMgr.Promises().AcceptRevocation(acceptCtx, stableStatus, revocation)
 		acceptSpan.End()
 	}
 	if err != nil {
@@ -631,7 +631,7 @@ func (pm *MultiPoolerManager) promoteLocked(ctx context.Context, req *consensusd
 	// Record the (rule, primary) — this pooler IS now the primary. Stamping
 	// the published ReplicationPrimary lets the health stream advertise the
 	// new leadership immediately.
-	pm.consensusPromises.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{
+	pm.consensusMgr.Promises().RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{
 		Rule:    proposedRule,
 		Primary: proposalLeader,
 	})
@@ -725,7 +725,7 @@ func (pm *MultiPoolerManager) SetPrimary(ctx context.Context, req *consensusdata
 	// the cohort will reconverge as it makes progress. Returning the cached
 	// status keeps the response shape consistent with the "incoming rule
 	// not higher" no-op below.
-	revocation, err := pm.consensusPromises.GetRevocation(ctx)
+	revocation, err := pm.consensusMgr.Promises().GetRevocation(ctx)
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to read revocation while validating SetPrimary")
 	}
@@ -745,11 +745,11 @@ func (pm *MultiPoolerManager) SetPrimary(ctx context.Context, req *consensusdata
 	//   - Pooler-side reconciliation: reads last-known-primary to retry
 	//     ALTER SYSTEM SET primary_conninfo if this SetPrimary arrived while
 	//     postgres was unavailable.
-	pm.consensusPromises.RecordTermPrimary(rp)
+	pm.consensusMgr.Promises().RecordTermPrimary(rp)
 
 	// Observe the freshest view of our rule. SetPrimary is the staleness gate,
 	// so we want authoritative state — not the cached snapshot.
-	selfPos, err := pm.rules.ObservePosition(ctx)
+	selfPos, err := pm.consensusMgr.Rules().ObservePosition(ctx)
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to observe local position")
 	}
@@ -830,7 +830,7 @@ func (pm *MultiPoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 		// Route it through the rule store's SyncStandbyManager (not a direct
 		// ALTER SYSTEM) so the manager stays the sole writer and its cache stays
 		// coherent.
-		if err := pm.rules.ClearSyncStandby(ctx); err != nil {
+		if err := pm.consensusMgr.Rules().ClearSyncStandby(ctx); err != nil {
 			pm.logger.WarnContext(ctx, "Failed to clear synchronous replication after demotion", "error", err)
 		}
 	} else {

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -16,7 +16,6 @@ package manager
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"google.golang.org/protobuf/proto"
@@ -34,130 +33,12 @@ import (
 	"github.com/multigres/multigres/go/tools/telemetry"
 )
 
-// buildConsensusStatus constructs a ConsensusStatus from a pre-resolved revocation,
-// position, and the highest-known RPC-told (rule, primary). Any argument may be
-// nil; the corresponding field is left unset. Never performs I/O.
-//
-// The published HighestKnownRule reflects best knowledge from any source:
-//   - rule: max of the observed position's rule and the rule from the most
-//     recent SetPrimary/Promote RPC.
-//   - primary: the contact info from the most recent SetPrimary/Promote, since
-//     ObservePosition cannot carry it.
-//
-// Result is left nil only when neither source has any information.
-func buildConsensusStatus(id *clustermetadatapb.ID, revocation *clustermetadatapb.TermRevocation, pos *clustermetadatapb.PoolerPosition, replicationPrimary *clustermetadatapb.ReplicationPrimary) *clustermetadatapb.ConsensusStatus {
-	status := &clustermetadatapb.ConsensusStatus{Id: id}
-	if revocation != nil {
-		status.TermRevocation = revocation
-	}
-	if pos != nil {
-		status.CurrentPosition = pos
-	}
-	if highest := buildStatusReplicationPrimary(pos, replicationPrimary); highest != nil {
-		status.ReplicationPrimary = highest
-	}
-	return status
-}
-
-// buildStatusReplicationPrimary returns the HighestKnownRule to publish given the most
-// recent observed position and the most recent rule+primary heard via RPC.
-// See buildConsensusStatus for the merge semantics.
-func buildStatusReplicationPrimary(pos *clustermetadatapb.PoolerPosition, replicationPrimary *clustermetadatapb.ReplicationPrimary) *clustermetadatapb.ReplicationPrimary {
-	// ruleStoreRule is read fresh from the rule store (the current_rule row in
-	// postgres, replicated through WAL). highestKnownRule is the rule last recorded
-	// via a SetPrimary/Promote RPC, which can lead the rule store before the write
-	// has been observed locally.
-	ruleStoreRule := pos.GetRule()
-	highestKnownRule := replicationPrimary.GetRule()
-	rpcPrimary := replicationPrimary.GetPrimary()
-	if ruleStoreRule == nil && highestKnownRule == nil && rpcPrimary == nil {
-		return nil
-	}
-	rule := ruleStoreRule
-	// rewind_ready is recorded alongside the rpc (rule, primary): on the primary
-	// it is the self-report ("checkpointed onto my current timeline", maintained
-	// by the postgres monitor / async-checkpoint completion); on a follower it is
-	// the value last relayed via SetPrimary about its leader. Republishing a
-	// relayed value is harmless — the leader's own status is the authority orch
-	// reads.
-	//
-	// Use the recorded rule and rewind_ready whenever it is at least as high as the
-	// rule-store observation — including a tie, which is the steady state for a
-	// leader (its rule-store rule catches up to the rule it recorded at promotion).
-	// Only a strictly-higher rule-store rule means the recorded rewind_ready no
-	// longer describes the rule we publish, so we fall back to false there.
-	rewindReady := false
-	if commonconsensus.CompareRuleNumbers(highestKnownRule.GetRuleNumber(), ruleStoreRule.GetRuleNumber()) >= 0 {
-		rule = highestKnownRule
-		rewindReady = replicationPrimary.GetRewindReady()
-	}
-	return &clustermetadatapb.ReplicationPrimary{
-		Rule:        rule,
-		Primary:     rpcPrimary,
-		RewindReady: rewindReady,
-	}
-}
-
-// getConsensusStatus builds a ConsensusStatus snapshot while holding the action lock.
-// Callers must already hold the action lock (i.e. this is called from Recruit or
-// executeRevoke). Uses a consistent disk read for the term and a fresh postgres query
-// for the current position.
-//
-// Returns an error if postgres is unreachable, since a partial status (term revocation
-// without current_position) could mislead callers about this pooler's rule position.
-func (pm *MultiPoolerManager) getConsensusStatus(ctx context.Context) (*clustermetadatapb.ConsensusStatus, error) {
-	revocation, err := pm.consensusMgr.Promises().GetRevocation(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read consensus term: %w", err)
-	}
-
-	pos, err := pm.consensusMgr.Rules().ObservePosition(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read current rule position: %w", err)
-	}
-	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusMgr.GetReplicationPrimary()), nil
-}
-
-// getCachedConsensusStatus builds a ConsensusStatus using the in-memory term cache and
-// the ruleStore's cached position. Never queries postgres or disk.
-//
-// The action lock must be held by the caller, which prevents concurrent term updates.
-// Returns nil if no position has been cached yet (i.e. ObservePosition or UpdateRule
-// has never been called).
-func (pm *MultiPoolerManager) getCachedConsensusStatus() *clustermetadatapb.ConsensusStatus {
-	pos := pm.consensusMgr.Rules().CachedPosition()
-	if pos == nil {
-		return nil
-	}
-	revocation := pm.consensusMgr.Promises().GetInconsistentRevocation()
-	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusMgr.GetReplicationPrimary())
-}
-
-// getInconsistentConsensusStatus builds a ConsensusStatus from a fresh postgres
-// position read, without holding the action lock. Like GetInconsistentTerm, it
-// may observe a partially-updated state during a concurrent Recruit, so it is
-// suitable for observability (StatusResponse, health monitors) but not for
-// decisions that require a consistent view.
-//
-// Returns an error if postgres is unreachable (ObservePosition fails). Callers
-// decide what to do with that — typically fall back to getCachedConsensusStatus
-// to derive the last-known position — rather than this returning stale data
-// silently.
-func (pm *MultiPoolerManager) getInconsistentConsensusStatus(ctx context.Context) (*clustermetadatapb.ConsensusStatus, error) {
-	pos, err := pm.consensusMgr.Rules().ObservePosition(ctx)
-	if err != nil {
-		return nil, err
-	}
-	revocation := pm.consensusMgr.Promises().GetInconsistentRevocation()
-	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusMgr.GetReplicationPrimary()), nil
-}
-
 // buildAvailabilityStatus returns the current AvailabilityStatus for this node.
 // Leaders that have resigned publish a LeadershipStatus. Every pooler publishes
 // its cohort eligibility, so the result is non-nil.
 func (pm *MultiPoolerManager) buildAvailabilityStatus() *clustermetadatapb.AvailabilityStatus {
 	return &clustermetadatapb.AvailabilityStatus{
-		LeadershipStatus:        pm.buildLeadershipStatus(),
+		LeadershipStatus:        pm.consensusMgr.LeadershipStatus(),
 		CohortEligibilityStatus: pm.buildCohortEligibilityStatus(),
 		SuspectedDivergence:     pm.consensusMgr.SuspectedDivergence(),
 	}
@@ -167,8 +48,8 @@ func (pm *MultiPoolerManager) buildAvailabilityStatus() *clustermetadatapb.Avail
 // to be a cohort member. Defaults to ELIGIBLE; downgraded to INELIGIBLE when
 // the WAL receiver was manually stopped (StopReplication cleared
 // primary_conninfo), so the coordinator does not try to re-include this node
-// while the admin signal is in effect. setCohortEligibility (currently
-// test-only) sets the base value the dynamic downgrade applies on top of.
+// while the admin signal is in effect. ConsensusManager.SetCohortEligibility
+// sets the base value the dynamic downgrade applies on top of.
 func (pm *MultiPoolerManager) buildCohortEligibilityStatus() *clustermetadatapb.CohortEligibilityStatus {
 	if pm.walReceiverManuallyStopped.Load() {
 		return &clustermetadatapb.CohortEligibilityStatus{
@@ -224,22 +105,6 @@ func (pm *MultiPoolerManager) markPoolerActive(ctx context.Context) {
 	}
 }
 
-// buildLeadershipStatus returns the LeadershipStatus for this node. Non-nil only
-// when the node has resigned leadership (i.e. after a Recruit-driven emergency
-// demotion or graceful shutdown of a leader). Nil means this node has not
-// recently held or resigned from primary leadership.
-func (pm *MultiPoolerManager) buildLeadershipStatus() *clustermetadatapb.LeadershipStatus {
-	resignedTerm := pm.consensusMgr.ResignedLeaderAtTerm()
-	if resignedTerm == 0 {
-		return nil
-	}
-
-	return &clustermetadatapb.LeadershipStatus{
-		LeaderTerm: resignedTerm,
-		Signal:     clustermetadatapb.LeadershipSignal_LEADERSHIP_SIGNAL_REQUESTING_DEMOTION,
-	}
-}
-
 // Recruit handles a coordinator's request to stop replication participation and
 // record a TermRevocation, returning the node's stable position afterward.
 //
@@ -277,7 +142,7 @@ func (pm *MultiPoolerManager) Recruit(ctx context.Context, req *consensusdatapb.
 	// State check — reject immediately if the node's committed WAL
 	// rule or stored revocation already conflicts with this request.
 	// Fails open on I/O error: a nil status passes ValidateRevocation safely.
-	preStatus, _ := pm.getConsensusStatus(ctx)
+	preStatus, _ := pm.consensusMgr.ConsensusStatus(ctx)
 	if err := commonconsensus.ValidateRevocation(preStatus, revocation); err != nil {
 		return nil, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION, err.Error())
 	}
@@ -331,7 +196,7 @@ func (pm *MultiPoolerManager) Recruit(ctx context.Context, req *consensusdatapb.
 	// Re-check against the stable position and persist atomically.
 	// AcceptRevocation combines the observed WAL position with the locked stored
 	// revocation so ValidateRevocation sees authoritative state for both checks.
-	stableStatus, err := pm.getConsensusStatus(ctx)
+	stableStatus, err := pm.consensusMgr.ConsensusStatus(ctx)
 	if err != nil {
 		eventlog.Emit(ctx, pm.logger, eventlog.Failed, termEvent, "error", err)
 		return nil, mterrors.Wrap(err, "failed to read stable status after stopping replication")
@@ -362,7 +227,7 @@ func (pm *MultiPoolerManager) Recruit(ctx context.Context, req *consensusdatapb.
 
 	// Step 5: Return ConsensusStatus with the stable post-revoke position.
 	// Uses the cached position warmed by the getConsensusStatus call in step 3.
-	return &consensusdatapb.RecruitResponse{ConsensusStatus: pm.getCachedConsensusStatus()}, nil
+	return &consensusdatapb.RecruitResponse{ConsensusStatus: pm.consensusMgr.CachedConsensusStatus()}, nil
 }
 
 // recruitDrainTimeout is the drain window when recruiting a primary.
@@ -476,7 +341,7 @@ func (pm *MultiPoolerManager) promoteLocked(ctx context.Context, req *consensusd
 	// Step 1: Validate the term revocation.
 	// ValidateRevocation ensures the WAL position is safe and the coordinator is consistent.
 	// Fails open on I/O error (nil status passes safely).
-	beforeStatus, err := pm.getConsensusStatus(ctx)
+	beforeStatus, err := pm.consensusMgr.ConsensusStatus(ctx)
 	if err != nil {
 		return nil, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION, err.Error())
 	}
@@ -581,7 +446,7 @@ func (pm *MultiPoolerManager) promoteLocked(ctx context.Context, req *consensusd
 
 	// Step 4: Return ConsensusStatus. The cache was warmed by getConsensusStatus in step 1
 	// and updated by UpdateRule (leader path); the replica position is unchanged.
-	return &consensusdatapb.PromoteResponse{ConsensusStatus: pm.getCachedConsensusStatus()}, nil
+	return &consensusdatapb.PromoteResponse{ConsensusStatus: pm.consensusMgr.CachedConsensusStatus()}, nil
 }
 
 // SetPrimary updates this pooler's replication settings to point at the supplied
@@ -673,7 +538,7 @@ func (pm *MultiPoolerManager) SetPrimary(ctx context.Context, req *consensusdata
 			"incoming_rule", rule.GetRuleNumber(),
 			"revoked_below_term", revocation.GetRevokedBelowTerm(),
 			"outgoing_rule", revocation.GetOutgoingRule())
-		return &consensusdatapb.SetPrimaryResponse{ConsensusStatus: pm.getCachedConsensusStatus()}, nil
+		return &consensusdatapb.SetPrimaryResponse{ConsensusStatus: pm.consensusMgr.CachedConsensusStatus()}, nil
 	}
 
 	// Record what we've been told, even if we don't end up applying the change.
@@ -701,7 +566,7 @@ func (pm *MultiPoolerManager) SetPrimary(ctx context.Context, req *consensusdata
 		pm.logger.InfoContext(ctx, "SetPrimary: incoming rule not higher, no-op",
 			"incoming_rule", rule.GetRuleNumber(),
 			"self_rule", selfPos.GetRule().GetRuleNumber())
-		return &consensusdatapb.SetPrimaryResponse{ConsensusStatus: pm.getCachedConsensusStatus()}, nil
+		return &consensusdatapb.SetPrimaryResponse{ConsensusStatus: pm.consensusMgr.CachedConsensusStatus()}, nil
 	}
 
 	// Both no-op gates passed — this call will actually reconfigure replication.
@@ -817,7 +682,7 @@ func (pm *MultiPoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 
 	pm.broadcastHealth()
 
-	cs, err := pm.getConsensusStatus(ctx)
+	cs, err := pm.consensusMgr.ConsensusStatus(ctx)
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to build consensus status after SetPrimary")
 	}

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -159,7 +159,7 @@ func (pm *MultiPoolerManager) buildAvailabilityStatus() *clustermetadatapb.Avail
 	return &clustermetadatapb.AvailabilityStatus{
 		LeadershipStatus:        pm.buildLeadershipStatus(),
 		CohortEligibilityStatus: pm.buildCohortEligibilityStatus(),
-		SuspectedDivergence:     pm.suspectedDivergence.Load(),
+		SuspectedDivergence:     pm.consensusMgr.SuspectedDivergence(),
 	}
 }
 
@@ -736,10 +736,10 @@ func (pm *MultiPoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 	consensusTerm := rule.GetRuleNumber().GetCoordinatorTerm()
 
 	if isPrimary {
-		pm.suspectedDivergence.Store(true)
+		pm.consensusMgr.SetSuspectedDivergence(true)
 	}
 
-	if pm.suspectedDivergence.Load() {
+	if pm.consensusMgr.SuspectedDivergence() {
 		// Demoting a (likely diverged) stale primary restarts it as a standby of the
 		// new leader, which requires a pg_rewind. Defer that until the leader is
 		// rewind-ready — it has checkpointed onto its current timeline, relayed here

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -29,7 +29,6 @@ import (
 	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
-	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
 	"github.com/multigres/multigres/go/services/multipooler/internal/poolerserver"
 	"github.com/multigres/multigres/go/tools/telemetry"
@@ -176,26 +175,7 @@ func (pm *MultiPoolerManager) buildCohortEligibilityStatus() *clustermetadatapb.
 			Signal: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE,
 		}
 	}
-	pm.mu.Lock()
-	signal := pm.cohortEligibility
-	pm.mu.Unlock()
-	return &clustermetadatapb.CohortEligibilityStatus{Signal: signal}
-}
-
-// setCohortEligibility records this pooler's cohort eligibility. If the
-// signal actually changed, an immediate health broadcast is pushed so the
-// coordinator sees the new value without waiting for the next heartbeat —
-// otherwise a transition INELIGIBLE → cohort removal could be delayed by up
-// to a heartbeat interval. Currently test-only — there is no operator/admin
-// RPC to flip it yet.
-func (pm *MultiPoolerManager) setCohortEligibility(signal clustermetadatapb.CohortEligibilitySignal) {
-	pm.mu.Lock()
-	changed := pm.cohortEligibility != signal
-	pm.cohortEligibility = signal
-	pm.mu.Unlock()
-	if changed {
-		pm.broadcastHealth()
-	}
+	return &clustermetadatapb.CohortEligibilityStatus{Signal: pm.consensusMgr.CohortEligibility()}
 }
 
 // markPoolerActive performs the STARTING → ACTIVE transition once postgres
@@ -245,12 +225,11 @@ func (pm *MultiPoolerManager) markPoolerActive(ctx context.Context) {
 }
 
 // buildLeadershipStatus returns the LeadershipStatus for this node. Non-nil only
-// when resignedLeaderAtTerm is set (i.e. after a Recruit-driven emergency
+// when the node has resigned leadership (i.e. after a Recruit-driven emergency
 // demotion or graceful shutdown of a leader). Nil means this node has not
 // recently held or resigned from primary leadership.
 func (pm *MultiPoolerManager) buildLeadershipStatus() *clustermetadatapb.LeadershipStatus {
-	resignedTerm := pm.getResignedLeaderAtTerm()
-
+	resignedTerm := pm.consensusMgr.ResignedLeaderAtTerm()
 	if resignedTerm == 0 {
 		return nil
 	}
@@ -259,48 +238,6 @@ func (pm *MultiPoolerManager) buildLeadershipStatus() *clustermetadatapb.Leaders
 		LeaderTerm: resignedTerm,
 		Signal:     clustermetadatapb.LeadershipSignal_LEADERSHIP_SIGNAL_REQUESTING_DEMOTION,
 	}
-}
-
-// setResignedLeaderAtTerm records that this node is requesting demotion as primary
-// for the given term. The signal is included in subsequent StatusResponses so the
-// coordinator can trigger an immediate election. Broadcasts to health stream
-// subscribers when the value actually changes, so the coordinator sees the new
-// signal without waiting for the next periodic snapshot.
-// Requires the action lock (ctx must be an action-lock context).
-func (pm *MultiPoolerManager) setResignedLeaderAtTerm(ctx context.Context, term int64) error {
-	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
-		return err
-	}
-	pm.mu.Lock()
-	changed := pm.resignedLeaderAtTerm != term
-	pm.resignedLeaderAtTerm = term
-	pm.mu.Unlock()
-	if changed {
-		pm.broadcastHealth()
-	}
-	return nil
-}
-
-// clearResignedLeaderAtTerm clears the leadership demotion request. Called when
-// this node is appointed as primary at a new term.
-// Requires the action lock (ctx must be an action-lock context).
-func (pm *MultiPoolerManager) clearResignedLeaderAtTerm(ctx context.Context) error {
-	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
-		return err
-	}
-	pm.mu.Lock()
-	pm.resignedLeaderAtTerm = 0
-	pm.mu.Unlock()
-	return nil
-}
-
-// getResignedLeaderAtTerm returns the term at which this node requested demotion as
-// primary, or 0 if it has not resigned. Reads under pm.mu so callers don't reach
-// into the field directly.
-func (pm *MultiPoolerManager) getResignedLeaderAtTerm() int64 {
-	pm.mu.Lock()
-	defer pm.mu.Unlock()
-	return pm.resignedLeaderAtTerm
 }
 
 // Recruit handles a coordinator's request to stop replication participation and
@@ -606,7 +543,7 @@ func (pm *MultiPoolerManager) promoteLocked(ctx context.Context, req *consensusd
 		WithAcceptedMembers(req.GetAcceptedNodeIds()).
 		WithWALPosition(beforeStatus.GetCurrentPosition().GetLsn()).
 		WithPromotionHook(func(hookCtx context.Context) error {
-			if err := pm.clearResignedLeaderAtTerm(ctx); err != nil {
+			if err := pm.consensusMgr.ClearResignedLeaderAtTerm(ctx); err != nil {
 				return mterrors.Wrap(err, "failed to clear resigned primary term")
 			}
 			return pm.promoteStandbyToPrimary(hookCtx, state, proposedRule.GetRuleNumber().GetCoordinatorTerm())
@@ -868,7 +805,7 @@ func (pm *MultiPoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 		LeaderTerm: consensusTerm,
 	})
 
-	if err := pm.clearResignedLeaderAtTerm(ctx); err != nil {
+	if err := pm.consensusMgr.ClearResignedLeaderAtTerm(ctx); err != nil {
 		pm.logger.WarnContext(ctx, "Failed to clear resigned leader term after promote", "error", err)
 	}
 

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -116,7 +116,7 @@ func (pm *MultiPoolerManager) getConsensusStatus(ctx context.Context) (*clusterm
 	if err != nil {
 		return nil, fmt.Errorf("failed to read current rule position: %w", err)
 	}
-	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusMgr.Promises().GetReplicationPrimary()), nil
+	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusMgr.GetReplicationPrimary()), nil
 }
 
 // getCachedConsensusStatus builds a ConsensusStatus using the in-memory term cache and
@@ -131,7 +131,7 @@ func (pm *MultiPoolerManager) getCachedConsensusStatus() *clustermetadatapb.Cons
 		return nil
 	}
 	revocation := pm.consensusMgr.Promises().GetInconsistentRevocation()
-	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusMgr.Promises().GetReplicationPrimary())
+	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusMgr.GetReplicationPrimary())
 }
 
 // getInconsistentConsensusStatus builds a ConsensusStatus from a fresh postgres
@@ -150,7 +150,7 @@ func (pm *MultiPoolerManager) getInconsistentConsensusStatus(ctx context.Context
 		return nil, err
 	}
 	revocation := pm.consensusMgr.Promises().GetInconsistentRevocation()
-	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusMgr.Promises().GetReplicationPrimary()), nil
+	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusMgr.GetReplicationPrimary()), nil
 }
 
 // buildAvailabilityStatus returns the current AvailabilityStatus for this node.
@@ -631,7 +631,7 @@ func (pm *MultiPoolerManager) promoteLocked(ctx context.Context, req *consensusd
 	// Record the (rule, primary) — this pooler IS now the primary. Stamping
 	// the published ReplicationPrimary lets the health stream advertise the
 	// new leadership immediately.
-	pm.consensusMgr.Promises().RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{
+	pm.consensusMgr.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{
 		Rule:    proposedRule,
 		Primary: proposalLeader,
 	})
@@ -745,7 +745,7 @@ func (pm *MultiPoolerManager) SetPrimary(ctx context.Context, req *consensusdata
 	//   - Pooler-side reconciliation: reads last-known-primary to retry
 	//     ALTER SYSTEM SET primary_conninfo if this SetPrimary arrived while
 	//     postgres was unavailable.
-	pm.consensusMgr.Promises().RecordTermPrimary(rp)
+	pm.consensusMgr.RecordTermPrimary(rp)
 
 	// Observe the freshest view of our rule. SetPrimary is the staleness gate,
 	// so we want authoritative state — not the cached snapshot.

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -107,7 +107,7 @@ func buildStatusReplicationPrimary(pos *clustermetadatapb.PoolerPosition, replic
 // Returns an error if postgres is unreachable, since a partial status (term revocation
 // without current_position) could mislead callers about this pooler's rule position.
 func (pm *MultiPoolerManager) getConsensusStatus(ctx context.Context) (*clustermetadatapb.ConsensusStatus, error) {
-	revocation, err := pm.consensusState.GetRevocation(ctx)
+	revocation, err := pm.consensusPromises.GetRevocation(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read consensus term: %w", err)
 	}
@@ -116,7 +116,7 @@ func (pm *MultiPoolerManager) getConsensusStatus(ctx context.Context) (*clusterm
 	if err != nil {
 		return nil, fmt.Errorf("failed to read current rule position: %w", err)
 	}
-	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusState.GetReplicationPrimary()), nil
+	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusPromises.GetReplicationPrimary()), nil
 }
 
 // getCachedConsensusStatus builds a ConsensusStatus using the in-memory term cache and
@@ -130,8 +130,8 @@ func (pm *MultiPoolerManager) getCachedConsensusStatus() *clustermetadatapb.Cons
 	if pos == nil {
 		return nil
 	}
-	revocation := pm.consensusState.GetInconsistentRevocation()
-	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusState.GetReplicationPrimary())
+	revocation := pm.consensusPromises.GetInconsistentRevocation()
+	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusPromises.GetReplicationPrimary())
 }
 
 // getInconsistentConsensusStatus builds a ConsensusStatus from a fresh postgres
@@ -149,8 +149,8 @@ func (pm *MultiPoolerManager) getInconsistentConsensusStatus(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	revocation := pm.consensusState.GetInconsistentRevocation()
-	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusState.GetReplicationPrimary()), nil
+	revocation := pm.consensusPromises.GetInconsistentRevocation()
+	return buildConsensusStatus(pm.serviceID, revocation, pos, pm.consensusPromises.GetReplicationPrimary()), nil
 }
 
 // buildAvailabilityStatus returns the current AvailabilityStatus for this node.
@@ -401,7 +401,7 @@ func (pm *MultiPoolerManager) Recruit(ctx context.Context, req *consensusdatapb.
 	}
 	{
 		acceptCtx, acceptSpan := telemetry.Tracer().Start(ctx, "consensus/accept-revocation")
-		err = pm.consensusState.AcceptRevocation(acceptCtx, stableStatus, revocation)
+		err = pm.consensusPromises.AcceptRevocation(acceptCtx, stableStatus, revocation)
 		acceptSpan.End()
 	}
 	if err != nil {
@@ -631,7 +631,7 @@ func (pm *MultiPoolerManager) promoteLocked(ctx context.Context, req *consensusd
 	// Record the (rule, primary) — this pooler IS now the primary. Stamping
 	// the published ReplicationPrimary lets the health stream advertise the
 	// new leadership immediately.
-	pm.consensusState.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{
+	pm.consensusPromises.RecordTermPrimary(&clustermetadatapb.ReplicationPrimary{
 		Rule:    proposedRule,
 		Primary: proposalLeader,
 	})
@@ -725,7 +725,7 @@ func (pm *MultiPoolerManager) SetPrimary(ctx context.Context, req *consensusdata
 	// the cohort will reconverge as it makes progress. Returning the cached
 	// status keeps the response shape consistent with the "incoming rule
 	// not higher" no-op below.
-	revocation, err := pm.consensusState.GetRevocation(ctx)
+	revocation, err := pm.consensusPromises.GetRevocation(ctx)
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to read revocation while validating SetPrimary")
 	}
@@ -745,7 +745,7 @@ func (pm *MultiPoolerManager) SetPrimary(ctx context.Context, req *consensusdata
 	//   - Pooler-side reconciliation: reads last-known-primary to retry
 	//     ALTER SYSTEM SET primary_conninfo if this SetPrimary arrived while
 	//     postgres was unavailable.
-	pm.consensusState.RecordTermPrimary(rp)
+	pm.consensusPromises.RecordTermPrimary(rp)
 
 	// Observe the freshest view of our rule. SetPrimary is the staleness gate,
 	// so we want authoritative state — not the cached snapshot.
@@ -860,7 +860,7 @@ func (pm *MultiPoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 	// reads/writes against it. The stale-primary branch gets this for free
 	// via demoteStalePrimaryLocked; the standby branch must do it explicitly.
 	// TODO: LeaderObservation is redundant with the (rule, primary) tuple
-	// already recorded in consensusState.replicationPrimary. Plan to make
+	// already recorded in consensusPromises.replicationPrimary. Plan to make
 	// RecordTermPrimary (or its successor) drive the health-stream
 	// observation directly, so callers don't have to remember to do both.
 	pm.healthStreamer.UpdateLeaderObservation(&poolerserver.LeaderObservation{

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -249,9 +249,7 @@ func (pm *MultiPoolerManager) markPoolerActive(ctx context.Context) {
 // demotion or graceful shutdown of a leader). Nil means this node has not
 // recently held or resigned from primary leadership.
 func (pm *MultiPoolerManager) buildLeadershipStatus() *clustermetadatapb.LeadershipStatus {
-	pm.mu.Lock()
-	resignedTerm := pm.resignedLeaderAtTerm
-	pm.mu.Unlock()
+	resignedTerm := pm.getResignedLeaderAtTerm()
 
 	if resignedTerm == 0 {
 		return nil
@@ -294,6 +292,15 @@ func (pm *MultiPoolerManager) clearResignedLeaderAtTerm(ctx context.Context) err
 	pm.resignedLeaderAtTerm = 0
 	pm.mu.Unlock()
 	return nil
+}
+
+// getResignedLeaderAtTerm returns the term at which this node requested demotion as
+// primary, or 0 if it has not resigned. Reads under pm.mu so callers don't reach
+// into the field directly.
+func (pm *MultiPoolerManager) getResignedLeaderAtTerm() int64 {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	return pm.resignedLeaderAtTerm
 }
 
 // Recruit handles a coordinator's request to stop replication participation and

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -97,7 +97,7 @@ func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService, r
 	// Assign mock pooler controller and rule store BEFORE starting the manager
 	// to avoid race conditions.
 	pm.qsc = &mockPoolerController{queryService: mockQueryService}
-	pm.rules = rules
+	setTestRuleStore(pm, rules)
 
 	senv := servenv.NewServEnv(viperutil.NewRegistry())
 	pm.Start(senv)
@@ -117,7 +117,7 @@ func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService, r
 
 	// Initialize consensus state
 	pm.mu.Lock()
-	pm.consensusPromises = consensus.NewConsensusPromises(tmpDir, serviceID)
+	setTestPromises(pm, consensus.NewConsensusPromises(tmpDir, serviceID))
 	pm.mu.Unlock()
 
 	return pm, tmpDir
@@ -390,7 +390,7 @@ func TestRecruit(t *testing.T) {
 			pm, tmpDir := setupManagerWithMockDB(t, mockQueryService, tt.ruleStore)
 
 			consensustest.SeedTerm(t, tmpDir, tt.initialRevocation)
-			_, err := pm.consensusPromises.Load()
+			_, err := pm.consensusMgr.Promises().Load()
 			require.NoError(t, err)
 
 			if tt.makeFilesystemReadOnly {
@@ -416,7 +416,7 @@ func TestRecruit(t *testing.T) {
 			}
 
 			// Verify persisted state matches expectations regardless of success/failure.
-			persisted := pm.consensusPromises.GetInconsistentRevocation()
+			persisted := pm.consensusMgr.Promises().GetInconsistentRevocation()
 			assert.Equal(t, tt.expectPersistedTerm, persisted.GetRevokedBelowTerm())
 			assert.Equal(t, tt.expectPersistedCoordinator, persisted.GetAcceptedCoordinatorId().GetName())
 
@@ -742,7 +742,7 @@ func TestPromote(t *testing.T) {
 				// ReplicationPrimary should advertise this pooler as the primary
 				// at the proposalLeader's host/port. Coordinators reading this
 				// pooler's health stream see (self, host, port).
-				rp := pm.consensusPromises.GetReplicationPrimary()
+				rp := pm.consensusMgr.Promises().GetReplicationPrimary()
 				require.NotNil(t, rp)
 				require.NotNil(t, rp.GetPrimary())
 				assert.True(t, proto.Equal(selfID, rp.GetPrimary().GetId()))
@@ -879,7 +879,7 @@ func TestPromote(t *testing.T) {
 			pm, tmpDir := setupManagerWithMockDB(t, mockQueryService, tt.ruleStore)
 
 			consensustest.SeedTerm(t, tmpDir, tt.initialTerm)
-			_, err := pm.consensusPromises.Load()
+			_, err := pm.consensusMgr.Promises().Load()
 			require.NoError(t, err)
 
 			if tt.preRun != nil {
@@ -939,7 +939,7 @@ func TestPromoteDropsUnloggedTables(t *testing.T) {
 		setupMocks(m)
 		pm, tmpDir := setupManagerWithMockDB(t, m, &fakeRuleStore{pos: makeRulePosition(0)})
 		consensustest.SeedTerm(t, tmpDir, recruitedTerm)
-		_, err := pm.consensusPromises.Load()
+		_, err := pm.consensusMgr.Promises().Load()
 		require.NoError(t, err)
 		_, err = pm.Promote(t.Context(), req)
 		return m, err

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -742,7 +742,7 @@ func TestPromote(t *testing.T) {
 				// ReplicationPrimary should advertise this pooler as the primary
 				// at the proposalLeader's host/port. Coordinators reading this
 				// pooler's health stream see (self, host, port).
-				rp := pm.consensusMgr.Promises().GetReplicationPrimary()
+				rp := pm.consensusMgr.GetReplicationPrimary()
 				require.NotNil(t, rp)
 				require.NotNil(t, rp.GetPrimary())
 				assert.True(t, proto.Equal(selfID, rp.GetPrimary().GetId()))

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -117,7 +117,7 @@ func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService, r
 
 	// Initialize consensus state
 	pm.mu.Lock()
-	pm.consensusState = consensus.NewConsensusState(tmpDir, serviceID)
+	pm.consensusPromises = consensus.NewConsensusPromises(tmpDir, serviceID)
 	pm.mu.Unlock()
 
 	return pm, tmpDir
@@ -390,7 +390,7 @@ func TestRecruit(t *testing.T) {
 			pm, tmpDir := setupManagerWithMockDB(t, mockQueryService, tt.ruleStore)
 
 			consensustest.SeedTerm(t, tmpDir, tt.initialRevocation)
-			_, err := pm.consensusState.Load()
+			_, err := pm.consensusPromises.Load()
 			require.NoError(t, err)
 
 			if tt.makeFilesystemReadOnly {
@@ -416,7 +416,7 @@ func TestRecruit(t *testing.T) {
 			}
 
 			// Verify persisted state matches expectations regardless of success/failure.
-			persisted := pm.consensusState.GetInconsistentRevocation()
+			persisted := pm.consensusPromises.GetInconsistentRevocation()
 			assert.Equal(t, tt.expectPersistedTerm, persisted.GetRevokedBelowTerm())
 			assert.Equal(t, tt.expectPersistedCoordinator, persisted.GetAcceptedCoordinatorId().GetName())
 
@@ -742,7 +742,7 @@ func TestPromote(t *testing.T) {
 				// ReplicationPrimary should advertise this pooler as the primary
 				// at the proposalLeader's host/port. Coordinators reading this
 				// pooler's health stream see (self, host, port).
-				rp := pm.consensusState.GetReplicationPrimary()
+				rp := pm.consensusPromises.GetReplicationPrimary()
 				require.NotNil(t, rp)
 				require.NotNil(t, rp.GetPrimary())
 				assert.True(t, proto.Equal(selfID, rp.GetPrimary().GetId()))
@@ -879,7 +879,7 @@ func TestPromote(t *testing.T) {
 			pm, tmpDir := setupManagerWithMockDB(t, mockQueryService, tt.ruleStore)
 
 			consensustest.SeedTerm(t, tmpDir, tt.initialTerm)
-			_, err := pm.consensusState.Load()
+			_, err := pm.consensusPromises.Load()
 			require.NoError(t, err)
 
 			if tt.preRun != nil {
@@ -939,7 +939,7 @@ func TestPromoteDropsUnloggedTables(t *testing.T) {
 		setupMocks(m)
 		pm, tmpDir := setupManagerWithMockDB(t, m, &fakeRuleStore{pos: makeRulePosition(0)})
 		consensustest.SeedTerm(t, tmpDir, recruitedTerm)
-		_, err := pm.consensusState.Load()
+		_, err := pm.consensusPromises.Load()
 		require.NoError(t, err)
 		_, err = pm.Promote(t.Context(), req)
 		return m, err

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -430,7 +430,7 @@ func TestRecruit(t *testing.T) {
 		// quorum. The actual rewind happens at SetPrimary.
 		mockQueryService := mock.NewQueryService()
 		pm, _ := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(0)})
-		pm.suspectedDivergence.Store(true)
+		pm.consensusMgr.SetSuspectedDivergence(true)
 
 		req := &consensusdatapb.RecruitRequest{
 			TermRevocation: &clustermetadatapb.TermRevocation{
@@ -1012,7 +1012,7 @@ func TestAvailabilityStatus(t *testing.T) {
 	t.Run("suspectedDivergence is published", func(t *testing.T) {
 		pm := newTestManager(t)
 		assert.False(t, pm.buildAvailabilityStatus().SuspectedDivergence, "defaults to false")
-		pm.suspectedDivergence.Store(true)
+		pm.consensusMgr.SetSuspectedDivergence(true)
 		assert.True(t, pm.buildAvailabilityStatus().SuspectedDivergence, "reflects the in-memory flag")
 	})
 }

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -430,7 +430,11 @@ func TestRecruit(t *testing.T) {
 		// quorum. The actual rewind happens at SetPrimary.
 		mockQueryService := mock.NewQueryService()
 		pm, _ := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(0)})
-		pm.consensusMgr.SetSuspectedDivergence(true)
+		seedLockCtx, err := pm.actionLock.Acquire(t.Context(), "test-seed")
+		require.NoError(t, err)
+		_, err = pm.consensusMgr.SetSuspectedDivergence(seedLockCtx, true)
+		require.NoError(t, err)
+		pm.actionLock.Release(seedLockCtx)
 
 		req := &consensusdatapb.RecruitRequest{
 			TermRevocation: &clustermetadatapb.TermRevocation{
@@ -440,7 +444,7 @@ func TestRecruit(t *testing.T) {
 				OutgoingRule:           &clustermetadatapb.RuleNumber{},
 			},
 		}
-		_, err := pm.Recruit(t.Context(), req)
+		_, err = pm.Recruit(t.Context(), req)
 		// We don't require success here (the minimal mock setup doesn't
 		// satisfy the full Recruit path); we only assert that suspectedDivergence
 		// is no longer the reason for rejection.
@@ -1012,7 +1016,11 @@ func TestAvailabilityStatus(t *testing.T) {
 	t.Run("suspectedDivergence is published", func(t *testing.T) {
 		pm := newTestManager(t)
 		assert.False(t, pm.buildAvailabilityStatus().SuspectedDivergence, "defaults to false")
-		pm.consensusMgr.SetSuspectedDivergence(true)
+		lockCtx, err := pm.actionLock.Acquire(t.Context(), "test-seed")
+		require.NoError(t, err)
+		_, err = pm.consensusMgr.SetSuspectedDivergence(lockCtx, true)
+		require.NoError(t, err)
+		pm.actionLock.Release(lockCtx)
 		assert.True(t, pm.buildAvailabilityStatus().SuspectedDivergence, "reflects the in-memory flag")
 	})
 }

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -90,14 +90,15 @@ func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService, r
 		TopoClient: ts,
 		PgctldAddr: pgctldAddr,
 	}
-	pm, err := NewMultiPoolerManager(logger, multipooler, config)
+	// Build through the real constructor with the mock query service and fake
+	// rule store injected, so the consensus manager (promises rooted at tmpDir
+	// via PoolerDir, rule store = the fake) is wired correctly from the start.
+	pm, err := NewMultiPoolerManagerForTesting(t, logger, multipooler, config,
+		withMockController(&mockPoolerController{queryService: mockQueryService}),
+		withFakeRules(rules),
+	)
 	require.NoError(t, err)
 	t.Cleanup(func() { pm.ShutdownForTest(context.Background()) })
-
-	// Assign mock pooler controller and rule store BEFORE starting the manager
-	// to avoid race conditions.
-	pm.qsc = &mockPoolerController{queryService: mockQueryService}
-	setTestRuleStore(t, pm, rules)
 
 	senv := servenv.NewServEnv(viperutil.NewRegistry())
 	pm.Start(senv)
@@ -114,11 +115,6 @@ func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService, r
 	err = os.WriteFile(pgDataDir+"/PG_VERSION", []byte("18\n"), 0o644)
 	require.NoError(t, err)
 	t.Setenv(constants.PgDataDirEnvVar, pgDataDir)
-
-	// Initialize consensus state
-	pm.mu.Lock()
-	setTestPromises(t, pm, consensus.NewConsensusPromises(tmpDir, serviceID))
-	pm.mu.Unlock()
 
 	return pm, tmpDir
 }

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -564,7 +564,7 @@ func TestPromote(t *testing.T) {
 		ruleStore         *fakeRuleStore
 		req               *consensusdatapb.PromoteRequest
 		setupMocks        func(*mock.QueryService)
-		preRun            func(*MultiPoolerManager)
+		preRun            func(*testing.T, *MultiPoolerManager)
 		expectError       bool
 		expectErrContains string
 		postCheck         func(*testing.T, *MultiPoolerManager, *fakeRuleStore)
@@ -712,11 +712,12 @@ func TestPromote(t *testing.T) {
 			},
 			// Verify the promotion was recorded with the right coordinator term and WAL
 			// position, and that the health streamer was updated for write traffic.
-			preRun: func(pm *MultiPoolerManager) {
+			preRun: func(t *testing.T, pm *MultiPoolerManager) {
 				// Pre-set so we can verify clearResignedLeaderAtTerm ran.
-				pm.mu.Lock()
-				pm.resignedLeaderAtTerm = 7
-				pm.mu.Unlock()
+				lockCtx, err := pm.actionLock.Acquire(t.Context(), "test-seed")
+				require.NoError(t, err)
+				require.NoError(t, pm.consensusMgr.SetResignedLeaderAtTerm(lockCtx, 7))
+				pm.actionLock.Release(lockCtx)
 			},
 			postCheck: func(t *testing.T, pm *MultiPoolerManager, rs *fakeRuleStore) {
 				update := rs.assertPromoteRecorded(t)
@@ -735,9 +736,7 @@ func TestPromote(t *testing.T) {
 				assert.True(t, proto.Equal(selfID, state.LeaderObservation.LeaderID))
 				assert.Equal(t, int64(7), state.LeaderObservation.LeaderTerm)
 
-				pm.mu.Lock()
-				assert.Equal(t, int64(0), pm.resignedLeaderAtTerm, "clearResignedLeaderAtTerm should have cleared the term")
-				pm.mu.Unlock()
+				assert.Equal(t, int64(0), pm.consensusMgr.ResignedLeaderAtTerm(), "clearResignedLeaderAtTerm should have cleared the term")
 
 				// ReplicationPrimary should advertise this pooler as the primary
 				// at the proposalLeader's host/port. Coordinators reading this
@@ -883,7 +882,7 @@ func TestPromote(t *testing.T) {
 			require.NoError(t, err)
 
 			if tt.preRun != nil {
-				tt.preRun(pm)
+				tt.preRun(t, pm)
 			}
 
 			resp, err := pm.Promote(ctx, tt.req)
@@ -971,7 +970,7 @@ func TestPromoteDropsUnloggedTables(t *testing.T) {
 
 func TestAvailabilityStatus(t *testing.T) {
 	t.Run("buildAvailabilityStatus publishes cohort eligibility with no leadership status when no resignation is set", func(t *testing.T) {
-		pm := &MultiPoolerManager{cohortEligibility: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE}
+		pm := newTestManager(t)
 		av := pm.buildAvailabilityStatus()
 		require.NotNil(t, av)
 		assert.Nil(t, av.LeadershipStatus)
@@ -980,8 +979,7 @@ func TestAvailabilityStatus(t *testing.T) {
 	})
 
 	t.Run("resignedLeaderAtTerm set adds a LeadershipStatus alongside cohort eligibility", func(t *testing.T) {
-		pm := &MultiPoolerManager{cohortEligibility: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE}
-		pm.resignedLeaderAtTerm = 7
+		pm := newTestManager(t, withResignedLeaderAtTerm(7))
 		av := pm.buildAvailabilityStatus()
 		require.NotNil(t, av)
 		require.NotNil(t, av.LeadershipStatus)
@@ -991,19 +989,20 @@ func TestAvailabilityStatus(t *testing.T) {
 		assert.Equal(t, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE, av.CohortEligibilityStatus.Signal)
 	})
 
-	t.Run("resignedLeaderAtTerm cleared drops LeadershipStatus but keeps cohort eligibility", func(t *testing.T) {
-		pm := &MultiPoolerManager{cohortEligibility: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE}
-		pm.resignedLeaderAtTerm = 3
-		pm.resignedLeaderAtTerm = 0
+	t.Run("no resignation -> no LeadershipStatus but keeps cohort eligibility", func(t *testing.T) {
+		pm := newTestManager(t)
 		av := pm.buildAvailabilityStatus()
 		require.NotNil(t, av)
 		assert.Nil(t, av.LeadershipStatus)
 		require.NotNil(t, av.CohortEligibilityStatus)
 	})
 
-	t.Run("setCohortEligibility flips the signal", func(t *testing.T) {
-		pm := &MultiPoolerManager{cohortEligibility: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE}
-		pm.setCohortEligibility(clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE)
+	t.Run("SetCohortEligibility flips the signal", func(t *testing.T) {
+		pm := newTestManager(t)
+		lockCtx, err := pm.actionLock.Acquire(t.Context(), "test")
+		require.NoError(t, err)
+		require.NoError(t, pm.consensusMgr.SetCohortEligibility(lockCtx, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE))
+		pm.actionLock.Release(lockCtx)
 		av := pm.buildAvailabilityStatus()
 		require.NotNil(t, av)
 		require.NotNil(t, av.CohortEligibilityStatus)
@@ -1011,7 +1010,7 @@ func TestAvailabilityStatus(t *testing.T) {
 	})
 
 	t.Run("suspectedDivergence is published", func(t *testing.T) {
-		pm := &MultiPoolerManager{cohortEligibility: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE}
+		pm := newTestManager(t)
 		assert.False(t, pm.buildAvailabilityStatus().SuspectedDivergence, "defaults to false")
 		pm.suspectedDivergence.Store(true)
 		assert.True(t, pm.buildAvailabilityStatus().SuspectedDivergence, "reflects the in-memory flag")
@@ -1031,6 +1030,7 @@ func TestSetResignedLeaderAtTerm_BroadcastsOnChange(t *testing.T) {
 		serviceID:      id,
 		healthStreamer: streamer,
 		actionLock:     actionlock.NewActionLock(),
+		consensusMgr:   consensus.NewConsensusManager(consensus.NewConsensusPromises("", id), &fakeRuleStore{}, streamer),
 	}
 
 	// Subscribe so we can observe broadcasts.
@@ -1052,15 +1052,15 @@ func TestSetResignedLeaderAtTerm_BroadcastsOnChange(t *testing.T) {
 	require.NoError(t, err)
 	defer pm.actionLock.Release(lockCtx)
 
-	require.NoError(t, pm.setResignedLeaderAtTerm(lockCtx, 5))
+	require.NoError(t, pm.consensusMgr.SetResignedLeaderAtTerm(lockCtx, 5))
 	assert.Equal(t, 1, drain(), "first call should broadcast on change from 0 to 5")
 
-	require.NoError(t, pm.setResignedLeaderAtTerm(lockCtx, 5))
+	require.NoError(t, pm.consensusMgr.SetResignedLeaderAtTerm(lockCtx, 5))
 	assert.Equal(t, 0, drain(), "repeating the same value should NOT broadcast")
 
-	require.NoError(t, pm.setResignedLeaderAtTerm(lockCtx, 7))
+	require.NoError(t, pm.consensusMgr.SetResignedLeaderAtTerm(lockCtx, 7))
 	assert.Equal(t, 1, drain(), "changing to a new term should broadcast")
 
-	require.NoError(t, pm.setResignedLeaderAtTerm(lockCtx, 0))
+	require.NoError(t, pm.consensusMgr.SetResignedLeaderAtTerm(lockCtx, 0))
 	assert.Equal(t, 1, drain(), "clearing the term is also a change and should broadcast")
 }

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -1030,11 +1030,8 @@ func TestSetResignedLeaderAtTerm_BroadcastsOnChange(t *testing.T) {
 	id := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "test"}
 	streamer := newHealthStreamer(logger, id, "tg", "0")
 	pm := &MultiPoolerManager{
-		logger:         logger,
-		serviceID:      id,
-		healthStreamer: streamer,
-		actionLock:     actionlock.NewActionLock(),
-		consensusMgr:   consensus.NewManagerForTesting(t, consensus.NewConsensusPromises("", id), &fakeRuleStore{}, streamer),
+		actionLock:   actionlock.NewActionLock(),
+		consensusMgr: consensus.NewManagerForTesting(t, id, consensus.NewConsensusPromises("", id), &fakeRuleStore{}, streamer),
 	}
 
 	// Subscribe so we can observe broadcasts.

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -97,7 +97,7 @@ func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService, r
 	// Assign mock pooler controller and rule store BEFORE starting the manager
 	// to avoid race conditions.
 	pm.qsc = &mockPoolerController{queryService: mockQueryService}
-	setTestRuleStore(pm, rules)
+	setTestRuleStore(t, pm, rules)
 
 	senv := servenv.NewServEnv(viperutil.NewRegistry())
 	pm.Start(senv)
@@ -117,7 +117,7 @@ func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService, r
 
 	// Initialize consensus state
 	pm.mu.Lock()
-	setTestPromises(pm, consensus.NewConsensusPromises(tmpDir, serviceID))
+	setTestPromises(t, pm, consensus.NewConsensusPromises(tmpDir, serviceID))
 	pm.mu.Unlock()
 
 	return pm, tmpDir
@@ -1038,7 +1038,7 @@ func TestSetResignedLeaderAtTerm_BroadcastsOnChange(t *testing.T) {
 		serviceID:      id,
 		healthStreamer: streamer,
 		actionLock:     actionlock.NewActionLock(),
-		consensusMgr:   consensus.NewConsensusManager(consensus.NewConsensusPromises("", id), &fakeRuleStore{}, streamer),
+		consensusMgr:   consensus.NewManagerForTesting(t, consensus.NewConsensusPromises("", id), &fakeRuleStore{}, streamer),
 	}
 
 	// Subscribe so we can observe broadcasts.

--- a/go/services/multipooler/internal/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/internal/manager/rpc_initialization_test.go
@@ -272,16 +272,17 @@ func newRemedialActionTestManager(t *testing.T, multipooler *clustermetadatapb.M
 	// Default the recorded service identity to this pooler unless an option
 	// overrode it, so the promises default is rooted at the right ID.
 	cfg := resolveTestManagerConfig(t, append([]testManagerOption{withServiceID(multipooler.Id)}, opts...)...)
-	return &MultiPoolerManager{
-		logger:            slog.Default(),
-		actionLock:        actionlock.NewActionLock(),
-		record:            record,
-		serviceID:         multipooler.Id,
-		topoClient:        ts,
-		servingState:      NewStateManager(slog.Default(), record),
-		cohortEligibility: cfg.cohortEligibility,
-		consensusMgr:      cfg.consensusManager(),
+	pm := &MultiPoolerManager{
+		logger:       slog.Default(),
+		actionLock:   actionlock.NewActionLock(),
+		record:       record,
+		serviceID:    multipooler.Id,
+		topoClient:   ts,
+		servingState: NewStateManager(slog.Default(), record),
+		consensusMgr: cfg.consensusManager(),
 	}
+	cfg.seedLockedState(t, pm)
+	return pm
 }
 
 // TestUpdateTopologyAfterPromotion_PublishesSelfLeadership verifies the

--- a/go/services/multipooler/internal/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/internal/manager/rpc_initialization_test.go
@@ -53,11 +53,10 @@ func NewTestMultiPoolerManager(t *testing.T) *MultiPoolerManager {
 		},
 		PoolerDir: t.TempDir(),
 	}
-	pm, err := NewMultiPoolerManager(slog.Default(), mp, &Config{})
-	require.NoError(t, err)
-	// Swap in a fake rule store so tests that exercise ObservePosition /
+	// Inject a fake rule store so tests that exercise ObservePosition /
 	// CachedPosition don't crash on the real store's nil query service.
-	setTestRuleStore(t, pm, &fakeRuleStore{})
+	pm, err := NewMultiPoolerManagerForTesting(t, slog.Default(), mp, &Config{}, withFakeRules(&fakeRuleStore{}))
+	require.NoError(t, err)
 	return pm
 }
 

--- a/go/services/multipooler/internal/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/internal/manager/rpc_initialization_test.go
@@ -57,7 +57,7 @@ func NewTestMultiPoolerManager(t *testing.T) *MultiPoolerManager {
 	require.NoError(t, err)
 	// Swap in a fake rule store so tests that exercise ObservePosition /
 	// CachedPosition don't crash on the real store's nil query service.
-	pm.rules = &fakeRuleStore{}
+	setTestRuleStore(pm, &fakeRuleStore{})
 	return pm
 }
 
@@ -261,7 +261,7 @@ func TestHelperMethods(t *testing.T) {
 // The decision logic for type adjustment is tested in TestDetermineRemedialAction above.
 // The resignation signal behavior is tested below without full infrastructure.
 
-func newRemedialActionTestManager(t *testing.T, multipooler *clustermetadatapb.MultiPooler) *MultiPoolerManager {
+func newRemedialActionTestManager(t *testing.T, multipooler *clustermetadatapb.MultiPooler, opts ...testManagerOption) *MultiPoolerManager {
 	t.Helper()
 	ctx := t.Context()
 	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
@@ -269,6 +269,9 @@ func newRemedialActionTestManager(t *testing.T, multipooler *clustermetadatapb.M
 	require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 	record, err := newPoolerRecord(slog.Default(), ts, multipooler)
 	require.NoError(t, err)
+	// Default the recorded service identity to this pooler unless an option
+	// overrode it, so the promises default is rooted at the right ID.
+	cfg := resolveTestManagerConfig(t, append([]testManagerOption{withServiceID(multipooler.Id)}, opts...)...)
 	return &MultiPoolerManager{
 		logger:            slog.Default(),
 		actionLock:        actionlock.NewActionLock(),
@@ -276,7 +279,8 @@ func newRemedialActionTestManager(t *testing.T, multipooler *clustermetadatapb.M
 		serviceID:         multipooler.Id,
 		topoClient:        ts,
 		servingState:      NewStateManager(slog.Default(), record),
-		cohortEligibility: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE,
+		cohortEligibility: cfg.cohortEligibility,
+		consensusMgr:      cfg.consensusManager(),
 	}
 }
 

--- a/go/services/multipooler/internal/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/internal/manager/rpc_initialization_test.go
@@ -57,7 +57,7 @@ func NewTestMultiPoolerManager(t *testing.T) *MultiPoolerManager {
 	require.NoError(t, err)
 	// Swap in a fake rule store so tests that exercise ObservePosition /
 	// CachedPosition don't crash on the real store's nil query service.
-	setTestRuleStore(pm, &fakeRuleStore{})
+	setTestRuleStore(t, pm, &fakeRuleStore{})
 	return pm
 }
 
@@ -279,7 +279,7 @@ func newRemedialActionTestManager(t *testing.T, multipooler *clustermetadatapb.M
 		serviceID:    multipooler.Id,
 		topoClient:   ts,
 		servingState: NewStateManager(slog.Default(), record),
-		consensusMgr: cfg.consensusManager(),
+		consensusMgr: cfg.consensusManager(t),
 	}
 	cfg.seedLockedState(t, pm)
 	return pm

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -327,10 +327,10 @@ func (pm *MultiPoolerManager) Status(ctx context.Context) (*multipoolermanagerda
 
 	// Best-effort status report: prefer a fresh read, fall back to the cached
 	// position if postgres is unreachable.
-	if cs, err := pm.getInconsistentConsensusStatus(ctx); err == nil {
+	if cs, err := pm.consensusMgr.InconsistentConsensusStatus(ctx); err == nil {
 		resp.ConsensusStatus = cs
 	} else {
-		resp.ConsensusStatus = pm.getCachedConsensusStatus()
+		resp.ConsensusStatus = pm.consensusMgr.CachedConsensusStatus()
 	}
 	resp.AvailabilityStatus = pm.buildAvailabilityStatus()
 

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -741,7 +741,9 @@ func (pm *MultiPoolerManager) emergencyDemoteLocked(ctx context.Context, consens
 	// Mark the WAL as rewind-suspect: this node was just demoted, so the next
 	// restart-as-standby (the coordinator's RewindToSource, or the monitor's own
 	// demote path) must run pg_rewind before trusting local WAL.
-	pm.consensusMgr.SetSuspectedDivergence(true)
+	if _, err := pm.consensusMgr.SetSuspectedDivergence(ctx, true); err != nil {
+		pm.logger.ErrorContext(ctx, "failed to set suspected divergence on emergency demote", "error", err)
+	}
 
 	pm.logger.InfoContext(ctx, "Demote completed successfully",
 		"final_lsn", finalLSN,
@@ -799,7 +801,9 @@ func (pm *MultiPoolerManager) RewindToSource(ctx context.Context, source *cluste
 	// the caller; raise suspectedDivergence so restartAsStandbyLocked runs the
 	// pg_rewind dry-run. The caller (orch's FixReplicationAction) has already
 	// confirmed the source is rewind-ready before issuing this RPC.
-	pm.consensusMgr.SetSuspectedDivergence(true)
+	if _, err := pm.consensusMgr.SetSuspectedDivergence(ctx, true); err != nil {
+		pm.logger.ErrorContext(ctx, "failed to set suspected divergence in RewindToSource", "error", err)
+	}
 	rewindPerformed, err := pm.restartAsStandbyLocked(ctx, source.Hostname, port)
 	if err != nil {
 		return nil, err
@@ -942,7 +946,9 @@ func (pm *MultiPoolerManager) restartAsStandbyLocked(
 		// dry-run detects no divergence and skips), so clearing as soon as
 		// pg_rewind returns is safe even if the restart or reconnect below
 		// fails: the next attempt will skip pg_rewind and just restart.
-		pm.consensusMgr.SetSuspectedDivergence(false)
+		if _, err := pm.consensusMgr.SetSuspectedDivergence(ctx, false); err != nil {
+			pm.logger.ErrorContext(ctx, "failed to clear suspected divergence after pg_rewind", "error", err)
+		}
 		// pg_rewind copies postgresql.auto.conf from source, baking source's
 		// own pooler paths into pgbackrest commands (restore_command,
 		// archive_command). Patch them back to this pooler's paths before

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -741,7 +741,7 @@ func (pm *MultiPoolerManager) emergencyDemoteLocked(ctx context.Context, consens
 	// Mark the WAL as rewind-suspect: this node was just demoted, so the next
 	// restart-as-standby (the coordinator's RewindToSource, or the monitor's own
 	// demote path) must run pg_rewind before trusting local WAL.
-	pm.suspectedDivergence.Store(true)
+	pm.consensusMgr.SetSuspectedDivergence(true)
 
 	pm.logger.InfoContext(ctx, "Demote completed successfully",
 		"final_lsn", finalLSN,
@@ -799,7 +799,7 @@ func (pm *MultiPoolerManager) RewindToSource(ctx context.Context, source *cluste
 	// the caller; raise suspectedDivergence so restartAsStandbyLocked runs the
 	// pg_rewind dry-run. The caller (orch's FixReplicationAction) has already
 	// confirmed the source is rewind-ready before issuing this RPC.
-	pm.suspectedDivergence.Store(true)
+	pm.consensusMgr.SetSuspectedDivergence(true)
 	rewindPerformed, err := pm.restartAsStandbyLocked(ctx, source.Hostname, port)
 	if err != nil {
 		return nil, err
@@ -908,7 +908,7 @@ func (pm *MultiPoolerManager) restartAsStandbyLocked(
 	// surviving timeline branched), so we never restart-without-rewind here; the
 	// pg_rewind dry-run (cheap when there's no divergence) runs whenever divergence
 	// is suspected.
-	wantRewind := pm.suspectedDivergence.Load()
+	wantRewind := pm.consensusMgr.SuspectedDivergence()
 	pm.logger.InfoContext(ctx, "Pausing manager and stopping PostgreSQL to restart as standby",
 		"source_host", sourceHost, "source_port", sourcePort, "rewind_pending", wantRewind)
 	resume := pm.Pause(ctx)
@@ -926,8 +926,8 @@ func (pm *MultiPoolerManager) restartAsStandbyLocked(
 		// seconds when we had to defer the rewind waiting for that checkpoint. Emit
 		// once per leader change so a rewind that fails and is re-attempted against
 		// the same leader is not double-counted.
-		if observedAt := pm.consensusMgr.LeaderObservedAt(); !observedAt.IsZero() && !observedAt.Equal(pm.rewindWaitEmittedFor) {
-			pm.rewindWaitEmittedFor = observedAt
+		if observedAt := pm.consensusMgr.LeaderObservedAt(); !observedAt.IsZero() && !observedAt.Equal(pm.consensusMgr.RewindWaitEmittedFor()) {
+			pm.consensusMgr.SetRewindWaitEmittedFor(observedAt)
 			waited := time.Since(observedAt)
 			pm.logger.InfoContext(ctx, "Proceeding with pg_rewind; leader is rewind-ready",
 				"waited_for_rewind_ready", waited.String(),
@@ -942,7 +942,7 @@ func (pm *MultiPoolerManager) restartAsStandbyLocked(
 		// dry-run detects no divergence and skips), so clearing as soon as
 		// pg_rewind returns is safe even if the restart or reconnect below
 		// fails: the next attempt will skip pg_rewind and just restart.
-		pm.suspectedDivergence.Store(false)
+		pm.consensusMgr.SetSuspectedDivergence(false)
 		// pg_rewind copies postgresql.auto.conf from source, baking source's
 		// own pooler paths into pgbackrest commands (restore_command,
 		// archive_command). Patch them back to this pooler's paths before

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -315,7 +315,7 @@ func (pm *MultiPoolerManager) Status(ctx context.Context) (*multipoolermanagerda
 	poolerStatus.WalPosition = walPosition
 
 	// Get cohort members from the current rule (best-effort).
-	if pos, err := pm.rules.ObservePosition(ctx); err != nil {
+	if pos, err := pm.consensusMgr.Rules().ObservePosition(ctx); err != nil {
 		pm.logger.WarnContext(ctx, "Failed to read current rule for status", "error", err)
 	} else if pos.Rule != nil {
 		poolerStatus.CohortMembers = pos.Rule.CohortMembers
@@ -441,7 +441,7 @@ func (pm *MultiPoolerManager) UpdateConsensusRule(ctx context.Context, operation
 	// === Parse Current Configuration ===
 
 	// Read current cohort from the rule store (authoritative source of truth).
-	pos, err := pm.rules.ObservePosition(ctx)
+	pos, err := pm.consensusMgr.Rules().ObservePosition(ctx)
 	if err != nil {
 		return err
 	}
@@ -926,7 +926,7 @@ func (pm *MultiPoolerManager) restartAsStandbyLocked(
 		// seconds when we had to defer the rewind waiting for that checkpoint. Emit
 		// once per leader change so a rewind that fails and is re-attempted against
 		// the same leader is not double-counted.
-		if observedAt := pm.consensusPromises.LeaderObservedAt(); !observedAt.IsZero() && !observedAt.Equal(pm.rewindWaitEmittedFor) {
+		if observedAt := pm.consensusMgr.Promises().LeaderObservedAt(); !observedAt.IsZero() && !observedAt.Equal(pm.rewindWaitEmittedFor) {
 			pm.rewindWaitEmittedFor = observedAt
 			waited := time.Since(observedAt)
 			pm.logger.InfoContext(ctx, "Proceeding with pg_rewind; leader is rewind-ready",

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -724,7 +724,7 @@ func (pm *MultiPoolerManager) emergencyDemoteLocked(ctx context.Context, consens
 	// sees leadership_status.REQUESTING_DEMOTION before the next periodic
 	// health stream interval fires.
 	if primaryTerm, err := pm.primaryTermLocked(ctx); err == nil && primaryTerm != 0 {
-		if err := pm.setResignedLeaderAtTerm(ctx, primaryTerm); err != nil {
+		if err := pm.consensusMgr.SetResignedLeaderAtTerm(ctx, primaryTerm); err != nil {
 			return mterrors.Wrap(err, "failed to set resigned primary term")
 		}
 	}

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -926,7 +926,7 @@ func (pm *MultiPoolerManager) restartAsStandbyLocked(
 		// seconds when we had to defer the rewind waiting for that checkpoint. Emit
 		// once per leader change so a rewind that fails and is re-attempted against
 		// the same leader is not double-counted.
-		if observedAt := pm.consensusState.LeaderObservedAt(); !observedAt.IsZero() && !observedAt.Equal(pm.rewindWaitEmittedFor) {
+		if observedAt := pm.consensusPromises.LeaderObservedAt(); !observedAt.IsZero() && !observedAt.Equal(pm.rewindWaitEmittedFor) {
 			pm.rewindWaitEmittedFor = observedAt
 			waited := time.Since(observedAt)
 			pm.logger.InfoContext(ctx, "Proceeding with pg_rewind; leader is rewind-ready",

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -926,7 +926,7 @@ func (pm *MultiPoolerManager) restartAsStandbyLocked(
 		// seconds when we had to defer the rewind waiting for that checkpoint. Emit
 		// once per leader change so a rewind that fails and is re-attempted against
 		// the same leader is not double-counted.
-		if observedAt := pm.consensusMgr.Promises().LeaderObservedAt(); !observedAt.IsZero() && !observedAt.Equal(pm.rewindWaitEmittedFor) {
+		if observedAt := pm.consensusMgr.LeaderObservedAt(); !observedAt.IsZero() && !observedAt.Equal(pm.rewindWaitEmittedFor) {
 			pm.rewindWaitEmittedFor = observedAt
 			waited := time.Since(observedAt)
 			pm.logger.InfoContext(ctx, "Proceeding with pg_rewind; leader is rewind-ready",

--- a/go/services/multipooler/internal/manager/rpc_manager_test.go
+++ b/go/services/multipooler/internal/manager/rpc_manager_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/multigres/multigres/go/common/topoclient"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor/mock"
-	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus/consensustest"
 	"github.com/multigres/multigres/go/test/utils"
 	"github.com/multigres/multigres/go/tools/viperutil"
@@ -123,16 +122,15 @@ func TestPrimaryPosition(t *testing.T) {
 			config := &Config{
 				TopoClient: ts,
 			}
-			manager, err := NewMultiPoolerManager(logger, multipooler, config)
+			mockQueryService := mock.NewQueryService()
+			manager, err := NewMultiPoolerManagerForTesting(t, logger, multipooler, config,
+				withMockController(&mockPoolerController{queryService: mockQueryService}))
 			require.NoError(t, err)
 			defer manager.ShutdownForTest(t.Context())
 
 			// Set up mock query service for isInRecovery checks during test
-			mockQueryService := mock.NewQueryService()
 			isReplica := tt.poolerType == clustermetadatapb.PoolerType_REPLICA
 			mockQueryService.AddQueryPattern("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{isReplica}}))
-			manager.qsc = &mockPoolerController{queryService: mockQueryService}
-			setTestRuleStore(t, manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
 
 			// Mark as initialized to skip auto-restore (not testing backup functionality)
 			err = manager.setInitialized()
@@ -204,15 +202,14 @@ func TestActionLock_MutationMethodsTimeout(t *testing.T) {
 	config := &Config{
 		TopoClient: ts,
 	}
-	manager, err := NewMultiPoolerManager(logger, multipooler, config)
+	mockQueryService := mock.NewQueryService()
+	manager, err := NewMultiPoolerManagerForTesting(t, logger, multipooler, config,
+		withMockController(&mockPoolerController{queryService: mockQueryService}))
 	require.NoError(t, err)
 	defer manager.ShutdownForTest(t.Context())
 
 	// Set up mock query service for isInRecovery check during startup
-	mockQueryService := mock.NewQueryService()
 	mockQueryService.AddQueryPatternOnce("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{false}}))
-	manager.qsc = &mockPoolerController{queryService: mockQueryService}
-	setTestRuleStore(t, manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
 
 	// Start and wait for ready
 	senv := servenv.NewServEnv(viperutil.NewRegistry())
@@ -366,12 +363,12 @@ func TestReplicationStatus(t *testing.T) {
 			TopoClient: ts,
 			PgctldAddr: pgctldAddr,
 		}
-		pm, err := NewMultiPoolerManager(logger, multipooler, config)
+		mockQueryService := mock.NewQueryService()
+		pm, err := NewMultiPoolerManagerForTesting(t, logger, multipooler, config,
+			withMockController(&mockPoolerController{queryService: mockQueryService}),
+			withFakeRules(&fakeRuleStore{}))
 		require.NoError(t, err)
 		t.Cleanup(func() { pm.ShutdownForTest(context.Background()) })
-
-		// Create mock query service and inject it
-		mockQueryService := mock.NewQueryService()
 
 		// Status() calls isInRecovery() to determine role
 		// pg_is_in_recovery returns false (not in recovery = primary)
@@ -388,10 +385,6 @@ func TestReplicationStatus(t *testing.T) {
 			mock.MakeQueryResult(
 				[]string{"synchronous_standby_names", "synchronous_commit", "max_wal_senders"},
 				[][]any{{"", "on", "5"}}))
-
-		pm.qsc = &mockPoolerController{queryService: mockQueryService}
-		setTestRuleStore(t, pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
-		setTestRuleStore(t, pm, &fakeRuleStore{})
 
 		senv := servenv.NewServEnv(viperutil.NewRegistry())
 		go pm.Start(senv)
@@ -447,15 +440,15 @@ func TestReplicationStatus(t *testing.T) {
 			TopoClient: ts,
 			PgctldAddr: pgctldAddr,
 		}
-		pm, err := NewMultiPoolerManager(logger, multipooler, config)
+		mockQueryService := mock.NewQueryService()
+		pm, err := NewMultiPoolerManagerForTesting(t, logger, multipooler, config,
+			withMockController(&mockPoolerController{queryService: mockQueryService}),
+			withFakeRules(&fakeRuleStore{}))
 		require.NoError(t, err)
 		t.Cleanup(func() { pm.ShutdownForTest(context.Background()) })
 		// Mark as initialized to skip auto-restore (not testing backup functionality)
 		err = pm.setInitialized()
 		require.NoError(t, err)
-
-		// Create mock query service and inject it
-		mockQueryService := mock.NewQueryService()
 
 		// Status() calls isInRecovery() - returns true (in recovery = standby)
 		mockQueryService.AddQueryPattern("SELECT pg_is_in_recovery",
@@ -479,10 +472,6 @@ func TestReplicationStatus(t *testing.T) {
 					"wal_receiver_timeout",
 				},
 				[][]any{{"0/12345600", "0/12345678", "f", "not paused", "2025-01-01 00:00:00", "host=primary port=5432 user=repl application_name=test", "streaming", nil, nil, nil}}))
-
-		pm.qsc = &mockPoolerController{queryService: mockQueryService}
-		setTestRuleStore(t, pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
-		setTestRuleStore(t, pm, &fakeRuleStore{})
 
 		senv := servenv.NewServEnv(viperutil.NewRegistry())
 		go pm.Start(senv)
@@ -538,12 +527,12 @@ func TestReplicationStatus(t *testing.T) {
 			TopoClient: ts,
 			PgctldAddr: pgctldAddr,
 		}
-		pm, err := NewMultiPoolerManager(logger, multipooler, config)
+		mockQueryService := mock.NewQueryService()
+		pm, err := NewMultiPoolerManagerForTesting(t, logger, multipooler, config,
+			withMockController(&mockPoolerController{queryService: mockQueryService}),
+			withFakeRules(&fakeRuleStore{}))
 		require.NoError(t, err)
 		t.Cleanup(func() { pm.ShutdownForTest(context.Background()) })
-
-		// Create mock query service and inject it
-		mockQueryService := mock.NewQueryService()
 
 		// PostgreSQL is actually a standby (pg_is_in_recovery = true)
 		mockQueryService.AddQueryPattern("SELECT pg_is_in_recovery",
@@ -567,10 +556,6 @@ func TestReplicationStatus(t *testing.T) {
 					"wal_receiver_timeout",
 				},
 				[][]any{{"0/12345600", "0/12345678", "f", "not paused", "2025-01-01 00:00:00", "host=primary port=5432 user=repl application_name=test", "streaming", nil, nil, nil}}))
-
-		pm.qsc = &mockPoolerController{queryService: mockQueryService}
-		setTestRuleStore(t, pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
-		setTestRuleStore(t, pm, &fakeRuleStore{})
 
 		senv := servenv.NewServEnv(viperutil.NewRegistry())
 		go pm.Start(senv)
@@ -623,11 +608,23 @@ func TestReplicationStatus(t *testing.T) {
 			TopoClient: ts,
 			PgctldAddr: pgctldAddr,
 		}
-		pm, err := NewMultiPoolerManager(logger, multipooler, config)
+		mockQueryService := mock.NewQueryService()
+		pm, err := NewMultiPoolerManagerForTesting(t, logger, multipooler, config,
+			withMockController(&mockPoolerController{queryService: mockQueryService}),
+			withFakeRules(&fakeRuleStore{
+				pos: &clustermetadatapb.PoolerPosition{
+					Rule: &clustermetadatapb.ShardRule{
+						RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
+						CohortMembers: []*clustermetadatapb.ID{
+							{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler-a"},
+							{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler-b"},
+						},
+					},
+					Lsn: "0/1000000",
+				},
+			}))
 		require.NoError(t, err)
 		t.Cleanup(func() { pm.ShutdownForTest(context.Background()) })
-
-		mockQueryService := mock.NewQueryService()
 
 		mockQueryService.AddQueryPattern("SELECT pg_is_in_recovery",
 			mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"f"}}))
@@ -639,20 +636,6 @@ func TestReplicationStatus(t *testing.T) {
 			mock.MakeQueryResult(
 				[]string{"synchronous_standby_names", "synchronous_commit", "max_wal_senders"},
 				[][]any{{"", "on", "5"}}))
-		pm.qsc = &mockPoolerController{queryService: mockQueryService}
-		setTestRuleStore(t, pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
-		setTestRuleStore(t, pm, &fakeRuleStore{
-			pos: &clustermetadatapb.PoolerPosition{
-				Rule: &clustermetadatapb.ShardRule{
-					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
-					CohortMembers: []*clustermetadatapb.ID{
-						{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler-a"},
-						{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler-b"},
-					},
-				},
-				Lsn: "0/1000000",
-			},
-		})
 
 		status, err := pm.Status(ctx)
 		require.NoError(t, err)
@@ -701,15 +684,15 @@ func TestReplicationStatus(t *testing.T) {
 			TopoClient: ts,
 			PgctldAddr: pgctldAddr,
 		}
-		pm, err := NewMultiPoolerManager(logger, multipooler, config)
+		mockQueryService := mock.NewQueryService()
+		pm, err := NewMultiPoolerManagerForTesting(t, logger, multipooler, config,
+			withMockController(&mockPoolerController{queryService: mockQueryService}),
+			withFakeRules(&fakeRuleStore{}))
 		require.NoError(t, err)
 		t.Cleanup(func() { pm.ShutdownForTest(context.Background()) })
 		// Mark as initialized to skip auto-restore (not testing backup functionality)
 		err = pm.setInitialized()
 		require.NoError(t, err)
-
-		// Create mock query service and inject it
-		mockQueryService := mock.NewQueryService()
 
 		// PostgreSQL is actually a primary (pg_is_in_recovery = false)
 		mockQueryService.AddQueryPattern("SELECT pg_is_in_recovery",
@@ -725,10 +708,6 @@ func TestReplicationStatus(t *testing.T) {
 			mock.MakeQueryResult(
 				[]string{"synchronous_standby_names", "synchronous_commit", "max_wal_senders"},
 				[][]any{{"", "on", "5"}}))
-
-		pm.qsc = &mockPoolerController{queryService: mockQueryService}
-		setTestRuleStore(t, pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
-		setTestRuleStore(t, pm, &fakeRuleStore{})
 
 		senv := servenv.NewServEnv(viperutil.NewRegistry())
 		go pm.Start(senv)
@@ -797,42 +776,34 @@ func TestUpdateConsensusRule_HistoryFailurePreventsGUCUpdate(t *testing.T) {
 	config := &Config{
 		TopoClient: ts,
 	}
-	manager, err := NewMultiPoolerManager(logger, multipooler, config)
+	mockQueryService := mock.NewQueryService()
+	// ObservePosition must succeed so UpdateCohortMembers reaches UpdateRule.
+	// updateErr simulates the history write timing out (the failure we're testing).
+	manager, err := NewMultiPoolerManagerForTesting(t, logger, multipooler, config,
+		withMockController(&mockPoolerController{queryService: mockQueryService}),
+		withFakeRules(&fakeRuleStore{
+			pos: &clustermetadatapb.PoolerPosition{
+				Rule: &clustermetadatapb.ShardRule{
+					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
+					CohortMembers: []*clustermetadatapb.ID{
+						{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "replica-1"},
+						{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "replica-2"},
+					},
+					DurabilityPolicy: testBootstrapPolicy(),
+				},
+			},
+			updateErr: mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, "timeout waiting for sync replication"),
+		}))
 	require.NoError(t, err)
 	defer manager.ShutdownForTest(t.Context())
 
-	// Initialize consensus state so the manager can read the term
-	manager.mu.Lock()
-	setTestPromises(t, manager, consensus.NewConsensusPromises(poolerDir, serviceID))
-	manager.mu.Unlock()
-
-	// Load the term from file
+	// Load the seeded term from disk (promises is rooted at the pooler dir).
 	_, err = manager.consensusMgr.Promises().Load()
 	require.NoError(t, err, "Failed to load consensus state")
-
-	// Set up mock query service
-	mockQueryService := mock.NewQueryService()
 
 	// Mock for startup
 	mockQueryService.AddQueryPattern("SELECT pg_is_in_recovery",
 		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{false}}))
-
-	manager.qsc = &mockPoolerController{queryService: mockQueryService}
-	// ObservePosition must succeed so UpdateCohortMembers reaches UpdateRule.
-	// updateErr simulates the history write timing out (the failure we're testing).
-	setTestRuleStore(t, manager, &fakeRuleStore{
-		pos: &clustermetadatapb.PoolerPosition{
-			Rule: &clustermetadatapb.ShardRule{
-				RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
-				CohortMembers: []*clustermetadatapb.ID{
-					{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "replica-1"},
-					{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "replica-2"},
-				},
-				DurabilityPolicy: testBootstrapPolicy(),
-			},
-		},
-		updateErr: mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, "timeout waiting for sync replication"),
-	})
 
 	err = manager.setInitialized()
 	require.NoError(t, err)
@@ -922,7 +893,8 @@ func TestRewindToSource_ManagerReopenedOnError(t *testing.T) {
 		PgctldAddr: pgctldAddr,
 	}
 
-	manager, err := NewMultiPoolerManager(logger, multipooler, config)
+	manager, err := NewMultiPoolerManagerForTesting(t, logger, multipooler, config,
+		withMockController(&mockPoolerController{queryService: mockQueryService}))
 	require.NoError(t, err)
 	defer manager.ShutdownForTest(t.Context())
 
@@ -933,8 +905,6 @@ func TestRewindToSource_ManagerReopenedOnError(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assign mock pooler controller BEFORE opening to avoid race conditions
-	manager.qsc = &mockPoolerController{queryService: mockQueryService}
-	setTestRuleStore(t, manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
 
 	// Simulate the manager being open and ready (set internal state without starting goroutines)
 	manager.mu.Lock()
@@ -1048,15 +1018,13 @@ func TestRewindToSource_RestoresPrimaryConnInfo(t *testing.T) {
 		PgctldAddr: pgctldAddr,
 	}
 
-	manager, err := NewMultiPoolerManager(logger, multipooler, config)
+	manager, err := NewMultiPoolerManagerForTesting(t, logger, multipooler, config,
+		withMockController(&mockPoolerController{queryService: mockQueryService}))
 	require.NoError(t, err)
 	defer manager.ShutdownForTest(t.Context())
 
 	createPgDataDir(t, poolerDir)
 	require.NoError(t, manager.setInitialized())
-
-	manager.qsc = &mockPoolerController{queryService: mockQueryService}
-	setTestRuleStore(t, manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
 
 	manager.mu.Lock()
 	manager.isOpen = true
@@ -1164,15 +1132,13 @@ func TestRewindToSource_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
 		PgctldAddr: pgctldAddr,
 	}
 
-	manager, err := NewMultiPoolerManager(logger, multipooler, config)
+	manager, err := NewMultiPoolerManagerForTesting(t, logger, multipooler, config,
+		withMockController(&mockPoolerController{queryService: mockQueryService}))
 	require.NoError(t, err)
 	defer manager.ShutdownForTest(t.Context())
 
 	createPgDataDir(t, poolerDir)
 	require.NoError(t, manager.setInitialized())
-
-	manager.qsc = &mockPoolerController{queryService: mockQueryService}
-	setTestRuleStore(t, manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
 
 	manager.mu.Lock()
 	manager.isOpen = true

--- a/go/services/multipooler/internal/manager/rpc_manager_test.go
+++ b/go/services/multipooler/internal/manager/rpc_manager_test.go
@@ -132,7 +132,7 @@ func TestPrimaryPosition(t *testing.T) {
 			isReplica := tt.poolerType == clustermetadatapb.PoolerType_REPLICA
 			mockQueryService.AddQueryPattern("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{isReplica}}))
 			manager.qsc = &mockPoolerController{queryService: mockQueryService}
-			setTestRuleStore(manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
+			setTestRuleStore(t, manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
 
 			// Mark as initialized to skip auto-restore (not testing backup functionality)
 			err = manager.setInitialized()
@@ -212,7 +212,7 @@ func TestActionLock_MutationMethodsTimeout(t *testing.T) {
 	mockQueryService := mock.NewQueryService()
 	mockQueryService.AddQueryPatternOnce("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{false}}))
 	manager.qsc = &mockPoolerController{queryService: mockQueryService}
-	setTestRuleStore(manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
+	setTestRuleStore(t, manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
 
 	// Start and wait for ready
 	senv := servenv.NewServEnv(viperutil.NewRegistry())
@@ -390,8 +390,8 @@ func TestReplicationStatus(t *testing.T) {
 				[][]any{{"", "on", "5"}}))
 
 		pm.qsc = &mockPoolerController{queryService: mockQueryService}
-		setTestRuleStore(pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
-		setTestRuleStore(pm, &fakeRuleStore{})
+		setTestRuleStore(t, pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
+		setTestRuleStore(t, pm, &fakeRuleStore{})
 
 		senv := servenv.NewServEnv(viperutil.NewRegistry())
 		go pm.Start(senv)
@@ -481,8 +481,8 @@ func TestReplicationStatus(t *testing.T) {
 				[][]any{{"0/12345600", "0/12345678", "f", "not paused", "2025-01-01 00:00:00", "host=primary port=5432 user=repl application_name=test", "streaming", nil, nil, nil}}))
 
 		pm.qsc = &mockPoolerController{queryService: mockQueryService}
-		setTestRuleStore(pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
-		setTestRuleStore(pm, &fakeRuleStore{})
+		setTestRuleStore(t, pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
+		setTestRuleStore(t, pm, &fakeRuleStore{})
 
 		senv := servenv.NewServEnv(viperutil.NewRegistry())
 		go pm.Start(senv)
@@ -569,8 +569,8 @@ func TestReplicationStatus(t *testing.T) {
 				[][]any{{"0/12345600", "0/12345678", "f", "not paused", "2025-01-01 00:00:00", "host=primary port=5432 user=repl application_name=test", "streaming", nil, nil, nil}}))
 
 		pm.qsc = &mockPoolerController{queryService: mockQueryService}
-		setTestRuleStore(pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
-		setTestRuleStore(pm, &fakeRuleStore{})
+		setTestRuleStore(t, pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
+		setTestRuleStore(t, pm, &fakeRuleStore{})
 
 		senv := servenv.NewServEnv(viperutil.NewRegistry())
 		go pm.Start(senv)
@@ -640,8 +640,8 @@ func TestReplicationStatus(t *testing.T) {
 				[]string{"synchronous_standby_names", "synchronous_commit", "max_wal_senders"},
 				[][]any{{"", "on", "5"}}))
 		pm.qsc = &mockPoolerController{queryService: mockQueryService}
-		setTestRuleStore(pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
-		setTestRuleStore(pm, &fakeRuleStore{
+		setTestRuleStore(t, pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
+		setTestRuleStore(t, pm, &fakeRuleStore{
 			pos: &clustermetadatapb.PoolerPosition{
 				Rule: &clustermetadatapb.ShardRule{
 					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
@@ -727,8 +727,8 @@ func TestReplicationStatus(t *testing.T) {
 				[][]any{{"", "on", "5"}}))
 
 		pm.qsc = &mockPoolerController{queryService: mockQueryService}
-		setTestRuleStore(pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
-		setTestRuleStore(pm, &fakeRuleStore{})
+		setTestRuleStore(t, pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
+		setTestRuleStore(t, pm, &fakeRuleStore{})
 
 		senv := servenv.NewServEnv(viperutil.NewRegistry())
 		go pm.Start(senv)
@@ -803,7 +803,7 @@ func TestUpdateConsensusRule_HistoryFailurePreventsGUCUpdate(t *testing.T) {
 
 	// Initialize consensus state so the manager can read the term
 	manager.mu.Lock()
-	setTestPromises(manager, consensus.NewConsensusPromises(poolerDir, serviceID))
+	setTestPromises(t, manager, consensus.NewConsensusPromises(poolerDir, serviceID))
 	manager.mu.Unlock()
 
 	// Load the term from file
@@ -820,7 +820,7 @@ func TestUpdateConsensusRule_HistoryFailurePreventsGUCUpdate(t *testing.T) {
 	manager.qsc = &mockPoolerController{queryService: mockQueryService}
 	// ObservePosition must succeed so UpdateCohortMembers reaches UpdateRule.
 	// updateErr simulates the history write timing out (the failure we're testing).
-	setTestRuleStore(manager, &fakeRuleStore{
+	setTestRuleStore(t, manager, &fakeRuleStore{
 		pos: &clustermetadatapb.PoolerPosition{
 			Rule: &clustermetadatapb.ShardRule{
 				RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
@@ -934,7 +934,7 @@ func TestRewindToSource_ManagerReopenedOnError(t *testing.T) {
 
 	// Assign mock pooler controller BEFORE opening to avoid race conditions
 	manager.qsc = &mockPoolerController{queryService: mockQueryService}
-	setTestRuleStore(manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
+	setTestRuleStore(t, manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
 
 	// Simulate the manager being open and ready (set internal state without starting goroutines)
 	manager.mu.Lock()
@@ -1056,7 +1056,7 @@ func TestRewindToSource_RestoresPrimaryConnInfo(t *testing.T) {
 	require.NoError(t, manager.setInitialized())
 
 	manager.qsc = &mockPoolerController{queryService: mockQueryService}
-	setTestRuleStore(manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
+	setTestRuleStore(t, manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
 
 	manager.mu.Lock()
 	manager.isOpen = true
@@ -1172,7 +1172,7 @@ func TestRewindToSource_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
 	require.NoError(t, manager.setInitialized())
 
 	manager.qsc = &mockPoolerController{queryService: mockQueryService}
-	setTestRuleStore(manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
+	setTestRuleStore(t, manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
 
 	manager.mu.Lock()
 	manager.isOpen = true

--- a/go/services/multipooler/internal/manager/rpc_manager_test.go
+++ b/go/services/multipooler/internal/manager/rpc_manager_test.go
@@ -803,11 +803,11 @@ func TestUpdateConsensusRule_HistoryFailurePreventsGUCUpdate(t *testing.T) {
 
 	// Initialize consensus state so the manager can read the term
 	manager.mu.Lock()
-	manager.consensusState = consensus.NewConsensusState(poolerDir, serviceID)
+	manager.consensusPromises = consensus.NewConsensusPromises(poolerDir, serviceID)
 	manager.mu.Unlock()
 
 	// Load the term from file
-	_, err = manager.consensusState.Load()
+	_, err = manager.consensusPromises.Load()
 	require.NoError(t, err, "Failed to load consensus state")
 
 	// Set up mock query service

--- a/go/services/multipooler/internal/manager/rpc_manager_test.go
+++ b/go/services/multipooler/internal/manager/rpc_manager_test.go
@@ -132,7 +132,7 @@ func TestPrimaryPosition(t *testing.T) {
 			isReplica := tt.poolerType == clustermetadatapb.PoolerType_REPLICA
 			mockQueryService.AddQueryPattern("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{isReplica}}))
 			manager.qsc = &mockPoolerController{queryService: mockQueryService}
-			manager.rules = consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{})
+			setTestRuleStore(manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
 
 			// Mark as initialized to skip auto-restore (not testing backup functionality)
 			err = manager.setInitialized()
@@ -212,7 +212,7 @@ func TestActionLock_MutationMethodsTimeout(t *testing.T) {
 	mockQueryService := mock.NewQueryService()
 	mockQueryService.AddQueryPatternOnce("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{false}}))
 	manager.qsc = &mockPoolerController{queryService: mockQueryService}
-	manager.rules = consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{})
+	setTestRuleStore(manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
 
 	// Start and wait for ready
 	senv := servenv.NewServEnv(viperutil.NewRegistry())
@@ -390,8 +390,8 @@ func TestReplicationStatus(t *testing.T) {
 				[][]any{{"", "on", "5"}}))
 
 		pm.qsc = &mockPoolerController{queryService: mockQueryService}
-		pm.rules = consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{})
-		pm.rules = &fakeRuleStore{}
+		setTestRuleStore(pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
+		setTestRuleStore(pm, &fakeRuleStore{})
 
 		senv := servenv.NewServEnv(viperutil.NewRegistry())
 		go pm.Start(senv)
@@ -481,8 +481,8 @@ func TestReplicationStatus(t *testing.T) {
 				[][]any{{"0/12345600", "0/12345678", "f", "not paused", "2025-01-01 00:00:00", "host=primary port=5432 user=repl application_name=test", "streaming", nil, nil, nil}}))
 
 		pm.qsc = &mockPoolerController{queryService: mockQueryService}
-		pm.rules = consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{})
-		pm.rules = &fakeRuleStore{}
+		setTestRuleStore(pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
+		setTestRuleStore(pm, &fakeRuleStore{})
 
 		senv := servenv.NewServEnv(viperutil.NewRegistry())
 		go pm.Start(senv)
@@ -569,8 +569,8 @@ func TestReplicationStatus(t *testing.T) {
 				[][]any{{"0/12345600", "0/12345678", "f", "not paused", "2025-01-01 00:00:00", "host=primary port=5432 user=repl application_name=test", "streaming", nil, nil, nil}}))
 
 		pm.qsc = &mockPoolerController{queryService: mockQueryService}
-		pm.rules = consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{})
-		pm.rules = &fakeRuleStore{}
+		setTestRuleStore(pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
+		setTestRuleStore(pm, &fakeRuleStore{})
 
 		senv := servenv.NewServEnv(viperutil.NewRegistry())
 		go pm.Start(senv)
@@ -640,8 +640,8 @@ func TestReplicationStatus(t *testing.T) {
 				[]string{"synchronous_standby_names", "synchronous_commit", "max_wal_senders"},
 				[][]any{{"", "on", "5"}}))
 		pm.qsc = &mockPoolerController{queryService: mockQueryService}
-		pm.rules = consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{})
-		pm.rules = &fakeRuleStore{
+		setTestRuleStore(pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
+		setTestRuleStore(pm, &fakeRuleStore{
 			pos: &clustermetadatapb.PoolerPosition{
 				Rule: &clustermetadatapb.ShardRule{
 					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
@@ -652,7 +652,7 @@ func TestReplicationStatus(t *testing.T) {
 				},
 				Lsn: "0/1000000",
 			},
-		}
+		})
 
 		status, err := pm.Status(ctx)
 		require.NoError(t, err)
@@ -727,8 +727,8 @@ func TestReplicationStatus(t *testing.T) {
 				[][]any{{"", "on", "5"}}))
 
 		pm.qsc = &mockPoolerController{queryService: mockQueryService}
-		pm.rules = consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{})
-		pm.rules = &fakeRuleStore{}
+		setTestRuleStore(pm, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
+		setTestRuleStore(pm, &fakeRuleStore{})
 
 		senv := servenv.NewServEnv(viperutil.NewRegistry())
 		go pm.Start(senv)
@@ -803,11 +803,11 @@ func TestUpdateConsensusRule_HistoryFailurePreventsGUCUpdate(t *testing.T) {
 
 	// Initialize consensus state so the manager can read the term
 	manager.mu.Lock()
-	manager.consensusPromises = consensus.NewConsensusPromises(poolerDir, serviceID)
+	setTestPromises(manager, consensus.NewConsensusPromises(poolerDir, serviceID))
 	manager.mu.Unlock()
 
 	// Load the term from file
-	_, err = manager.consensusPromises.Load()
+	_, err = manager.consensusMgr.Promises().Load()
 	require.NoError(t, err, "Failed to load consensus state")
 
 	// Set up mock query service
@@ -820,7 +820,7 @@ func TestUpdateConsensusRule_HistoryFailurePreventsGUCUpdate(t *testing.T) {
 	manager.qsc = &mockPoolerController{queryService: mockQueryService}
 	// ObservePosition must succeed so UpdateCohortMembers reaches UpdateRule.
 	// updateErr simulates the history write timing out (the failure we're testing).
-	manager.rules = &fakeRuleStore{
+	setTestRuleStore(manager, &fakeRuleStore{
 		pos: &clustermetadatapb.PoolerPosition{
 			Rule: &clustermetadatapb.ShardRule{
 				RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
@@ -832,7 +832,7 @@ func TestUpdateConsensusRule_HistoryFailurePreventsGUCUpdate(t *testing.T) {
 			},
 		},
 		updateErr: mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, "timeout waiting for sync replication"),
-	}
+	})
 
 	err = manager.setInitialized()
 	require.NoError(t, err)
@@ -934,7 +934,7 @@ func TestRewindToSource_ManagerReopenedOnError(t *testing.T) {
 
 	// Assign mock pooler controller BEFORE opening to avoid race conditions
 	manager.qsc = &mockPoolerController{queryService: mockQueryService}
-	manager.rules = consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{})
+	setTestRuleStore(manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
 
 	// Simulate the manager being open and ready (set internal state without starting goroutines)
 	manager.mu.Lock()
@@ -1056,7 +1056,7 @@ func TestRewindToSource_RestoresPrimaryConnInfo(t *testing.T) {
 	require.NoError(t, manager.setInitialized())
 
 	manager.qsc = &mockPoolerController{queryService: mockQueryService}
-	manager.rules = consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{})
+	setTestRuleStore(manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
 
 	manager.mu.Lock()
 	manager.isOpen = true
@@ -1172,7 +1172,7 @@ func TestRewindToSource_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
 	require.NoError(t, manager.setInitialized())
 
 	manager.qsc = &mockPoolerController{queryService: mockQueryService}
-	manager.rules = consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{})
+	setTestRuleStore(manager, consensus.NewRuleStore(logger, mockQueryService, noopSyncStandbyManager{}))
 
 	manager.mu.Lock()
 	manager.isOpen = true

--- a/go/services/multipooler/internal/manager/rpc_set_primary_test.go
+++ b/go/services/multipooler/internal/manager/rpc_set_primary_test.go
@@ -201,7 +201,7 @@ func TestSetPrimary_NoOpWhenPositionNotHigher(t *testing.T) {
 			// future redundant SetPrimary calls. The proof that the apply
 			// branch wasn't reached is that no apply-path postgres queries
 			// were issued (ExpectationsWereMet below).
-			highest := pm.consensusState.GetReplicationPrimary()
+			highest := pm.consensusPromises.GetReplicationPrimary()
 			require.NotNil(t, highest, "SetPrimary should record the rule even on no-op")
 			assert.Equal(t, tt.incomingPos.GetRule().GetRuleNumber().GetCoordinatorTerm(),
 				highest.GetRule().GetRuleNumber().GetCoordinatorTerm())
@@ -270,7 +270,7 @@ func TestSetPrimary_StandbyAppliesNewPrimary(t *testing.T) {
 	assert.Contains(t, capturedConnInfoSQL, "host=primary-host",
 		"rendered primary_conninfo should reference the new primary host")
 
-	recorded := pm.consensusState.GetReplicationPrimary().GetPrimary()
+	recorded := pm.consensusPromises.GetReplicationPrimary().GetPrimary()
 	require.NotNil(t, recorded, "primary should be recorded after standby update")
 	assert.Equal(t, "new-primary", recorded.GetId().GetName())
 	assert.Equal(t, "primary-host", recorded.GetHost())
@@ -319,7 +319,7 @@ func TestSetPrimary_StalePrimaryDemotes(t *testing.T) {
 	// Seed an initial revocation so we can verify SetPrimary leaves it
 	// untouched even when the incoming rule's coordinator_term is higher.
 	consensustest.SeedTerm(t, tmpDir, &clustermetadatapb.TermRevocation{RevokedBelowTerm: 3})
-	_, err := pm.consensusState.Load()
+	_, err := pm.consensusPromises.Load()
 	require.NoError(t, err)
 
 	leader := newLeaderAddress("new-primary", "primary-host", 5432)
@@ -342,7 +342,7 @@ func TestSetPrimary_StalePrimaryDemotes(t *testing.T) {
 		"rendered primary_conninfo should reference the new primary host")
 
 	// Manager state recorded the new primary.
-	recorded := pm.consensusState.GetReplicationPrimary().GetPrimary()
+	recorded := pm.consensusPromises.GetReplicationPrimary().GetPrimary()
 	require.NotNil(t, recorded)
 	assert.Equal(t, "new-primary", recorded.GetId().GetName())
 	assert.Equal(t, "primary-host", recorded.GetHost())
@@ -350,7 +350,7 @@ func TestSetPrimary_StalePrimaryDemotes(t *testing.T) {
 	// SetPrimary must NOT touch term_revocation. The revocation seeded above
 	// (revoked_below_term=3) is preserved verbatim. Revocations are authored
 	// by coordinators via Recruit, not by side effects of SetPrimary.
-	rev := pm.consensusState.GetInconsistentRevocation()
+	rev := pm.consensusPromises.GetInconsistentRevocation()
 	assert.Equal(t, int64(3), rev.GetRevokedBelowTerm(),
 		"SetPrimary must not bump revoked_below_term — that's a coordinator responsibility")
 
@@ -409,7 +409,7 @@ func TestSetPrimary_IgnoresRevokedRule(t *testing.T) {
 				RevokedBelowTerm: tt.revokedBelow,
 				OutgoingRule:     tt.outgoing,
 			})
-			_, err := pm.consensusState.Load()
+			_, err := pm.consensusPromises.Load()
 			require.NoError(t, err)
 
 			leader := newLeaderAddress("new-primary", "primary-host", 5432)
@@ -427,7 +427,7 @@ func TestSetPrimary_IgnoresRevokedRule(t *testing.T) {
 			// RecordTermPrimary must not have run: the (rule, leader) tuple
 			// is not the substrate multiorch should read from a refused FYI.
 			// This is also the proof the apply branch wasn't reached.
-			highest := pm.consensusState.GetReplicationPrimary()
+			highest := pm.consensusPromises.GetReplicationPrimary()
 			assert.Nil(t, highest, "revoked SetPrimary should not be recorded")
 
 			assert.NoError(t, mockQueryService.ExpectationsWereMet())
@@ -455,7 +455,7 @@ func TestSetPrimary_AppliesViaOutgoingRuleOverride(t *testing.T) {
 		RevokedBelowTerm: 5,
 		OutgoingRule:     &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
 	})
-	_, err := pm.consensusState.Load()
+	_, err := pm.consensusPromises.Load()
 	require.NoError(t, err)
 
 	leader := newLeaderAddress("new-primary", "primary-host", 5432)
@@ -471,7 +471,7 @@ func TestSetPrimary_AppliesViaOutgoingRuleOverride(t *testing.T) {
 	require.NotNil(t, resp.ConsensusStatus)
 
 	// Override fired → RecordTermPrimary ran → the rule + primary are observable.
-	highest := pm.consensusState.GetReplicationPrimary()
+	highest := pm.consensusPromises.GetReplicationPrimary()
 	require.NotNil(t, highest, "override should let RecordTermPrimary persist the rule")
 	require.NotNil(t, highest.GetPrimary())
 	assert.Equal(t, "new-primary", highest.GetPrimary().Id.Name)

--- a/go/services/multipooler/internal/manager/rpc_set_primary_test.go
+++ b/go/services/multipooler/internal/manager/rpc_set_primary_test.go
@@ -201,7 +201,7 @@ func TestSetPrimary_NoOpWhenPositionNotHigher(t *testing.T) {
 			// future redundant SetPrimary calls. The proof that the apply
 			// branch wasn't reached is that no apply-path postgres queries
 			// were issued (ExpectationsWereMet below).
-			highest := pm.consensusPromises.GetReplicationPrimary()
+			highest := pm.consensusMgr.Promises().GetReplicationPrimary()
 			require.NotNil(t, highest, "SetPrimary should record the rule even on no-op")
 			assert.Equal(t, tt.incomingPos.GetRule().GetRuleNumber().GetCoordinatorTerm(),
 				highest.GetRule().GetRuleNumber().GetCoordinatorTerm())
@@ -270,7 +270,7 @@ func TestSetPrimary_StandbyAppliesNewPrimary(t *testing.T) {
 	assert.Contains(t, capturedConnInfoSQL, "host=primary-host",
 		"rendered primary_conninfo should reference the new primary host")
 
-	recorded := pm.consensusPromises.GetReplicationPrimary().GetPrimary()
+	recorded := pm.consensusMgr.Promises().GetReplicationPrimary().GetPrimary()
 	require.NotNil(t, recorded, "primary should be recorded after standby update")
 	assert.Equal(t, "new-primary", recorded.GetId().GetName())
 	assert.Equal(t, "primary-host", recorded.GetHost())
@@ -319,7 +319,7 @@ func TestSetPrimary_StalePrimaryDemotes(t *testing.T) {
 	// Seed an initial revocation so we can verify SetPrimary leaves it
 	// untouched even when the incoming rule's coordinator_term is higher.
 	consensustest.SeedTerm(t, tmpDir, &clustermetadatapb.TermRevocation{RevokedBelowTerm: 3})
-	_, err := pm.consensusPromises.Load()
+	_, err := pm.consensusMgr.Promises().Load()
 	require.NoError(t, err)
 
 	leader := newLeaderAddress("new-primary", "primary-host", 5432)
@@ -342,7 +342,7 @@ func TestSetPrimary_StalePrimaryDemotes(t *testing.T) {
 		"rendered primary_conninfo should reference the new primary host")
 
 	// Manager state recorded the new primary.
-	recorded := pm.consensusPromises.GetReplicationPrimary().GetPrimary()
+	recorded := pm.consensusMgr.Promises().GetReplicationPrimary().GetPrimary()
 	require.NotNil(t, recorded)
 	assert.Equal(t, "new-primary", recorded.GetId().GetName())
 	assert.Equal(t, "primary-host", recorded.GetHost())
@@ -350,7 +350,7 @@ func TestSetPrimary_StalePrimaryDemotes(t *testing.T) {
 	// SetPrimary must NOT touch term_revocation. The revocation seeded above
 	// (revoked_below_term=3) is preserved verbatim. Revocations are authored
 	// by coordinators via Recruit, not by side effects of SetPrimary.
-	rev := pm.consensusPromises.GetInconsistentRevocation()
+	rev := pm.consensusMgr.Promises().GetInconsistentRevocation()
 	assert.Equal(t, int64(3), rev.GetRevokedBelowTerm(),
 		"SetPrimary must not bump revoked_below_term — that's a coordinator responsibility")
 
@@ -409,7 +409,7 @@ func TestSetPrimary_IgnoresRevokedRule(t *testing.T) {
 				RevokedBelowTerm: tt.revokedBelow,
 				OutgoingRule:     tt.outgoing,
 			})
-			_, err := pm.consensusPromises.Load()
+			_, err := pm.consensusMgr.Promises().Load()
 			require.NoError(t, err)
 
 			leader := newLeaderAddress("new-primary", "primary-host", 5432)
@@ -427,7 +427,7 @@ func TestSetPrimary_IgnoresRevokedRule(t *testing.T) {
 			// RecordTermPrimary must not have run: the (rule, leader) tuple
 			// is not the substrate multiorch should read from a refused FYI.
 			// This is also the proof the apply branch wasn't reached.
-			highest := pm.consensusPromises.GetReplicationPrimary()
+			highest := pm.consensusMgr.Promises().GetReplicationPrimary()
 			assert.Nil(t, highest, "revoked SetPrimary should not be recorded")
 
 			assert.NoError(t, mockQueryService.ExpectationsWereMet())
@@ -455,7 +455,7 @@ func TestSetPrimary_AppliesViaOutgoingRuleOverride(t *testing.T) {
 		RevokedBelowTerm: 5,
 		OutgoingRule:     &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
 	})
-	_, err := pm.consensusPromises.Load()
+	_, err := pm.consensusMgr.Promises().Load()
 	require.NoError(t, err)
 
 	leader := newLeaderAddress("new-primary", "primary-host", 5432)
@@ -471,7 +471,7 @@ func TestSetPrimary_AppliesViaOutgoingRuleOverride(t *testing.T) {
 	require.NotNil(t, resp.ConsensusStatus)
 
 	// Override fired → RecordTermPrimary ran → the rule + primary are observable.
-	highest := pm.consensusPromises.GetReplicationPrimary()
+	highest := pm.consensusMgr.Promises().GetReplicationPrimary()
 	require.NotNil(t, highest, "override should let RecordTermPrimary persist the rule")
 	require.NotNil(t, highest.GetPrimary())
 	assert.Equal(t, "new-primary", highest.GetPrimary().Id.Name)

--- a/go/services/multipooler/internal/manager/rpc_set_primary_test.go
+++ b/go/services/multipooler/internal/manager/rpc_set_primary_test.go
@@ -201,7 +201,7 @@ func TestSetPrimary_NoOpWhenPositionNotHigher(t *testing.T) {
 			// future redundant SetPrimary calls. The proof that the apply
 			// branch wasn't reached is that no apply-path postgres queries
 			// were issued (ExpectationsWereMet below).
-			highest := pm.consensusMgr.Promises().GetReplicationPrimary()
+			highest := pm.consensusMgr.GetReplicationPrimary()
 			require.NotNil(t, highest, "SetPrimary should record the rule even on no-op")
 			assert.Equal(t, tt.incomingPos.GetRule().GetRuleNumber().GetCoordinatorTerm(),
 				highest.GetRule().GetRuleNumber().GetCoordinatorTerm())
@@ -270,7 +270,7 @@ func TestSetPrimary_StandbyAppliesNewPrimary(t *testing.T) {
 	assert.Contains(t, capturedConnInfoSQL, "host=primary-host",
 		"rendered primary_conninfo should reference the new primary host")
 
-	recorded := pm.consensusMgr.Promises().GetReplicationPrimary().GetPrimary()
+	recorded := pm.consensusMgr.GetReplicationPrimary().GetPrimary()
 	require.NotNil(t, recorded, "primary should be recorded after standby update")
 	assert.Equal(t, "new-primary", recorded.GetId().GetName())
 	assert.Equal(t, "primary-host", recorded.GetHost())
@@ -342,7 +342,7 @@ func TestSetPrimary_StalePrimaryDemotes(t *testing.T) {
 		"rendered primary_conninfo should reference the new primary host")
 
 	// Manager state recorded the new primary.
-	recorded := pm.consensusMgr.Promises().GetReplicationPrimary().GetPrimary()
+	recorded := pm.consensusMgr.GetReplicationPrimary().GetPrimary()
 	require.NotNil(t, recorded)
 	assert.Equal(t, "new-primary", recorded.GetId().GetName())
 	assert.Equal(t, "primary-host", recorded.GetHost())
@@ -427,7 +427,7 @@ func TestSetPrimary_IgnoresRevokedRule(t *testing.T) {
 			// RecordTermPrimary must not have run: the (rule, leader) tuple
 			// is not the substrate multiorch should read from a refused FYI.
 			// This is also the proof the apply branch wasn't reached.
-			highest := pm.consensusMgr.Promises().GetReplicationPrimary()
+			highest := pm.consensusMgr.GetReplicationPrimary()
 			assert.Nil(t, highest, "revoked SetPrimary should not be recorded")
 
 			assert.NoError(t, mockQueryService.ExpectationsWereMet())
@@ -471,7 +471,7 @@ func TestSetPrimary_AppliesViaOutgoingRuleOverride(t *testing.T) {
 	require.NotNil(t, resp.ConsensusStatus)
 
 	// Override fired → RecordTermPrimary ran → the rule + primary are observable.
-	highest := pm.consensusMgr.Promises().GetReplicationPrimary()
+	highest := pm.consensusMgr.GetReplicationPrimary()
 	require.NotNil(t, highest, "override should let RecordTermPrimary persist the rule")
 	require.NotNil(t, highest.GetPrimary())
 	assert.Equal(t, "new-primary", highest.GetPrimary().Id.Name)

--- a/go/tools/ruleguard/rules.go
+++ b/go/tools/ruleguard/rules.go
@@ -238,9 +238,10 @@ func disallowMultiPoolerTypeForRouting(m dsl.Matcher) {
 // commonconsensus.ReplicationPrimaryOrNil, which returns nil for a 0/0 entry.
 //
 // Excluded:
-//   - go/common/consensus: implements the safe accessor (reads the field itself).
-//   - rpc_consensus.go: builds a ConsensusStatus and must assign the field; the
-//     DSL can't distinguish an assignment target from a read.
+//   - any .../consensus package: go/common/consensus implements the safe accessor
+//     (reads the field itself), and the multipooler's manager/consensus package
+//     builds a ConsensusStatus and must assign the field — the DSL can't
+//     distinguish an assignment target from a read.
 //   - test files.
 //
 // The unrelated ConsensusPromises.GetReplicationPrimary() (the multipooler's
@@ -251,8 +252,7 @@ func disallowRawConsensusStatusReplicationPrimary(m dsl.Matcher) {
 	m.Match(`$x.GetReplicationPrimary()`, `$x.ReplicationPrimary`).
 		Where(
 			m["x"].Type.Is("*clustermetadata.ConsensusStatus") &&
-				!m.File().PkgPath.Matches(`common/consensus`) &&
-				!m.File().Name.Matches(`rpc_consensus\.go$`) &&
+				!m.File().PkgPath.Matches(`/consensus$`) &&
 				!m.File().Name.Matches(`_test\.go$`)).
 		Report("do not read ConsensusStatus.ReplicationPrimary directly; use commonconsensus.ReplicationPrimaryOrNil, which treats a phantom 0/0 entry as absent")
 }

--- a/go/tools/ruleguard/rules.go
+++ b/go/tools/ruleguard/rules.go
@@ -243,7 +243,7 @@ func disallowMultiPoolerTypeForRouting(m dsl.Matcher) {
 //     DSL can't distinguish an assignment target from a read.
 //   - test files.
 //
-// The unrelated ConsensusState.GetReplicationPrimary() (the multipooler's
+// The unrelated ConsensusPromises.GetReplicationPrimary() (the multipooler's
 // in-memory holder) is a different receiver type and is not matched.
 func disallowRawConsensusStatusReplicationPrimary(m dsl.Matcher) {
 	m.Import("github.com/multigres/multigres/go/pb/clustermetadata")


### PR DESCRIPTION
Multipooler's consensus-related state was scattered across `MultiPoolerManager`:
the durable term-revocation store, the rule store, the observed replication
primary, leader-resignation term, cohort eligibility, suspected-divergence and
rewind-wait flags, plus all the status-assembly code. This PR gathers it onto a
single `consensus.ConsensusManager` in the `consensus` package.

Almost entirely code movement — no behavior change.

### What moved
- `ConsensusManager` now owns the durable promises store, rule store, observed
  replication primary, resignation term, cohort eligibility, suspected
  divergence, and rewind-wait state.
- ConsensusStatus / LeadershipStatus assembly moved onto `ConsensusManager`.
- `MultiPoolerManager` keeps only what isn't consensus state: `promotionInProgress`
  (pg_promote mechanics), `buildAvailabilityStatus` (the composition point), and
  `buildCohortEligibilityStatus` (folds in `walReceiverManuallyStopped`).

### Incidental cleanup
- Renamed `ConsensusState` → `ConsensusPromises` to reflect that it's durable
  term-revocation promises only.
- Removed dead term-number code (`validateAndUpdateTerm` chain,
  `GetCurrentTermNumber`/`GetInconsistentCurrentTermNumber`, etc.).
- Production `NewConsensusManager(Deps)` builds its own components; tests inject
  fakes through `NewManagerForTesting` / `NewMultiPoolerManagerForTesting`, so
  production `Config`/`Deps` carry no test-only fields.

### Locking
Sync regimes are preserved, not unified: the action lock serializes writers,
atomics back lock-free scalar reads, and a mutex guards the proto-pointer/time
fields. `ConsensusManager` mutators assert the action lock is held (the one
exception, `MarkSelfRewindReady`, is documented — the async post-promotion
checkpoint calls it lock-free). Each field documents what guards it.
