### PR TITLE
refactor(multipooler): derive writable from recovery + committed leadership

### DIFF
--- a/go/services/multipooler/internal/heartbeat/repltracker.go
+++ b/go/services/multipooler/internal/heartbeat/repltracker.go
@@ -22,6 +22,7 @@ import (
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 // TODO: add stats for heartbeat reads and writes
@@ -82,12 +83,12 @@ func (rt *ReplTracker) makeNonPrimary() {
 }
 
 // OnStateChange transitions the heartbeat tracker based on the serving state.
-// The writer runs only when this pooler is the consensus leader AND postgres is
-// out of recovery AND serving; otherwise the reader runs. Being the leader does
-// not imply a writable postgres — writing heartbeats to a standby fails every
-// interval and spams the log — so postgresPrimary must gate the writer too.
-func (rt *ReplTracker) OnStateChange(_ context.Context, isConsensusLeader, postgresPrimary bool, servingStatus clustermetadatapb.PoolerServingStatus) error {
-	if isConsensusLeader && postgresPrimary && servingStatus == clustermetadatapb.PoolerServingStatus_SERVING {
+// The writer runs only when this pooler is writable AND serving; otherwise the
+// reader runs. Writability (postgres out of recovery AND highest committed
+// leader) is exactly the gate the writer needs — writing heartbeats to a standby
+// or a deposed primary fails every interval and spams the log.
+func (rt *ReplTracker) OnStateChange(_ context.Context, state servingstate.State) error {
+	if state.Writable && state.ServingStatus == clustermetadatapb.PoolerServingStatus_SERVING {
 		rt.makePrimary()
 	} else {
 		rt.makeNonPrimary()

--- a/go/services/multipooler/internal/heartbeat/repltracker_test.go
+++ b/go/services/multipooler/internal/heartbeat/repltracker_test.go
@@ -22,6 +22,7 @@ import (
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor/mock"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -156,9 +157,11 @@ func TestReplTrackerOnStateChangeGating(t *testing.T) {
 			wantPrimary:       false,
 		},
 		{
-			name:              "writable but not leader -> writer stays off",
+			// A non-leader is never writable (Writable encodes committed
+			// leadership), so the not-writable gate keeps the writer off.
+			name:              "not leader, not writable -> writer stays off",
 			isConsensusLeader: false,
-			postgresPrimary:   true,
+			postgresPrimary:   false,
 			servingStatus:     clustermetadatapb.PoolerServingStatus_SERVING,
 			wantPrimary:       false,
 		},
@@ -190,7 +193,7 @@ func TestReplTrackerOnStateChangeGating(t *testing.T) {
 			rt := NewReplTracker(queryService, slog.Default(), []byte("test-shard"), "test-pooler", 250)
 			defer rt.Close()
 
-			err := rt.OnStateChange(context.Background(), tt.isConsensusLeader, tt.postgresPrimary, tt.servingStatus)
+			err := rt.OnStateChange(context.Background(), servingstate.State{IsHighestKnownLeader: tt.isConsensusLeader, Writable: tt.postgresPrimary, ServingStatus: tt.servingStatus})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantPrimary, rt.IsPrimary())
 			assert.Equal(t, tt.wantPrimary, rt.hw.IsOpen(), "writer open state must match primary mode")

--- a/go/services/multipooler/internal/manager/graceful_shutdown_test.go
+++ b/go/services/multipooler/internal/manager/graceful_shutdown_test.go
@@ -117,7 +117,7 @@ func newGracefulShutdownTestManager(t *testing.T, pgctldClient pgctldpb.PgCtldCl
 		// GracefulShutdown transitions serving state to DISABLED; wire a real
 		// StateManager (fanning out to the healthStreamer) so the shutdown path
 		// runs as in production rather than relying on a nil-check.
-		stateManager: NewStateManager(logger, record, hs),
+		stateManager: NewStateManager(logger, record, func() bool { return true }, hs),
 	}
 }
 

--- a/go/services/multipooler/internal/manager/health_provider.go
+++ b/go/services/multipooler/internal/manager/health_provider.go
@@ -23,6 +23,7 @@ import (
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/poolerserver"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 const (
@@ -127,27 +128,27 @@ func (hs *healthStreamer) UpdateLeaderObservation(obs *poolerserver.LeaderObserv
 // discovering the new primary before the pooler can actually serve that type.
 // not-serving transitions broadcast immediately so the gateway can start
 // buffering without delay.
-func (hs *healthStreamer) OnStateChange(ctx context.Context, isConsensusLeader, postgresPrimary bool, servingStatus clustermetadatapb.PoolerServingStatus) error {
-	if servingStatus == clustermetadatapb.PoolerServingStatus_SERVING && hs.queryServer != nil {
-		hs.queryServer.AwaitStateChange(ctx, isConsensusLeader, servingStatus)
+func (hs *healthStreamer) OnStateChange(ctx context.Context, state servingstate.State) error {
+	if state.ServingStatus == clustermetadatapb.PoolerServingStatus_SERVING && hs.queryServer != nil {
+		hs.queryServer.AwaitStateChange(ctx, state.IsHighestKnownLeader, state.ServingStatus)
 	}
 
 	hs.mu.Lock()
 	defer hs.mu.Unlock()
 
 	prev := hs.servingStatus
-	// The health stream still reports the PoolerType routing label to the gateway.
-	// PoolerType tracks the consensus term (leadership), not postgres writability —
-	// a leader can be the term leader before it has finished promoting. Translate
-	// the leader fact to the wire label: a non-leader is a read replica for routing.
-	hs.poolerType = poolerTypeForLeader(isConsensusLeader)
-	// writable is published separately so the gateway gates write traffic on actual
-	// write-readiness (postgres out of recovery), not on leadership.
-	hs.writable = postgresPrimary
-	hs.servingStatus = servingStatus
+	// The health stream reports the PoolerType routing label from highest-known
+	// leadership (the consensus term), not writability — a node can be the term
+	// leader before it has finished promoting. A non-leader is a read replica for
+	// routing.
+	hs.poolerType = poolerTypeForLeader(state.IsHighestKnownLeader)
+	// writable is published separately so the gateway gates write traffic on
+	// write-safety (out of recovery AND highest committed leader), not routing.
+	hs.writable = state.Writable
+	hs.servingStatus = state.ServingStatus
 	hs.broadcastLocked()
-	if prev != servingStatus {
-		hs.metrics.recordTransition(ctx, prev, servingStatus)
+	if prev != state.ServingStatus {
+		hs.metrics.recordTransition(ctx, prev, state.ServingStatus)
 	}
 	return nil
 }

--- a/go/services/multipooler/internal/manager/health_provider_test.go
+++ b/go/services/multipooler/internal/manager/health_provider_test.go
@@ -26,6 +26,7 @@ import (
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/poolerserver"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 func TestHealthStreamer_BroadcastToSubscribers(t *testing.T) {
@@ -44,7 +45,7 @@ func TestHealthStreamer_BroadcastToSubscribers(t *testing.T) {
 	assert.Equal(t, 2, hs.clientCount())
 
 	// Update state (triggers broadcast)
-	require.NoError(t, hs.OnStateChange(context.Background(), false, false, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, hs.OnStateChange(context.Background(), servingstate.State{IsHighestKnownLeader: false, Writable: false, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// Both clients should receive the state
 	timeout1 := time.After(100 * time.Millisecond)
@@ -75,7 +76,7 @@ func TestHealthStreamer_SubscribeReceivesCurrentState(t *testing.T) {
 	hs := newHealthStreamer(logger, serviceID, "initial", "0")
 
 	// Set initial state via OnStateChange
-	require.NoError(t, hs.OnStateChange(context.Background(), false, false, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, hs.OnStateChange(context.Background(), servingstate.State{IsHighestKnownLeader: false, Writable: false, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// Subscribe should return current state
 	state, _ := hs.subscribe()
@@ -101,7 +102,7 @@ func TestHealthStreamer_FullBufferClosesChannel(t *testing.T) {
 
 	// Send more than buffer size without draining
 	for range defaultHealthStreamBufferSize + 5 {
-		require.NoError(t, hs.OnStateChange(context.Background(), false, false, clustermetadatapb.PoolerServingStatus_SERVING))
+		require.NoError(t, hs.OnStateChange(context.Background(), servingstate.State{IsHighestKnownLeader: false, Writable: false, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	}
 
 	// Channel should be closed due to buffer overflow
@@ -139,7 +140,7 @@ func TestHealthStreamer_GetState(t *testing.T) {
 	assert.Equal(t, clustermetadatapb.PoolerServingStatus_DISABLED, got.ServingStatus)
 
 	// Update and verify
-	require.NoError(t, hs.OnStateChange(context.Background(), false, false, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, hs.OnStateChange(context.Background(), servingstate.State{IsHighestKnownLeader: false, Writable: false, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	got = hs.getState()
 	assert.Equal(t, clustermetadatapb.PoolerServingStatus_SERVING, got.ServingStatus)
 }
@@ -238,7 +239,7 @@ func TestHealthStreamer_OnStateChange(t *testing.T) {
 	_, ch := hs.subscribe()
 
 	// Call OnStateChange — updates both fields atomically with one broadcast
-	err := hs.OnStateChange(context.Background(), true, true, clustermetadatapb.PoolerServingStatus_SERVING)
+	err := hs.OnStateChange(context.Background(), servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING})
 	require.NoError(t, err)
 
 	// Verify subscriber receives a single broadcast with both fields updated
@@ -317,7 +318,7 @@ func TestHealthStreamer_WaitsForQueryServerOnServing(t *testing.T) {
 	// It should block because qps hasn't transitioned yet.
 	hsDone := make(chan struct{})
 	go func() {
-		_ = hs.OnStateChange(t.Context(), true, true, clustermetadatapb.PoolerServingStatus_SERVING)
+		_ = hs.OnStateChange(t.Context(), servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING})
 		close(hsDone)
 	}()
 
@@ -329,7 +330,7 @@ func TestHealthStreamer_WaitsForQueryServerOnServing(t *testing.T) {
 	}
 
 	// Now transition the query server.
-	require.NoError(t, qps.OnStateChange(t.Context(), true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, qps.OnStateChange(t.Context(), servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// Health streamer should unblock and broadcast.
 	select {
@@ -355,7 +356,7 @@ func TestHealthStreamer_DoesNotWaitOnNotServing(t *testing.T) {
 
 	// Create a query server that is PRIMARY/SERVING.
 	qps := poolerserver.NewQueryPoolerServer(logger, nil, nil, "", "", nil, 0, false)
-	require.NoError(t, qps.OnStateChange(t.Context(), true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, qps.OnStateChange(t.Context(), servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	hs.SetQueryServer(qps)
 
 	ch := make(chan *poolerserver.HealthState, 10)
@@ -364,7 +365,7 @@ func TestHealthStreamer_DoesNotWaitOnNotServing(t *testing.T) {
 	// DISABLED should broadcast immediately, even though qps is still PRIMARY/SERVING.
 	hsDone := make(chan struct{})
 	go func() {
-		_ = hs.OnStateChange(t.Context(), false, false, clustermetadatapb.PoolerServingStatus_DISABLED)
+		_ = hs.OnStateChange(t.Context(), servingstate.State{IsHighestKnownLeader: false, Writable: false, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
 		close(hsDone)
 	}()
 
@@ -387,17 +388,21 @@ func TestHealthStreamer_PublishesWritability(t *testing.T) {
 	hs.clients[ch] = struct{}{}
 
 	// Leader, SERVING (can answer reads), but postgres still in recovery: not writable.
-	require.NoError(t, hs.OnStateChange(t.Context(),
-		true /* isConsensusLeader */, false, /* postgresPrimary */
-		clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, hs.OnStateChange(t.Context(), servingstate.State{
+		IsHighestKnownLeader: true,
+		Writable:             false,
+		ServingStatus:        clustermetadatapb.PoolerServingStatus_SERVING,
+	}))
 	st := <-ch
 	assert.Equal(t, clustermetadatapb.PoolerServingStatus_SERVING, st.ServingStatus)
 	assert.False(t, st.Writable, "leader still in recovery must not advertise writable")
 
 	// Promotion completes (out of recovery): now writable.
-	require.NoError(t, hs.OnStateChange(t.Context(),
-		true /* isConsensusLeader */, true, /* postgresPrimary */
-		clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, hs.OnStateChange(t.Context(), servingstate.State{
+		IsHighestKnownLeader: true,
+		Writable:             true,
+		ServingStatus:        clustermetadatapb.PoolerServingStatus_SERVING,
+	}))
 	st = <-ch
 	assert.True(t, st.Writable, "writable once postgres leaves recovery")
 }

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -369,7 +369,7 @@ func newMultiPoolerManager(logger *slog.Logger, multiPooler *clustermetadatapb.M
 
 	// Create the serving state manager with the query service and health streamer as initial components.
 	// The ReplTracker is registered later when heartbeat is started.
-	pm.stateManager = NewStateManager(logger, pm.record, pm.qsc, pm.healthStreamer)
+	pm.stateManager = NewStateManager(logger, pm.record, pm.isHighestNonRevokedCommittedLeader, pm.qsc, pm.healthStreamer)
 
 	// Construct the pgBackRest engine. It owns all pgBackRest interaction and its
 	// own metrics. The pgbackrest.conf path, pgpass file, and repo config are
@@ -1577,7 +1577,7 @@ func (pm *MultiPoolerManager) updateTopologyAfterPromotion(ctx context.Context, 
 	// it. Mutate is idempotent — if already at this state it short-circuits.
 	if err := pm.stateManager.Mutate(ctx, func(s *servingStateMutation) {
 		s.SelfLeadership = pm.leaderObs(rule)
-		s.PostgresPrimary = true
+		s.InRecovery = false // promotion already waited for postgres to leave recovery
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	}); err != nil {
 		return mterrors.Wrap(err, "failed to set serving state for promotion")

--- a/go/services/multipooler/internal/manager/metrics_test.go
+++ b/go/services/multipooler/internal/manager/metrics_test.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 	"github.com/multigres/multigres/go/tools/telemetry"
 )
 
@@ -82,20 +83,26 @@ func TestServingTransitions(t *testing.T) {
 	ctx := t.Context()
 
 	// DISABLED (initial) → SERVING records one transition.
-	require.NoError(t, hs.OnStateChange(ctx,
-		true /* isConsensusLeader */, true, /* postgresPrimary */
-		clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, hs.OnStateChange(ctx, servingstate.State{
+		IsHighestKnownLeader: true,
+		Writable:             true,
+		ServingStatus:        clustermetadatapb.PoolerServingStatus_SERVING,
+	}))
 
 	// SERVING → SERVING is a no-op (role change only, leader/primary → replica):
 	// no new transition.
-	require.NoError(t, hs.OnStateChange(ctx,
-		false /* isConsensusLeader */, false, /* postgresPrimary */
-		clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, hs.OnStateChange(ctx, servingstate.State{
+		IsHighestKnownLeader: false,
+		Writable:             false,
+		ServingStatus:        clustermetadatapb.PoolerServingStatus_SERVING,
+	}))
 
 	// SERVING → DISABLED records a second transition.
-	require.NoError(t, hs.OnStateChange(ctx,
-		false /* isConsensusLeader */, false, /* postgresPrimary */
-		clustermetadatapb.PoolerServingStatus_DISABLED))
+	require.NoError(t, hs.OnStateChange(ctx, servingstate.State{
+		IsHighestKnownLeader: false,
+		Writable:             false,
+		ServingStatus:        clustermetadatapb.PoolerServingStatus_DISABLED,
+	}))
 
 	m := findMetric(t, reader, "mg.pooler.serving.transitions")
 	sum, ok := m.Data.(metricdata.Sum[int64])

--- a/go/services/multipooler/internal/manager/pg_multischema_test.go
+++ b/go/services/multipooler/internal/manager/pg_multischema_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
 	"github.com/multigres/multigres/go/services/multipooler/internal/poolerserver"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pubsub"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -43,7 +44,7 @@ func (m *mockPoolerController) Open(context.Context) error { return nil }
 func (m *mockPoolerController) Close() error               { return nil }
 func (m *mockPoolerController) IsHealthy() error           { return nil }
 func (m *mockPoolerController) IsServing() bool            { return true }
-func (m *mockPoolerController) OnStateChange(context.Context, bool, bool, clustermetadatapb.PoolerServingStatus) error {
+func (m *mockPoolerController) OnStateChange(context.Context, servingstate.State) error {
 	return nil
 }
 

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -49,7 +49,7 @@ func deriveTypeAndObs(rule *clustermetadatapb.ShardRule, selfID *clustermetadata
 	return clustermetadatapb.PoolerType_REPLICA, nil
 }
 
-// latestRule returns the highest-numbered rule this pooler knows of, combining
+// highestKnownRule returns the highest-numbered rule this pooler knows of, combining
 // the rule it has applied into its own position with the rule it was most
 // recently told to follow via SetPrimary/Promote (consensusPromises's recorded
 // ReplicationPrimary). A standby told of a newer leader before its own position
@@ -63,17 +63,49 @@ func deriveTypeAndObs(rule *clustermetadatapb.ShardRule, selfID *clustermetadata
 // commonconsensus.HighestKnownRule — the same method the orchestrator uses to
 // identify the shard leader — so the pooler and orch can never rank rules
 // differently.
-func (pm *MultiPoolerManager) latestRule() *clustermetadatapb.ShardRule {
+func (pm *MultiPoolerManager) highestKnownRule() *clustermetadatapb.ShardRule {
 	return commonconsensus.HighestKnownRule([]*clustermetadatapb.ConsensusStatus{
 		pm.consensusMgr.CachedConsensusStatus(),
 	})
+}
+
+// highestCommittedRule returns the highest rule this pooler has durably committed
+// into its own CurrentPosition — the leader recorded in the rule store (the
+// WAL-replicated current_rule row). It is the committed counterpart to
+// highestKnownRule, and deliberately EXCLUDES the ReplicationPrimary recorded via
+// SetPrimary/RecordTermPrimary, which can name a leader at a rule number ahead of
+// what we have committed. Returns nil if no position has been observed yet.
+//
+// Leadership terminology used throughout this package:
+//   - "highest committed leader": highestCommittedRule names us. The authority
+//     for write-safety (writable) — durable, never ahead of what we've committed.
+//   - "highest known leader": highestKnownRule names us (also factors in
+//     ReplicationPrimary). Drives the routing label (PoolerType) and
+//     skip-redundant-RPC decisions, and must NOT gate writes.
+func (pm *MultiPoolerManager) highestCommittedRule() *clustermetadatapb.ShardRule {
+	return pm.consensusMgr.Rules().CachedPosition().GetRule()
+}
+
+// isHighestNonRevokedCommittedLeader reports whether this pooler is the highest committed
+// leader: our highest committed rule names us AND that rule has not been revoked.
+// Revocation matters because a Recruit establishing a higher term revokes the
+// lower terms — so being the WAL leader at term 7 does not count once we've
+// recorded a revocation of terms below 8. This is the committed-leadership input
+// to write-safety (writable); a deposed-but-not-yet-demoted primary is excluded.
+func (pm *MultiPoolerManager) isHighestNonRevokedCommittedLeader() bool {
+	rule := pm.highestCommittedRule()
+	role, _ := deriveTypeAndObs(rule, pm.serviceID)
+	if role != clustermetadatapb.PoolerType_PRIMARY {
+		return false
+	}
+	return !commonconsensus.IsRuleRevoked(rule, pm.consensusMgr.Promises().GetInconsistentRevocation())
 }
 
 // intendedRole is the pooler role implied by the highest rule it knows of — the
 // consensus-authoritative source of truth for the published PoolerType,
 // independent of the observed postgres recovery mode.
 func (pm *MultiPoolerManager) intendedRole() clustermetadatapb.PoolerType {
-	t, _ := deriveTypeAndObs(pm.latestRule(), pm.serviceID)
+	t, _ := deriveTypeAndObs(pm.highestKnownRule(), pm.serviceID)
 	return t
 }
 
@@ -123,11 +155,16 @@ func (pm *MultiPoolerManager) staleStandbyDemoteTarget() *clustermetadatapb.Pool
 
 // postgresState represents the state of PostgreSQL for monitoring
 type postgresState struct {
-	pgctldAvailable          bool
-	dirInitialized           bool
-	postgresRunning          bool
-	backupsAvailable         bool
-	isPrimary                bool
+	pgctldAvailable  bool
+	dirInitialized   bool
+	postgresRunning  bool
+	backupsAvailable bool
+	isPrimary        bool
+	// writable is the derived write-safety signal: postgres is out of recovery
+	// (isPrimary) AND our highest unrevoked *committed* rule names us leader. Distinct from
+	// isPrimary (raw recovery, used for stale-primary/resign detection) and from
+	// highest-known leadership (routing). See highestCommittedRule.
+	writable                 bool
 	bootstrapSentinelPresent bool
 	// primaryTerm is the coordinator term at which this pooler is the primary
 	// per the highest known rule. 0 if we are not the primary for that rule.
@@ -146,6 +183,7 @@ func postgresStateEqual(a, b postgresState) bool {
 		a.postgresRunning == b.postgresRunning &&
 		a.backupsAvailable == b.backupsAvailable &&
 		a.isPrimary == b.isPrimary &&
+		a.writable == b.writable &&
 		a.bootstrapSentinelPresent == b.bootstrapSentinelPresent &&
 		a.primaryTerm == b.primaryTerm &&
 		a.rewindSourceReady == b.rewindSourceReady
@@ -228,7 +266,7 @@ func (pm *MultiPoolerManager) monitorPostgresIteration(ctx context.Context) (pos
 	}
 
 	// Determine what remediation is needed
-	action := pm.determineRemedialAction(ctx, currentState, pm.stateManager.isPostgresPrimary())
+	action := pm.determineRemedialAction(ctx, currentState, pm.stateManager.lastAppliedWritable())
 	if action == remedialActionNone {
 		// No action needed - just log status
 		if currentState.postgresRunning {
@@ -258,7 +296,7 @@ func (pm *MultiPoolerManager) monitorPostgresIteration(ctx context.Context) (pos
 	}
 
 	// Re-determine action based on current state
-	action = pm.determineRemedialAction(lockCtx, currentState, pm.stateManager.isPostgresPrimary())
+	action = pm.determineRemedialAction(lockCtx, currentState, pm.stateManager.lastAppliedWritable())
 
 	// Take remedial action with lock held
 	pm.takeRemedialAction(lockCtx, action, currentState)
@@ -332,6 +370,14 @@ func (pm *MultiPoolerManager) discoverPostgresState(ctx context.Context) (postgr
 			cs = pm.consensusMgr.CachedConsensusStatus()
 		}
 		state.primaryTerm = commonconsensus.LeaderTerm(cs)
+
+		// Derive write-safety: out of recovery AND we are the highest committed
+		// leader (committed rule names us and is not revoked). Gated on committed —
+		// not highest-known — leadership, so we never report writable during the
+		// window between pg_promote() and the rule commit, nor as a deposed primary
+		// still running at a revoked term. isPrimary stays the raw recovery fact for
+		// stale-primary/resign detection.
+		state.writable = state.isPrimary && pm.isHighestNonRevokedCommittedLeader()
 	}
 
 	// Check if backups are available (only if directory not initialized)
@@ -451,7 +497,7 @@ func (pm *MultiPoolerManager) primaryConnInfoDiffersFromRecorded(ctx context.Con
 // determineRoleAction returns the action needed to align this pooler's role with
 // the rule-derived intended role: demote a stale primary, resign when the rule
 // names us leader but postgres is a standby, etc.
-func (pm *MultiPoolerManager) determineRoleAction(intended clustermetadatapb.PoolerType, state postgresState, lastAppliedPrimary bool) remedialAction {
+func (pm *MultiPoolerManager) determineRoleAction(intended clustermetadatapb.PoolerType, state postgresState, lastAppliedWritable bool) remedialAction {
 	// Rule: FOLLOWER
 	// Postgres: PRIMARY
 	// Diagnosis: Stale primary. We should restart as a replica, but we anticipate
@@ -484,10 +530,10 @@ func (pm *MultiPoolerManager) determineRoleAction(intended clustermetadatapb.Poo
 	// Here we reconcile the StateManager's effective state against what we've
 	// observed and fix any drift:
 	//   - role drift (e.g. an RPC that timed out before republishing the label);
-	//   - physical primary-ness drift that did not trigger a role action (postgres
-	//     entering/leaving recovery while the role is unchanged — the resign window,
-	//     or recovery clearing again), so the heartbeat writer doesn't spam failed
-	//     writes against a standby;
+	//   - writable drift that did not trigger a role action (write-safety changing
+	//     while the role is unchanged — postgres entering/leaving recovery in the
+	//     resign window, or a committed-leadership change), so the heartbeat writer
+	//     doesn't spam failed writes against a non-writable backend;
 	//   - DRAINING: serving was disabled transiently for an in-place transition
 	//     (demotion) and is re-enabled here once the node is healthy and role-aligned
 	//     — e.g. after a demote restarts the node as a standby, or a demote that
@@ -497,7 +543,7 @@ func (pm *MultiPoolerManager) determineRoleAction(intended clustermetadatapb.Poo
 	//     and restoring SERVING is safe. A resigned leader is handled by the branch
 	//     above.
 	if pm.getPoolerType() != intended ||
-		state.isPrimary != lastAppliedPrimary ||
+		state.writable != lastAppliedWritable ||
 		pm.record.ServingStatus() == clustermetadatapb.PoolerServingStatus_DRAINING {
 		return remedialActionReconcileState
 	}
@@ -541,7 +587,7 @@ func (pm *MultiPoolerManager) determineReplicationSettingsAction(ctx context.Con
 
 // determineRemedialAction decides what action to take based on discovered state.
 // This is pure decision logic with no side effects.
-func (pm *MultiPoolerManager) determineRemedialAction(ctx context.Context, currentState postgresState, lastAppliedPrimary bool) remedialAction {
+func (pm *MultiPoolerManager) determineRemedialAction(ctx context.Context, currentState postgresState, lastAppliedWritable bool) remedialAction {
 	// Pgctld unavailable: No action possible
 	if !currentState.pgctldAvailable {
 		return remedialActionNone
@@ -559,7 +605,7 @@ func (pm *MultiPoolerManager) determineRemedialAction(ctx context.Context, curre
 			// matching the "healthy and role-aligned" contract on PoolerServingStatus.
 			return remedialActionNone
 		}
-		if action := pm.determineRoleAction(intended, currentState, lastAppliedPrimary); action != remedialActionNone {
+		if action := pm.determineRoleAction(intended, currentState, lastAppliedWritable); action != remedialActionNone {
 			return action
 		}
 		if action := pm.determineReplicationSettingsAction(ctx, currentState); action != remedialActionNone {
@@ -665,38 +711,32 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 		// demoted), so the role resolves to REPLICA (nil self-leadership); we just
 		// restarted as a standby, so postgres is no longer primary. Serving status
 		// is unchanged (a healthy standby keeps serving reads).
-		_, obs := deriveTypeAndObs(pm.latestRule(), pm.serviceID)
+		_, obs := deriveTypeAndObs(pm.highestKnownRule(), pm.serviceID)
 		if err := pm.stateManager.Mutate(ctx, func(s *servingStateMutation) {
 			s.SelfLeadership = obs
-			s.PostgresPrimary = false
+			s.InRecovery = true // just restarted as a standby
 		}); err != nil {
 			pm.logger.WarnContext(ctx, "MonitorPostgres: failed to apply role after demote", "error", err)
 		}
 
 	case remedialActionReconcileState:
 		pm.setMonitorReason(ctx, reasonPostgresRunning, "MonitorPostgres: PostgreSQL is running")
-		// The StateManager's effective state has drifted (role, physical
-		// primary-ness, and/or a transient drain). Reconcile in one Mutate: the
-		// leadership obs sets the derived role, and the observed isPrimary syncs the
-		// writable state that gates the heartbeat writer / LISTEN. Serving is
-		// re-enabled only out of DRAINING (the transient drain this loop owns); a
-		// DISABLED pooler (stopping/paused/operator-drained) is left not-serving,
-		// since this case also fires for plain role/primary drift.
-		intended, obs := deriveTypeAndObs(pm.latestRule(), pm.serviceID)
+		// The StateManager's effective state has drifted (role, write-safety,
+		// and/or a transient drain). Reconcile in one Mutate: the leadership obs
+		// sets the derived role, and the derived writable syncs the write-safety
+		// state that gates the heartbeat writer / LISTEN. Serving is re-enabled
+		// only out of DRAINING (the transient drain this loop owns); a DISABLED
+		// pooler (stopping/paused/operator-drained) is left not-serving, since this
+		// case also fires for plain role/writable drift.
+		intended, obs := deriveTypeAndObs(pm.highestKnownRule(), pm.serviceID)
 		pm.logger.InfoContext(ctx, "MonitorPostgres: reconciling state from rule",
-			"intended_role", intended.String(), "postgres_primary", state.isPrimary)
+			"intended_role", intended.String(), "in_recovery", !state.isPrimary)
 		if err := pm.stateManager.Mutate(ctx, func(s *servingStateMutation) {
 			s.SelfLeadership = obs
-			// TODO: There's a subtle but important bug here. We're currently conflating
-			// being a postgres primary (not in recovery mode) with being able to accept
-			// user transactions. Need to gate user transactions on being a primary, and
-			// also being the leader in the most recent non-revoked committed consensus rule.
-			// SelfLeadership actually holds the highest known rule, not the highest non-revoked
-			// locally-committed rule, so the way we're dealing with state here could cause a bug
-			// if a Promote() RPC times out and then this remedial action ends up telling multigateway
-			// that it's ok to send user traffic when we actually never finished consensus propagation
-			// and establishment.
-			s.PostgresPrimary = state.isPrimary
+			// Feed the observed recovery fact; the StateManager derives writable
+			// from it plus the committed-leadership query. (isPrimary == out of
+			// recovery; postgresState keeps that name pending a follow-up rename.)
+			s.InRecovery = !state.isPrimary
 			if s.ServingStatus == clustermetadatapb.PoolerServingStatus_DRAINING {
 				s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 			}
@@ -723,9 +763,9 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 		// the writer keeps issuing INSERTs against a read-only standby every
 		// interval until re-election.
 		if err := pm.stateManager.Mutate(ctx, func(s *servingStateMutation) {
-			s.PostgresPrimary = false
+			s.InRecovery = true // postgres is running as a standby
 		}); err != nil {
-			pm.logger.WarnContext(ctx, "MonitorPostgres: failed to sync postgres primary status on resign", "error", err)
+			pm.logger.WarnContext(ctx, "MonitorPostgres: failed to sync recovery status on resign", "error", err)
 		}
 
 	case remedialActionFixPrimaryConnInfo:

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -362,6 +362,7 @@ func TestDetermineRemedialAction(t *testing.T) {
 				pgctldAvailable: true,
 				postgresRunning: true,
 				isPrimary:       true,
+				writable:        true,
 			},
 			poolerType:      clustermetadatapb.PoolerType_PRIMARY,
 			cachedPos:       selfPos(5, selfID),
@@ -389,6 +390,7 @@ func TestDetermineRemedialAction(t *testing.T) {
 				pgctldAvailable: true,
 				postgresRunning: true,
 				isPrimary:       true,
+				writable:        true,
 			},
 			poolerType:     clustermetadatapb.PoolerType_PRIMARY,
 			cachedPos:      selfPos(5, selfID),
@@ -474,10 +476,10 @@ func TestDetermineRemedialAction(t *testing.T) {
 			)
 			tt.state.primaryTerm = tt.primaryTerm
 
-			// lastAppliedPrimary == state.isPrimary: this table exercises role,
-			// demote, resign and GUC decisions, not physical-primary drift (covered
+			// lastAppliedWritable == state.writable: this table exercises role,
+			// demote, resign and GUC decisions, not writable drift (covered
 			// separately), so pass no drift here.
-			got := pm.determineRemedialAction(t.Context(), tt.state, tt.state.isPrimary)
+			got := pm.determineRemedialAction(t.Context(), tt.state, tt.state.writable)
 			require.Equal(t, tt.expectedAction, got)
 		})
 	}
@@ -511,20 +513,21 @@ func TestDetermineRemedialAction_PrimaryDrift(t *testing.T) {
 		)
 	}
 
-	runningPrimary := postgresState{pgctldAvailable: true, postgresRunning: true, isPrimary: true}
+	runningPrimary := postgresState{pgctldAvailable: true, postgresRunning: true, isPrimary: true, writable: true}
 
 	t.Run("primary drift reconciles", func(t *testing.T) {
 		pm := newAlignedPrimaryManager(clustermetadatapb.PoolerServingStatus_SERVING)
-		// Components last saw a standby (false) but postgres is now a primary (true).
-		got := pm.determineRemedialAction(t.Context(), runningPrimary, false /* lastAppliedPrimary */)
+		// Components last saw a non-writable backend (false) but postgres is now
+		// writable (true): the writable drift must reconcile.
+		got := pm.determineRemedialAction(t.Context(), runningPrimary, false /* lastAppliedWritable */)
 		require.Equal(t, remedialActionReconcileState, got)
 	})
 
 	t.Run("draining reconciles", func(t *testing.T) {
-		// Role and primary aligned, but serving was left DRAINING (e.g. a demotion
+		// Role and writability aligned, but serving was left DRAINING (e.g. a demotion
 		// that errored before re-serving). The monitor re-enables it.
 		pm := newAlignedPrimaryManager(clustermetadatapb.PoolerServingStatus_DRAINING)
-		got := pm.determineRemedialAction(t.Context(), runningPrimary, true /* lastAppliedPrimary */)
+		got := pm.determineRemedialAction(t.Context(), runningPrimary, true /* lastAppliedWritable */)
 		require.Equal(t, remedialActionReconcileState, got)
 	})
 
@@ -532,13 +535,13 @@ func TestDetermineRemedialAction_PrimaryDrift(t *testing.T) {
 		// DISABLED is a deliberate non-serving state (stopping/paused/operator);
 		// the monitor must NOT auto-re-enable it.
 		pm := newAlignedPrimaryManager(clustermetadatapb.PoolerServingStatus_DISABLED)
-		got := pm.determineRemedialAction(t.Context(), runningPrimary, true /* lastAppliedPrimary */)
+		got := pm.determineRemedialAction(t.Context(), runningPrimary, true /* lastAppliedWritable */)
 		require.Equal(t, remedialActionNone, got)
 	})
 
 	t.Run("no drift is a no-op", func(t *testing.T) {
 		pm := newAlignedPrimaryManager(clustermetadatapb.PoolerServingStatus_SERVING)
-		got := pm.determineRemedialAction(t.Context(), runningPrimary, true /* lastAppliedPrimary */)
+		got := pm.determineRemedialAction(t.Context(), runningPrimary, true /* lastAppliedWritable */)
 		require.Equal(t, remedialActionNone, got)
 	})
 }
@@ -638,7 +641,9 @@ func TestDetermineRemedialAction_StalePrimaryDemote(t *testing.T) {
 				withRuleStore(&fakeRuleStore{pos: tt.cachedPos}),
 			)
 
-			got := pm.determineRemedialAction(t.Context(), runningPrimary, runningPrimary.isPrimary)
+			// No writable drift here: pass the state's own writable so this table
+			// isolates the demote-vs-wait decision (covered by writable drift separately).
+			got := pm.determineRemedialAction(t.Context(), runningPrimary, runningPrimary.writable)
 			require.Equal(t, tt.expectedAction, got)
 		})
 	}

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -667,14 +667,14 @@ func (pm *MultiPoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 	// step on its replica branch for the same reason.
 	// A REPLICA pooler record carries no self leadership observation.
 	// Republish REPLICA (clear any stale PRIMARY self-leadership) so the
-	// stale-leader analyzer stops firing, and sync physical primary-ness: we
-	// just restarted as a standby, so postgres is no longer primary and the
-	// published writable signal must reflect that immediately rather than
-	// waiting a monitor cycle. Serving status is owned by the lifecycle and the
-	// monitor's reconcileState, not by "here is your primary" bookkeeping.
+	// stale-leader analyzer stops firing, and sync the recovery fact: we just
+	// restarted as a standby, so the derived writable signal must reflect that
+	// immediately rather than waiting a monitor cycle. Serving status is owned by
+	// the lifecycle and the monitor's reconcileState, not by "here is your
+	// primary" bookkeeping.
 	if err := pm.stateManager.Mutate(ctx, func(s *servingStateMutation) {
 		s.SelfLeadership = nil
-		s.PostgresPrimary = false
+		s.InRecovery = true // just restarted as a standby
 	}); err != nil {
 		pm.logger.WarnContext(ctx, "Failed to update pooler type to REPLICA after SetPrimary", "error", err)
 	}

--- a/go/services/multipooler/internal/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/internal/manager/rpc_initialization_test.go
@@ -277,7 +277,7 @@ func newRemedialActionTestManager(t *testing.T, multipooler *clustermetadatapb.M
 		record:       record,
 		serviceID:    multipooler.Id,
 		topoClient:   ts,
-		stateManager: NewStateManager(slog.Default(), record),
+		stateManager: NewStateManager(slog.Default(), record, func() bool { return true }),
 		consensusMgr: cfg.consensusManager(t),
 	}
 	cfg.seedLockedState(t, pm)

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -756,12 +756,13 @@ func (pm *MultiPoolerManager) demoteToStandbyLocked(ctx context.Context, consens
 
 	// Re-enable serving now that we're back as a healthy standby: the drain
 	// existed only to gracefully restart, so there's no reason to make reads wait
-	// for the monitor. postgresPrimary=false keeps the heartbeat writer off (we're
-	// a standby); the role stays as the record holds it until the monitor
-	// reconciles it to the rule-derived role. Leaving DRAINING for the monitor is
-	// only the fallback for the error paths above that return before this point.
+	// for the monitor. InRecovery=true keeps the heartbeat writer off (we're a
+	// standby) via the derived writable; the role stays as the record holds it
+	// until the monitor reconciles it to the rule-derived role. Leaving DRAINING
+	// for the monitor is only the fallback for the error paths above that return
+	// before this point.
 	if err := pm.stateManager.Mutate(ctx, func(s *servingStateMutation) {
-		s.PostgresPrimary = false
+		s.InRecovery = true // back as a healthy standby
 		if s.ServingStatus == clustermetadatapb.PoolerServingStatus_DRAINING {
 			s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 		}

--- a/go/services/multipooler/internal/manager/state_manager.go
+++ b/go/services/multipooler/internal/manager/state_manager.go
@@ -23,29 +23,32 @@ import (
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 // StateAware is implemented by components that need to react to serving state changes.
 // Each component decides internally what action to take based on the target state.
-// For example, a heartbeat component starts writing when it is the writable leader
-// and serving, while a query service component adjusts which queries it accepts.
+// For example, a heartbeat component starts writing when it is writable and
+// serving, while a query service component adjusts which queries it accepts.
 type StateAware interface {
 	// OnStateChange is called when the effective serving state changes; the
-	// component transitions to match it.
-	//
-	// isConsensusLeader reports whether this pooler is the consensus-elected
-	// leader (the shard's write target). postgresPrimary reports the physical
-	// recovery state (!pg_is_in_recovery): being the leader does NOT imply
-	// postgres is out of recovery, so components that need a writable backend
-	// (heartbeat writer, LISTEN/NOTIFY) must require both. servingStatus is the
-	// serving intent.
-	OnStateChange(ctx context.Context, isConsensusLeader, postgresPrimary bool, servingStatus clustermetadatapb.PoolerServingStatus) error
+	// component transitions to match it. See servingstate.State for the meaning
+	// of each field (notably IsHighestKnownLeader for routing vs Writable for
+	// write-safety).
+	OnStateChange(ctx context.Context, state servingstate.State) error
 }
 
 // StateManager coordinates serving state transitions across components.
 //
 // The current state lives in the poolerRecord (Type and ServingStatus),
 // which is the source of truth for topology.
+//
+// Writability is computed, not stored: the StateManager caches only inRecovery
+// (the one input it can't derive — an async postgres observation it is told of)
+// and recomputes writable = !inRecovery && committedLeader() live. So a
+// revocation or a new committed-rule observation flips writability with no
+// stored copy to update; callers poke the facts (recovery, leadership, serving),
+// never writable directly.
 //
 // On Mutate, the manager fans out OnStateChange to all registered components
 // in parallel, waits for completion, then updates the record via Mutate. The
@@ -59,41 +62,63 @@ type StateManager struct {
 	// is the exclusive caller of record.Mutate for Type/ServingStatus.
 	record *poolerRecord
 
-	// postgresPrimary is the physical recovery state (!pg_is_in_recovery), fed by
-	// the postgres monitor via Mutate's PostgresPrimary field. Unlike
-	// Type/ServingStatus it is local-only and never published to topology. Guarded by mu.
-	postgresPrimary bool
+	// inRecovery is whether postgres is in recovery (a standby — not a writable
+	// backend), fed by the postgres monitor via Mutate's InRecovery field. It is
+	// the one write-safety input the StateManager cannot compute itself (an async
+	// postgres observation). Local-only, never published to topology. Guarded by mu.
+	inRecovery bool
+
+	// committedLeader reports whether our highest non-revoked committed rule names
+	// us — the consensus half of write-safety. Injected (a downward capability,
+	// queried live rather than stored) so the StateManager recomputes writability
+	// from the rule store + revocation on demand: a revocation or new committed-rule
+	// observation flips writable without any explicit set. See writableLocked.
+	committedLeader func() bool
 
 	// lastFannedOut is the effective state most recently delivered to components,
 	// or nil if none has been yet. Used to skip redundant fan-outs: components
-	// react to the (leader, postgresPrimary, servingStatus) tuple, and distinct
-	// PoolerTypes (REPLICA vs UNKNOWN) collapse to the same tuple, so a record-only
-	// change that leaves the tuple identical must not re-notify components.
-	lastFannedOut *effectiveState
+	// react to the (IsHighestKnownLeader, Writable, ServingStatus) tuple, and
+	// distinct PoolerTypes (REPLICA vs UNKNOWN) collapse to the same tuple, so a
+	// record-only change that leaves the tuple identical must not re-notify.
+	lastFannedOut *servingstate.State
 
 	// Registered components that react to state changes.
 	components []StateAware
 }
 
-// effectiveState is what registered components react to, distinct from the
-// topology record's PoolerType/ServingStatus: leader is the consensus-leadership
-// fact, postgresPrimary the physical recovery state.
-type effectiveState struct {
-	leader          bool
-	postgresPrimary bool
-	servingStatus   clustermetadatapb.PoolerServingStatus
-}
-
-// NewStateManager creates a new StateManager.
+// NewStateManager creates a new StateManager. committedLeader is the live
+// committed-leadership query (whether our highest non-revoked committed rule
+// names us); the StateManager combines it with its cached recovery state to
+// compute writability.
 func NewStateManager(
 	logger *slog.Logger,
 	record *poolerRecord,
+	committedLeader func() bool,
 	components ...StateAware,
 ) *StateManager {
 	return &StateManager{
-		logger:     logger,
-		record:     record,
-		components: components,
+		logger:          logger,
+		record:          record,
+		committedLeader: committedLeader,
+		components:      components,
+	}
+}
+
+// writableLocked computes the live write-safety signal: postgres out of recovery
+// AND we are the highest non-revoked committed leader. Caller must hold mu.
+func (ssm *StateManager) writableLocked() bool {
+	return !ssm.inRecovery && ssm.committedLeader()
+}
+
+// effectiveStateLocked builds the servingstate.State components react to from the
+// given mutation result. IsHighestKnownLeader is the self-leadership observation
+// being non-nil (highest-known leadership, the PoolerType source); Writable is
+// recomputed live from recovery + committed leadership. Caller must hold mu.
+func (ssm *StateManager) effectiveStateLocked(m servingStateMutation) servingstate.State {
+	return servingstate.State{
+		IsHighestKnownLeader: m.SelfLeadership != nil,
+		Writable:             !m.InRecovery && ssm.committedLeader(),
+		ServingStatus:        m.ServingStatus,
 	}
 }
 
@@ -114,16 +139,16 @@ func (ssm *StateManager) RegisterAndSync(ctx context.Context, component StateAwa
 	ssm.mu.Lock()
 	defer ssm.mu.Unlock()
 	ssm.components = append(ssm.components, component)
-	return component.OnStateChange(ctx, ssm.record.SelfLeadership() != nil, ssm.postgresPrimary, ssm.record.ServingStatus())
+	return component.OnStateChange(ctx, servingstate.State{
+		IsHighestKnownLeader: ssm.record.SelfLeadership() != nil,
+		Writable:             ssm.writableLocked(),
+		ServingStatus:        ssm.record.ServingStatus(),
+	})
 }
 
 // fanOutLocked notifies every registered component of the target effective state
 // in parallel and waits for them to converge. Caller must hold mu.
-//
-// Leadership — whether this pooler is the consensus-elected write target — is the
-// self-leadership observation being non-nil, the consensus fact from which the
-// PoolerType routing label is derived. Components react to that fact, not the label.
-func (ssm *StateManager) fanOutLocked(ctx context.Context, target effectiveState) error {
+func (ssm *StateManager) fanOutLocked(ctx context.Context, target servingstate.State) error {
 	if ssm.lastFannedOut != nil && *ssm.lastFannedOut == target {
 		// Components are already at this effective state; nothing to notify.
 		return nil
@@ -131,7 +156,7 @@ func (ssm *StateManager) fanOutLocked(ctx context.Context, target effectiveState
 	g, ctx := errgroup.WithContext(ctx)
 	for _, c := range ssm.components {
 		g.Go(func() error {
-			return c.OnStateChange(ctx, target.leader, target.postgresPrimary, target.servingStatus)
+			return c.OnStateChange(ctx, target)
 		})
 	}
 	if err := g.Wait(); err != nil {
@@ -147,15 +172,17 @@ func (ssm *StateManager) fanOutLocked(ctx context.Context, target effectiveState
 // servingStateMutation is the mutable view passed to Mutate. A callback changes
 // any subset of fields and sees the previous values; fields it leaves alone are
 // carried forward. SelfLeadership and ServingStatus are topology-backed (persisted
-// to the poolerRecord); PostgresPrimary is local-only physical state.
+// to the poolerRecord); InRecovery is the local-only recovery observation. There
+// is deliberately no Writable field — writability is derived from InRecovery and
+// the committed-leadership query, never set directly.
 //
-// There is deliberately no PoolerType field: the consensus-leadership observation
-// is the source of truth, and PoolerType (PRIMARY iff a self-leadership obs is
-// held, REPLICA otherwise) is derived from it when persisting the record.
+// There is also no PoolerType field: the consensus-leadership observation is the
+// source of truth, and PoolerType (PRIMARY iff a self-leadership obs is held,
+// REPLICA otherwise) is derived from it when persisting the record.
 type servingStateMutation struct {
-	SelfLeadership  *clustermetadatapb.LeaderObservation
-	PostgresPrimary bool
-	ServingStatus   clustermetadatapb.PoolerServingStatus
+	SelfLeadership *clustermetadatapb.LeaderObservation
+	InRecovery     bool
+	ServingStatus  clustermetadatapb.PoolerServingStatus
 }
 
 // Mutate applies fn to the current state, fans the resulting effective state out
@@ -164,10 +191,10 @@ type servingStateMutation struct {
 // leaves alone are preserved.
 //
 // The action lock is always required: record.Mutate asserts it for topology
-// writes, and routing physical-state changes through the same gate keeps a
-// recovery flip from racing a role transition. It is asserted up front, before
-// fanning out, so a caller without the lock cannot half-transition the components
-// and only fail later at record.Mutate.
+// writes, and routing recovery changes through the same gate keeps a recovery
+// flip from racing a role transition. It is asserted up front, before fanning
+// out, so a caller without the lock cannot half-transition the components and
+// only fail later at record.Mutate.
 //
 // PoolerType is derived from the leadership observation, and the poolerRecord
 // enforces the Type ⇔ SelfLeadership invariant.
@@ -180,9 +207,9 @@ func (ssm *StateManager) Mutate(ctx context.Context, fn func(s *servingStateMuta
 	defer ssm.mu.Unlock()
 
 	cur := servingStateMutation{
-		SelfLeadership:  ssm.record.SelfLeadership(),
-		PostgresPrimary: ssm.postgresPrimary,
-		ServingStatus:   ssm.record.ServingStatus(),
+		SelfLeadership: ssm.record.SelfLeadership(),
+		InRecovery:     ssm.inRecovery,
+		ServingStatus:  ssm.record.ServingStatus(),
 	}
 	next := cur
 	fn(&next)
@@ -192,28 +219,32 @@ func (ssm *StateManager) Mutate(ctx context.Context, fn func(s *servingStateMuta
 	// new rule number) is published via UpdateLeaderObservation, not here.
 	leaderChanged := (next.SelfLeadership != nil) != (cur.SelfLeadership != nil)
 	servingChanged := next.ServingStatus != cur.ServingStatus
-	primaryChanged := next.PostgresPrimary != cur.PostgresPrimary
-	if !leaderChanged && !servingChanged && !primaryChanged {
+	recoveryChanged := next.InRecovery != cur.InRecovery
+
+	// Writability is recomputed live, so the effective state can differ from what
+	// was last fanned out even when fn changed nothing here (e.g. a revocation
+	// flipped committed leadership). Compare the freshly computed effective state,
+	// not just the mutated fields, so such a change still re-notifies.
+	nextEffective := ssm.effectiveStateLocked(next)
+	effectiveChanged := ssm.lastFannedOut == nil || *ssm.lastFannedOut != nextEffective
+	if !leaderChanged && !servingChanged && !recoveryChanged && !effectiveChanged {
 		return nil
 	}
 
 	ssm.logger.InfoContext(ctx, "Applying serving state",
-		"leader", next.SelfLeadership != nil, "status", next.ServingStatus, "postgres_primary", next.PostgresPrimary,
-		"prev_leader", cur.SelfLeadership != nil, "prev_status", cur.ServingStatus, "prev_postgres_primary", cur.PostgresPrimary)
+		"leader", nextEffective.IsHighestKnownLeader, "status", nextEffective.ServingStatus,
+		"writable", nextEffective.Writable, "in_recovery", next.InRecovery,
+		"prev_leader", cur.SelfLeadership != nil, "prev_status", cur.ServingStatus, "prev_in_recovery", cur.InRecovery)
 
 	// Fan out first so a failed transition leaves the record untouched. The
-	// fan-out dedups on the effective tuple, so a primary-only or record-only
+	// fan-out dedups on the effective tuple, so a recovery-only or record-only
 	// change that leaves the tuple identical does not re-notify.
-	if err := ssm.fanOutLocked(ctx, effectiveState{
-		leader:          next.SelfLeadership != nil,
-		postgresPrimary: next.PostgresPrimary,
-		servingStatus:   next.ServingStatus,
-	}); err != nil {
+	if err := ssm.fanOutLocked(ctx, nextEffective); err != nil {
 		return err
 	}
-	// Components converged — keep the local physical state in step with what they
-	// received before the (fallible) record write.
-	ssm.postgresPrimary = next.PostgresPrimary
+	// Components converged — keep the local recovery state in step with what they
+	// were computed from before the (fallible) record write.
+	ssm.inRecovery = next.InRecovery
 
 	if leaderChanged || servingChanged {
 		if err := ssm.record.Mutate(ctx, func(s *MutablePoolerRecordState) {
@@ -227,11 +258,21 @@ func (ssm *StateManager) Mutate(ctx context.Context, fn func(s *servingStateMuta
 	return nil
 }
 
-// isPostgresPrimary returns the physical recovery state last applied to
-// components. The monitor compares its fresh observation against this (lock-free)
-// to decide whether a sync under the action lock is needed.
-func (ssm *StateManager) isPostgresPrimary() bool {
+// lastAppliedWritable returns the write-safety value most recently delivered to
+// components (what they currently believe), or false if nothing has been fanned
+// out yet. The monitor compares its freshly recomputed writable against this to
+// decide whether components are stale and a reconcile is needed.
+//
+// This deliberately returns the last-delivered value, NOT a live recompute: if it
+// recomputed live it would already reflect a revocation or recovery change, agree
+// with the monitor's fresh value, and the monitor would detect no drift — leaving
+// components stuck at the old writability. Returning what was last delivered lets
+// the monitor see the divergence and re-notify.
+func (ssm *StateManager) lastAppliedWritable() bool {
 	ssm.mu.Lock()
 	defer ssm.mu.Unlock()
-	return ssm.postgresPrimary
+	if ssm.lastFannedOut == nil {
+		return false
+	}
+	return ssm.lastFannedOut.Writable
 }

--- a/go/services/multipooler/internal/manager/state_manager_test.go
+++ b/go/services/multipooler/internal/manager/state_manager_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 // testComponent records state transitions for testing.
@@ -36,15 +37,15 @@ type testComponent struct {
 	err         error // if set, OnStateChange returns this error
 }
 
-func (c *testComponent) OnStateChange(_ context.Context, isConsensusLeader, postgresPrimary bool, servingStatus clustermetadatapb.PoolerServingStatus) error {
+func (c *testComponent) OnStateChange(_ context.Context, state servingstate.State) error {
 	c.callCount++
 	if c.err != nil {
 		return c.err
 	}
 	// Record the derived PoolerType so existing assertions keep reading lastType.
-	c.lastType = poolerTypeForLeader(isConsensusLeader)
-	c.lastPrimary = postgresPrimary
-	c.lastStatus = servingStatus
+	c.lastType = poolerTypeForLeader(state.IsHighestKnownLeader)
+	c.lastPrimary = state.Writable
+	c.lastStatus = state.ServingStatus
 	return nil
 }
 
@@ -53,7 +54,7 @@ type slowComponent struct {
 	called atomic.Bool
 }
 
-func (c *slowComponent) OnStateChange(_ context.Context, _, _ bool, _ clustermetadatapb.PoolerServingStatus) error {
+func (c *slowComponent) OnStateChange(_ context.Context, _ servingstate.State) error {
 	c.called.Store(true)
 	return nil
 }
@@ -105,7 +106,7 @@ func TestStateManager_SetState_PrimaryServing(t *testing.T) {
 	comp := &testComponent{}
 	r := newTestRecord(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED)
 
-	ssm := NewStateManager(newTestLogger(), r, comp)
+	ssm := NewStateManager(newTestLogger(), r, func() bool { return true }, comp)
 
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
 		s.SelfLeadership = primaryObs()
@@ -127,7 +128,7 @@ func TestStateManager_SetState_NotServing(t *testing.T) {
 	comp := &testComponent{}
 	r := newTestRecord(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
 
-	ssm := NewStateManager(newTestLogger(), r, comp)
+	ssm := NewStateManager(newTestLogger(), r, func() bool { return true }, comp)
 
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
 		s.SelfLeadership = primaryObs()
@@ -146,7 +147,7 @@ func TestStateManager_SetState_ComponentError(t *testing.T) {
 	comp := &testComponent{err: errors.New("transition failed")}
 	r := newTestRecord(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
 
-	ssm := NewStateManager(newTestLogger(), r, comp)
+	ssm := NewStateManager(newTestLogger(), r, func() bool { return true }, comp)
 
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
 		s.SelfLeadership = nil
@@ -167,7 +168,7 @@ func TestStateManager_DemotionFlow(t *testing.T) {
 	comp := &testComponent{}
 	r := newTestRecord(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
 
-	ssm := NewStateManager(newTestLogger(), r, comp)
+	ssm := NewStateManager(newTestLogger(), r, func() bool { return true }, comp)
 
 	// Step 1: Stop serving
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
@@ -205,7 +206,7 @@ func TestStateManager_MultipleComponents(t *testing.T) {
 	comp2 := &testComponent{}
 	r := newTestRecord(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED)
 
-	ssm := NewStateManager(newTestLogger(), r, comp1, comp2)
+	ssm := NewStateManager(newTestLogger(), r, func() bool { return true }, comp1, comp2)
 
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
 		s.SelfLeadership = primaryObs()
@@ -225,7 +226,7 @@ func TestStateManager_MultipleComponents_OneError(t *testing.T) {
 	comp2 := &testComponent{err: errors.New("comp2 failed")}
 	r := newTestRecord(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
 
-	ssm := NewStateManager(newTestLogger(), r, comp1, comp2)
+	ssm := NewStateManager(newTestLogger(), r, func() bool { return true }, comp1, comp2)
 
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
 		s.SelfLeadership = nil
@@ -244,7 +245,7 @@ func TestStateManager_Register(t *testing.T) {
 	comp2 := &testComponent{}
 	r := newTestRecord(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED)
 
-	ssm := NewStateManager(newTestLogger(), r, comp1)
+	ssm := NewStateManager(newTestLogger(), r, func() bool { return true }, comp1)
 
 	// Register a second component after creation.
 	ssm.Register(comp2)
@@ -264,7 +265,7 @@ func TestStateManager_RegisterAndSync(t *testing.T) {
 	r := newTestRecord(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
 
 	// Create manager with no components, then transition state.
-	ssm := NewStateManager(newTestLogger(), r)
+	ssm := NewStateManager(newTestLogger(), r, func() bool { return true })
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
 		s.SelfLeadership = primaryObs()
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
@@ -286,6 +287,7 @@ func TestStateManager_RegisterAndSync(t *testing.T) {
 	// A subsequent SetState should notify both the constructor components and the late one.
 	ssm2 := NewStateManager(newTestLogger(),
 		newTestRecord(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED),
+		func() bool { return true },
 		comp1)
 	comp3 := &testComponent{}
 	err = ssm2.RegisterAndSync(context.Background(), comp3)
@@ -296,7 +298,7 @@ func TestStateManager_RegisterAndSync(t *testing.T) {
 
 func TestStateManager_RegisterAndSync_Error(t *testing.T) {
 	r := newTestRecord(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
-	ssm := NewStateManager(newTestLogger(), r)
+	ssm := NewStateManager(newTestLogger(), r, func() bool { return true })
 
 	comp := &testComponent{err: errors.New("sync failed")}
 	err := ssm.RegisterAndSync(context.Background(), comp)
@@ -307,7 +309,7 @@ func TestStateManager_RegisterAndSync_Error(t *testing.T) {
 func TestStateManager_NoComponents(t *testing.T) {
 	r := newTestRecord(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED)
 
-	ssm := NewStateManager(newTestLogger(), r)
+	ssm := NewStateManager(newTestLogger(), r, func() bool { return true })
 
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
 		s.SelfLeadership = primaryObs()
@@ -333,7 +335,7 @@ func TestStateManager_HealthStreamerIntegration(t *testing.T) {
 	comp := &testComponent{}
 	r := newTestRecord(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED)
 
-	ssm := NewStateManager(logger, r, comp, hs)
+	ssm := NewStateManager(logger, r, func() bool { return true }, comp, hs)
 
 	// Subscribe to health stream before state change
 	_, ch := hs.subscribe()
@@ -369,7 +371,7 @@ func TestStateManager_ParallelExecution(t *testing.T) {
 	comp2 := &slowComponent{}
 	r := newTestRecord(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED)
 
-	ssm := NewStateManager(newTestLogger(), r, comp1, comp2)
+	ssm := NewStateManager(newTestLogger(), r, func() bool { return true }, comp1, comp2)
 
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
 		s.SelfLeadership = primaryObs()
@@ -384,7 +386,7 @@ func TestStateManager_ParallelExecution(t *testing.T) {
 func TestStateManager_SetState_RequiresActionLock(t *testing.T) {
 	comp := &testComponent{}
 	r := newTestRecord(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED)
-	ssm := NewStateManager(newTestLogger(), r, comp)
+	ssm := NewStateManager(newTestLogger(), r, func() bool { return true }, comp)
 
 	// No action lock on the context: SetState must reject before doing anything.
 	err := ssm.Mutate(t.Context(), func(s *servingStateMutation) {

--- a/go/services/multipooler/internal/poolerserver/controller.go
+++ b/go/services/multipooler/internal/poolerserver/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/multigres/multigres/go/pb/query"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pubsub"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 // PoolerController defines the control interface for query serving.
@@ -39,20 +40,20 @@ type PoolerController interface {
 	// OnStateChange transitions the query service to match the new serving state.
 	// This is called by StateManager during state transitions.
 	//
-	// isConsensusLeader determines query behavior:
+	// state.IsHighestKnownLeader determines query behavior:
 	//   - leader: Accept reads + writes
 	//   - non-leader (replica): Accept reads only
 	//
-	// postgresPrimary reports the physical recovery state; the query server does
-	// not gate admission on it today (writability surfaces via the leader role and
-	// serving status), but it is part of the uniform StateAware signature.
+	// state.Writable reports write-safety; the query server does not gate
+	// admission on it today (it routes on highest-known leadership, matching the
+	// gateway's PoolerType), but it is part of the uniform state.
 	//
-	// The servingStatus determines whether queries are accepted at all:
+	// state.ServingStatus determines whether queries are accepted at all:
 	//   - SERVING: Accept queries
 	//   - not-serving: Reject all queries
 	//
 	// Returns error if the transition fails.
-	OnStateChange(ctx context.Context, isConsensusLeader, postgresPrimary bool, servingStatus clustermetadatapb.PoolerServingStatus) error
+	OnStateChange(ctx context.Context, state servingstate.State) error
 
 	// StartRequest checks whether a request should be admitted, based on its
 	// RequestKind and the pooler's drain phase. It returns MTF01 (which the

--- a/go/services/multipooler/internal/poolerserver/metrics_test.go
+++ b/go/services/multipooler/internal/poolerserver/metrics_test.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 	"github.com/multigres/multigres/go/tools/telemetry"
 )
 
@@ -117,9 +118,9 @@ func TestDrainMetricGracefulOutcome(t *testing.T) {
 	pooler.gracePeriod = 5 * time.Second
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	// No in-flight connections → WaitForDrain returns immediately.
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_DISABLED))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
 
 	assert.Equal(t, int64(1), readCounterByOutcome(t, reader, "mg.pooler.drain.outcome", "graceful"))
 	assert.Equal(t, int64(0), readCounterByOutcome(t, reader, "mg.pooler.drain.outcome", "force_close"))
@@ -141,11 +142,11 @@ func TestDrainMetricForceCloseOutcome(t *testing.T) {
 	pooler.gracePeriod = 50 * time.Millisecond
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// Simulate an in-flight connection that never returns → WaitForDrain blocks until grace period.
 	mock.regularAdd(1)
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_DISABLED))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
 
 	assert.Equal(t, int64(0), readCounterByOutcome(t, reader, "mg.pooler.drain.outcome", "graceful"))
 	assert.Equal(t, int64(1), readCounterByOutcome(t, reader, "mg.pooler.drain.outcome", "force_close"))
@@ -168,8 +169,8 @@ func TestDrainMetricDurationBuckets(t *testing.T) {
 	pooler.gracePeriod = 50 * time.Millisecond
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_DISABLED))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
 
 	hist := readHistogramFloat64(t, reader, "mg.pooler.drain.duration")
 	require.NotNil(t, hist)

--- a/go/services/multipooler/internal/poolerserver/pooler.go
+++ b/go/services/multipooler/internal/poolerserver/pooler.go
@@ -54,12 +54,18 @@ type QueryPoolerServer struct {
 	shard      string
 
 	mu sync.Mutex
-	// isHighestKnownLeader reports whether this pooler is the consensus-elected
-	// leader (the shard's write target). Set from OnStateChange; replaces the
-	// PoolerType label, which the gateway no longer routes on.
+	// isHighestKnownLeader reports highest-known leadership (the routing signal).
+	// Set from OnStateChange. CONSISTENT reads gate on this — a deposed-but-
+	// running leader can still serve read-consistent queries.
 	isHighestKnownLeader bool
-	servingStatus        clustermetadatapb.PoolerServingStatus
-	healthProvider       HealthProvider
+	// writable is true iff this pooler can accept a write: postgres is out of
+	// recovery AND the last-written committed WAL rule names this pooler as the
+	// (non-revoked) leader. WRITABLE requests gate on this, so a write is never
+	// admitted on the strength of merely highest-known leadership (a mid-promote
+	// or deposed-but-running node).
+	writable       bool
+	servingStatus  clustermetadatapb.PoolerServingStatus
+	healthProvider HealthProvider
 
 	// pubsubListener is the shared LISTEN/NOTIFY listener, set by MultiPoolerManager.
 	pubsubListener *pubsub.Listener
@@ -176,6 +182,7 @@ func (s *QueryPoolerServer) OnStateChange(ctx context.Context, state servingstat
 
 	if servingStatus == clustermetadatapb.PoolerServingStatus_SERVING {
 		s.isHighestKnownLeader = isHighestKnownLeader
+		s.writable = state.Writable
 		s.servingStatus = servingStatus
 		s.drainPhase = drainNone
 		s.notifyStateChangedLocked()
@@ -235,6 +242,7 @@ func (s *QueryPoolerServer) OnStateChange(ctx context.Context, state servingstat
 	// in-flight requests saw the old role throughout the drain phase.
 	s.mu.Lock()
 	s.isHighestKnownLeader = isHighestKnownLeader
+	s.writable = state.Writable
 	s.servingStatus = servingStatus
 	s.drainPhase = drainNone
 	s.notifyStateChangedLocked()
@@ -350,22 +358,25 @@ func (s *QueryPoolerServer) checkTargetLocked(target *query.Target, existingRese
 		return nil
 	}
 
-	// A leader-bound request (WRITABLE / CONSISTENT) hitting a non-leader means the
-	// gateway thinks this pooler is still the primary, but it was demoted. Return
-	// MTF01 to trigger buffering. Target side uses the Mode enum (#1183); pooler
-	// side uses highest-known leadership (the routing signal), not the topology
-	// PoolerType label.
+	// A leader-bound request hitting a pooler that can't serve it as leader means
+	// the gateway has stale topology (a demotion happened). Return MTF01 to trigger
+	// buffering and re-discovery. The required leadership differs by mode:
 	//
-	// TODO: split this gate by mode. WRITABLE should reject unless we are writable
-	// (out of recovery AND the highest non-revoked *committed* leader), not merely
-	// the highest *known* leader — otherwise a mid-promote or deposed-but-running
-	// node could accept a write before consensus committed. CONSISTENT (a read)
-	// correctly stays on highest-known leadership. The Writable signal is already
-	// delivered via OnStateChange (servingstate.State).
-	mode := target.GetMode()
-	if (mode == query.Mode_MODE_WRITABLE || mode == query.Mode_MODE_CONSISTENT) &&
-		!s.isHighestKnownLeader {
-		return mterrors.MTF01.New()
+	//   - WRITABLE gates on writability: postgres out of recovery AND we are the
+	//     last-written committed (non-revoked) leader. Highest-known leadership is
+	//     NOT sufficient — a mid-promote or deposed-but-running node could otherwise
+	//     admit a write before consensus committed.
+	//   - CONSISTENT (a read) gates on highest-known leadership: a deposed-but-
+	//     running leader can still serve read-consistent queries.
+	switch target.GetMode() {
+	case query.Mode_MODE_WRITABLE:
+		if !s.writable {
+			return mterrors.MTF01.New()
+		}
+	case query.Mode_MODE_CONSISTENT:
+		if !s.isHighestKnownLeader {
+			return mterrors.MTF01.New()
+		}
 	}
 
 	return nil

--- a/go/services/multipooler/internal/poolerserver/pooler.go
+++ b/go/services/multipooler/internal/poolerserver/pooler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pubsub"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 // QueryPoolerServer is the core pooler implementation for query serving.
@@ -53,12 +54,12 @@ type QueryPoolerServer struct {
 	shard      string
 
 	mu sync.Mutex
-	// isConsensusLeader reports whether this pooler is the consensus-elected
+	// isHighestKnownLeader reports whether this pooler is the consensus-elected
 	// leader (the shard's write target). Set from OnStateChange; replaces the
 	// PoolerType label, which the gateway no longer routes on.
-	isConsensusLeader bool
-	servingStatus     clustermetadatapb.PoolerServingStatus
-	healthProvider    HealthProvider
+	isHighestKnownLeader bool
+	servingStatus        clustermetadatapb.PoolerServingStatus
+	healthProvider       HealthProvider
 
 	// pubsubListener is the shared LISTEN/NOTIFY listener, set by MultiPoolerManager.
 	pubsubListener *pubsub.Listener
@@ -164,15 +165,17 @@ func NewQueryPoolerServer(logger *slog.Logger, poolManager connpoolmanager.PoolM
 // any still-running single queries are killed by the postgres demotion that
 // follows. On timeout, errors are acceptable — that is what the grace period
 // bounds.
-func (s *QueryPoolerServer) OnStateChange(ctx context.Context, isConsensusLeader, _ bool, servingStatus clustermetadatapb.PoolerServingStatus) error {
+func (s *QueryPoolerServer) OnStateChange(ctx context.Context, state servingstate.State) error {
+	isHighestKnownLeader := state.IsHighestKnownLeader
+	servingStatus := state.ServingStatus
 	s.mu.Lock()
 
 	s.logger.InfoContext(ctx, "Transitioning serving type",
-		"leader_from", s.isConsensusLeader, "leader_to", isConsensusLeader,
+		"leader_from", s.isHighestKnownLeader, "leader_to", isHighestKnownLeader,
 		"status_from", s.servingStatus, "status_to", servingStatus)
 
 	if servingStatus == clustermetadatapb.PoolerServingStatus_SERVING {
-		s.isConsensusLeader = isConsensusLeader
+		s.isHighestKnownLeader = isHighestKnownLeader
 		s.servingStatus = servingStatus
 		s.drainPhase = drainNone
 		s.notifyStateChangedLocked()
@@ -231,7 +234,7 @@ func (s *QueryPoolerServer) OnStateChange(ctx context.Context, isConsensusLeader
 	// Complete the transition. The leader role is set here (after drain) so that
 	// in-flight requests saw the old role throughout the drain phase.
 	s.mu.Lock()
-	s.isConsensusLeader = isConsensusLeader
+	s.isHighestKnownLeader = isHighestKnownLeader
 	s.servingStatus = servingStatus
 	s.drainPhase = drainNone
 	s.notifyStateChangedLocked()
@@ -350,11 +353,18 @@ func (s *QueryPoolerServer) checkTargetLocked(target *query.Target, existingRese
 	// A leader-bound request (WRITABLE / CONSISTENT) hitting a non-leader means the
 	// gateway thinks this pooler is still the primary, but it was demoted. Return
 	// MTF01 to trigger buffering. Target side uses the Mode enum (#1183); pooler
-	// side uses the consensus-leadership observation, not the topology PoolerType
-	// label (PR 1184 — the gateway derives role from consensus observations).
+	// side uses highest-known leadership (the routing signal), not the topology
+	// PoolerType label.
+	//
+	// TODO: split this gate by mode. WRITABLE should reject unless we are writable
+	// (out of recovery AND the highest non-revoked *committed* leader), not merely
+	// the highest *known* leader — otherwise a mid-promote or deposed-but-running
+	// node could accept a write before consensus committed. CONSISTENT (a read)
+	// correctly stays on highest-known leadership. The Writable signal is already
+	// delivered via OnStateChange (servingstate.State).
 	mode := target.GetMode()
 	if (mode == query.Mode_MODE_WRITABLE || mode == query.Mode_MODE_CONSISTENT) &&
-		!s.isConsensusLeader {
+		!s.isHighestKnownLeader {
 		return mterrors.MTF01.New()
 	}
 
@@ -372,10 +382,10 @@ func (s *QueryPoolerServer) notifyStateChangedLocked() {
 // AwaitStateChange blocks until the pooler's type and serving status match
 // the given targets, or ctx is cancelled. Used by the health streamer to
 // ensure the query server is ready before broadcasting the new state.
-func (s *QueryPoolerServer) AwaitStateChange(ctx context.Context, isConsensusLeader bool, servingStatus clustermetadatapb.PoolerServingStatus) {
+func (s *QueryPoolerServer) AwaitStateChange(ctx context.Context, isHighestKnownLeader bool, servingStatus clustermetadatapb.PoolerServingStatus) {
 	for {
 		s.mu.Lock()
-		if s.isConsensusLeader == isConsensusLeader && s.servingStatus == servingStatus {
+		if s.isHighestKnownLeader == isHighestKnownLeader && s.servingStatus == servingStatus {
 			s.mu.Unlock()
 			return
 		}
@@ -429,7 +439,11 @@ func (s *QueryPoolerServer) RegisterGRPCServices() {
 func (s *QueryPoolerServer) StartServiceForTests() error {
 	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
 	defer cancel()
-	return s.OnStateChange(ctx, true /* isConsensusLeader */, true /* postgresPrimary */, clustermetadatapb.PoolerServingStatus_SERVING)
+	return s.OnStateChange(ctx, servingstate.State{
+		IsHighestKnownLeader: true,
+		Writable:             true,
+		ServingStatus:        clustermetadatapb.PoolerServingStatus_SERVING,
+	})
 }
 
 // Executor returns the executor instance for use by gRPC service handlers.

--- a/go/services/multipooler/internal/poolerserver/pooler_test.go
+++ b/go/services/multipooler/internal/poolerserver/pooler_test.go
@@ -30,6 +30,7 @@ import (
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/pb/query"
 	"github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 func TestNewQueryPoolerServer_NilPoolManager(t *testing.T) {
@@ -144,7 +145,7 @@ func TestStartRequest_DrainRegular_RejectsSingleQueries(t *testing.T) {
 func TestStartRequest_PrimaryOpOnReplica_ReservedConnAllowed(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_DISABLED
-	s.isConsensusLeader = false
+	s.isHighestKnownLeader = false
 
 	target := &query.Target{Mode: query.Mode_MODE_WRITABLE}
 	// A fresh PRIMARY-targeted request on a demoted (REPLICA) pooler is rejected
@@ -160,7 +161,7 @@ func TestStartRequest_PrimaryOpOnReplica_ReservedConnAllowed(t *testing.T) {
 func TestStartRequest_PrimaryQueryOnReplica_Rejected(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
-	s.isConsensusLeader = false
+	s.isHighestKnownLeader = false
 
 	// PRIMARY query hitting a REPLICA pooler should be rejected with MTF01.
 	target := &query.Target{Mode: query.Mode_MODE_WRITABLE}
@@ -170,7 +171,7 @@ func TestStartRequest_PrimaryQueryOnReplica_Rejected(t *testing.T) {
 func TestStartRequest_PrimaryQueryOnPrimary_Allowed(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
-	s.isConsensusLeader = true
+	s.isHighestKnownLeader = true
 
 	target := &query.Target{Mode: query.Mode_MODE_WRITABLE}
 	require.NoError(t, s.StartRequest(target, RequestSingleQuery))
@@ -179,7 +180,7 @@ func TestStartRequest_PrimaryQueryOnPrimary_Allowed(t *testing.T) {
 func TestStartRequest_ReplicaQueryOnPrimary_Allowed(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
-	s.isConsensusLeader = true
+	s.isHighestKnownLeader = true
 
 	// PRIMARY pooler can serve REPLICA traffic.
 	target := &query.Target{Mode: query.Mode_MODE_INCONSISTENT}
@@ -189,7 +190,7 @@ func TestStartRequest_ReplicaQueryOnPrimary_Allowed(t *testing.T) {
 func TestStartRequest_NilTarget_Skipped(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
-	s.isConsensusLeader = false
+	s.isHighestKnownLeader = false
 
 	// Nil target should skip target validation (e.g., GetAuthCredentials).
 	require.NoError(t, s.StartRequest(nil, RequestSingleQuery))
@@ -198,7 +199,7 @@ func TestStartRequest_NilTarget_Skipped(t *testing.T) {
 func TestStartRequest_TableGroupMismatch_Bug(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
-	s.isConsensusLeader = true
+	s.isHighestKnownLeader = true
 	s.tableGroup = "tg1"
 	s.shard = "0"
 
@@ -214,7 +215,7 @@ func TestStartRequest_TableGroupMismatch_Bug(t *testing.T) {
 func TestStartRequest_ShardMismatch_Bug(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
-	s.isConsensusLeader = true
+	s.isHighestKnownLeader = true
 	s.tableGroup = "tg1"
 	s.shard = "0"
 
@@ -229,7 +230,7 @@ func TestStartRequest_ShardMismatch_Bug(t *testing.T) {
 func TestStartRequest_FullTargetMatch_Allowed(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
-	s.isConsensusLeader = true
+	s.isHighestKnownLeader = true
 	s.tableGroup = "tg1"
 	s.shard = "0"
 
@@ -368,7 +369,7 @@ func TestOnStateChange_TwoStageDrain(t *testing.T) {
 	pooler.gracePeriod = 5 * time.Second
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// One in-flight transaction (reserved) and one in-flight single query (regular).
 	mock.reservedAdd(1)
@@ -377,7 +378,7 @@ func TestOnStateChange_TwoStageDrain(t *testing.T) {
 	drainDone := make(chan struct{})
 	go func() {
 		defer close(drainDone)
-		_ = pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_DISABLED)
+		_ = pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
 	}()
 
 	// Stage 1: blocked on the in-flight transaction. Single queries are served,
@@ -415,13 +416,13 @@ func TestOnStateChange_GracePeriodExpiresInStage1(t *testing.T) {
 	pooler.gracePeriod = 100 * time.Millisecond
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// A transaction that never commits — stage 1 (WaitForReservedDrain) blocks.
 	mock.reservedAdd(1)
 
 	start := time.Now()
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_DISABLED))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
 	elapsed := time.Since(start)
 
 	assert.GreaterOrEqual(t, elapsed, 80*time.Millisecond, "should block ~grace period waiting on the held transaction")
@@ -440,7 +441,7 @@ func TestOnStateChange_WaitsForInflightRequests(t *testing.T) {
 	pooler.gracePeriod = 5 * time.Second
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// Simulate two in-flight connections
 	mock.regularAdd(1)
@@ -449,7 +450,7 @@ func TestOnStateChange_WaitsForInflightRequests(t *testing.T) {
 	drainDone := make(chan struct{})
 	go func() {
 		defer close(drainDone)
-		_ = pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_DISABLED)
+		_ = pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
 	}()
 
 	// Drain should not complete while connections are in-flight
@@ -482,7 +483,7 @@ func TestOnStateChange_GracePeriodExpires(t *testing.T) {
 	pooler.gracePeriod = 100 * time.Millisecond
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// Simulate a connection that will never return
 	mock.regularAdd(1)
@@ -491,7 +492,7 @@ func TestOnStateChange_GracePeriodExpires(t *testing.T) {
 	drainDone := make(chan struct{})
 	go func() {
 		defer close(drainDone)
-		_ = pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_DISABLED)
+		_ = pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
 	}()
 
 	select {
@@ -518,14 +519,14 @@ func TestOnStateChange_BackToServing(t *testing.T) {
 	ctx := t.Context()
 
 	// SERVING → DISABLED → SERVING
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	assert.True(t, pooler.IsServing())
 
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_DISABLED))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
 	assert.False(t, pooler.IsServing())
 
 	// Transition back to SERVING
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	assert.True(t, pooler.IsServing())
 
 	// Requests should work again
@@ -541,7 +542,7 @@ func TestOnStateChange_ConcurrentRequests(t *testing.T) {
 	pooler.gracePeriod = 2 * time.Second
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	const numRequests = 50
 	var wg sync.WaitGroup
@@ -567,7 +568,7 @@ func TestOnStateChange_ConcurrentRequests(t *testing.T) {
 	drainDone := make(chan struct{})
 	go func() {
 		defer close(drainDone)
-		_ = pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_DISABLED)
+		_ = pooler.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
 	}()
 
 	// Wait for all goroutines and drain to complete
@@ -586,7 +587,7 @@ func TestAwaitStateChange_AlreadyMatches(t *testing.T) {
 	ctx := t.Context()
 
 	// Transition to PRIMARY/SERVING
-	require.NoError(t, s.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, s.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// AwaitStateChange should return immediately when state already matches
 	done := make(chan struct{})
@@ -621,7 +622,7 @@ func TestAwaitStateChange_BlocksUntilTransition(t *testing.T) {
 	}
 
 	// Transition to the awaited state
-	require.NoError(t, s.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, s.OnStateChange(ctx, servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	select {
 	case <-done:

--- a/go/services/multipooler/internal/poolerserver/pooler_test.go
+++ b/go/services/multipooler/internal/poolerserver/pooler_test.go
@@ -172,9 +172,47 @@ func TestStartRequest_PrimaryQueryOnPrimary_Allowed(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	s.isHighestKnownLeader = true
+	s.writable = true // writable primary admits WRITABLE traffic
 
 	target := &query.Target{Mode: query.Mode_MODE_WRITABLE}
 	require.NoError(t, s.StartRequest(target, RequestSingleQuery))
+}
+
+// A WRITABLE request is rejected on a node that is the highest-known leader but
+// not yet writable (e.g. mid-promote, before the rule committed / out of
+// recovery) — write admission gates on writability, not highest-known leadership.
+func TestStartRequest_WritableQueryOnNonWritableLeader_Rejected(t *testing.T) {
+	s := newStartRequestTestServer()
+	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
+	s.isHighestKnownLeader = true
+	s.writable = false
+
+	target := &query.Target{Mode: query.Mode_MODE_WRITABLE}
+	requireMTF01(t, s.StartRequest(target, RequestSingleQuery))
+}
+
+// A CONSISTENT (read) request is allowed on the highest-known leader even when
+// it is not writable: a deposed-but-still-running leader can serve
+// read-consistent queries.
+func TestStartRequest_ConsistentQueryOnNonWritableLeader_Allowed(t *testing.T) {
+	s := newStartRequestTestServer()
+	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
+	s.isHighestKnownLeader = true
+	s.writable = false
+
+	target := &query.Target{Mode: query.Mode_MODE_CONSISTENT}
+	require.NoError(t, s.StartRequest(target, RequestSingleQuery))
+}
+
+// A CONSISTENT request hitting a non-leader is rejected with MTF01 (stale
+// routing) so the gateway re-discovers the leader.
+func TestStartRequest_ConsistentQueryOnNonLeader_Rejected(t *testing.T) {
+	s := newStartRequestTestServer()
+	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
+	s.isHighestKnownLeader = false
+
+	target := &query.Target{Mode: query.Mode_MODE_CONSISTENT}
+	requireMTF01(t, s.StartRequest(target, RequestSingleQuery))
 }
 
 func TestStartRequest_ReplicaQueryOnPrimary_Allowed(t *testing.T) {
@@ -231,6 +269,7 @@ func TestStartRequest_FullTargetMatch_Allowed(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	s.isHighestKnownLeader = true
+	s.writable = true // writable primary admits WRITABLE traffic
 	s.tableGroup = "tg1"
 	s.shard = "0"
 

--- a/go/services/multipooler/internal/pubsub/listener.go
+++ b/go/services/multipooler/internal/pubsub/listener.go
@@ -31,6 +31,7 @@ import (
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pools/reserved"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 // request types for the serialized event loop.
@@ -112,12 +113,12 @@ func (l *Listener) Stop() {
 }
 
 // OnStateChange implements manager.StateAware. The listener runs only when this
-// pooler is the consensus leader AND postgres is out of recovery AND serving; it
-// is stopped on any other state transition. LISTEN/NOTIFY only carries
-// notifications on the actual postgres primary — standbys never receive them — so
-// postgresPrimary must gate it in addition to leadership.
-func (l *Listener) OnStateChange(_ context.Context, isConsensusLeader bool, postgresPrimary bool, servingStatus clustermetadatapb.PoolerServingStatus) error {
-	if isConsensusLeader && postgresPrimary && servingStatus == clustermetadatapb.PoolerServingStatus_SERVING {
+// pooler is writable AND serving; it is stopped on any other state transition.
+// LISTEN/NOTIFY only carries notifications on the actual postgres primary —
+// standbys never receive them — so writability (out of recovery AND highest
+// committed leader) is exactly the right gate.
+func (l *Listener) OnStateChange(_ context.Context, state servingstate.State) error {
+	if state.Writable && state.ServingStatus == clustermetadatapb.PoolerServingStatus_SERVING {
 		//nolint:gocritic // Long-lived background listener; must not use the transient state-change ctx.
 		l.Start(context.Background())
 	} else {

--- a/go/services/multipooler/internal/pubsub/listener_test.go
+++ b/go/services/multipooler/internal/pubsub/listener_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -70,9 +71,11 @@ func TestListenerOnStateChangeGating(t *testing.T) {
 			wantRunning:       false,
 		},
 		{
-			name:              "writable but not leader -> listener stays off",
+			// A non-leader is never writable (Writable encodes committed
+			// leadership), so the not-writable gate keeps the listener off.
+			name:              "not leader, not writable -> listener stays off",
 			isConsensusLeader: false,
-			postgresPrimary:   true,
+			postgresPrimary:   false,
 			servingStatus:     clustermetadatapb.PoolerServingStatus_SERVING,
 			wantRunning:       false,
 		},
@@ -95,7 +98,7 @@ func TestListenerOnStateChangeGating(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			l := newTestListener(t)
-			err := l.OnStateChange(context.Background(), tt.isConsensusLeader, tt.postgresPrimary, tt.servingStatus)
+			err := l.OnStateChange(context.Background(), servingstate.State{IsHighestKnownLeader: tt.isConsensusLeader, Writable: tt.postgresPrimary, ServingStatus: tt.servingStatus})
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantRunning, running(l))
 		})
@@ -108,11 +111,11 @@ func TestListenerOnStateChangeGating(t *testing.T) {
 func TestListenerOnStateChangeStopsOnDemotion(t *testing.T) {
 	l := newTestListener(t)
 
-	require.NoError(t, l.OnStateChange(context.Background(), true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, l.OnStateChange(context.Background(), servingstate.State{IsHighestKnownLeader: true, Writable: true, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	require.True(t, running(l), "listener should run while leader+writable+serving")
 
 	// Postgres falls back into recovery (demoted to standby) while still nominally
 	// the leader: the listener must stop.
-	require.NoError(t, l.OnStateChange(context.Background(), true, false, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, l.OnStateChange(context.Background(), servingstate.State{IsHighestKnownLeader: true, Writable: false, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	assert.False(t, running(l), "listener must stop once postgres is no longer writable")
 }

--- a/go/services/multipooler/internal/servingstate/servingstate.go
+++ b/go/services/multipooler/internal/servingstate/servingstate.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package servingstate defines the effective serving state that the multipooler
+// manager's StateManager delivers to components via OnStateChange.
+//
+// It lives in its own leaf package because the components that react to state
+// changes (heartbeat, pubsub, query server) satisfy the manager's StateAware
+// interface structurally and cannot import the manager package back.
+package servingstate
+
+import clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+
+// State is the effective serving state components react to. It carries two
+// distinct leadership notions deliberately — see the field docs — so a consumer
+// is forced to pick the one its decision actually needs rather than conflating
+// routing with write-safety.
+type State struct {
+	// IsHighestKnownLeader reports highest-known leadership: the highest rule we
+	// know of (including ReplicationPrimary observations recorded via
+	// SetPrimary/Promote, which can be ahead of what we've committed) names us.
+	// It drives routing — the PoolerType label and the gateway-staleness check —
+	// and must NOT be used to gate writes.
+	//
+	// It deliberately ignores revocation: a deposed-but-still-running leader
+	// (committed at a now-revoked term) is not Writable, but it remains the
+	// highest-known leader for routing so read-consistent queries can still be
+	// served from it. Only Writable is revocation-aware.
+	IsHighestKnownLeader bool
+
+	// Writable reports write-safety: postgres is out of recovery AND our highest
+	// *committed* rule names us leader. This is the authority for accepting
+	// writes — heartbeats, LISTEN/NOTIFY, and the gateway's write traffic. Unlike
+	// IsHighestKnownLeader it is never true on the strength of a not-yet-committed
+	// rule, so it stays false during the window between pg_promote() and the rule
+	// commit.
+	Writable bool
+
+	// ServingStatus is the serving intent (SERVING / DISABLED / DRAINING).
+	ServingStatus clustermetadatapb.PoolerServingStatus
+}


### PR DESCRIPTION
## What

Make write-safety a *derived* value rather than a single physical-recovery bit,
and gate write admission on it.

A pooler is **writable** iff: postgres is out of recovery **AND** this pooler is
the highest **non-revoked committed** leader. This is delivered to components on
a new `servingstate.State`, which carries two deliberately distinct leadership
notions:

- **`IsHighestKnownLeader`** — highest-*known* rule, revocation-ignorant. Drives
  routing (the `PoolerType` label, gateway staleness) and can still route reads
  to a deposed-but-running leader.
- **`Writable`** — committed, non-revoked leadership + out of recovery. Gates
  writes.

The query server then splits admission by mode:

- **WRITABLE** queries require `Writable`.
- **CONSISTENT** reads keep gating on `IsHighestKnownLeader`, so a
  deposed-but-running leader can still serve them.

## Why

Gating on the *committed* (not highest-known) rule and excluding revoked terms
closes two windows where a node would otherwise advertise/accept writes
incorrectly:

1. The gap between `pg_promote()` and the new rule actually committing — the node
   is physically primary but not yet the committed leader.
2. A deposed-but-not-yet-demoted primary still running at a revoked term.

When a committed leader is briefly not writable it returns `MTF01`, so the
gateway buffers and holds the write (via its own writable-gating) until the
pooler publishes writable — rather than admitting a write postgres would reject.

## How it's derived

The `StateManager` stores only `inRecovery` (the async postgres observation it
can't compute itself) and recomputes `writable` live via an injected
`committedLeader` query — so a revocation or a new committed-rule observation
flips writability with no stored copy to keep in sync. Set-sites poke the
recovery fact, never `writable` directly. Terminology is made explicit:
`highestKnownRule` vs `highestCommittedRule`, with
`isHighestNonRevokedCommittedLeader` as the write-safety input.

## Behavior change

- WRITABLE admission now follows committed, non-revoked leadership + recovery
  state instead of highest-known leadership. CONSISTENT/INCONSISTENT routing is
  unchanged.
- Heartbeat/LISTEN and the health publisher react to `Writable`; health labels
  still come from `IsHighestKnownLeader`.
