### PR TITLE
fix(multigateway): accept empty/comment-only prepared statements (EmptyQueryResponse)

### DIFF
--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -1210,6 +1210,19 @@ func (c *Conn) handleExecute() error {
 	// Call the handler to execute the portal with streaming callback.
 	// The handler is responsible for retrieving the portal and executing it.
 	err = c.handler.HandleExecute(queryCtx, c, portalName, maxRows, includeDescribe, func(ctx context.Context, result *sqltypes.Result) error {
+		// A nil result signals an empty / comment-only query, mirroring the
+		// simple-query path. PostgreSQL answers Execute of an empty-string
+		// portal with EmptyQueryResponse. If a Describe('P') was folded into
+		// this Execute, its answer (NoData for an empty portal) is owed first.
+		if result == nil {
+			if includeDescribe && !sentRowDescription {
+				if err := c.writeMessage(protocol.MsgNoData, nil); err != nil {
+					return fmt.Errorf("writing no data: %w", err)
+				}
+			}
+			return c.writeEmptyQueryResponse()
+		}
+
 		// Send notices immediately (zero-buffering delivery).
 		for _, notice := range result.Notices {
 			if err := c.writeNoticeResponse(notice); err != nil {

--- a/go/common/pgprotocol/server/extended_query_test.go
+++ b/go/common/pgprotocol/server/extended_query_test.go
@@ -1584,3 +1584,61 @@ func TestDrainModeTerminateExits(t *testing.T) {
 	require.ErrorIs(t, conn.handleMessage(msgType), io.EOF,
 		"Terminate in drain mode must return io.EOF, not silently drain")
 }
+
+// An Execute whose handler signals an empty query (callback with nil result)
+// must produce a single EmptyQueryResponse ('I'), mirroring the simple-query path.
+func TestHandleExecute_EmptyQueryResponse(t *testing.T) {
+	var readBuf, writeBuf bytes.Buffer
+	handler := &testHandler{
+		executeFunc: func(ctx context.Context, conn *Conn, portalName string, maxRows int32, callback func(ctx context.Context, result *sqltypes.Result) error) error {
+			return callback(ctx, nil) // signal empty query
+		},
+	}
+	conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, handler)
+
+	portalName := "portal1"
+	writeTestInt32(&readBuf, int32(4+len(portalName)+1+4))
+	writeTestString(&readBuf, portalName)
+	writeTestInt32(&readBuf, 0) // maxRows
+
+	require.NoError(t, conn.handleExecute())
+
+	msgType, bodyLen, _ := readMessageTypeAndLength(t, &writeBuf)
+	assert.Equal(t, byte(protocol.MsgEmptyQueryResponse), msgType)
+	assert.Equal(t, int32(0), bodyLen)
+	// No further messages.
+	assert.Equal(t, 0, writeBuf.Len(), "EmptyQueryResponse must be the only message")
+}
+
+// When Describe('P') is folded into Execute (includeDescribe=true) for an empty
+// portal, the wire order is NoData (the describe answer) then EmptyQueryResponse.
+func TestHandleExecute_EmptyQueryFoldedDescribe(t *testing.T) {
+	var readBuf, writeBuf bytes.Buffer
+	handler := &testHandler{
+		describeFunc: func(ctx context.Context, conn *Conn, typ byte, name string) (*query.StatementDescription, error) {
+			return &query.StatementDescription{}, nil // empty: NoData
+		},
+		executeFunc: func(ctx context.Context, conn *Conn, portalName string, maxRows int32, callback func(ctx context.Context, result *sqltypes.Result) error) error {
+			return callback(ctx, nil)
+		},
+	}
+	conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, handler)
+
+	// Describe('P', "portal1") — deferred/folded.
+	portalName := "portal1"
+	writeTestInt32(&readBuf, int32(4+1+len(portalName)+1))
+	readBuf.WriteByte('P')
+	writeTestString(&readBuf, portalName)
+	require.NoError(t, conn.handleDescribe())
+
+	// Execute on the same portal — folds the describe in.
+	writeTestInt32(&readBuf, int32(4+len(portalName)+1+4))
+	writeTestString(&readBuf, portalName)
+	writeTestInt32(&readBuf, 0)
+	require.NoError(t, conn.handleExecute())
+
+	msgType, _, _ := readMessageTypeAndLength(t, &writeBuf)
+	assert.Equal(t, byte(protocol.MsgNoData), msgType, "folded Describe('P') answer")
+	msgType, _, _ = readMessageTypeAndLength(t, &writeBuf)
+	assert.Equal(t, byte(protocol.MsgEmptyQueryResponse), msgType, "Execute answer")
+}

--- a/go/common/preparedstatement/consolidator.go
+++ b/go/common/preparedstatement/consolidator.go
@@ -83,6 +83,13 @@ func (psi *PreparedStatementInfo) AstStmt() ast.Stmt {
 	return psi.astStruct
 }
 
+// IsEmpty reports whether this prepared statement was created from an empty or
+// comment-only query string (zero parsed statements). An empty statement has a
+// nil AST; Execute answers it with EmptyQueryResponse, matching PostgreSQL.
+func (psi *PreparedStatementInfo) IsEmpty() bool {
+	return psi.astStruct == nil
+}
+
 // NewPreparedStatementInfo parses the query in the prepared statement and stores it along with the
 // prepared statement information for future use.
 func NewPreparedStatementInfo(ps *querypb.PreparedStatement) (*PreparedStatementInfo, error) {
@@ -98,8 +105,20 @@ func NewPreparedStatementInfo(ps *querypb.PreparedStatement) (*PreparedStatement
 		}
 		return nil, mterrors.NewParseError(err.Error())
 	}
-	if len(asts) != 1 {
-		return nil, errors.New("more than 1 query in prepare statement")
+	switch {
+	case len(asts) == 0:
+		// Empty or comment-only query: PostgreSQL accepts this and answers a
+		// subsequent Execute with EmptyQueryResponse. Represent it as a prepared
+		// statement with a nil AST (the empty-statement sentinel). The gateway
+		// short-circuits empty statements before they reach the planner.
+		return &PreparedStatementInfo{
+			PreparedStatement: ps,
+			astStruct:         nil,
+		}, nil
+	case len(asts) > 1:
+		// PostgreSQL: a Parse message "cannot insert multiple commands into a
+		// prepared statement" (SQLSTATE 42601).
+		return nil, mterrors.NewParseError("cannot insert multiple commands into a prepared statement")
 	}
 	return &PreparedStatementInfo{
 		PreparedStatement: ps,

--- a/go/common/preparedstatement/consolidator_test.go
+++ b/go/common/preparedstatement/consolidator_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	querypb "github.com/multigres/multigres/go/pb/query"
 )
 
@@ -163,14 +164,41 @@ func TestConsolidator_InvalidSQL(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestConsolidator_EmptyQueryAllowed(t *testing.T) {
+	consolidator := NewConsolidator()
+	connID := uint32(1)
+
+	// An empty query string and a comment-only string both parse to zero
+	// statements. PostgreSQL accepts these; the prepared statement is "empty".
+	for _, q := range []string{"", "   ", "-- just a comment\n", "/* block */"} {
+		psi, err := consolidator.AddPreparedStatement(connID, "", q, nil)
+		require.NoError(t, err, "query %q should be accepted as an empty statement", q)
+		require.NotNil(t, psi)
+		require.True(t, psi.IsEmpty(), "query %q should produce an empty prepared statement", q)
+		require.Nil(t, psi.AstStmt(), "empty prepared statement should have a nil AST")
+	}
+}
+
+func TestConsolidator_SingleStatementNotEmpty(t *testing.T) {
+	consolidator := NewConsolidator()
+	psi, err := consolidator.AddPreparedStatement(1, "stmt1", "SELECT 1", nil)
+	require.NoError(t, err)
+	require.False(t, psi.IsEmpty())
+	require.NotNil(t, psi.AstStmt())
+}
+
 func TestConsolidator_MultipleStatementsInQuery(t *testing.T) {
 	consolidator := NewConsolidator()
 	connID := uint32(1)
 
-	// Prepared statements should only contain a single query
+	// Prepared statements may contain only a single command (PG: 42601).
 	_, err := consolidator.AddPreparedStatement(connID, "stmt1", "SELECT 1; SELECT 2", nil)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "more than 1 query")
+	require.Contains(t, err.Error(), "cannot insert multiple commands into a prepared statement")
+
+	var diag *mterrors.PgDiagnostic
+	require.ErrorAs(t, err, &diag)
+	require.Equal(t, mterrors.PgSSSyntaxError, diag.Code) // 42601
 }
 
 func TestConsolidator_ConcurrentAccess(t *testing.T) {

--- a/go/services/multigateway/handler/handler.go
+++ b/go/services/multigateway/handler/handler.go
@@ -388,6 +388,21 @@ func (h *MultiGatewayHandler) HandleBind(ctx context.Context, conn *server.Conn,
 		return mterrors.NewInvalidPreparedStatementError(stmtName)
 	}
 
+	// For an empty / comment-only statement the gateway knows the parameter
+	// count authoritatively (there is no query body in which postgres could
+	// infer extra parameters), and the backend never sees the Bind because
+	// Execute is short-circuited. Validate the supplied parameter count here so
+	// a mismatch surfaces the same 08P01 protocol_violation PostgreSQL raises,
+	// rather than silently succeeding. Non-empty statements are validated by the
+	// backend, which may infer parameters beyond those declared at Parse.
+	if psi.IsEmpty() {
+		if declared := len(psi.GetParamTypes()); len(params) != declared {
+			return mterrors.NewPgError("ERROR", mterrors.PgSSProtocolViolation,
+				fmt.Sprintf("bind message supplies %d parameters, but prepared statement %q requires %d",
+					len(params), stmtName, declared), "")
+		}
+	}
+
 	// Get the connection state.
 	state := h.getConnectionState(conn)
 

--- a/go/services/multigateway/handler/handler.go
+++ b/go/services/multigateway/handler/handler.go
@@ -370,11 +370,9 @@ func (h *MultiGatewayHandler) getConnectionState(conn *server.Conn) *MultiGatewa
 func (h *MultiGatewayHandler) HandleParse(ctx context.Context, conn *server.Conn, name, queryStr string, paramTypes []uint32) error {
 	h.logger.DebugContext(ctx, "parse", "name", name, "query", queryStr, "param_count", len(paramTypes))
 
-	// Basic validation: query must not be empty.
-	if queryStr == "" {
-		return errors.New("query string cannot be empty")
-	}
-
+	// An empty or comment-only query string parses to zero statements;
+	// AddPreparedStatement produces an empty PreparedStatementInfo for it, which
+	// the gateway answers with EmptyQueryResponse — matching PostgreSQL.
 	_, err := h.psc.AddPreparedStatement(conn.ConnectionID(), name, queryStr, paramTypes)
 	return err
 }
@@ -416,6 +414,18 @@ func (h *MultiGatewayHandler) HandleExecute(ctx context.Context, conn *server.Co
 		// Record before span creation since we don't have an operation name yet.
 		h.recordQueryCompletion(ctx, conn, "UNKNOWN", "extended", 0, 0, time.Since(queryStart), 0, nil, portalErr)
 		return portalErr
+	}
+
+	// Empty / comment-only prepared statement: answer Execute with
+	// EmptyQueryResponse, mirroring the simple-query path. Short-circuit here so
+	// the nil AST never reaches the planner (resolvePortalPlan/isCacheable would
+	// dereference it). This also bypasses the aborted-transaction gate, matching
+	// PostgreSQL, which returns EmptyQueryResponse for an empty query regardless
+	// of transaction state.
+	if portalInfo.IsEmpty() {
+		err := callback(ctx, nil)
+		h.recordQueryCompletion(ctx, conn, "EMPTY", "extended", 0, 0, time.Since(queryStart), 0, nil, err)
+		return err
 	}
 
 	operationName := "UNKNOWN"
@@ -484,6 +494,10 @@ func (h *MultiGatewayHandler) HandleDescribe(ctx context.Context, conn *server.C
 		if stmt == nil {
 			return nil, mterrors.NewInvalidPreparedStatementError(name)
 		}
+		if stmt.IsEmpty() {
+			// Empty statement: ParameterDescription(0) + NoData, no backend call.
+			return &query.StatementDescription{}, nil
+		}
 
 		// Call executor to get description from multipooler
 		return h.executor.Describe(ctx, conn, state, nil, stmt)
@@ -492,6 +506,10 @@ func (h *MultiGatewayHandler) HandleDescribe(ctx context.Context, conn *server.C
 		portalInfo := state.GetPortalInfo(name)
 		if portalInfo == nil {
 			return nil, mterrors.NewInvalidPortalError(name)
+		}
+		if portalInfo.IsEmpty() {
+			// Empty portal: NoData, no backend call.
+			return &query.StatementDescription{}, nil
 		}
 
 		// Call executor to get description from multipooler

--- a/go/services/multigateway/handler/handler_test.go
+++ b/go/services/multigateway/handler/handler_test.go
@@ -511,6 +511,38 @@ func TestHandleParse_EmptyAndCommentOnlyAccepted(t *testing.T) {
 	}
 }
 
+// TestHandleBind_EmptyStatementParamCountMismatch verifies that binding the
+// wrong number of parameters to an empty (comment-only) prepared statement is
+// rejected as a protocol violation (08P01), matching PostgreSQL. For an empty
+// statement the gateway authoritatively knows the parameter count (there is no
+// query body in which postgres could infer additional parameters), so the
+// check belongs at the gateway rather than being deferred to the backend.
+func TestHandleBind_EmptyStatementParamCountMismatch(t *testing.T) {
+	logger := slog.Default()
+	executor := &mockExecutor{}
+	h := NewMultiGatewayHandler(executor, logger, 0)
+	conn := server.NewTestConn(&bytes.Buffer{}).Conn
+
+	// Empty statement declaring zero parameters.
+	require.NoError(t, h.HandleParse(t.Context(), conn, "s0", "-- comment\n", nil))
+
+	// Binding any parameter is a protocol violation.
+	err := h.HandleBind(t.Context(), conn, "p0", "s0", [][]byte{[]byte("1")}, []int16{0}, nil)
+	require.Error(t, err)
+	require.True(t, mterrors.IsErrorCode(err, mterrors.PgSSProtocolViolation))
+
+	// Binding the correct (zero) count still succeeds.
+	require.NoError(t, h.HandleBind(t.Context(), conn, "p0", "s0", nil, nil, nil))
+
+	// Empty statement that declares parameter types still validates against the
+	// declared count: too few is rejected, the exact count succeeds.
+	require.NoError(t, h.HandleParse(t.Context(), conn, "s1", "-- comment\n", []uint32{23}))
+	err = h.HandleBind(t.Context(), conn, "p1", "s1", nil, nil, nil)
+	require.Error(t, err)
+	require.True(t, mterrors.IsErrorCode(err, mterrors.PgSSProtocolViolation))
+	require.NoError(t, h.HandleBind(t.Context(), conn, "p1", "s1", [][]byte{[]byte("1")}, []int16{0}, nil))
+}
+
 // TestHandleDescribe_EmptyStatementAndPortal verifies that describing an empty
 // (comment-only) prepared statement or portal returns an empty description
 // (rendered as ParameterDescription(0)/NoData) without calling the executor.

--- a/go/services/multigateway/handler/handler_test.go
+++ b/go/services/multigateway/handler/handler_test.go
@@ -38,8 +38,10 @@ import (
 
 // mockExecutor is a mock implementation of the Executor interface for testing.
 type mockExecutor struct {
-	streamExecuteErr error
-	releaseAllCalled bool
+	streamExecuteErr         error
+	releaseAllCalled         bool
+	portalStreamExecuteCalls int
+	describeCalls            int
 }
 
 func (m *mockExecutor) StreamExecute(ctx context.Context, conn *server.Conn, state *MultiGatewayConnectionState, queryStr string, astStmt ast.Stmt, callback func(ctx context.Context, result *sqltypes.Result) error) (*ExecuteResult, error) {
@@ -62,6 +64,7 @@ func (m *mockExecutor) StreamExecute(ctx context.Context, conn *server.Conn, sta
 }
 
 func (m *mockExecutor) PortalStreamExecute(ctx context.Context, conn *server.Conn, state *MultiGatewayConnectionState, portalInfo *preparedstatement.PortalInfo, maxRows int32, _ bool, callback func(ctx context.Context, result *sqltypes.Result) error) (*ExecuteResult, error) {
+	m.portalStreamExecuteCalls++
 	// Return a simple test result
 	err := callback(ctx, &sqltypes.Result{
 		Fields: []*query.Field{
@@ -77,6 +80,7 @@ func (m *mockExecutor) PortalStreamExecute(ctx context.Context, conn *server.Con
 }
 
 func (m *mockExecutor) Describe(ctx context.Context, conn *server.Conn, state *MultiGatewayConnectionState, portalInfo *preparedstatement.PortalInfo, preparedStatementInfo *preparedstatement.PreparedStatementInfo) (*query.StatementDescription, error) {
+	m.describeCalls++
 	// Return a simple test description
 	return &query.StatementDescription{
 		Fields: []*query.Field{
@@ -224,9 +228,12 @@ func TestPreparedStatementHandling(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, mterrors.IsErrorCode(err, mterrors.PgSSInvalidSQLStatementName))
 
-	// 7. Empty query fails
+	// 7. Empty query is accepted as an empty prepared statement (matches PostgreSQL).
 	err = handler.HandleParse(ctx, conn, "empty", "", nil)
-	require.Error(t, err)
+	require.NoError(t, err)
+	emptyPSI := handler.psc.GetPreparedStatementInfo(conn.ConnectionID(), "empty")
+	require.NotNil(t, emptyPSI)
+	require.True(t, emptyPSI.IsEmpty())
 
 	// 8. Invalid describe type fails
 	_, err = handler.HandleDescribe(ctx, conn, 'X', "name")
@@ -483,6 +490,79 @@ func TestHandleQuery_ErrorOutsideTransactionStaysIdle(t *testing.T) {
 	require.Error(t, err)
 	// Should stay idle (not in a transaction)
 	require.Equal(t, protocol.TxnStatusIdle, conn.TxnStatus())
+}
+
+// TestHandleParse_EmptyAndCommentOnlyAccepted verifies that an empty or
+// comment-only query string parses to an empty prepared statement instead of
+// being rejected, matching PostgreSQL.
+func TestHandleParse_EmptyAndCommentOnlyAccepted(t *testing.T) {
+	logger := slog.Default()
+	executor := &mockExecutor{}
+	h := NewMultiGatewayHandler(executor, logger, 0)
+	conn := server.NewTestConn(&bytes.Buffer{}).Conn
+
+	for _, q := range []string{"", "-- only a comment\n"} {
+		err := h.HandleParse(t.Context(), conn, "", q, nil)
+		require.NoError(t, err, "empty/comment-only Parse should be accepted: %q", q)
+
+		psi := h.psc.GetPreparedStatementInfo(conn.ConnectionID(), "")
+		require.NotNil(t, psi)
+		require.True(t, psi.IsEmpty())
+	}
+}
+
+// TestHandleDescribe_EmptyStatementAndPortal verifies that describing an empty
+// (comment-only) prepared statement or portal returns an empty description
+// (rendered as ParameterDescription(0)/NoData) without calling the executor.
+func TestHandleDescribe_EmptyStatementAndPortal(t *testing.T) {
+	logger := slog.Default()
+	executor := &mockExecutor{}
+	h := NewMultiGatewayHandler(executor, logger, 0)
+	conn := server.NewTestConn(&bytes.Buffer{}).Conn
+
+	require.NoError(t, h.HandleParse(t.Context(), conn, "s", "-- comment\n", nil))
+	require.NoError(t, h.HandleBind(t.Context(), conn, "p", "s", nil, nil, nil))
+
+	// Describe('S') of an empty statement: zero params, no row fields, no executor call.
+	descS, err := h.HandleDescribe(t.Context(), conn, 'S', "s")
+	require.NoError(t, err)
+	require.NotNil(t, descS)
+	require.Empty(t, descS.Parameters)
+	require.Nil(t, descS.Fields)
+
+	// Describe('P') of an empty portal: no row fields.
+	descP, err := h.HandleDescribe(t.Context(), conn, 'P', "p")
+	require.NoError(t, err)
+	require.NotNil(t, descP)
+	require.Nil(t, descP.Fields)
+
+	require.Zero(t, executor.describeCalls, "executor must not be called for empty describe")
+}
+
+// TestHandleExecute_EmptyPortalShortCircuits verifies that executing an empty
+// (comment-only) prepared statement answers via a nil result without reaching
+// the executor (whose plan path would dereference the nil AST).
+func TestHandleExecute_EmptyPortalShortCircuits(t *testing.T) {
+	logger := slog.Default()
+	executor := &mockExecutor{}
+	h := NewMultiGatewayHandler(executor, logger, 0)
+	conn := server.NewTestConn(&bytes.Buffer{}).Conn
+
+	// Parse + Bind a comment-only statement so the portal carries an empty PSI.
+	require.NoError(t, h.HandleParse(t.Context(), conn, "s", "-- nothing\n", nil))
+	require.NoError(t, h.HandleBind(t.Context(), conn, "p", "s", nil, nil, nil))
+
+	var gotResult *sqltypes.Result
+	gotCalled := false
+	err := h.HandleExecute(t.Context(), conn, "p", 0, false, func(ctx context.Context, r *sqltypes.Result) error {
+		gotCalled = true
+		gotResult = r
+		return nil
+	})
+	require.NoError(t, err)
+	require.True(t, gotCalled, "callback must run for the empty query")
+	require.Nil(t, gotResult, "empty query signals via nil result")
+	require.Zero(t, executor.portalStreamExecuteCalls, "executor must not be called for an empty portal")
 }
 
 // TestHandleExecute_AbortedTransactionRejects tests that Execute messages

--- a/go/test/endtoend/queryserving/extended_query_protocol_test.go
+++ b/go/test/endtoend/queryserving/extended_query_protocol_test.go
@@ -865,6 +865,42 @@ func TestExtendedQueryProtocol_CommentOnlyStatement(t *testing.T) {
 				assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSProtocolViolation),
 					"expected 08P01 protocol_violation, got: %v", err)
 			})
+
+			// Describe('P') of an empty portal, both unfolded and folded into
+			// Execute. Asserted against both targets so the gateway's NoData /
+			// EmptyQueryResponse handling is confirmed to match stock PostgreSQL.
+			t.Run("describe and execute empty portal", func(t *testing.T) {
+				conn := connectLowLevelToPort(t, ctx, target.Port)
+				defer conn.Close()
+
+				require.NoError(t, conn.Parse(ctx, "empty_dp", "-- comment\n", nil))
+
+				// Unfolded Bind → Describe('P') → Sync. An empty portal answers
+				// with NoData, so the client surfaces nil Fields. (A RowDescription
+				// would leave Fields non-nil — that is the divergence this guards
+				// against.) PostgreSQL sends no ParameterDescription for a portal.
+				desc, err := conn.BindAndDescribe(ctx, "empty_dp", nil, nil, nil)
+				require.NoError(t, err)
+				require.NotNil(t, desc)
+				assert.Nil(t, desc.Fields, "Describe('P') of an empty portal must answer NoData, not RowDescription")
+				assert.Empty(t, desc.Parameters, "portal describe never returns ParameterDescription")
+
+				// Folded Bind → Describe('P') → Execute → Sync. The describe's
+				// NoData and the execute's EmptyQueryResponse collapse to a single
+				// empty result with no fields, no rows, and no command tag.
+				var results []*sqltypes.Result
+				completed, err := conn.BindDescribeAndExecute(ctx, "", "empty_dp", nil, nil, nil, 0,
+					func(ctx context.Context, result *sqltypes.Result) error {
+						results = append(results, result)
+						return nil
+					})
+				require.NoError(t, err)
+				assert.True(t, completed)
+				require.Len(t, results, 1)
+				assert.Nil(t, results[0].Fields)
+				assert.Empty(t, results[0].Rows)
+				assert.Empty(t, results[0].CommandTag)
+			})
 		})
 	}
 }

--- a/go/test/endtoend/queryserving/extended_query_protocol_test.go
+++ b/go/test/endtoend/queryserving/extended_query_protocol_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/sqltypes"
@@ -846,6 +847,24 @@ func TestExtendedQueryProtocol_CommentOnlyStatement(t *testing.T) {
 					assert.Equal(t, "1", string(after[0].Rows[0].Values[0]))
 				})
 			}
+
+			// Binding a parameter to an empty statement that declares none is a
+			// protocol violation (08P01), matching PostgreSQL. Asserted against
+			// both targets to confirm parity.
+			t.Run("bind param mismatch on empty statement", func(t *testing.T) {
+				conn := connectLowLevelToPort(t, ctx, target.Port)
+				defer conn.Close()
+
+				require.NoError(t, conn.Parse(ctx, "empty_mismatch", "-- comment\n", nil))
+
+				_, err := conn.BindAndExecute(ctx, "", "empty_mismatch", [][]byte{[]byte("1")}, []int16{0}, nil, 0,
+					func(ctx context.Context, result *sqltypes.Result) error {
+						return nil
+					})
+				require.Error(t, err, "binding params to a zero-parameter empty statement must be rejected")
+				assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSProtocolViolation),
+					"expected 08P01 protocol_violation, got: %v", err)
+			})
 		})
 	}
 }

--- a/go/test/endtoend/queryserving/extended_query_protocol_test.go
+++ b/go/test/endtoend/queryserving/extended_query_protocol_test.go
@@ -776,3 +776,76 @@ func TestExtendedQueryProtocol_SetConfigBoundParam(t *testing.T) {
 		})
 	}
 }
+
+// TestExtendedQueryProtocol_CommentOnlyStatement verifies that an empty or
+// comment-only prepared statement Parses, Describes, Binds, and Executes
+// cleanly through the gateway — returning ParameterDescription(0)/NoData and
+// EmptyQueryResponse — instead of being rejected with MTD04 "parse failed".
+// Reproduces the Realtime tenant-migration failure, where a comment-only
+// migration statement broke the extended-protocol path.
+//
+// Each subtest runs against both direct PostgreSQL and multigateway to confirm
+// the proxy's wire behavior matches native PostgreSQL exactly.
+func TestExtendedQueryProtocol_CommentOnlyStatement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	queries := []struct {
+		name  string
+		query string
+	}{
+		{"empty string", ""},
+		{"comment only", "-- Commented to have oriole compatibility\n-- ALTER TABLE realtime.messages SET UNLOGGED;\n"},
+	}
+
+	for _, target := range setup.GetComparisonTargets(t) {
+		t.Run(target.Name, func(t *testing.T) {
+			for _, q := range queries {
+				t.Run(q.name, func(t *testing.T) {
+					conn := connectLowLevelToPort(t, ctx, target.Port)
+					defer conn.Close()
+
+					// Parse must succeed (ParseComplete), not MTD04.
+					require.NoError(t, conn.Parse(ctx, "empty_stmt", q.query, nil),
+						"comment-only/empty Parse must be accepted")
+
+					// Describe('S'): zero parameters, no row fields.
+					desc, err := conn.DescribePrepared(ctx, "empty_stmt")
+					require.NoError(t, err)
+					require.NotNil(t, desc)
+					assert.Empty(t, desc.Parameters, "empty statement has no parameters")
+					assert.Empty(t, desc.Fields, "empty statement has no result fields")
+
+					// Bind + Execute: EmptyQueryResponse, surfaced as an empty result.
+					var results []*sqltypes.Result
+					completed, err := conn.BindAndExecute(ctx, "", "empty_stmt", nil, nil, nil, 0,
+						func(ctx context.Context, result *sqltypes.Result) error {
+							results = append(results, result)
+							return nil
+						})
+					require.NoError(t, err, "Execute of an empty statement must not error")
+					assert.True(t, completed)
+					require.Len(t, results, 1)
+					assert.Empty(t, results[0].Rows, "empty query returns no rows")
+					assert.Empty(t, results[0].CommandTag, "empty query has no command tag")
+
+					require.NoError(t, conn.CloseStatement(ctx, "empty_stmt"))
+
+					// The connection must remain usable for subsequent queries.
+					after, err := conn.Query(ctx, "SELECT 1")
+					require.NoError(t, err)
+					require.NotEmpty(t, after)
+					require.NotEmpty(t, after[0].Rows)
+					assert.Equal(t, "1", string(after[0].Rows[0].Values[0]))
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The multigateway's extended-query (Parse/Bind/Describe/Execute) path rejected an empty or comment-only prepared statement with `MTD04 "parse failed"`, instead of treating it as PostgreSQL does. This broke Realtime tenant migrations whose statements were comment-only (e.g. migration `20240801235015`).

**Root cause:** `NewPreparedStatementInfo` used a single `len(asts) != 1` guard that conflated the *zero-statement* case (empty/comment-only) with the *multi-statement* case, rejecting both with the bespoke `MTD04`. `HandleParse` also rejected an empty string even earlier.

**Fix:**
- An empty/comment-only query (zero parsed statements) is now represented as a `PreparedStatementInfo` with a nil AST (the empty-statement sentinel), surfaced via a new `IsEmpty()` accessor.
- `HandleParse` no longer rejects empty strings; `HandleExecute` and `HandleDescribe` short-circuit the empty statement at the gateway edge so the nil AST never reaches the planner (`resolvePortalPlan`/`isCacheable` would dereference it).
- The conn-level extended Execute callback now writes `EmptyQueryResponse` (plus a folded `NoData` when a `Describe('P')` was folded in) on a nil result, mirroring the simple-query path.
- The genuine multi-statement case (`SELECT 1; SELECT 2`) now surfaces as a standard `42601` syntax error ("cannot insert multiple commands into a prepared statement") instead of `MTD04`.

Resulting wire behavior for an empty/comment-only Parse matches PostgreSQL: `ParseComplete`, `ParameterDescription(0)`/`NoData`, `BindComplete`, and `EmptyQueryResponse`.

## Test Plan
- [x] `go/common/preparedstatement` unit tests (empty accepted, single not-empty, multi → 42601)
- [x] `go/common/pgprotocol/server` unit tests (`EmptyQueryResponse` on nil result; folded `Describe('P')` → `NoData` then `EmptyQueryResponse`)
- [x] `go/services/multigateway/handler` unit tests (Parse/Execute/Describe short-circuit empty without reaching the executor)
- [x] End-to-end test `TestExtendedQueryProtocol_CommentOnlyStatement` drives Parse→Describe→Bind→Execute over the wire against **both direct PostgreSQL and the multigateway** (parity confirmed), for empty-string and comment-only inputs, and verifies the connection stays usable
- [x] `make build`, full affected unit suites, and `golangci-lint` all clean