### PR TITLE
fix(test): give etcd a dedicated metrics port to avoid e2e port collision

### DIFF
--- a/go/provisioner/local/config.go
+++ b/go/provisioner/local/config.go
@@ -80,10 +80,11 @@ type LocalProvisionerConfig struct {
 
 // EtcdConfig holds etcd service configuration
 type EtcdConfig struct {
-	Version  string `yaml:"version"`
-	DataDir  string `yaml:"data-dir"`
-	Port     int    `yaml:"port"`                // Client port
-	PeerPort int    `yaml:"peer-port,omitempty"` // Optional peer port, defaults to Port+1
+	Version     string `yaml:"version"`
+	DataDir     string `yaml:"data-dir"`
+	Port        int    `yaml:"port"`                   // Client port
+	PeerPort    int    `yaml:"peer-port,omitempty"`    // Optional peer port, defaults to Port+1
+	MetricsPort int    `yaml:"metrics-port,omitempty"` // Optional metrics port, defaults to Port+2
 }
 
 // MultigatewayConfig holds multigateway service configuration
@@ -436,10 +437,11 @@ func (p *localProvisioner) getServiceConfig(service string) map[string]any {
 	switch service {
 	case "etcd":
 		return map[string]any{
-			"version":   p.config.Etcd.Version,
-			"data-dir":  p.config.Etcd.DataDir,
-			"port":      p.config.Etcd.Port,
-			"peer-port": p.config.Etcd.PeerPort,
+			"version":      p.config.Etcd.Version,
+			"data-dir":     p.config.Etcd.DataDir,
+			"port":         p.config.Etcd.Port,
+			"peer-port":    p.config.Etcd.PeerPort,
+			"metrics-port": p.config.Etcd.MetricsPort,
 		}
 	case constants.ServiceMultiadmin:
 		return map[string]any{

--- a/go/test/endtoend/localprovisioner/cluster_test.go
+++ b/go/test/endtoend/localprovisioner/cluster_test.go
@@ -90,6 +90,7 @@ type testPortConfig struct {
 	// Global services (shared across zones)
 	EtcdClientPort     int
 	EtcdPeerPort       int
+	EtcdMetricsPort    int
 	MultiadminHTTPPort int
 	MultiadminGRPCPort int
 
@@ -102,6 +103,7 @@ func getTestPortConfig(t *testing.T, numZones int) *testPortConfig {
 	config := &testPortConfig{
 		EtcdClientPort:     utils.GetFreePort(t),
 		EtcdPeerPort:       utils.GetFreePort(t),
+		EtcdMetricsPort:    utils.GetFreePort(t),
 		MultiadminHTTPPort: utils.GetFreePort(t),
 		MultiadminGRPCPort: utils.GetFreePort(t),
 		Zones:              make([]zonePortConfig, numZones),
@@ -202,10 +204,11 @@ func createTestConfigWithDatabase(tempDir string, portConfig *testPortConfig, db
 		RootWorkingDir: tempDir,
 		DefaultDbName:  dbName,
 		Etcd: local.EtcdConfig{
-			Version:  "3.5.9",
-			DataDir:  filepath.Join(tempDir, "data", "etcd-data"),
-			Port:     portConfig.EtcdClientPort,
-			PeerPort: portConfig.EtcdPeerPort,
+			Version:     "3.5.9",
+			DataDir:     filepath.Join(tempDir, "data", "etcd-data"),
+			Port:        portConfig.EtcdClientPort,
+			PeerPort:    portConfig.EtcdPeerPort,
+			MetricsPort: portConfig.EtcdMetricsPort,
 		},
 		Topology: local.TopologyConfig{
 			GlobalRootPath: "/multigres/global",


### PR DESCRIPTION
The local provisioner defaults etcd's metrics listener to clientPort+2 (local.go) and getServiceConfig never supplied an explicit metrics-port. With the test port pool handing out sequential ports, the localprovisioner allocation order put EtcdClientPort=N, EtcdPeerPort=N+1, MultiadminHTTPPort=N+2 — so etcd's metrics listener (N+2) bound multiadmin's HTTP port, and multiadmin's pre-start port-conflict check failed deterministically ("port N+2 already in use").

Add an optional MetricsPort to EtcdConfig, surface it via getServiceConfig, and allocate a dedicated one in the localprovisioner test's port config. Production keeps the clientPort+2 default via the omitempty fallback.