### PR TITLE
fix(pgprotocol): drain unsupported FunctionCall frames

### DIFF
--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -853,6 +853,16 @@ func (c *Conn) handleMessage(msgType byte) error {
 		// attached: more pipelined messages typically follow.
 		return c.flush()
 
+	case protocol.MsgFunctionCall:
+		// Fast-path FunctionCall is not implemented yet, but it is still a
+		// normal length-prefixed frontend message. Drain the frame before
+		// rejecting it so we do not close the socket while the client is still
+		// writing the rest of the packet, which can surface as ECONNRESET/SIGPIPE.
+		if err := c.discardMessageBody(); err != nil {
+			return fmt.Errorf("failed to discard unsupported FunctionCall message: %w", err)
+		}
+		return fmt.Errorf("unsupported message type: %c (0x%02x)", msgType, msgType)
+
 	default:
 		return fmt.Errorf("unsupported message type: %c (0x%02x)", msgType, msgType)
 	}

--- a/go/common/pgprotocol/server/extended_query_test.go
+++ b/go/common/pgprotocol/server/extended_query_test.go
@@ -776,6 +776,52 @@ func TestDescribePortalThenFlush(t *testing.T) {
 		"Flush after Describe('P') must surface NoData/RowDescription")
 }
 
+func TestUnsupportedFunctionCallDrainsMessageBody(t *testing.T) {
+	var readBuf bytes.Buffer
+	var writeBuf bytes.Buffer
+	conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, &testHandler{})
+
+	body := []byte{
+		0, 0, 0, 177, // function oid: int4pl
+		0, 1, // one argument format code
+		0, 0, // text format
+		0, 2, // two arguments
+		0, 0, 0, 1, '2',
+		0, 0, 0, 1, '3',
+		0, 0, // text result format
+	}
+	writeTestInt32(&readBuf, int32(4+len(body)))
+	readBuf.Write(body)
+
+	err := conn.handleMessage(protocol.MsgFunctionCall)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported message type: F")
+	assert.Zero(t, readBuf.Len(), "unsupported FunctionCall must be drained before rejection")
+}
+
+func TestUnsupportedFunctionCallDrainsEmptyMessageBody(t *testing.T) {
+	var readBuf bytes.Buffer
+	var writeBuf bytes.Buffer
+	conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, &testHandler{})
+
+	writeTestInt32(&readBuf, 4)
+
+	err := conn.handleMessage(protocol.MsgFunctionCall)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported message type: F")
+	assert.Zero(t, readBuf.Len(), "unsupported FunctionCall must consume the length field")
+}
+
+func TestUnsupportedFunctionCallReportsDrainError(t *testing.T) {
+	var readBuf bytes.Buffer
+	var writeBuf bytes.Buffer
+	conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, &testHandler{})
+
+	err := conn.handleMessage(protocol.MsgFunctionCall)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to discard unsupported FunctionCall message")
+}
+
 // TestHandleClose tests the Close message handler.
 func TestHandleClose(t *testing.T) {
 	tests := []struct {

--- a/go/common/pgprotocol/server/packet.go
+++ b/go/common/pgprotocol/server/packet.go
@@ -106,6 +106,20 @@ func (c *Conn) returnReadBuffer() {
 	}
 }
 
+// discardMessageBody reads and discards the length-prefixed body of the
+// current frontend message. The message type byte has already been consumed.
+func (c *Conn) discardMessageBody() error {
+	bodyLen, err := c.ReadMessageLength()
+	if err != nil {
+		return err
+	}
+	if bodyLen == 0 {
+		return nil
+	}
+	_, err = c.bufferedReader.Discard(bodyLen)
+	return err
+}
+
 // returnOutboundBuffer releases the buffer held by outboundPoolBuf
 // back to the listener bufpool. Normally writePacket releases it via
 // defer; this method exists for defensive cleanup on Conn.Close so a


### PR DESCRIPTION
## Summary
- drain fast-path FunctionCall frames before returning unsupported-message errors
- prevent closing the socket while pgproto is still writing the frame body
- add unit coverage that unsupported FunctionCall input is fully consumed

## Tests
- /mt-dev unit ./go/common/pgprotocol/server TestUnsupportedFunctionCallDrainsMessageBody -count=1
- /mt-dev unit ./go/common/pgprotocol/server -count=1