### PR TITLE
fix(queryserving): manage idle session timeout at gateway

### DIFF
--- a/go/common/mterrors/code.go
+++ b/go/common/mterrors/code.go
@@ -40,6 +40,7 @@ const (
 	PgSSSyntaxError             = "42601" // syntax_error
 	PgSSUndefinedObject         = "42704" // undefined_object
 	PgSSQueryCanceled           = "57014" // query_canceled
+	PgSSIdleSessionTimeout      = "57P05" // idle_session_timeout
 	PgSSInternalError           = "XX000" // internal_error
 	PgSSReadOnlyTransaction     = "25006" // read_only_sql_transaction
 	PgSSSerializationFailure    = "40001" // serialization_failure
@@ -57,6 +58,14 @@ func NewQueryCanceled() *PgDiagnostic {
 func NewStatementTimeout() *PgDiagnostic {
 	return NewPgError("ERROR", PgSSQueryCanceled,
 		"canceling statement due to statement timeout", "")
+}
+
+// NewIdleSessionTimeout creates a PgDiagnostic for an idle_session_timeout
+// expiry. SQLSTATE 57P05, severity FATAL — matches PostgreSQL's behavior of
+// terminating the client session after emitting the error.
+func NewIdleSessionTimeout() *PgDiagnostic {
+	return NewPgError("FATAL", PgSSIdleSessionTimeout,
+		"terminating connection due to idle-session timeout", "")
 }
 
 // NewReservedConnectionTerminated creates a PgDiagnostic for a reserved

--- a/go/common/mterrors/errors_test.go
+++ b/go/common/mterrors/errors_test.go
@@ -417,6 +417,11 @@ func TestIsConnectionError(t *testing.T) {
 			err:      &PgDiagnostic{MessageType: 'E', Severity: "FATAL", Code: "57P03"},
 			expected: true,
 		},
+		{
+			name:     "57P05 idle_session_timeout",
+			err:      &PgDiagnostic{MessageType: 'E', Severity: "FATAL", Code: PgSSIdleSessionTimeout},
+			expected: true,
+		},
 
 		// PgDiagnostic: Class 57 codes that are NOT connection errors.
 		{

--- a/go/common/mterrors/mterrors.go
+++ b/go/common/mterrors/mterrors.go
@@ -453,8 +453,9 @@ func IsConnectionError(err error) bool {
 		// generic 57000 since those don't indicate a lost connection.
 		switch diag.Code {
 		case "57P01", // admin_shutdown
-			"57P02", // crash_shutdown
-			"57P03": // cannot_connect_now
+			"57P02",                // crash_shutdown
+			"57P03",                // cannot_connect_now
+			PgSSIdleSessionTimeout: // idle_session_timeout
 			return true
 		}
 		// Don't return false here — fall through to check for I/O errors.

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -703,16 +703,38 @@ func (c *Conn) serve() error {
 		}
 	}
 
-	// Main command loop.
+	// Main command loop. Startup already sent ReadyForQuery, so the first
+	// frontend message is the start of a new command cycle. For extended query
+	// protocol, only Sync completes that cycle and returns to ReadyForQuery;
+	// Parse/Bind/Execute/Flush/etc. remain within the same cycle.
+	waitingForCommand := true
 	for {
 		// Check if connection is closed.
 		if c.closed.Load() {
 			return nil
 		}
 
-		// Read the message type (1 byte).
-		msgType, err := c.ReadMessageType()
+		// Read the message type (1 byte). If the handler manages
+		// idle_session_timeout, arm a read deadline only while waiting for the
+		// first client message of a new command cycle in an idle transaction state.
+		// Clear it as soon as a byte arrives so message-body reads and query
+		// execution are not accidentally governed by the idle-session clock.
+		idleDeadlineArmed, err := c.armIdleSessionTimeout(waitingForCommand)
 		if err != nil {
+			c.logger.Error("failed to arm idle_session_timeout", "error", err)
+			return err
+		}
+		msgType, err := c.ReadMessageType()
+		if err == nil && idleDeadlineArmed {
+			if clearErr := c.conn.SetReadDeadline(time.Time{}); clearErr != nil {
+				c.logger.Error("failed to clear idle_session_timeout read deadline", "error", clearErr)
+				return clearErr
+			}
+		}
+		if err != nil {
+			if idleDeadlineArmed && isNetTimeout(err) {
+				return c.handleIdleSessionTimeout()
+			}
 			// EOF or connection error - close gracefully.
 			if errors.Is(err, io.EOF) {
 				c.logger.Debug("client closed connection")
@@ -721,6 +743,7 @@ func (c *Conn) serve() error {
 			c.logger.Error("error reading message type", "error", err)
 			return err
 		}
+		waitingForCommand = false
 
 		// Open a buffering window if one isn't already attached. Per-
 		// handler bodies no longer manage this themselves; they just
@@ -764,8 +787,57 @@ func (c *Conn) serve() error {
 				c.logger.Error("flush at batch boundary failed", "type", string(msgType), "error", err)
 				return err
 			}
+			waitingForCommand = true
 		}
 	}
+}
+
+// armIdleSessionTimeout applies the effective idle_session_timeout as a read
+// deadline while the server is waiting for the first client message of a new
+// command cycle. PostgreSQL's idle_session_timeout is armed around
+// ReadyForQuery/ReadCommand, not between every extended-protocol message, and it
+// applies only when the session is idle outside a transaction.
+// Returns true when a timeout deadline was armed for the next ReadMessageType.
+func (c *Conn) armIdleSessionTimeout(waitingForCommand bool) (bool, error) {
+	if !waitingForCommand {
+		return false, nil
+	}
+	provider, ok := c.handler.(IdleSessionTimeoutProvider)
+	if !ok {
+		return false, nil
+	}
+	if c.txnStatus != protocol.TxnStatusIdle {
+		return false, nil
+	}
+
+	timeout := provider.IdleSessionTimeout(c)
+	if timeout <= 0 {
+		return false, nil
+	}
+	return true, c.conn.SetReadDeadline(time.Now().Add(timeout))
+}
+
+func isNetTimeout(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+// handleIdleSessionTimeout sends the PostgreSQL-native FATAL 57P05 error and
+// then lets the connection teardown path close the socket. Write/flush errors
+// are not returned: the timeout already decided to terminate the session, and a
+// concurrent client disconnect should not surface as a noisy handler error.
+func (c *Conn) handleIdleSessionTimeout() error {
+	c.logger.Debug("idle_session_timeout expired; closing connection")
+	_ = c.conn.SetReadDeadline(time.Time{})
+	// Brief grace window: long enough to flush the FATAL to a well-behaved
+	// client, short enough that a wedged client can't keep this goroutine
+	// pinned after the idle-session timeout has already decided to terminate
+	// the session.
+	_ = c.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	c.startWriterBuffering()
+	_ = c.writePgDiagnosticResponse(protocol.MsgErrorResponse, mterrors.NewIdleSessionTimeout())
+	_ = c.endWriterBuffering()
+	return nil
 }
 
 // handleMessage processes a single message from the client.

--- a/go/common/pgprotocol/server/handler.go
+++ b/go/common/pgprotocol/server/handler.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"time"
 
 	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/sqltypes"
@@ -139,4 +140,13 @@ type Handler interface {
 // startup state (replication mode, startup parameters) once it is settled.
 type ConnectionEstablishedHandler interface {
 	ConnectionEstablished(conn *Conn)
+}
+
+// IdleSessionTimeoutProvider is an optional interface a Handler may implement
+// to expose the effective idle_session_timeout for a client connection. A zero
+// duration disables the timeout. The protocol layer applies the timeout only
+// while the client-facing session is idle outside a transaction, then emits a
+// PostgreSQL-compatible FATAL 57P05 before closing the connection.
+type IdleSessionTimeoutProvider interface {
+	IdleSessionTimeout(conn *Conn) time.Duration
 }

--- a/go/common/pgprotocol/server/idle_session_timeout_test.go
+++ b/go/common/pgprotocol/server/idle_session_timeout_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+)
+
+type idleSessionTimeoutHandler struct {
+	mockHandler
+	timeout time.Duration
+}
+
+func (h *idleSessionTimeoutHandler) IdleSessionTimeout(*Conn) time.Duration {
+	return h.timeout
+}
+
+func writeIdleSessionTimeoutParse(t *testing.T, conn net.Conn, stmtName, query string) {
+	t.Helper()
+	var body bytes.Buffer
+	body.WriteString(stmtName)
+	body.WriteByte(0)
+	body.WriteString(query)
+	body.WriteByte(0)
+	require.NoError(t, binary.Write(&body, binary.BigEndian, int16(0)))
+	writeMessage(t, conn, protocol.MsgParse, body.Bytes())
+}
+
+func TestIdleSessionTimeout_EmitsFatalAndCloses(t *testing.T) {
+	const timeout = 150 * time.Millisecond
+	h := &idleSessionTimeoutHandler{timeout: timeout}
+
+	listener, err := NewListener(ListenerConfig{
+		Address:            "127.0.0.1:0",
+		Handler:            h,
+		CredentialProvider: newMockCredentialProvider("postgres"),
+		Logger:             testLogger(t),
+	})
+	require.NoError(t, err)
+	defer listener.Close()
+
+	go func() {
+		_ = listener.Serve()
+	}()
+
+	clientConn, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	defer clientConn.Close()
+	require.NoError(t, clientConn.SetReadDeadline(time.Now().Add(5*time.Second)))
+
+	writeStartupPacketToPipe(t, clientConn, protocol.ProtocolVersionNumber,
+		map[string]string{"user": "idleuser", "database": "testdb"})
+	scramClientHelper(t, clientConn, "idleuser", "postgres")
+
+	start := time.Now()
+	msgType, body := readMessage(t, clientConn)
+	elapsed := time.Since(start)
+
+	assert.Equal(t, byte(protocol.MsgErrorResponse), msgType)
+	assert.True(t, containsErrField(body, 'S', "FATAL"), "severity should be FATAL")
+	assert.True(t, containsErrField(body, 'C', "57P05"), "SQLSTATE should be 57P05 (idle_session_timeout)")
+	assert.True(t, containsErrField(body, 'M', "terminating connection due to idle-session timeout"))
+	assert.GreaterOrEqual(t, elapsed, timeout-50*time.Millisecond,
+		"server should not respond before the idle-session deadline")
+	assert.Less(t, elapsed, 5*time.Second,
+		"server should respond shortly after the idle-session deadline")
+}
+
+func TestIdleSessionTimeout_DoesNotFireMidExtendedQueryCycle(t *testing.T) {
+	const timeout = 150 * time.Millisecond
+	const readDeadline = 5 * time.Second
+	h := &idleSessionTimeoutHandler{timeout: timeout}
+
+	listener, err := NewListener(ListenerConfig{
+		Address:            "127.0.0.1:0",
+		Handler:            h,
+		CredentialProvider: newMockCredentialProvider("postgres"),
+		Logger:             testLogger(t),
+	})
+	require.NoError(t, err)
+	defer listener.Close()
+
+	go func() {
+		_ = listener.Serve()
+	}()
+
+	clientConn, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	defer clientConn.Close()
+	require.NoError(t, clientConn.SetReadDeadline(time.Now().Add(readDeadline)))
+
+	writeStartupPacketToPipe(t, clientConn, protocol.ProtocolVersionNumber,
+		map[string]string{"user": "idleuser", "database": "testdb"})
+	scramClientHelper(t, clientConn, "idleuser", "postgres")
+
+	writeIdleSessionTimeoutParse(t, clientConn, "stmt", "SELECT 1")
+	// PostgreSQL arms idle_session_timeout only at ReadyForQuery/command-cycle
+	// boundaries. Parse is an extended-protocol message within the current
+	// command cycle, so the session must not time out while the client waits
+	// before sending Sync.
+	time.Sleep(3 * timeout)
+	writeMessage(t, clientConn, protocol.MsgSync, nil)
+
+	msgType, _ := readMessage(t, clientConn)
+	assert.Equal(t, byte(protocol.MsgParseComplete), msgType)
+	msgType, _ = readMessage(t, clientConn)
+	assert.Equal(t, byte(protocol.MsgReadyForQuery), msgType)
+
+	// Once Sync completes and ReadyForQuery has been emitted, the connection is
+	// idle at a new command boundary and the timeout should fire again.
+	require.NoError(t, clientConn.SetReadDeadline(time.Now().Add(readDeadline)))
+	start := time.Now()
+	msgType, body := readMessage(t, clientConn)
+	elapsed := time.Since(start)
+
+	assert.Equal(t, byte(protocol.MsgErrorResponse), msgType)
+	assert.True(t, containsErrField(body, 'S', "FATAL"), "severity should be FATAL")
+	assert.True(t, containsErrField(body, 'C', "57P05"), "SQLSTATE should be 57P05 (idle_session_timeout)")
+	assert.True(t, containsErrField(body, 'M', "terminating connection due to idle-session timeout"))
+	assert.GreaterOrEqual(t, elapsed, timeout-50*time.Millisecond,
+		"server should not respond before the idle-session deadline after Sync")
+}

--- a/go/services/multigateway/engine/apply_session_state_test.go
+++ b/go/services/multigateway/engine/apply_session_state_test.go
@@ -386,10 +386,13 @@ func TestApplySessionState_RESET_UpdatesStateAndReturnsSynthetic(t *testing.T) {
 func TestApplySessionState_RESET_ALL_ClearsAllVariables(t *testing.T) {
 	state := &handler.MultiGatewayConnectionState{}
 	state.InitStatementTimeout(30 * time.Second)
+	state.InitIdleSessionTimeout(0)
 	state.SetSessionVariable("work_mem", "256MB")
 	state.SetSessionVariable("search_path", "myschema")
 	state.SetSessionVariable("statement_timeout", "30s")
+	state.SetSessionVariable("idle_session_timeout", "30s")
 	state.SetStatementTimeout(5 * time.Second)
+	state.SetIdleSessionTimeout(5 * time.Second)
 
 	testConn := server.NewTestConn(&bytes.Buffer{})
 	ctx := context.Background()
@@ -411,7 +414,10 @@ func TestApplySessionState_RESET_ALL_ClearsAllVariables(t *testing.T) {
 	assert.False(t, exists)
 	_, exists = state.GetSessionVariable("statement_timeout")
 	assert.False(t, exists)
+	_, exists = state.GetSessionVariable("idle_session_timeout")
+	assert.False(t, exists)
 	assert.Equal(t, 30*time.Second, state.GetStatementTimeout(), "RESET ALL should reset gateway-managed statement_timeout")
+	assert.Equal(t, time.Duration(0), state.GetIdleSessionTimeout(), "RESET ALL should reset gateway-managed idle_session_timeout")
 
 	// Should receive synthetic CommandComplete
 	require.Len(t, results, 1)
@@ -640,6 +646,89 @@ func TestGatewaySessionState_SETLOCAL_InsideTxnUpdatesState(t *testing.T) {
 	assert.Equal(t, 100*time.Millisecond, state.GetStatementTimeout())
 	require.Len(t, results, 1)
 	assert.Empty(t, results[0].Notices, "inside-txn SET LOCAL emits no warning")
+}
+
+func TestGatewaySessionState_IdleSessionTimeoutVariants(t *testing.T) {
+	t.Run("SET", func(t *testing.T) {
+		testConn := server.NewTestConn(&bytes.Buffer{})
+		state := handler.NewMultiGatewayConnectionState()
+		state.InitIdleSessionTimeout(30 * time.Second)
+		prim := NewIdleSessionTimeoutSet("SET idle_session_timeout = '5s'", 5*time.Second, false)
+
+		var results []*sqltypes.Result
+		err := prim.StreamExecute(context.Background(), nil, testConn.Conn, state, nil, PlanExecInfo{}, collectCallback(&results))
+		require.NoError(t, err)
+		assert.Equal(t, 5*time.Second, state.GetIdleSessionTimeout())
+		require.Len(t, results, 1)
+		assert.Equal(t, "SET", results[0].CommandTag)
+	})
+
+	t.Run("SET LOCAL inside transaction", func(t *testing.T) {
+		testConn := server.NewTestConn(&bytes.Buffer{})
+		testConn.SetTxnStatus(protocol.TxnStatusInBlock)
+		state := handler.NewMultiGatewayConnectionState()
+		state.InitIdleSessionTimeout(30 * time.Second)
+		state.SetIdleSessionTimeout(5 * time.Second)
+		prim := NewIdleSessionTimeoutSet("SET LOCAL idle_session_timeout = '250ms'", 250*time.Millisecond, true)
+
+		var results []*sqltypes.Result
+		err := prim.StreamExecute(context.Background(), nil, testConn.Conn, state, nil, PlanExecInfo{}, collectCallback(&results))
+		require.NoError(t, err)
+		assert.Equal(t, 250*time.Millisecond, state.GetIdleSessionTimeout())
+		state.ResetAllLocalGUCs()
+		assert.Equal(t, 5*time.Second, state.GetIdleSessionTimeout())
+		require.Len(t, results, 1)
+		assert.Empty(t, results[0].Notices)
+	})
+
+	t.Run("RESET", func(t *testing.T) {
+		testConn := server.NewTestConn(&bytes.Buffer{})
+		state := handler.NewMultiGatewayConnectionState()
+		state.InitIdleSessionTimeout(30 * time.Second)
+		state.SetIdleSessionTimeout(5 * time.Second)
+		prim := NewGatewaySessionStateReset("RESET idle_session_timeout", "idle_session_timeout", false, true)
+
+		var results []*sqltypes.Result
+		err := prim.StreamExecute(context.Background(), nil, testConn.Conn, state, nil, PlanExecInfo{}, collectCallback(&results))
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Second, state.GetIdleSessionTimeout())
+		require.Len(t, results, 1)
+		assert.Equal(t, "RESET", results[0].CommandTag)
+	})
+
+	t.Run("SET LOCAL TO DEFAULT inside transaction", func(t *testing.T) {
+		testConn := server.NewTestConn(&bytes.Buffer{})
+		testConn.SetTxnStatus(protocol.TxnStatusInBlock)
+		state := handler.NewMultiGatewayConnectionState()
+		state.InitIdleSessionTimeout(30 * time.Second)
+		state.SetIdleSessionTimeout(5 * time.Second)
+		prim := NewGatewaySessionStateReset("SET LOCAL idle_session_timeout TO DEFAULT", "idle_session_timeout", true, false)
+
+		var results []*sqltypes.Result
+		err := prim.StreamExecute(context.Background(), nil, testConn.Conn, state, nil, PlanExecInfo{}, collectCallback(&results))
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Second, state.GetIdleSessionTimeout())
+		state.ResetAllLocalGUCs()
+		assert.Equal(t, 5*time.Second, state.GetIdleSessionTimeout())
+		require.Len(t, results, 1)
+		assert.Equal(t, "SET", results[0].CommandTag)
+	})
+}
+
+func TestGatewayShowVariable_IdleSessionTimeout(t *testing.T) {
+	state := handler.NewMultiGatewayConnectionState()
+	state.SetIdleSessionTimeout(5 * time.Second)
+	prim := NewGatewayShowVariable("SHOW idle_session_timeout", "idle_session_timeout")
+
+	var results []*sqltypes.Result
+	err := prim.StreamExecute(context.Background(), nil, nil, state, nil, PlanExecInfo{}, collectCallback(&results))
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "SHOW", results[0].CommandTag)
+	require.Len(t, results[0].Fields, 1)
+	assert.Equal(t, "idle_session_timeout", results[0].Fields[0].Name)
+	require.Len(t, results[0].Rows, 1)
+	assert.Equal(t, []byte("5s"), []byte(results[0].Rows[0].Values[0]))
 }
 
 func TestGatewaySessionState_SETLOCAL_TODefault_PreservesSession(t *testing.T) {

--- a/go/services/multigateway/engine/gateway_session_state.go
+++ b/go/services/multigateway/engine/gateway_session_state.go
@@ -42,7 +42,8 @@ type GatewaySessionState struct {
 
 	// Typed fields for each gateway-managed variable.
 	// Only the field matching `variable` is used.
-	statementTimeout time.Duration
+	statementTimeout   time.Duration
+	idleSessionTimeout time.Duration
 
 	// The (isReset, isLocal) flags map to the four user-visible variants:
 	//
@@ -71,6 +72,19 @@ func NewStatementTimeoutSet(sql string, statementTimeout time.Duration, isLocal 
 		variable:         "statement_timeout",
 		statementTimeout: statementTimeout,
 		isLocal:          isLocal,
+	}
+}
+
+// NewIdleSessionTimeoutSet creates a primitive that SETs `idle_session_timeout`.
+// The value is pre-parsed and stored in the appropriate typed field. The
+// protocol layer enforces it while the client-facing connection is idle outside
+// a transaction.
+func NewIdleSessionTimeoutSet(sql string, idleSessionTimeout time.Duration, isLocal bool) *GatewaySessionState {
+	return &GatewaySessionState{
+		sql:                sql,
+		variable:           "idle_session_timeout",
+		idleSessionTimeout: idleSessionTimeout,
+		isLocal:            isLocal,
 	}
 }
 
@@ -147,6 +161,17 @@ func (g *GatewaySessionState) StreamExecute(
 			state.SetLocalStatementTimeout(g.statementTimeout)
 		default:
 			state.SetStatementTimeout(g.statementTimeout)
+		}
+	case "idle_session_timeout":
+		switch {
+		case g.isReset && g.isLocal:
+			state.SetLocalIdleSessionTimeoutToDefault()
+		case g.isReset:
+			state.ResetIdleSessionTimeout()
+		case g.isLocal:
+			state.SetLocalIdleSessionTimeout(g.idleSessionTimeout)
+		default:
+			state.SetIdleSessionTimeout(g.idleSessionTimeout)
 		}
 	default:
 		// Unreachable: the planner validates the variable name before creating

--- a/go/services/multigateway/engine/gateway_show_variable.go
+++ b/go/services/multigateway/engine/gateway_show_variable.go
@@ -58,6 +58,8 @@ func (g *GatewayShowVariable) StreamExecute(
 	switch g.variable {
 	case "statement_timeout":
 		value = state.ShowStatementTimeout()
+	case "idle_session_timeout":
+		value = state.ShowIdleSessionTimeout()
 	default:
 		// Unreachable: the planner validates the variable name before creating
 		// this primitive. If we get here, there's a code bug (new variable added

--- a/go/services/multigateway/handler/connection_state.go
+++ b/go/services/multigateway/handler/connection_state.go
@@ -150,6 +150,12 @@ type MultiGatewayConnectionState struct {
 	// repeated parsing on every query.
 	statementTimeout GatewayManagedVariable[time.Duration]
 
+	// idleSessionTimeout is managed entirely by the gateway and is NOT forwarded
+	// to PostgreSQL. It applies to the client-facing gateway session while idle
+	// outside a transaction; forwarding it to pooled PostgreSQL backends would
+	// make backend sockets die independently of the client session.
+	idleSessionTimeout GatewayManagedVariable[time.Duration]
+
 	// savepoints is the stack of per-savepoint snapshots driving GUC revert
 	// semantics on ROLLBACK / ROLLBACK TO. Each frame captures SessionSettings
 	// and OpenHoldCursors; gateway-managed variables maintain parallel
@@ -438,9 +444,10 @@ func (m *MultiGatewayConnectionState) ResetAllSessionVariables() {
 // transaction-boundary paths and a slice literal would escape to the heap on
 // every call. Adding a GMV means bumping the array size and adding the element
 // here; the compiler flags a size mismatch if you forget one.
-func (m *MultiGatewayConnectionState) gatewayManagedVariablesLocked() [1]gmvLifecycle {
-	return [1]gmvLifecycle{
+func (m *MultiGatewayConnectionState) gatewayManagedVariablesLocked() [2]gmvLifecycle {
+	return [2]gmvLifecycle{
 		&m.statementTimeout,
+		&m.idleSessionTimeout,
 	}
 }
 
@@ -481,6 +488,41 @@ func (m *MultiGatewayConnectionState) SetLocalStatementTimeoutToDefault() {
 	m.statementTimeout.SetLocalToDefault()
 }
 
+// SetIdleSessionTimeout sets the session-level idle-session timeout override.
+func (m *MultiGatewayConnectionState) SetIdleSessionTimeout(d time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.idleSessionTimeout.Set(d)
+}
+
+// ResetIdleSessionTimeout clears both the session-level override and any active
+// transaction-local override, reverting to the default (0 unless set at startup).
+func (m *MultiGatewayConnectionState) ResetIdleSessionTimeout() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.idleSessionTimeout.Reset()
+}
+
+// SetLocalIdleSessionTimeout stores a transaction-local idle-session timeout
+// override, cleared on COMMIT/ROLLBACK. While the transaction is active the
+// protocol layer does not enforce idle_session_timeout; idle-in-transaction
+// semantics are governed by idle_in_transaction_session_timeout, which is not a
+// gateway-managed variable here.
+func (m *MultiGatewayConnectionState) SetLocalIdleSessionTimeout(d time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.idleSessionTimeout.SetLocal(d)
+}
+
+// SetLocalIdleSessionTimeoutToDefault sets a transaction-local override to the
+// startup/default idle_session_timeout value without destroying any session
+// override, matching SET LOCAL ... TO DEFAULT GUC semantics.
+func (m *MultiGatewayConnectionState) SetLocalIdleSessionTimeoutToDefault() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.idleSessionTimeout.SetLocalToDefault()
+}
+
 // gatewayManagedVariableNames is the canonical set of session variables the
 // gateway manages itself: SET / SHOW / RESET are handled locally and the value
 // is never written to SessionSettings (so it is not replayed to backends on
@@ -488,7 +530,8 @@ func (m *MultiGatewayConnectionState) SetLocalStatementTimeoutToDefault() {
 // (routing decisions) and the engine (set_config execution). Names compare
 // case-insensitively.
 var gatewayManagedVariableNames = map[string]struct{}{
-	"statement_timeout": {},
+	"statement_timeout":    {},
+	"idle_session_timeout": {},
 }
 
 // IsGatewayManagedVariable reports whether name (case-insensitive) is a session
@@ -522,6 +565,17 @@ func (m *MultiGatewayConnectionState) ApplyGatewayManagedVariable(name, value st
 			m.SetLocalStatementTimeout(d)
 		} else {
 			m.SetStatementTimeout(d)
+		}
+		return true, nil
+	case "idle_session_timeout":
+		d, err := ParsePostgresInterval("idle_session_timeout", value)
+		if err != nil {
+			return true, err
+		}
+		if isLocal {
+			m.SetLocalIdleSessionTimeout(d)
+		} else {
+			m.SetIdleSessionTimeout(d)
 		}
 		return true, nil
 	default:
@@ -789,6 +843,30 @@ func (m *MultiGatewayConnectionState) InitStatementTimeout(defaultValue time.Dur
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.statementTimeout = NewGatewayManagedVariable(defaultValue)
+}
+
+// GetIdleSessionTimeout returns the effective idle_session_timeout. A zero
+// duration disables idle-session termination, matching PostgreSQL's default.
+func (m *MultiGatewayConnectionState) GetIdleSessionTimeout() time.Duration {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.idleSessionTimeout.GetEffective()
+}
+
+// ShowIdleSessionTimeout returns the effective idle_session_timeout formatted
+// using PostgreSQL's GUC_UNIT_MS display convention for SHOW output.
+func (m *MultiGatewayConnectionState) ShowIdleSessionTimeout() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return formatDurationPg(m.idleSessionTimeout.GetEffective())
+}
+
+// InitIdleSessionTimeout sets the default for idle_session_timeout. Called once
+// during connection initialization with the value from startup params, or 0.
+func (m *MultiGatewayConnectionState) InitIdleSessionTimeout(defaultValue time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.idleSessionTimeout = NewGatewayManagedVariable(defaultValue)
 }
 
 // TargetReplica returns true if this connection targets a replica.

--- a/go/services/multigateway/handler/gateway_managed_variable_apply_test.go
+++ b/go/services/multigateway/handler/gateway_managed_variable_apply_test.go
@@ -16,6 +16,7 @@ package handler
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,10 +28,12 @@ func TestIsGatewayManagedVariable(t *testing.T) {
 		want bool
 	}{
 		{"statement_timeout", true},
+		{"idle_session_timeout", true},
 		// Case-insensitive: PostgreSQL lowercases unquoted identifiers, but a
 		// quoted identifier preserves case and must still be recognized.
 		{"STATEMENT_TIMEOUT", true},
 		{"Statement_Timeout", true},
+		{"IDLE_SESSION_TIMEOUT", true},
 		{"application_name", false},
 		{"work_mem", false},
 		{"search_path", false},
@@ -65,9 +68,41 @@ func TestApplyGatewayManagedVariable_RoutesToGatewayState(t *testing.T) {
 		assert.Equal(t, "5s", s.ShowStatementTimeout())
 	})
 
+	t.Run("idle_session_timeout session", func(t *testing.T) {
+		s := &MultiGatewayConnectionState{}
+		handled, err := s.ApplyGatewayManagedVariable("idle_session_timeout", "5s", false)
+		require.NoError(t, err)
+		assert.True(t, handled)
+		assert.Equal(t, "5s", s.ShowIdleSessionTimeout())
+		assert.Equal(t, 5*time.Second, s.GetIdleSessionTimeout())
+		_, exists := s.GetSessionVariable("idle_session_timeout")
+		assert.False(t, exists)
+	})
+
+	t.Run("idle_session_timeout local", func(t *testing.T) {
+		s := &MultiGatewayConnectionState{}
+		s.InitIdleSessionTimeout(30 * time.Second)
+		s.SetIdleSessionTimeout(5 * time.Second)
+		handled, err := s.ApplyGatewayManagedVariable("idle_session_timeout", "250ms", true)
+		require.NoError(t, err)
+		assert.True(t, handled)
+		assert.Equal(t, 250*time.Millisecond, s.GetIdleSessionTimeout())
+		s.ResetAllLocalGUCs()
+		assert.Equal(t, 5*time.Second, s.GetIdleSessionTimeout(), "session value restored after local reset")
+		_, exists := s.GetSessionVariable("idle_session_timeout")
+		assert.False(t, exists)
+	})
+
 	t.Run("invalid statement_timeout returns handled with error", func(t *testing.T) {
 		s := &MultiGatewayConnectionState{}
 		handled, err := s.ApplyGatewayManagedVariable("statement_timeout", "not-a-duration", false)
+		require.Error(t, err)
+		assert.True(t, handled, "still gateway-managed even though the value is invalid")
+	})
+
+	t.Run("invalid idle_session_timeout returns handled with error", func(t *testing.T) {
+		s := &MultiGatewayConnectionState{}
+		handled, err := s.ApplyGatewayManagedVariable("idle_session_timeout", "not-a-duration", false)
 		require.Error(t, err)
 		assert.True(t, handled, "still gateway-managed even though the value is invalid")
 	})
@@ -82,4 +117,26 @@ func TestApplyGatewayManagedVariable_RoutesToGatewayState(t *testing.T) {
 		_, exists := s.GetSessionVariable("work_mem")
 		assert.False(t, exists)
 	})
+}
+
+func TestIdleSessionTimeoutGatewayManagedVariableLifecycle(t *testing.T) {
+	s := &MultiGatewayConnectionState{}
+	s.InitIdleSessionTimeout(30 * time.Second)
+	assert.Equal(t, 30*time.Second, s.GetIdleSessionTimeout())
+
+	s.SetIdleSessionTimeout(5 * time.Second)
+	assert.Equal(t, 5*time.Second, s.GetIdleSessionTimeout())
+
+	s.SetLocalIdleSessionTimeout(250 * time.Millisecond)
+	assert.Equal(t, 250*time.Millisecond, s.GetIdleSessionTimeout())
+
+	s.SetLocalIdleSessionTimeoutToDefault()
+	assert.Equal(t, 30*time.Second, s.GetIdleSessionTimeout(), "LOCAL TO DEFAULT masks session value with default")
+
+	s.ResetAllLocalGUCs()
+	assert.Equal(t, 5*time.Second, s.GetIdleSessionTimeout(), "transaction end restores session value")
+
+	s.SetLocalIdleSessionTimeout(250 * time.Millisecond)
+	s.ResetIdleSessionTimeout()
+	assert.Equal(t, 30*time.Second, s.GetIdleSessionTimeout(), "RESET clears session and local overrides")
 }

--- a/go/services/multigateway/handler/handler.go
+++ b/go/services/multigateway/handler/handler.go
@@ -330,6 +330,13 @@ func (h *MultiGatewayHandler) startsWithAbortRecovery(asts []ast.Stmt) bool {
 	return len(asts) > 0 && ast.IsAllowedInAbortedTransaction(asts[0])
 }
 
+// IdleSessionTimeout exposes the effective idle_session_timeout to the pgwire
+// protocol loop. The loop enforces it only while waiting for the next client
+// message in an idle transaction state.
+func (h *MultiGatewayHandler) IdleSessionTimeout(conn *server.Conn) time.Duration {
+	return h.getConnectionState(conn).GetIdleSessionTimeout()
+}
+
 // getConnectionState retrieves and typecasts the connection state for this handler.
 // Initializes a new state if it doesn't exist.
 func (h *MultiGatewayHandler) getConnectionState(conn *server.Conn) *MultiGatewayConnectionState {
@@ -351,6 +358,18 @@ func (h *MultiGatewayHandler) getConnectionState(conn *server.Conn) *MultiGatewa
 			delete(newState.StartupParams, "statement_timeout")
 		}
 		newState.InitStatementTimeout(stDefault)
+
+		idleDefault := time.Duration(0)
+		if v, ok := newState.StartupParams["idle_session_timeout"]; ok {
+			if d, err := ParsePostgresInterval("idle_session_timeout", v); err == nil {
+				idleDefault = d
+			} else {
+				h.logger.Warn("ignoring invalid idle_session_timeout startup parameter, using default",
+					"value", v, "default", idleDefault, "error", err)
+			}
+			delete(newState.StartupParams, "idle_session_timeout")
+		}
+		newState.InitIdleSessionTimeout(idleDefault)
 		newState.targetReplica = h.targetReplica
 
 		newState.SubSync = &handlerSubSync{

--- a/go/services/multigateway/handler/handler_test.go
+++ b/go/services/multigateway/handler/handler_test.go
@@ -95,6 +95,16 @@ func (m *mockExecutor) ReleaseAll(ctx context.Context, conn *server.Conn, state 
 }
 
 // TestHandleQueryEmptyQuery tests that empty queries are handled correctly.
+func TestMultiGatewayHandler_IdleSessionTimeoutProvider(t *testing.T) {
+	h := NewMultiGatewayHandler(&mockExecutor{}, slog.Default(), 0)
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	state := NewMultiGatewayConnectionState()
+	state.SetIdleSessionTimeout(5 * time.Second)
+	testConn.SetConnectionState(state)
+
+	require.Equal(t, 5*time.Second, h.IdleSessionTimeout(testConn.Conn))
+}
+
 func TestHandleQueryEmptyQuery(t *testing.T) {
 	logger := slog.Default()
 	executor := &mockExecutor{}

--- a/go/services/multigateway/planner/variable_set_stmt.go
+++ b/go/services/multigateway/planner/variable_set_stmt.go
@@ -201,6 +201,14 @@ func (p *Planner) planGatewayManagedVariable(
 			p.logger.Debug("planning SET statement_timeout (gateway-managed)",
 				"value", value, "parsed", d, "is_local", stmt.IsLocal)
 			return engine.NewStatementTimeoutSet(sql, d, stmt.IsLocal), nil
+		case "idle_session_timeout":
+			d, err := handler.ParsePostgresInterval(name, value)
+			if err != nil {
+				return nil, err
+			}
+			p.logger.Debug("planning SET idle_session_timeout (gateway-managed)",
+				"value", value, "parsed", d, "is_local", stmt.IsLocal)
+			return engine.NewIdleSessionTimeoutSet(sql, d, stmt.IsLocal), nil
 		default:
 			return nil, mterrors.NewUnrecognizedParameter(name)
 		}

--- a/go/services/multigateway/planner/variable_set_stmt_test.go
+++ b/go/services/multigateway/planner/variable_set_stmt_test.go
@@ -53,6 +53,40 @@ func TestPlanVariableSetStmt_SET(t *testing.T) {
 	assert.True(t, ok, "second primitive should be ApplySessionState (track + emit SET), got %T", seq.Primitives[1])
 }
 
+func TestPlanVariableSetStmt_SET_IdleSessionTimeoutGatewayManaged(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	p := NewPlanner("default", logger, nil)
+	testConn := server.NewTestConn(&bytes.Buffer{})
+
+	stmt := &ast.VariableSetStmt{
+		Kind: ast.VAR_SET_VALUE,
+		Name: "idle_session_timeout",
+		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "58s"}}}},
+	}
+
+	plan, err := p.planVariableSetStmt("SET idle_session_timeout = '58s'", stmt, testConn.Conn)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	_, ok := plan.Primitive.(*engine.GatewaySessionState)
+	assert.True(t, ok, "idle_session_timeout should be handled by the gateway, got %T", plan.Primitive)
+}
+
+func TestPlanVariableSetStmt_SET_IdleSessionTimeoutInvalidErrors(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	p := NewPlanner("default", logger, nil)
+	testConn := server.NewTestConn(&bytes.Buffer{})
+
+	stmt := &ast.VariableSetStmt{
+		Kind: ast.VAR_SET_VALUE,
+		Name: "idle_session_timeout",
+		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "not-a-duration"}}}},
+	}
+
+	plan, err := p.planVariableSetStmt("SET idle_session_timeout = 'not-a-duration'", stmt, testConn.Conn)
+	require.Error(t, err)
+	assert.Nil(t, plan)
+}
+
 func TestPlanVariableSetStmt_RESET(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
 	p := NewPlanner("default", logger, nil)

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -445,9 +445,9 @@ func (e *Executor) reserveAndStreamExecute(
 
 	// Do the first state-modifying writes on a newly borrowed socket inside the
 	// reserved-pool validate callback. If the regular pool hands us a stale socket
-	// that PostgreSQL closed while idle (for example after a backend restart), the
-	// validate path taints it and retries on a fresh socket before this reserved
-	// connection is registered.
+	// that PostgreSQL closed while idle (for example after a backend restart or a
+	// client-set idle_session_timeout), the validate path taints it and retries on
+	// a fresh socket before registering the reserved connection.
 	//
 	// Parse is a session-level operation in PostgreSQL, so running it before BEGIN
 	// is safe; the prepared statement persists into the transaction. VPID stamping

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -225,6 +225,79 @@ func boolResult(b bool) []*sqltypes.Result {
 	return []*sqltypes.Result{makeResult(makeRow(v))}
 }
 
+// TestReserveAndStreamExecute_BeginRetriesIdleSessionTimeout verifies the
+// dashboard-refocus failure mode: the first write on a newly reserved backend is
+// BEGIN, and PostgreSQL may have killed the pooled socket while it sat idle
+// after a client SET idle_session_timeout. BEGIN must run inside the reserved
+// pool's validation hook so acquireValidated can discard the stale connection
+// and retry on a fresh one before surfacing an error to the client.
+func TestReserveAndStreamExecute_BeginRetriesIdleSessionTimeout(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.OrderMatters()
+
+	server.AddExpectedExecuteFetch(fakepgserver.ExpectedExecuteFetch{
+		Query:       "SELECT warmup",
+		QueryResult: fakepgserver.MakeResult([]string{"?column?"}, [][]any{{1}}),
+	})
+	server.AddExpectedExecuteFetch(fakepgserver.ExpectedExecuteFetch{
+		Query: "BEGIN",
+		Error: mterrors.NewIdleSessionTimeout(),
+	})
+	server.AddExpectedExecuteFetch(fakepgserver.ExpectedExecuteFetch{
+		Query:       "BEGIN",
+		QueryResult: &sqltypes.Result{CommandTag: "BEGIN"},
+	})
+	server.AddExpectedExecuteFetch(fakepgserver.ExpectedExecuteFetch{
+		Query:       "SELECT 1",
+		QueryResult: fakepgserver.MakeResult([]string{"?column?"}, [][]any{{1}}),
+	})
+
+	pool := reserved.NewPool(context.Background(), &reserved.PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig: server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{
+				Capacity:     2,
+				MaxIdleCount: 2,
+			},
+		},
+	})
+	defer pool.Close()
+
+	// Put a backend through a successful borrow/recycle cycle so the BEGIN below
+	// exercises a pooled idle socket rather than a brand-new connection.
+	warm, err := pool.NewConn(context.Background(), nil)
+	require.NoError(t, err)
+	_, err = warm.Query(context.Background(), "SELECT warmup")
+	require.NoError(t, err)
+	warm.Release(reserved.ReleaseCommit, nil)
+
+	e := newTestExecutor()
+	e.metrics = newQueryStats()
+	e.poolManager = &stubPoolManager{newReservedPool: pool}
+
+	var results []*sqltypes.Result
+	state, err := e.reserveAndStreamExecute(
+		context.Background(),
+		"SELECT 1",
+		&query.ExecuteOptions{User: "dashboard"},
+		&query.ReservationOptions{Reasons: protoutil.ReasonTransaction},
+		func(_ context.Context, result *sqltypes.Result) error {
+			results = append(results, result)
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.NotZero(t, state.GetReservedConnectionId())
+	assert.Equal(t, protoutil.ReasonTransaction, state.GetReservationReasons())
+	require.Len(t, results, 1)
+	assert.Equal(t, "SELECT 1", results[0].CommandTag)
+	server.VerifyAllExecutedOrFail()
+}
+
 // TestStreamExecuteOnReservedConn_AdvisoryLockStillHeld verifies that after a
 // statement on an advisory-lock-reserved connection, if PostgreSQL still
 // reports an advisory lock the connection stays reserved.


### PR DESCRIPTION
## Summary
- manage `idle_session_timeout` in multigateway instead of replaying it to pooled PostgreSQL backends
- enforce idle-session expiry at the pgwire layer with PostgreSQL-compatible FATAL 57P05
- keep multipooler stale-backend retry behavior for safe first-use connection errors

## Tests
- `go test -short ./go/common/mterrors ./go/common/pgprotocol/server ./go/services/multigateway/handler ./go/services/multigateway/engine ./go/services/multigateway/planner ./go/services/multipooler/internal/executor -count=1`
- `go test -short ./go/services/multigateway/... ./go/services/multipooler/internal/... -count=1`

## Manual validation
- rebuilt and restarted a local Multigres cluster from this branch
- verified `SET idle_session_timeout = '2s'` terminates the idle client session with FATAL 57P05\n- verified fresh connections continue to work afterward