### PR TITLE
feat(docker-compose): support custom PostgreSQL base image

### DIFF
--- a/Dockerfile.cluster
+++ b/Dockerfile.cluster
@@ -15,6 +15,14 @@
 #   docker compose up
 # =========================================================================
 
+# Overridable PostgreSQL base image for the final stage. Declared here, before
+# the first FROM, so it is in scope for the stage-3 FROM (a global ARG). Pass
+# --build-arg POSTGRES_IMAGE=postgres:18 (or MULTIGRES_POSTGRES_IMAGE for
+# compose) to build against a different PostgreSQL, or a prebuilt base image. For
+# a base that already bundles the required extensions and pgBackRest, combine it
+# with PROVISION_PG_PACKAGES=false (see stage 3).
+ARG POSTGRES_IMAGE=postgres:17.7
+
 # =========================================================================
 # Stage 1: Build the multigres binaries
 # =========================================================================
@@ -69,7 +77,8 @@ RUN case "${TARGETARCH}" in \
 # =========================================================================
 # Stage 3: Final image (PostgreSQL + pgBackRest + etcd + multigres)
 # =========================================================================
-FROM postgres:17.7
+# Base image is the global POSTGRES_IMAGE ARG declared at the top of this file.
+FROM ${POSTGRES_IMAGE}
 
 LABEL org.opencontainers.image.source="https://github.com/multigres/multigres"
 LABEL org.opencontainers.image.description="All-in-one Multigres cluster for docker-compose / CI compatibility testing."
@@ -77,12 +86,27 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Install pgBackRest and pgvector from the PostgreSQL APT repository plus procps
-# (pgrep is used by the entrypoint to detect if the gateway dies). pgvector is
-# preinstalled so compatibility suites can CREATE EXTENSION vector against the
-# bundled PostgreSQL; the PGDG package is built for these exact pg17 binaries.
+# Run the build steps as root. The official postgres base already builds as
+# root (no-op here); some base images switch to a non-root USER, which can't
+# install packages or write to /multigres. A later USER postgres resets this
+# for runtime.
+USER root
+
+# With the default PROVISION_PG_PACKAGES=true (the official Debian postgres
+# base), install pgBackRest and pgvector from the PostgreSQL APT repository plus
+# procps (pgrep is used by the entrypoint to detect if the gateway dies).
+# pgvector is preinstalled so compatibility suites can CREATE EXTENSION vector
+# against the bundled PostgreSQL; the PGDG package follows the base image's
+# PG_MAJOR. Set PROVISION_PG_PACKAGES=false when building on a prebuilt base that
+# already ships these (often such bases are not Debian-based, so apt would not
+# work there anyway); the guardrail below asserts the base actually provides them.
+ARG PROVISION_PG_PACKAGES=true
+# Re-declare the global POSTGRES_IMAGE inside this stage so the guardrail's error
+# message can name the offending base image (global ARGs aren't visible to RUN).
+ARG POSTGRES_IMAGE
 # hadolint ignore=DL3008
-RUN apt-get update && \
+RUN if [ "${PROVISION_PG_PACKAGES}" = "true" ]; then \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
@@ -93,12 +117,32 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
     pgbackrest \
-    postgresql-17-pgvector \
+    "postgresql-${PG_MAJOR}-pgvector" \
     procps && \
     pgbackrest version && \
     apt-get remove -y gnupg lsb-release && \
     apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* ; \
+    fi
+
+# Guardrail: when provisioning is skipped, the base image must already provide
+# everything the step above would have installed. Assert it at build time so a
+# missing dependency fails fast with a clear message instead of surfacing as a
+# confusing runtime failure mid-bootstrap (pgrep -> dead-gateway detection,
+# pgbackrest -> shard init/first backup, pgvector -> CREATE EXTENSION vector).
+RUN if [ "${PROVISION_PG_PACKAGES}" != "true" ]; then \
+      missing=""; \
+      command -v pgbackrest >/dev/null 2>&1 || missing="${missing} pgbackrest"; \
+      command -v pgrep >/dev/null 2>&1 || missing="${missing} pgrep(procps)"; \
+      ext_dir="$(pg_config --sharedir 2>/dev/null)/extension"; \
+      [ -f "${ext_dir}/vector.control" ] || missing="${missing} pgvector"; \
+      if [ -n "${missing}" ]; then \
+        echo "ERROR: PROVISION_PG_PACKAGES=false but the base image ${POSTGRES_IMAGE} is missing:${missing}" >&2; \
+        echo "Provide an image that bundles these, or build with PROVISION_PG_PACKAGES=true." >&2; \
+        exit 1; \
+      fi; \
+      echo "Guardrail OK: base image provides pgbackrest, pgrep, and pgvector."; \
+    fi
 
 # etcd client and server binaries.
 COPY --from=etcd /usr/local/bin/etcd /usr/local/bin/etcdctl /usr/local/bin/
@@ -129,7 +173,7 @@ USER postgres
 WORKDIR /multigres/cluster
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=60s --retries=12 \
-    CMD PGPASSWORD=postgres psql -h 127.0.0.1 -p "${MULTIGRES_GATEWAY_PG_PORT:-15432}" -U postgres -d postgres -tAc 'SELECT 1' || exit 1
+    CMD PGPASSWORD=postgres psql -h 127.0.0.1 -p "${MULTIGRES_GATEWAY_PG_PORT:-15432}" -U "${POSTGRES_USER:-postgres}" -d postgres -tAc 'SELECT 1' || exit 1
 
 # Reset the base image's CMD (["postgres"]) so it isn't passed to the entrypoint.
 ENTRYPOINT ["/usr/local/bin/cluster-entrypoint.sh"]

--- a/Dockerfile.cluster
+++ b/Dockerfile.cluster
@@ -78,6 +78,7 @@ RUN case "${TARGETARCH}" in \
 # Stage 3: Final image (PostgreSQL + pgBackRest + etcd + multigres)
 # =========================================================================
 # Base image is the global POSTGRES_IMAGE ARG declared at the top of this file.
+# checkov:skip=CKV_DOCKER_7:overridable base image, pinned to postgres:17.7 by default
 FROM ${POSTGRES_IMAGE}
 
 LABEL org.opencontainers.image.source="https://github.com/multigres/multigres"
@@ -101,7 +102,7 @@ USER root
 # already ships these (often such bases are not Debian-based, so apt would not
 # work there anyway); the guardrail below asserts the base actually provides them.
 ARG PROVISION_PG_PACKAGES=true
-# Re-declare the global POSTGRES_IMAGE inside this stage so the guardrail's error
+# Redeclare the global POSTGRES_IMAGE inside this stage so the guardrail's error
 # message can name the offending base image (global ARGs aren't visible to RUN).
 ARG POSTGRES_IMAGE
 # hadolint ignore=DL3008

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,14 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.cluster
+      args:
+        # PostgreSQL base image to build the cluster on. Defaults to the
+        # official Debian postgres. Point it at a prebuilt image that already
+        # bundles the required extensions + pgBackRest and set
+        # MULTIGRES_PROVISION_PG_PACKAGES=false to skip the apt provisioning,
+        # which only works on the Debian base.
+        POSTGRES_IMAGE: "${MULTIGRES_POSTGRES_IMAGE:-postgres:17.7}"
+        PROVISION_PG_PACKAGES: "${MULTIGRES_PROVISION_PG_PACKAGES:-true}"
     image: multigres-cluster:local
     # Run a real init (tini) as PID 1 to reap the cluster's orphaned child
     # processes and forward signals to the entrypoint.
@@ -44,7 +52,12 @@ services:
       # probe follows the gateway whenever the port is reconfigured above.
       test:
         - "CMD-SHELL"
-        - 'PGPASSWORD=postgres psql -h 127.0.0.1 -p "${MULTIGRES_GATEWAY_PG_PORT:-15432}" -U postgres -d postgres -tAc ''SELECT 1'' || exit 1'
+        # ${MULTIGRES_GATEWAY_PG_PORT} is interpolated by compose from the host
+        # env (it mirrors the port configured above). $${POSTGRES_USER} is
+        # escaped ($$) so compose passes it through literally for the container
+        # shell to expand against the image's env — defaulting to postgres, but
+        # following a base image that sets POSTGRES_USER to a custom superuser.
+        - 'PGPASSWORD=postgres psql -h 127.0.0.1 -p "${MULTIGRES_GATEWAY_PG_PORT:-15432}" -U "$${POSTGRES_USER:-postgres}" -d postgres -tAc ''SELECT 1'' || exit 1'
       interval: 10s
       timeout: 5s
       retries: 12

--- a/docker/README.md
+++ b/docker/README.md
@@ -92,6 +92,32 @@ it is applied only at first init. Advanced callers can instead point
 `POSTGRES_INITDB_EXTRA_CONF` at a mounted snippet directly — if both are set,
 the values from these knobs are appended last and win.
 
+### Custom base image (`MULTIGRES_POSTGRES_IMAGE`)
+
+By default the image builds on the official Debian `postgres` and installs
+pgBackRest, pgvector, and procps via apt. To build on a different PostgreSQL — a
+newer version, or a prebuilt image that already bundles those — override the base
+and skip the apt provisioning:
+
+```bash
+MULTIGRES_POSTGRES_IMAGE=registry.example.com/postgres:custom \
+MULTIGRES_PROVISION_PG_PACKAGES=false \
+docker compose up --build
+```
+
+- `MULTIGRES_POSTGRES_IMAGE` — base image (default `postgres:17.7`).
+- `MULTIGRES_PROVISION_PG_PACKAGES` — `true` (default) installs the dependencies
+  via apt; set `false` when the base already provides them (required for a
+  non-Debian base, where apt won't work).
+
+The cluster's superuser follows the base image's `POSTGRES_USER` (default
+`postgres`). If the image sets a custom role, connect as it — password is still
+`postgres`:
+
+```bash
+PGPASSWORD=postgres psql -h 127.0.0.1 -p 15432 -U "$CUSTOM_SUPERUSER" -d postgres
+```
+
 ## Usage
 
 From the repository root:
@@ -130,7 +156,9 @@ docker compose down
 | database | `postgres` |
 
 The gateway/pooler is pinned to the `postgres` database and the `postgres`
-superuser; use those for connections.
+superuser; use those for connections. (A [custom base
+image](#custom-base-image-multigres_postgres_image) can change the superuser
+name — see that section.)
 
 ## CI
 

--- a/docker/cluster-entrypoint.sh
+++ b/docker/cluster-entrypoint.sh
@@ -22,6 +22,14 @@ set -euo pipefail
 
 CONFIG_PATH="${MULTIGRES_CONFIG_PATH:-/multigres/cluster}"
 
+# PostgreSQL superuser for the cluster. Defaults to `postgres`. A base image can
+# customize it by exporting POSTGRES_USER (e.g. an image that ships post-initdb
+# SQL assuming a specific superuser role); we honor it end-to-end: it flows into
+# the generated config's pg-user (driving pgctld's initdb and the cluster-start
+# probe) and is inherited by the multipooler's admin connection, so initdb, any
+# init SQL, the pooler, and the healthcheck all agree on one superuser.
+PG_SUPERUSER="${POSTGRES_USER:-postgres}"
+
 # Number of cells to run. Each cell is a full stack: one PostgreSQL + pgctld,
 # one multipooler, one multiorch, and one multigateway. The local provisioner
 # bootstraps the shard with an AtLeastN(2) durability policy, so the cluster
@@ -99,6 +107,16 @@ set_gateway_ports() {
   done
 }
 
+# set_pg_user rewrites every cell's pgctld pg-user (a sibling of pg-port, same
+# indentation) to ${PG_SUPERUSER}. `cluster init` always generates `postgres`;
+# overriding it makes pgctld's initdb and the cluster-start probe use the base
+# image's superuser so they agree with the multipooler (which inherits
+# POSTGRES_USER) and any post-initdb SQL the image ships.
+set_pg_user() {
+  local file="$1" user="$2"
+  sed -i "s/^\(                pg-user: \).*\$/\1${user}/" "${file}"
+}
+
 shutdown() {
   echo "==> Received shutdown signal, stopping Multigres cluster..."
   multigres cluster stop --config-path "${CONFIG_PATH}" || true
@@ -143,6 +161,9 @@ if [ ! -f "${CONFIG_PATH}/multigres.yaml" ]; then
   multigres cluster init --config-path "${CONFIG_PATH}"
   trim_cells "${CONFIG_PATH}/multigres.yaml" "${NUM_CELLS}"
   set_gateway_ports "${CONFIG_PATH}/multigres.yaml" "${GATEWAY_PG_PORT}" "${NUM_CELLS}"
+  if [ "${PG_SUPERUSER}" != "postgres" ]; then
+    set_pg_user "${CONFIG_PATH}/multigres.yaml" "${PG_SUPERUSER}"
+  fi
 fi
 
 # Assemble extra PostgreSQL config from the max_connections knob and any raw

--- a/docker/cluster-entrypoint.sh
+++ b/docker/cluster-entrypoint.sh
@@ -103,7 +103,7 @@ set_gateway_ports() {
   for i in $(seq 1 "${keep}"); do
     src=$((15432 + i - 1))
     dst=$((base + i - 1))
-    sed -i "s/^\(                pg-port: \)${src}\$/\1${dst}/" "${file}"
+    sed -i "s/^\([[:space:]]*pg-port: \)${src}\$/\1${dst}/" "${file}"
   done
 }
 
@@ -114,7 +114,7 @@ set_gateway_ports() {
 # POSTGRES_USER) and any post-initdb SQL the image ships.
 set_pg_user() {
   local file="$1" user="$2"
-  sed -i "s/^\(                pg-user: \).*\$/\1${user}/" "${file}"
+  sed -i "s/^\([[:space:]]*pg-user: \).*\$/\1${user}/" "${file}"
 }
 
 shutdown() {


### PR DESCRIPTION
## Summary

- Make the PostgreSQL base image the all-in-one cluster builds on overridable via `MULTIGRES_POSTGRES_IMAGE` (build arg `POSTGRES_IMAGE`, default `postgres:17.7`), so the compose cluster can run on a newer PostgreSQL or a prebuilt image without editing the Dockerfile.
- Add `MULTIGRES_PROVISION_PG_PACKAGES` (build arg `PROVISION_PG_PACKAGES`, default `true`) to skip the Debian/apt provisioning when the base image already bundles pgBackRest, pgvector, and procps — required for non-Debian bases where apt won't work.
- Honor the base image's `POSTGRES_USER` end-to-end so an image that ships post-`initdb` SQL for a custom superuser bootstraps correctly.
- The official `postgres` path is behavior-preserving: defaults reproduce the previous build exactly.

## Description

Previously `Dockerfile.cluster` hardcoded `FROM postgres:17.7` and always installed pgBackRest/pgvector/procps from the PostgreSQL APT repo, so the all-in-one compose cluster could only run on the official Debian base. This change parameterizes that. The mechanism is fully generic — any base image that bundles the required dependencies works — and this PR was validated end-to-end against the `supabase/postgres` `*-multigres` image as the motivating example.

**Base image + provisioning.** `POSTGRES_IMAGE` is now a global build ARG used by the final stage's `FROM`, and the apt provisioning step is wrapped so it only runs when `PROVISION_PG_PACKAGES=true`. When skipped, the build asserts the base actually provides the skipped dependencies (`pgbackrest`, `pgrep`, pgvector) so a missing one fails the build with a clear message instead of surfacing as a confusing runtime failure mid-bootstrap. The pgvector apt package now follows the base image's `PG_MAJOR` instead of hardcoding `17`. Build steps run as `USER root` since some base images switch to a non-root user, which can't install packages or write to `/multigres`.

**Superuser.** The cluster's PostgreSQL superuser now follows the base image's `POSTGRES_USER` (default `postgres`). The entrypoint flows it into the generated config's `pg-user` (driving pgctld's `initdb` and the cluster-start probe), the multipooler inherits it, and both healthchecks connect as it — so `initdb`, any post-`initdb` init SQL, the pooler, and the healthcheck all agree on one superuser. With the default unset, everything resolves to `postgres` as before.

**Docs.** `docker/README.md` gains a short "Custom base image" section covering the two env vars and the custom-superuser login.

## Testing

### Official base image (default)

```bash
docker compose up --build -d
# wait for healthy, then connect as the default `postgres` superuser
PGPASSWORD=postgres psql -h 127.0.0.1 -p 15432 -U postgres -d postgres -c 'select version();'
docker compose down
```

### Custom base image (validated with `supabase/postgres`, but generic)

```bash
MULTIGRES_POSTGRES_IMAGE=ghcr.io/supabase/postgres:17.6.1.129-multigres \
MULTIGRES_PROVISION_PG_PACKAGES=false \
docker compose up --build -d
# the superuser follows the image's POSTGRES_USER (here: supabase_admin)
PGPASSWORD=postgres psql -h 127.0.0.1 -p 15432 -U supabase_admin -d postgres -c 'select current_user;'
```

Check the extensions the image ships (installed and available):

```bash
PGPASSWORD=postgres psql -h 127.0.0.1 -p 15432 -U supabase_admin -d postgres \
  -c 'select extname, extversion from pg_extension order by extname;' \
  -c 'select count(*) as available from pg_available_extensions;'
```

Confirm the image's bundled migrations ran during bootstrap — the supabase `initial-schema.sql` creates its roles, schemas, and publications:

```bash
PGPASSWORD=postgres psql -h 127.0.0.1 -p 15432 -U supabase_admin -d postgres \
  -c "select rolname from pg_roles where rolname like 'supabase%' or rolname in ('anon','authenticated','authenticator','service_role') order by 1;" \
  -c '\dn' \
  -c 'select pubname from pg_publication;'
```

Exercise a loaded extension end-to-end through the gateway:

```bash
PGPASSWORD=postgres psql -h 127.0.0.1 -p 15432 -U supabase_admin -d postgres <<'SQL'
CREATE EXTENSION IF NOT EXISTS vector;
CREATE TABLE items (id bigserial PRIMARY KEY, embedding vector(3));
INSERT INTO items (embedding) VALUES ('[1,0,0]'), ('[0,1,0]'), ('[0.9,0.1,0]');
SELECT id, embedding FROM items ORDER BY embedding <-> '[1,0,0]' LIMIT 3;
SQL
```

Also verified the skip-path assertion fails the build on the official base (missing pgbackrest/pgvector) and passes on a base that bundles them.