### PR TITLE
refactor(consensus): introduce ConsensusRole and adopt it over NamesSelfAsLeader/PoolerType

### DIFF
--- a/go/common/consensus/compare.go
+++ b/go/common/consensus/compare.go
@@ -206,9 +206,15 @@ func idsEqual(a, b *clustermetadatapb.ID) bool {
 }
 
 // RuleNamesLeader reports whether rule names id as its leader. Returns false
-// when rule or its leader ID is absent.
+// when rule, its leader ID, or id is absent — two absent IDs must not be treated
+// as a match (idsEqual(nil, nil) is true), or a pooler with no ID would be
+// classified as the leader of a leaderless bootstrap rule.
 func RuleNamesLeader(rule *clustermetadatapb.ShardRule, id *clustermetadatapb.ID) bool {
-	return rule != nil && idsEqual(rule.GetLeaderId(), id)
+	leader := rule.GetLeaderId()
+	if leader == nil || id == nil {
+		return false
+	}
+	return idsEqual(leader, id)
 }
 
 // ComparePosition returns negative, zero, or positive based on whether a is

--- a/go/common/consensus/compare.go
+++ b/go/common/consensus/compare.go
@@ -205,6 +205,12 @@ func idsEqual(a, b *clustermetadatapb.ID) bool {
 		a.GetName() == b.GetName()
 }
 
+// RuleNamesLeader reports whether rule names id as its leader. Returns false
+// when rule or its leader ID is absent.
+func RuleNamesLeader(rule *clustermetadatapb.ShardRule, id *clustermetadatapb.ID) bool {
+	return rule != nil && idsEqual(rule.GetLeaderId(), id)
+}
+
 // ComparePosition returns negative, zero, or positive based on whether a is
 // behind, equal to, or ahead of b. Rule number takes precedence; LSN breaks
 // ties within the same rule. A missing or unparsable LSN is treated as less

--- a/go/common/consensus/compare_test.go
+++ b/go/common/consensus/compare_test.go
@@ -26,6 +26,31 @@ func rn(term, subterm int64) *clustermetadatapb.RuleNumber {
 	return &clustermetadatapb.RuleNumber{CoordinatorTerm: term, LeaderSubterm: subterm}
 }
 
+func TestRuleNamesLeader(t *testing.T) {
+	id := func(cell, name string) *clustermetadatapb.ID {
+		return &clustermetadatapb.ID{Cell: cell, Name: name}
+	}
+	self := id("zone1", "pooler-1")
+
+	tests := []struct {
+		name string
+		rule *clustermetadatapb.ShardRule
+		id   *clustermetadatapb.ID
+		want bool
+	}{
+		{name: "nil rule", rule: nil, id: self, want: false},
+		{name: "nil leader id", rule: &clustermetadatapb.ShardRule{}, id: self, want: false},
+		{name: "leader matches", rule: &clustermetadatapb.ShardRule{LeaderId: self}, id: self, want: true},
+		{name: "leader differs", rule: &clustermetadatapb.ShardRule{LeaderId: id("zone1", "pooler-2")}, id: self, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, RuleNamesLeader(tt.rule, tt.id))
+		})
+	}
+}
+
 func pos(term int64, lsn string) *clustermetadatapb.PoolerPosition {
 	return &clustermetadatapb.PoolerPosition{
 		Rule: &clustermetadatapb.ShardRule{RuleNumber: rn(term, 0)},

--- a/go/common/consensus/compare_test.go
+++ b/go/common/consensus/compare_test.go
@@ -40,6 +40,8 @@ func TestRuleNamesLeader(t *testing.T) {
 	}{
 		{name: "nil rule", rule: nil, id: self, want: false},
 		{name: "nil leader id", rule: &clustermetadatapb.ShardRule{}, id: self, want: false},
+		{name: "nil leader id and nil id", rule: &clustermetadatapb.ShardRule{}, id: nil, want: false},
+		{name: "leader present but nil id", rule: &clustermetadatapb.ShardRule{LeaderId: self}, id: nil, want: false},
 		{name: "leader matches", rule: &clustermetadatapb.ShardRule{LeaderId: self}, id: self, want: true},
 		{name: "leader differs", rule: &clustermetadatapb.ShardRule{LeaderId: id("zone1", "pooler-2")}, id: self, want: false},
 	}

--- a/go/common/consensus/pooler.go
+++ b/go/common/consensus/pooler.go
@@ -59,6 +59,9 @@ func (r ConsensusRole) String() string {
 func SelfConsensusRole(cs *clustermetadatapb.ConsensusStatus) ConsensusRole {
 	rule := HighestKnownRule([]*clustermetadatapb.ConsensusStatus{cs})
 	self := cs.GetId()
+	if self == nil {
+		return ConsensusRoleObserver
+	}
 	if RuleNamesLeader(rule, self) {
 		return ConsensusRoleLeader
 	}

--- a/go/common/consensus/pooler.go
+++ b/go/common/consensus/pooler.go
@@ -16,29 +16,79 @@ package consensus
 
 import clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 
-// NamesSelfAsLeader reports whether cs names its own pooler as the leader of the
-// highest rule it knows — across both its current position and the replication
-// primary it follows (HighestKnownRule over this single status).
+// ConsensusRole is the role a pooler plays in the highest consensus rule it
+// knows about: leader, follower (a cohort member that is not the leader), or
+// observer (not a cohort member, or no rule is known yet). It is derived from
+// ConsensusStatus and answers "what does consensus say this node is?" — distinct
+// from the routing role (writability self-report) the gateway uses.
+type ConsensusRole int
+
+const (
+	// ConsensusRoleObserver means the pooler is not a cohort member of the
+	// highest known rule (or no rule is known yet).
+	ConsensusRoleObserver ConsensusRole = iota
+	// ConsensusRoleFollower means the pooler is a cohort member of the highest
+	// known rule but is not its leader.
+	ConsensusRoleFollower
+	// ConsensusRoleLeader means the highest known rule names the pooler as leader.
+	ConsensusRoleLeader
+)
+
+// String returns a human-readable name for the consensus role.
+func (r ConsensusRole) String() string {
+	switch r {
+	case ConsensusRoleLeader:
+		return "leader"
+	case ConsensusRoleFollower:
+		return "follower"
+	case ConsensusRoleObserver:
+		return "observer"
+	default:
+		return "unknown"
+	}
+}
+
+// SelfConsensusRole reports the pooler's role in the highest rule it knows
+// (HighestKnownRule over this single status): leader if that rule names self,
+// follower if self is one of that rule's cohort members, observer otherwise
+// (including when cs, its ID, or any known rule is absent).
 //
-// Returns false when cs, its ID, or any known rule is absent.
-func NamesSelfAsLeader(cs *clustermetadatapb.ConsensusStatus) bool {
+// Callers that only need a leader/non-leader answer compare against
+// ConsensusRoleLeader; keep follower and observer distinct otherwise, since
+// treating a non-cohort observer as a follower is a bug.
+func SelfConsensusRole(cs *clustermetadatapb.ConsensusStatus) ConsensusRole {
+	rule := HighestKnownRule([]*clustermetadatapb.ConsensusStatus{cs})
 	self := cs.GetId()
-	if self == nil {
+	if RuleNamesLeader(rule, self) {
+		return ConsensusRoleLeader
+	}
+	for _, member := range rule.GetCohortMembers() {
+		if idsEqual(member, self) {
+			return ConsensusRoleFollower
+		}
+	}
+	return ConsensusRoleObserver
+}
+
+// IsNonRevokedCommittedLeader reports whether cs's committed position names its
+// own pooler as leader and that committed rule has not been revoked. This is the
+// write-safety leadership input: it stays false in the window between pg_promote
+// and the new rule being committed to WAL, so a freshly-promoted pooler is not
+// treated as the writable leader until its leadership is durably committed.
+func IsNonRevokedCommittedLeader(cs *clustermetadatapb.ConsensusStatus) bool {
+	committed := cs.GetCurrentPosition().GetRule()
+	if !RuleNamesLeader(committed, cs.GetId()) {
 		return false
 	}
-	leader := HighestKnownRule([]*clustermetadatapb.ConsensusStatus{cs}).GetLeaderId()
-	if leader == nil {
-		return false
-	}
-	return idsEqual(self, leader)
+	return !IsRuleRevoked(committed, cs.GetTermRevocation())
 }
 
 // LeaderTerm returns the coordinator term of the pooler's current recorded
-// rule if the pooler names itself as leader (per NamesSelfAsLeader). Returns 0
-// when it does not, when the consensus status is nil/empty, or when the rule has
-// no coordinator term.
+// rule if the pooler names itself as leader (SelfConsensusRole is leader).
+// Returns 0 when it does not, when the consensus status is nil/empty, or when
+// the rule has no coordinator term.
 func LeaderTerm(cs *clustermetadatapb.ConsensusStatus) int64 {
-	if !NamesSelfAsLeader(cs) {
+	if SelfConsensusRole(cs) != ConsensusRoleLeader {
 		return 0
 	}
 	return cs.GetCurrentPosition().GetRule().GetRuleNumber().GetCoordinatorTerm()

--- a/go/common/consensus/pooler_test.go
+++ b/go/common/consensus/pooler_test.go
@@ -127,6 +127,23 @@ func TestSelfConsensusRoleLeadership(t *testing.T) {
 	}
 }
 
+func TestConsensusRoleString(t *testing.T) {
+	tests := []struct {
+		role ConsensusRole
+		want string
+	}{
+		{ConsensusRoleLeader, "leader"},
+		{ConsensusRoleFollower, "follower"},
+		{ConsensusRoleObserver, "observer"},
+		{ConsensusRole(99), "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.role.String())
+		})
+	}
+}
+
 func TestSelfConsensusRole(t *testing.T) {
 	id := func(cell, name string) *clustermetadatapb.ID {
 		return &clustermetadatapb.ID{Cell: cell, Name: name}

--- a/go/common/consensus/pooler_test.go
+++ b/go/common/consensus/pooler_test.go
@@ -179,6 +179,16 @@ func TestSelfConsensusRole(t *testing.T) {
 			},
 			want: ConsensusRoleObserver,
 		},
+		{
+			// A pooler with no ID and a leaderless bootstrap rule must not be
+			// classified as leader: idsEqual(nil, nil) is true, so this guards the
+			// nil self against matching a nil leader ID.
+			name: "nil self id with leaderless rule is observer",
+			cs: &clustermetadatapb.ConsensusStatus{
+				CurrentPosition: &clustermetadatapb.PoolerPosition{Rule: &clustermetadatapb.ShardRule{}},
+			},
+			want: ConsensusRoleObserver,
+		},
 	}
 
 	for _, tt := range tests {
@@ -246,6 +256,15 @@ func TestIsNonRevokedCommittedLeader(t *testing.T) {
 				Id:              self,
 				CurrentPosition: &clustermetadatapb.PoolerPosition{Rule: &clustermetadatapb.ShardRule{LeaderId: self, RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4}}},
 				TermRevocation:  &clustermetadatapb.TermRevocation{RevokedBelowTerm: 5},
+			},
+			want: false,
+		},
+		{
+			// nil self id + leaderless committed rule must not self-certify as the
+			// committed leader (write-safety input must fail closed here).
+			name: "nil self id with leaderless committed rule",
+			cs: &clustermetadatapb.ConsensusStatus{
+				CurrentPosition: &clustermetadatapb.PoolerPosition{Rule: &clustermetadatapb.ShardRule{}},
 			},
 			want: false,
 		},

--- a/go/common/consensus/pooler_test.go
+++ b/go/common/consensus/pooler_test.go
@@ -22,7 +22,7 @@ import (
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
 
-func TestNamesSelfAsLeader(t *testing.T) {
+func TestSelfConsensusRoleLeadership(t *testing.T) {
 	id := func(cell, name string) *clustermetadatapb.ID {
 		return &clustermetadatapb.ID{Cell: cell, Name: name}
 	}
@@ -122,7 +122,138 @@ func TestNamesSelfAsLeader(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, NamesSelfAsLeader(tt.cs))
+			assert.Equal(t, tt.want, SelfConsensusRole(tt.cs) == ConsensusRoleLeader)
+		})
+	}
+}
+
+func TestSelfConsensusRole(t *testing.T) {
+	id := func(cell, name string) *clustermetadatapb.ID {
+		return &clustermetadatapb.ID{Cell: cell, Name: name}
+	}
+	self := id("zone1", "pooler-1")
+	other := id("zone1", "pooler-2")
+
+	tests := []struct {
+		name string
+		cs   *clustermetadatapb.ConsensusStatus
+		want ConsensusRole
+	}{
+		{
+			name: "nil status is observer",
+			cs:   nil,
+			want: ConsensusRoleObserver,
+		},
+		{
+			name: "no known rule is observer",
+			cs:   &clustermetadatapb.ConsensusStatus{Id: self},
+			want: ConsensusRoleObserver,
+		},
+		{
+			name: "rule names self as leader",
+			cs: &clustermetadatapb.ConsensusStatus{
+				Id: self,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{
+					Rule: &clustermetadatapb.ShardRule{LeaderId: self, CohortMembers: []*clustermetadatapb.ID{self, other}},
+				},
+			},
+			want: ConsensusRoleLeader,
+		},
+		{
+			name: "self is a cohort member but not leader",
+			cs: &clustermetadatapb.ConsensusStatus{
+				Id: self,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{
+					Rule: &clustermetadatapb.ShardRule{LeaderId: other, CohortMembers: []*clustermetadatapb.ID{self, other}},
+				},
+			},
+			want: ConsensusRoleFollower,
+		},
+		{
+			name: "self is not in the cohort",
+			cs: &clustermetadatapb.ConsensusStatus{
+				Id: self,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{
+					Rule: &clustermetadatapb.ShardRule{LeaderId: other, CohortMembers: []*clustermetadatapb.ID{other}},
+				},
+			},
+			want: ConsensusRoleObserver,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, SelfConsensusRole(tt.cs))
+		})
+	}
+}
+
+func TestIsNonRevokedCommittedLeader(t *testing.T) {
+	id := func(cell, name string) *clustermetadatapb.ID {
+		return &clustermetadatapb.ID{Cell: cell, Name: name}
+	}
+	self := id("zone1", "pooler-1")
+	other := id("zone1", "pooler-2")
+	committedRule := func(leader *clustermetadatapb.ID, term int64) *clustermetadatapb.ConsensusStatus {
+		return &clustermetadatapb.ConsensusStatus{
+			Id: self,
+			CurrentPosition: &clustermetadatapb.PoolerPosition{
+				Rule: &clustermetadatapb.ShardRule{
+					LeaderId:   leader,
+					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: term},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		cs   *clustermetadatapb.ConsensusStatus
+		want bool
+	}{
+		{
+			name: "nil status",
+			cs:   nil,
+			want: false,
+		},
+		{
+			name: "committed rule names another pooler",
+			cs:   committedRule(other, 5),
+			want: false,
+		},
+		{
+			name: "committed rule names self, not revoked",
+			cs:   committedRule(self, 5),
+			want: true,
+		},
+		{
+			// The pg_promote→WAL-commit window: the highest known rule may name
+			// self, but the *committed* position does not yet — so write-safety
+			// leadership stays false until the new rule is durably committed.
+			name: "self-claim only in replication primary, not yet committed",
+			cs: &clustermetadatapb.ConsensusStatus{
+				Id:              self,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{Rule: &clustermetadatapb.ShardRule{LeaderId: other, RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4}}},
+				ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
+					Rule: &clustermetadatapb.ShardRule{LeaderId: self, RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "committed rule names self but is revoked",
+			cs: &clustermetadatapb.ConsensusStatus{
+				Id:              self,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{Rule: &clustermetadatapb.ShardRule{LeaderId: self, RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4}}},
+				TermRevocation:  &clustermetadatapb.TermRevocation{RevokedBelowTerm: 5},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsNonRevokedCommittedLeader(tt.cs))
 		})
 	}
 }

--- a/go/common/pgprotocol/client/ssl_test.go
+++ b/go/common/pgprotocol/client/ssl_test.go
@@ -123,6 +123,7 @@ func TestBuildTLSConfig_RequireAndPrefer(t *testing.T) {
 		}
 		if cfg == nil {
 			t.Fatalf("BuildTLSConfig(%s) = nil, want non-nil", mode)
+			return // staticcheck SA5011: t.Fatalf isn't modeled as no-return; make it explicit before dereferencing cfg
 		}
 		if !cfg.InsecureSkipVerify {
 			t.Errorf("BuildTLSConfig(%s).InsecureSkipVerify = false, want true (libpq parity)", mode)
@@ -294,6 +295,7 @@ func tlsStateFromPEM(t *testing.T, certPEM, keyPEM []byte) tls.ConnectionState {
 	block, _ := pem.Decode(certPEM)
 	if block == nil {
 		t.Fatal("failed to decode cert PEM")
+		return tls.ConnectionState{} // staticcheck SA5011: t.Fatal isn't modeled as no-return; make it explicit before dereferencing block
 	}
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {

--- a/go/services/multiorch/recovery/actions/leader.go
+++ b/go/services/multiorch/recovery/actions/leader.go
@@ -51,7 +51,7 @@ func pollLeaderHealth(ctx context.Context, rpcClient rpcclient.MultiPoolerClient
 	if err != nil {
 		return nil, mterrors.Wrap(err, "consensus leader unreachable during health check")
 	}
-	if !commonconsensus.NamesSelfAsLeader(statusResp.GetConsensusStatus()) {
+	if commonconsensus.SelfConsensusRole(statusResp.GetConsensusStatus()) != commonconsensus.ConsensusRoleLeader {
 		return nil, mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
 			"consensus leader %s no longer reports itself as the leader", leader.Health().GetMultiPooler().GetId().GetName())
 	}

--- a/go/services/multiorch/recovery/analysis/cohort_mismatch_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/cohort_mismatch_analyzer.go
@@ -211,7 +211,7 @@ func (a *CohortMismatchAnalyzer) Analyze(sa *ShardAnalysis) ([]types.Problem, er
 // problem an acting primary adding itself to the cohort. This may be useful
 // in some propagation scenarios.
 func (a *CohortMismatchAnalyzer) isAdditionCandidate(_ *ShardAnalysis, pa *PoolerAnalysis) bool {
-	if pa.NamesSelfAsLeader {
+	if pa.SelfConsensusRole == commonconsensus.ConsensusRoleLeader {
 		return false
 	}
 	if !pa.LastCheckValid {

--- a/go/services/multiorch/recovery/analysis/cohort_mismatch_analyzer_test.go
+++ b/go/services/multiorch/recovery/analysis/cohort_mismatch_analyzer_test.go
@@ -19,6 +19,8 @@ import (
 	"log/slog"
 	"testing"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -70,7 +72,7 @@ func TestCohortMismatchAnalyzer_Analyze(t *testing.T) {
 	leaderPA := &PoolerAnalysis{
 		PoolerID:          primaryID,
 		ShardKey:          shardKey,
-		NamesSelfAsLeader: true,
+		SelfConsensusRole: commonconsensus.ConsensusRoleLeader,
 		LastCheckValid:    true,
 		IsInitialized:     true,
 	}

--- a/go/services/multiorch/recovery/analysis/generator.go
+++ b/go/services/multiorch/recovery/analysis/generator.go
@@ -227,7 +227,7 @@ func (g *AnalysisGenerator) generateAnalysisForPooler(
 	analysis := &PoolerAnalysis{
 		PoolerID:          pooler.Health().MultiPooler.Id,
 		ShardKey:          shardKey,
-		NamesSelfAsLeader: commonconsensus.NamesSelfAsLeader(pooler.Health().GetConsensusStatus()),
+		SelfConsensusRole: commonconsensus.SelfConsensusRole(pooler.Health().GetConsensusStatus()),
 		LastCheckValid:    pooler.Health().IsLastCheckValid,
 		IsInitialized:     pooler.IsInitialized(),
 		HasDataDirectory:  pooler.Health().GetStatus().GetHasDataDirectory(),
@@ -243,8 +243,8 @@ func (g *AnalysisGenerator) generateAnalysisForPooler(
 	analysis.ConsensusStatus = pooler.Health().GetConsensusStatus()
 	analysis.AvailabilityStatus = pooler.Health().GetAvailabilityStatus()
 
-	// If this is a REPLICA, populate replica-specific fields
-	if !analysis.NamesSelfAsLeader {
+	// If this is not the leader, populate replica-specific fields
+	if analysis.SelfConsensusRole != commonconsensus.ConsensusRoleLeader {
 		if rs := pooler.Health().GetStatus().GetReplicationStatus(); rs != nil {
 			analysis.WalReplayNotPaused = !rs.GetIsWalReplayPaused()
 
@@ -301,7 +301,7 @@ func (g *AnalysisGenerator) allReplicasConnectedToLeader(
 			continue
 		}
 
-		if commonconsensus.NamesSelfAsLeader(pooler.Health().GetConsensusStatus()) {
+		if commonconsensus.SelfConsensusRole(pooler.Health().GetConsensusStatus()) == commonconsensus.ConsensusRoleLeader {
 			continue
 		}
 
@@ -453,7 +453,7 @@ func (g *AnalysisGenerator) computeShardLevelFields(sa *ShardAnalysis, poolers m
 
 	// HasInitializedReplica: any non-primary, reachable, initialized pooler.
 	for _, pa := range sa.Analyses {
-		if !pa.NamesSelfAsLeader && pa.LastCheckValid && pa.IsInitialized {
+		if pa.SelfConsensusRole != commonconsensus.ConsensusRoleLeader && pa.LastCheckValid && pa.IsInitialized {
 			sa.HasInitializedReplica = true
 			break
 		}

--- a/go/services/multiorch/recovery/analysis/generator_test.go
+++ b/go/services/multiorch/recovery/analysis/generator_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -33,7 +35,7 @@ import (
 
 // primaryConsensusStatus builds a ConsensusStatus that names id as the leader
 // in its current rule with the given coordinator term. This is the minimal
-// fixture required for commonconsensus.NamesSelfAsLeader to return true for a given pooler.
+// fixture required for commonconsensus.SelfConsensusRole to report leader for a given pooler.
 func primaryConsensusStatus(id *clustermetadatapb.ID, term int64) *clustermetadatapb.ConsensusStatus {
 	return &clustermetadatapb.ConsensusStatus{
 		Id: id,
@@ -97,7 +99,7 @@ func TestAnalysisGenerator_GenerateShardAnalyses_SinglePrimary(t *testing.T) {
 	assert.Equal(t, "testdb", analysis.ShardKey.Database)
 	assert.Equal(t, "testtg", analysis.ShardKey.TableGroup)
 	assert.Equal(t, "0", analysis.ShardKey.Shard)
-	assert.True(t, analysis.NamesSelfAsLeader)
+	assert.Equal(t, commonconsensus.ConsensusRoleLeader, analysis.SelfConsensusRole)
 	assert.True(t, analysis.LastCheckValid)
 }
 
@@ -205,14 +207,14 @@ func TestAnalysisGenerator_GenerateShardAnalyses_PrimaryWithReplicas(t *testing.
 	// Find the primary analysis
 	var primaryAnalysis *PoolerAnalysis
 	for _, a := range analyses {
-		if a.NamesSelfAsLeader {
+		if a.SelfConsensusRole == commonconsensus.ConsensusRoleLeader {
 			primaryAnalysis = a
 			break
 		}
 	}
 
 	require.NotNil(t, primaryAnalysis, "should find primary analysis")
-	assert.True(t, primaryAnalysis.NamesSelfAsLeader)
+	assert.Equal(t, commonconsensus.ConsensusRoleLeader, primaryAnalysis.SelfConsensusRole)
 }
 
 func TestAnalysisGenerator_GenerateShardAnalyses_Replica(t *testing.T) {
@@ -287,7 +289,7 @@ func TestAnalysisGenerator_GenerateShardAnalyses_Replica(t *testing.T) {
 	// Find the replica analysis
 	replicaAnalysis := sa.Replicas()
 	require.Len(t, replicaAnalysis, 1, "should find one replica")
-	assert.False(t, replicaAnalysis[0].NamesSelfAsLeader)
+	assert.NotEqual(t, commonconsensus.ConsensusRoleLeader, replicaAnalysis[0].SelfConsensusRole)
 
 	// Primary health is now a shard-level field
 	assert.NotNil(t, sa.HighestShardRule.GetLeaderId(), "should have topology primary ID populated")

--- a/go/services/multiorch/recovery/analysis/leader_is_dead_analyzer_test.go
+++ b/go/services/multiorch/recovery/analysis/leader_is_dead_analyzer_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/rpcclient"
@@ -64,7 +66,7 @@ func TestLeaderIsDeadAnalyzer_Analyze(t *testing.T) {
 				{
 					PoolerID:          &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "follower-1"},
 					ShardKey:          shardKey,
-					NamesSelfAsLeader: false,
+					SelfConsensusRole: commonconsensus.ConsensusRoleFollower,
 					IsInitialized:     true,
 				},
 			},

--- a/go/services/multiorch/recovery/analysis/replica_not_replicating_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/replica_not_replicating_analyzer.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
 )
 
@@ -49,8 +50,8 @@ func (a *ReplicaNotReplicatingAnalyzer) analyzePooler(sa *ShardAnalysis, poolerA
 		return nil, errors.New("recovery action factory not initialized")
 	}
 
-	// Only analyze replicas
-	if poolerAnalysis.NamesSelfAsLeader {
+	// Only analyze non-leaders
+	if poolerAnalysis.SelfConsensusRole == commonconsensus.ConsensusRoleLeader {
 		return nil, nil
 	}
 

--- a/go/services/multiorch/recovery/analysis/replica_not_replicating_analyzer_test.go
+++ b/go/services/multiorch/recovery/analysis/replica_not_replicating_analyzer_test.go
@@ -19,6 +19,8 @@ import (
 	"log/slog"
 	"testing"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/rpcclient"
@@ -67,7 +69,7 @@ func TestReplicaNotReplicatingAnalyzer_Analyze(t *testing.T) {
 			Analyses: []*PoolerAnalysis{{
 				PoolerID:            replicaID,
 				ShardKey:            shardKey,
-				NamesSelfAsLeader:   false,
+				SelfConsensusRole:   commonconsensus.ConsensusRoleFollower,
 				IsInitialized:       true,
 				PrimaryConnInfoHost: "", // No primary_conninfo configured
 				WalReplayNotPaused:  true,
@@ -91,7 +93,7 @@ func TestReplicaNotReplicatingAnalyzer_Analyze(t *testing.T) {
 			Analyses: []*PoolerAnalysis{{
 				PoolerID:            replicaID,
 				ShardKey:            shardKey,
-				NamesSelfAsLeader:   false,
+				SelfConsensusRole:   commonconsensus.ConsensusRoleFollower,
 				IsInitialized:       true,
 				PrimaryConnInfoHost: "primary.example.com",
 				WalReplayNotPaused:  false, // Replication stopped
@@ -114,7 +116,7 @@ func TestReplicaNotReplicatingAnalyzer_Analyze(t *testing.T) {
 			Analyses: []*PoolerAnalysis{{
 				PoolerID:            replicaID,
 				ShardKey:            shardKey,
-				NamesSelfAsLeader:   false,
+				SelfConsensusRole:   commonconsensus.ConsensusRoleFollower,
 				IsInitialized:       true,
 				PrimaryConnInfoHost: "",
 			}},
@@ -131,7 +133,7 @@ func TestReplicaNotReplicatingAnalyzer_Analyze(t *testing.T) {
 			Analyses: []*PoolerAnalysis{{
 				PoolerID:            replicaID,
 				ShardKey:            shardKey,
-				NamesSelfAsLeader:   false,
+				SelfConsensusRole:   commonconsensus.ConsensusRoleFollower,
 				IsInitialized:       true,
 				PrimaryConnInfoHost: "primary.example.com",
 				WalReplayNotPaused:  true,
@@ -149,7 +151,7 @@ func TestReplicaNotReplicatingAnalyzer_Analyze(t *testing.T) {
 			Analyses: []*PoolerAnalysis{{
 				PoolerID:            primaryID,
 				ShardKey:            shardKey,
-				NamesSelfAsLeader:   true,
+				SelfConsensusRole:   commonconsensus.ConsensusRoleLeader,
 				IsInitialized:       true,
 				PrimaryConnInfoHost: "", // Primaries don't have primary_conninfo
 			}},
@@ -166,7 +168,7 @@ func TestReplicaNotReplicatingAnalyzer_Analyze(t *testing.T) {
 			Analyses: []*PoolerAnalysis{{
 				PoolerID:            replicaID,
 				ShardKey:            shardKey,
-				NamesSelfAsLeader:   false,
+				SelfConsensusRole:   commonconsensus.ConsensusRoleFollower,
 				IsInitialized:       false, // Not initialized
 				PrimaryConnInfoHost: "",
 			}},
@@ -184,7 +186,7 @@ func TestReplicaNotReplicatingAnalyzer_Analyze(t *testing.T) {
 			Analyses: []*PoolerAnalysis{{
 				PoolerID:            replicaID,
 				ShardKey:            shardKey,
-				NamesSelfAsLeader:   false,
+				SelfConsensusRole:   commonconsensus.ConsensusRoleFollower,
 				IsInitialized:       true,
 				PrimaryConnInfoHost: "",
 			}},
@@ -207,7 +209,7 @@ func TestReplicaNotReplicatingAnalyzer_Analyze(t *testing.T) {
 			Analyses: []*PoolerAnalysis{{
 				PoolerID:            replicaID,
 				ShardKey:            shardKey,
-				NamesSelfAsLeader:   false,
+				SelfConsensusRole:   commonconsensus.ConsensusRoleFollower,
 				IsInitialized:       true,
 				PrimaryConnInfoHost: "",
 			}},

--- a/go/services/multiorch/recovery/analysis/shard_analysis.go
+++ b/go/services/multiorch/recovery/analysis/shard_analysis.go
@@ -131,7 +131,7 @@ func (sa *ShardAnalysis) IsInStandbyList(id *clustermetadatapb.ID) bool {
 func (sa *ShardAnalysis) Replicas() []*PoolerAnalysis {
 	var replicas []*PoolerAnalysis
 	for _, pa := range sa.Analyses {
-		if !pa.NamesSelfAsLeader {
+		if pa.SelfConsensusRole != commonconsensus.ConsensusRoleLeader {
 			replicas = append(replicas, pa)
 		}
 	}
@@ -147,7 +147,11 @@ type PoolerAnalysis struct {
 	ShardKey *clustermetadatapb.ShardKey
 
 	// Pooler properties
-	NamesSelfAsLeader bool
+
+	// SelfConsensusRole is the pooler's role in the highest consensus rule it
+	// knows (leader/follower/observer), derived from ConsensusStatus via
+	// commonconsensus.SelfConsensusRole. Distinct from any routing role.
+	SelfConsensusRole commonconsensus.ConsensusRole
 	// Represents if the poolerID is reachable and it's returning a
 	// valid status response
 	LastCheckValid   bool

--- a/go/services/multiorch/recovery/analysis/shard_needs_initialization_analyzer_test.go
+++ b/go/services/multiorch/recovery/analysis/shard_needs_initialization_analyzer_test.go
@@ -19,6 +19,8 @@ import (
 	"log/slog"
 	"testing"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/rpcclient"
@@ -104,7 +106,7 @@ func TestShardNeedsInitializationAnalyzer_Analyze(t *testing.T) {
 	t.Run("suppresses when any pooler is a primary (has cohort members)", func(t *testing.T) {
 		// A genuine primary always has cohort members; the cohort-members check covers this case.
 		withCohortAndPrimary := initialized("pooler-1")
-		withCohortAndPrimary.NamesSelfAsLeader = true
+		withCohortAndPrimary.SelfConsensusRole = commonconsensus.ConsensusRoleLeader
 		withCohortAndPrimary.CohortMembers = []*clustermetadatapb.ID{
 			{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler-1"},
 		}

--- a/go/services/multiorch/recovery/analysis/stale_leader_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/stale_leader_analyzer.go
@@ -60,7 +60,7 @@ func (a *StaleLeaderAnalyzer) Analyze(sa *ShardAnalysis) ([]types.Problem, error
 
 	// The shard's leader is the pooler named by the highest known consensus rule.
 	// Any reachable pooler whose own consensus status says it believes itself the
-	// leader of its term (commonconsensus.NamesSelfAsLeader) but is not that named leader is
+	// leader of its term (consensus role leader) but is not that named leader is
 	// a stale leader to be demoted.
 	leaderID := sa.HighestShardRule.GetLeaderId()
 	if leaderID == nil {
@@ -69,7 +69,7 @@ func (a *StaleLeaderAnalyzer) Analyze(sa *ShardAnalysis) ([]types.Problem, error
 
 	var staleLeaders []*PoolerAnalysis
 	for _, pa := range sa.Analyses {
-		if !pa.LastCheckValid || !commonconsensus.NamesSelfAsLeader(pa.ConsensusStatus) {
+		if !pa.LastCheckValid || commonconsensus.SelfConsensusRole(pa.ConsensusStatus) != commonconsensus.ConsensusRoleLeader {
 			continue
 		}
 		if proto.Equal(pa.PoolerID, leaderID) {

--- a/go/services/multiorch/recovery/analysis/stale_leader_analyzer_test.go
+++ b/go/services/multiorch/recovery/analysis/stale_leader_analyzer_test.go
@@ -17,6 +17,8 @@ package analysis
 import (
 	"testing"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -50,7 +52,7 @@ func TestStaleLeaderAnalyzer_Analyze(t *testing.T) {
 		stalePA := &PoolerAnalysis{
 			PoolerID:          staleID,
 			ShardKey:          &clustermetadatapb.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
-			NamesSelfAsLeader: true,
+			SelfConsensusRole: commonconsensus.ConsensusRoleLeader,
 			IsInitialized:     true,
 			LastCheckValid:    true,
 			ConsensusStatus:   primaryRuleStatus(staleID, 5),
@@ -85,7 +87,7 @@ func TestStaleLeaderAnalyzer_Analyze(t *testing.T) {
 		newPA := &PoolerAnalysis{
 			PoolerID:          newID,
 			ShardKey:          &clustermetadatapb.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
-			NamesSelfAsLeader: true,
+			SelfConsensusRole: commonconsensus.ConsensusRoleLeader,
 			IsInitialized:     true,
 			ConsensusStatus:   primaryRuleStatus(newID, 6),
 			ConsensusTerm:     11,
@@ -126,7 +128,7 @@ func TestStaleLeaderAnalyzer_Analyze(t *testing.T) {
 				Name:      "replica1",
 			},
 			ShardKey:          &clustermetadatapb.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
-			NamesSelfAsLeader: false,
+			SelfConsensusRole: commonconsensus.ConsensusRoleFollower,
 			IsInitialized:     true,
 		}
 
@@ -142,7 +144,7 @@ func TestStaleLeaderAnalyzer_Analyze(t *testing.T) {
 		pa := &PoolerAnalysis{
 			PoolerID:          primaryID,
 			ShardKey:          &clustermetadatapb.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
-			NamesSelfAsLeader: true,
+			SelfConsensusRole: commonconsensus.ConsensusRoleLeader,
 			IsInitialized:     true,
 			ConsensusStatus:   primaryRuleStatus(primaryID, 5),
 			ConsensusTerm:     10,
@@ -164,7 +166,7 @@ func TestStaleLeaderAnalyzer_Analyze(t *testing.T) {
 
 	t.Run("returns error when factory is nil", func(t *testing.T) {
 		analyzer := &StaleLeaderAnalyzer{factory: nil}
-		analysis := &PoolerAnalysis{NamesSelfAsLeader: true}
+		analysis := &PoolerAnalysis{SelfConsensusRole: commonconsensus.ConsensusRoleLeader}
 
 		_, err := analyzeOne(analyzer, analysis)
 
@@ -180,7 +182,7 @@ func TestStaleLeaderAnalyzer_Analyze(t *testing.T) {
 		newPA := &PoolerAnalysis{
 			PoolerID:          newID,
 			ShardKey:          &clustermetadatapb.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
-			NamesSelfAsLeader: true,
+			SelfConsensusRole: commonconsensus.ConsensusRoleLeader,
 			IsInitialized:     true,
 			ConsensusStatus:   primaryRuleStatus(newID, 6),
 			ConsensusTerm:     11,

--- a/go/services/multiorch/recovery/recovery_loop_test.go
+++ b/go/services/multiorch/recovery/recovery_loop_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
@@ -573,7 +575,7 @@ func (m *mockPrimaryDeadAnalyzer) RecoveryAction() types.RecoveryAction {
 func (m *mockPrimaryDeadAnalyzer) Analyze(sa *analysis.ShardAnalysis) ([]types.Problem, error) {
 	var problems []types.Problem
 	for _, a := range sa.Analyses {
-		if a.NamesSelfAsLeader && !a.LastCheckValid {
+		if a.SelfConsensusRole == commonconsensus.ConsensusRoleLeader && !a.LastCheckValid {
 			problems = append(problems, types.Problem{
 				Code:           types.ProblemLeaderIsDead,
 				CheckName:      m.Name(),
@@ -610,7 +612,7 @@ func (m *mockReplicaNotReplicatingAnalyzer) RecoveryAction() types.RecoveryActio
 func (m *mockReplicaNotReplicatingAnalyzer) Analyze(sa *analysis.ShardAnalysis) ([]types.Problem, error) {
 	var problems []types.Problem
 	for _, a := range sa.Analyses {
-		if !a.NamesSelfAsLeader && !a.WalReplayNotPaused {
+		if a.SelfConsensusRole != commonconsensus.ConsensusRoleLeader && !a.WalReplayNotPaused {
 			problems = append(problems, types.Problem{
 				Code:           types.ProblemReplicaNotReplicating,
 				CheckName:      m.Name(),
@@ -1387,7 +1389,7 @@ func TestRecoveryLoop_PriorityOrdering(t *testing.T) {
 	// Create three separate analyzers, each detecting a problem with different priority
 	normalAnalyzer := &customAnalyzer{
 		analyzeFn: func(a *analysis.PoolerAnalysis) *types.Problem {
-			if !a.NamesSelfAsLeader && !a.WalReplayNotPaused {
+			if a.SelfConsensusRole != commonconsensus.ConsensusRoleLeader && !a.WalReplayNotPaused {
 				return &types.Problem{
 					Code:           types.ProblemReplicaNotReplicating,
 					CheckName:      "NormalPriorityAnalyzer",
@@ -1409,7 +1411,7 @@ func TestRecoveryLoop_PriorityOrdering(t *testing.T) {
 
 	emergencyAnalyzer := &customAnalyzer{
 		analyzeFn: func(a *analysis.PoolerAnalysis) *types.Problem {
-			if !a.NamesSelfAsLeader && !a.WalReplayNotPaused {
+			if a.SelfConsensusRole != commonconsensus.ConsensusRoleLeader && !a.WalReplayNotPaused {
 				return &types.Problem{
 					Code:           types.ProblemReplicaNotReplicating,
 					CheckName:      "EmergencyPriorityAnalyzer",
@@ -1431,7 +1433,7 @@ func TestRecoveryLoop_PriorityOrdering(t *testing.T) {
 
 	highAnalyzer := &customAnalyzer{
 		analyzeFn: func(a *analysis.PoolerAnalysis) *types.Problem {
-			if !a.NamesSelfAsLeader && !a.WalReplayNotPaused {
+			if a.SelfConsensusRole != commonconsensus.ConsensusRoleLeader && !a.WalReplayNotPaused {
 				return &types.Problem{
 					Code:           types.ProblemReplicaNotReplicating,
 					CheckName:      "HighPriorityAnalyzer",
@@ -1548,7 +1550,7 @@ func TestRecoveryLoop_TracingSpans(t *testing.T) {
 
 	analyzeFunc := func(a *analysis.PoolerAnalysis) *types.Problem {
 		// Detect replica with paused WAL replay
-		if !a.NamesSelfAsLeader && !a.WalReplayNotPaused {
+		if a.SelfConsensusRole != commonconsensus.ConsensusRoleLeader && !a.WalReplayNotPaused {
 			return &types.Problem{
 				Code:           types.ProblemReplicaNotReplicating,
 				CheckName:      "TracingTestAnalyzer",

--- a/go/services/multipooler/internal/manager/fake_rule_store_test.go
+++ b/go/services/multipooler/internal/manager/fake_rule_store_test.go
@@ -65,6 +65,7 @@ type fakeRuleStore struct {
 	mu                 sync.Mutex
 	pos                *clustermetadatapb.PoolerPosition
 	posSequence        []*clustermetadatapb.PoolerPosition
+	observeCalls       int
 	observeErr         error
 	updateErr          error
 	updateErrAfterHook error
@@ -76,9 +77,16 @@ type fakeRuleStore struct {
 	clearSyncErr       error
 }
 
+func (f *fakeRuleStore) observePositionCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.observeCalls
+}
+
 func (f *fakeRuleStore) ObservePosition(_ context.Context) (*clustermetadatapb.PoolerPosition, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.observeCalls++
 	if len(f.posSequence) > 0 {
 		pos := f.posSequence[0]
 		f.posSequence = f.posSequence[1:]

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -321,6 +321,17 @@ func (pm *MultiPoolerManager) discoverPostgresState(ctx context.Context) (postgr
 				state.rewindSourceReady = ready
 			}
 		}
+		// Refresh the cached consensus position from postgres so this iteration's
+		// role decisions (highestKnownRule / SelfConsensusRole read the cache)
+		// converge on current state rather than lagging the periodic Status RPC that
+		// otherwise refreshes it. If the position can't be read — postgres or the
+		// multischema is unreadable (readCurrentRule errors when current_rule is
+		// missing) — the role would rest on stale/absent consensus state, so surface
+		// the error and let the monitor skip remediation this tick, matching the
+		// isPrimary probe above.
+		if _, err := pm.consensusMgr.Rules().ObservePosition(ctx); err != nil {
+			return state, fmt.Errorf("refresh consensus position: %w", err)
+		}
 	}
 
 	// Check if backups are available (only if directory not initialized)

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -49,12 +49,21 @@ func deriveTypeAndObs(rule *clustermetadatapb.ShardRule, selfID *clustermetadata
 	return clustermetadatapb.PoolerType_REPLICA, nil
 }
 
-// latestRule returns the highest-numbered rule this pooler knows of, combining
-// the rule it has applied into its own position with the rule it was most
-// recently told to follow via SetPrimary/Promote (consensusPromises's recorded
-// ReplicationPrimary). A standby told of a newer leader before its own position
-// advances still reads the newer rule. Returns nil if neither source carries a
-// rule.
+// highestKnownRule returns the highest-numbered rule this pooler knows of,
+// combining the rule it has applied into its own position with the rule it was
+// most recently told to follow via SetPrimary/Promote (consensusPromises's
+// recorded ReplicationPrimary). A standby told of a newer leader before its own
+// position advances still reads the newer rule. Returns nil if neither source
+// carries a rule.
+//
+// "Known" is deliberately distinct from "committed": this ranks across both the
+// committed position and the replication primary, so it can name a leader whose
+// rule has not yet committed to local WAL.
+//
+// TODO: decisions that must be write-safe (e.g. admitting writes, advertising a
+// rewind source) need the committed rule, not the highest *known* rule — add a
+// highestCommittedRule companion that reads only the committed position's rule
+// so those callers don't act on not-yet-committed leadership.
 //
 // Both sources arrive as a single ConsensusStatus from getCachedConsensusStatus
 // (in-memory only — no postgres query, so this stays side-effect free for the
@@ -63,7 +72,7 @@ func deriveTypeAndObs(rule *clustermetadatapb.ShardRule, selfID *clustermetadata
 // commonconsensus.HighestKnownRule — the same method the orchestrator uses to
 // identify the shard leader — so the pooler and orch can never rank rules
 // differently.
-func (pm *MultiPoolerManager) latestRule() *clustermetadatapb.ShardRule {
+func (pm *MultiPoolerManager) highestKnownRule() *clustermetadatapb.ShardRule {
 	return commonconsensus.HighestKnownRule([]*clustermetadatapb.ConsensusStatus{
 		pm.consensusMgr.CachedConsensusStatus(),
 	})
@@ -73,7 +82,7 @@ func (pm *MultiPoolerManager) latestRule() *clustermetadatapb.ShardRule {
 // consensus-authoritative source of truth for the published PoolerType,
 // independent of the observed postgres recovery mode.
 func (pm *MultiPoolerManager) intendedRole() clustermetadatapb.PoolerType {
-	t, _ := deriveTypeAndObs(pm.latestRule(), pm.serviceID)
+	t, _ := deriveTypeAndObs(pm.highestKnownRule(), pm.serviceID)
 	return t
 }
 
@@ -129,9 +138,6 @@ type postgresState struct {
 	backupsAvailable         bool
 	isPrimary                bool
 	bootstrapSentinelPresent bool
-	// primaryTerm is the coordinator term at which this pooler is the primary
-	// per the highest known rule. 0 if we are not the primary for that rule.
-	primaryTerm int64
 	// rewindSourceReady is true when this pooler is a primary whose last completed
 	// checkpoint is on its current running timeline, so it is safe to pg_rewind
 	// from. False on standbys and on a freshly promoted primary that has not yet
@@ -147,7 +153,6 @@ func postgresStateEqual(a, b postgresState) bool {
 		a.backupsAvailable == b.backupsAvailable &&
 		a.isPrimary == b.isPrimary &&
 		a.bootstrapSentinelPresent == b.bootstrapSentinelPresent &&
-		a.primaryTerm == b.primaryTerm &&
 		a.rewindSourceReady == b.rewindSourceReady
 }
 
@@ -324,14 +329,6 @@ func (pm *MultiPoolerManager) discoverPostgresState(ctx context.Context) (postgr
 				state.rewindSourceReady = ready
 			}
 		}
-		// Lock-free first pass from the monitor: prefer a fresh read, fall back to
-		// the cached rule when postgres is unreachable so we keep the last-known
-		// primary term across postgres restarts and crashes.
-		cs, err := pm.consensusMgr.InconsistentConsensusStatus(ctx)
-		if err != nil {
-			cs = pm.consensusMgr.CachedConsensusStatus()
-		}
-		state.primaryTerm = commonconsensus.LeaderTerm(cs)
 	}
 
 	// Check if backups are available (only if directory not initialized)
@@ -665,7 +662,7 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 		// demoted), so the role resolves to REPLICA (nil self-leadership); we just
 		// restarted as a standby, so postgres is no longer primary. Serving status
 		// is unchanged (a healthy standby keeps serving reads).
-		_, obs := deriveTypeAndObs(pm.latestRule(), pm.serviceID)
+		_, obs := deriveTypeAndObs(pm.highestKnownRule(), pm.serviceID)
 		if err := pm.stateManager.Mutate(ctx, func(s *servingStateMutation) {
 			s.SelfLeadership = obs
 			s.PostgresPrimary = false
@@ -682,7 +679,7 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 		// re-enabled only out of DRAINING (the transient drain this loop owns); a
 		// DISABLED pooler (stopping/paused/operator-drained) is left not-serving,
 		// since this case also fires for plain role/primary drift.
-		intended, obs := deriveTypeAndObs(pm.latestRule(), pm.serviceID)
+		intended, obs := deriveTypeAndObs(pm.highestKnownRule(), pm.serviceID)
 		pm.logger.InfoContext(ctx, "MonitorPostgres: reconciling state from rule",
 			"intended_role", intended.String(), "postgres_primary", state.isPrimary)
 		if err := pm.stateManager.Mutate(ctx, func(s *servingStateMutation) {
@@ -707,13 +704,14 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 	case remedialActionResignLeadership:
 		pm.setMonitorReason(ctx, reasonPostgresRunning, "MonitorPostgres: PostgreSQL is running")
 		// The rule names us leader but postgres is running as a standby. Signal
-		// voluntary resignation so the coordinator re-elects; use primary_term (the
-		// term at which we were elected) so the coordinator knows the signal is
+		// voluntary resignation at the highest-known rule's term so the coordinator
+		// re-elects; this branch only fires when that rule names us, so the term is
 		// current. We do not self-promote.
+		term := pm.highestKnownRule().GetRuleNumber().GetCoordinatorTerm()
 		pm.logger.InfoContext(ctx, "MonitorPostgres: rule names us leader but postgres is a standby; resigning",
-			"primary_term", state.primaryTerm)
-		if state.primaryTerm != 0 {
-			if err := pm.consensusMgr.SetResignedLeaderAtTerm(ctx, state.primaryTerm); err != nil {
+			"primary_term", term)
+		if term != 0 {
+			if err := pm.consensusMgr.SetResignedLeaderAtTerm(ctx, term); err != nil {
 				pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to set resigned primary term", "error", err)
 			}
 		}

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -78,14 +78,6 @@ func (pm *MultiPoolerManager) highestKnownRule() *clustermetadatapb.ShardRule {
 	})
 }
 
-// intendedRole is the pooler role implied by the highest rule it knows of — the
-// consensus-authoritative source of truth for the published PoolerType,
-// independent of the observed postgres recovery mode.
-func (pm *MultiPoolerManager) intendedRole() clustermetadatapb.PoolerType {
-	t, _ := deriveTypeAndObs(pm.highestKnownRule(), pm.serviceID)
-	return t
-}
-
 // staleStandbyDemoteTarget returns the leader this pooler should restart as a
 // standby of, for the case where consensus has moved on but postgres is still
 // running as a primary on a deposed term. Returns nil unless there is a recorded
@@ -448,13 +440,13 @@ func (pm *MultiPoolerManager) primaryConnInfoDiffersFromRecorded(ctx context.Con
 // determineRoleAction returns the action needed to align this pooler's role with
 // the rule-derived intended role: demote a stale primary, resign when the rule
 // names us leader but postgres is a standby, etc.
-func (pm *MultiPoolerManager) determineRoleAction(intended clustermetadatapb.PoolerType, state postgresState, lastAppliedPrimary bool) remedialAction {
-	// Rule: FOLLOWER
+func (pm *MultiPoolerManager) determineRoleAction(role commonconsensus.ConsensusRole, state postgresState, lastAppliedPrimary bool) remedialAction {
+	// Consensus role: not leader (follower/observer)
 	// Postgres: PRIMARY
 	// Diagnosis: Stale primary. We should restart as a replica, but we anticipate
 	// having extra / phantom transactions so don't restart until we've been informed
 	// the current leader to allow rewinding.
-	if intended == clustermetadatapb.PoolerType_REPLICA && state.isPrimary {
+	if role != commonconsensus.ConsensusRoleLeader && state.isPrimary {
 		if pm.staleStandbyDemoteTarget() != nil {
 			return remedialActionDemoteStalePrimary
 		}
@@ -471,7 +463,7 @@ func (pm *MultiPoolerManager) determineRoleAction(intended clustermetadatapb.Poo
 	// Promote's promoteStandbyToPrimary), and disambiguate resign (we lost our
 	// postgres) from promote (newly elected). Embedding the leader host/port in the
 	// WAL rule would also let replicas reconcile without waiting for SetPrimary.
-	if intended == clustermetadatapb.PoolerType_PRIMARY && !state.isPrimary {
+	if role == commonconsensus.ConsensusRoleLeader && !state.isPrimary {
 		if pm.consensusMgr.ResignedLeaderAtTerm() == 0 {
 			return remedialActionResignLeadership
 		}
@@ -493,7 +485,7 @@ func (pm *MultiPoolerManager) determineRoleAction(intended clustermetadatapb.Poo
 	//     under the action lock, so an actionable DRAINING means the drain finished
 	//     and restoring SERVING is safe. A resigned leader is handled by the branch
 	//     above.
-	if pm.getPoolerType() != intended ||
+	if pm.getPoolerType() != poolerTypeForLeader(role == commonconsensus.ConsensusRoleLeader) ||
 		state.isPrimary != lastAppliedPrimary ||
 		pm.record.ServingStatus() == clustermetadatapb.PoolerServingStatus_DRAINING {
 		return remedialActionReconcileState
@@ -548,21 +540,21 @@ func (pm *MultiPoolerManager) determineRemedialAction(ctx context.Context, curre
 	// role (determineRoleAction), then when the role needs no action
 	// reconcile the replication settings (determineReplicationSettingsAction).
 	if currentState.postgresRunning {
-		intended := pm.intendedRole()
-		if intended == clustermetadatapb.PoolerType_UNKNOWN {
+		if pm.highestKnownRule() == nil {
 			// No rule-bearing position observed yet; wait rather than act on the
 			// observed postgres state. This also defers DRAINING -> SERVING recovery:
 			// a node only re-enables serving once it knows its rule-derived role,
 			// matching the "healthy and role-aligned" contract on PoolerServingStatus.
 			return remedialActionNone
 		}
-		if action := pm.determineRoleAction(intended, currentState, lastAppliedPrimary); action != remedialActionNone {
+		role := commonconsensus.SelfConsensusRole(pm.consensusMgr.CachedConsensusStatus())
+		if action := pm.determineRoleAction(role, currentState, lastAppliedPrimary); action != remedialActionNone {
 			return action
 		}
 		if action := pm.determineReplicationSettingsAction(ctx, currentState); action != remedialActionNone {
 			return action
 		}
-		if pm.shouldMarkRewindReady(currentState, intended) {
+		if pm.shouldMarkRewindReady(currentState, role) {
 			return remedialActionMarkRewindReady
 		}
 		return remedialActionNone
@@ -578,8 +570,8 @@ func (pm *MultiPoolerManager) determineRemedialAction(ctx context.Context, curre
 // leadership, and the published ReplicationPrimary has not yet advertised it. The
 // last check makes the resulting action a false->true edge, so its broadcast
 // fires once per promotion rather than every tick.
-func (pm *MultiPoolerManager) shouldMarkRewindReady(state postgresState, intended clustermetadatapb.PoolerType) bool {
-	if !state.rewindSourceReady || intended != clustermetadatapb.PoolerType_PRIMARY {
+func (pm *MultiPoolerManager) shouldMarkRewindReady(state postgresState, role commonconsensus.ConsensusRole) bool {
+	if !state.rewindSourceReady || role != commonconsensus.ConsensusRoleLeader {
 		return false
 	}
 	if pm.consensusMgr.ResignedLeaderAtTerm() != 0 {

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -103,23 +103,31 @@ func TestDiscoverPostgresState_InitializedNotRunning(t *testing.T) {
 	assert.False(t, state.bootstrapSentinelPresent)
 }
 
-func TestDiscoverPostgresState_Running(t *testing.T) {
-	ctx := t.Context()
-
-	mockPgctld := &mockPgctldClient{
-		statusResponse: &pgctldpb.StatusResponse{
-			Status: pgctldpb.ServerStatus_RUNNING,
-		},
+// newRunningStandbyManagerForTest builds a manager whose pgctld reports RUNNING
+// and pg_is_in_recovery=t (standby), backed by the given rule store, for
+// discoverPostgresState tests. The rule store controls whether the per-iteration
+// ObservePosition refresh succeeds.
+func newRunningStandbyManagerForTest(t *testing.T, rs consensus.RuleStorer) *MultiPoolerManager {
+	t.Helper()
+	mp := &clustermetadatapb.MultiPooler{
+		Id:        &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "test-cell", Name: "test-pooler"},
+		ShardKey:  &clustermetadatapb.ShardKey{TableGroup: "default", Shard: "0-inf"},
+		PoolerDir: t.TempDir(),
 	}
-
-	pm := NewTestMultiPoolerManager(t)
-	pm.pgctldClient = mockPgctld
-
-	// Running postgres triggers a pg_is_in_recovery probe; stub it as a standby
-	// so discovery determines the role rather than failing on an unreadable one.
+	pm, err := NewMultiPoolerManagerForTesting(t, slog.Default(), mp, &Config{}, withFakeRules(rs))
+	require.NoError(t, err)
+	pm.pgctldClient = &mockPgctldClient{
+		statusResponse: &pgctldpb.StatusResponse{Status: pgctldpb.ServerStatus_RUNNING},
+	}
 	mockQueryService := mock.NewQueryService()
 	mockQueryService.AddQueryPattern("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
 	pm.qsc = &mockPoolerController{queryService: mockQueryService}
+	return pm
+}
+
+func TestDiscoverPostgresState_Running(t *testing.T) {
+	ctx := t.Context()
+	pm := newRunningStandbyManagerForTest(t, &fakeRuleStore{pos: makeRulePosition(1)})
 
 	state, err := pm.discoverPostgresState(ctx)
 	require.NoError(t, err)
@@ -129,6 +137,38 @@ func TestDiscoverPostgresState_Running(t *testing.T) {
 	assert.True(t, state.postgresRunning)
 	assert.False(t, state.isPrimary, "pg_is_in_recovery=t means standby")
 	assert.False(t, state.bootstrapSentinelPresent)
+}
+
+// TestDiscoverPostgresState_RefreshesConsensusPosition is a regression test:
+// even when the monitor takes no remedial action, a running postgres must
+// refresh the cached consensus position each iteration (via ObservePosition) so
+// the recovery loop converges on current state instead of lagging the periodic
+// Status RPC that otherwise refreshes the cache.
+func TestDiscoverPostgresState_RefreshesConsensusPosition(t *testing.T) {
+	ctx := t.Context()
+	rs := &fakeRuleStore{pos: makeRulePosition(1)}
+	pm := newRunningStandbyManagerForTest(t, rs)
+
+	before := rs.observePositionCallCount()
+	_, err := pm.discoverPostgresState(ctx)
+	require.NoError(t, err)
+	assert.Greater(t, rs.observePositionCallCount(), before,
+		"running postgres must refresh the cached consensus position each iteration")
+}
+
+// TestDiscoverPostgresState_ConsensusPositionUnreadable is a regression test:
+// when postgres is running but the consensus position cannot be read (postgres
+// or the multischema is unreadable — readCurrentRule errors when current_rule is
+// missing), discovery must surface an error so the monitor skips remediation
+// this tick rather than acting on stale/absent consensus state.
+func TestDiscoverPostgresState_ConsensusPositionUnreadable(t *testing.T) {
+	ctx := t.Context()
+	rs := &fakeRuleStore{observeErr: errors.New("current_rule initial row missing: tables may not be initialized")}
+	pm := newRunningStandbyManagerForTest(t, rs)
+
+	_, err := pm.discoverPostgresState(ctx)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "refresh consensus position")
 }
 
 // TestDiscoverPostgresState_RunningRoleProbeFails is a regression test: when

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/constants"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
@@ -720,6 +721,42 @@ func TestStaleStandbyDemoteTarget(t *testing.T) {
 			withRuleStore(&fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Rule: rule(4, selfID)}}),
 		)
 		require.Nil(t, pm.staleStandbyDemoteTarget())
+	})
+}
+
+func TestShouldMarkRewindReady(t *testing.T) {
+	selfID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "test-cell", Name: "self"}
+	// newMgr builds a manager whose consensus state controls the two inputs
+	// shouldMarkRewindReady reads beyond (rewindSourceReady, role): the resigned
+	// term and the recorded ReplicationPrimary's rewind-ready flag.
+	newMgr := func(resignedTerm int64, rp *clustermetadatapb.ReplicationPrimary) *MultiPoolerManager {
+		return newTestManager(t,
+			withServiceID(selfID),
+			withResignedLeaderAtTerm(resignedTerm),
+			withReplicationPrimary(rp),
+		)
+	}
+	rewindReadyState := postgresState{rewindSourceReady: true}
+
+	t.Run("not a rewind source yet", func(t *testing.T) {
+		assert.False(t, newMgr(0, nil).shouldMarkRewindReady(postgresState{}, commonconsensus.ConsensusRoleLeader))
+	})
+	t.Run("not the consensus leader", func(t *testing.T) {
+		assert.False(t, newMgr(0, nil).shouldMarkRewindReady(rewindReadyState, commonconsensus.ConsensusRoleFollower))
+	})
+	t.Run("leadership resigned", func(t *testing.T) {
+		assert.False(t, newMgr(5, nil).shouldMarkRewindReady(rewindReadyState, commonconsensus.ConsensusRoleLeader))
+	})
+	t.Run("already advertised as rewind-ready", func(t *testing.T) {
+		// RecordTermPrimary only records an rp that carries a rule, so give it one.
+		rp := &clustermetadatapb.ReplicationPrimary{
+			Rule:        &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}},
+			RewindReady: true,
+		}
+		assert.False(t, newMgr(0, rp).shouldMarkRewindReady(rewindReadyState, commonconsensus.ConsensusRoleLeader))
+	})
+	t.Run("leader, checkpointed, not yet advertised", func(t *testing.T) {
+		assert.True(t, newMgr(0, nil).shouldMarkRewindReady(rewindReadyState, commonconsensus.ConsensusRoleLeader))
 	})
 }
 

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -242,7 +242,6 @@ func TestDetermineRemedialAction(t *testing.T) {
 		poolerType         clustermetadatapb.PoolerType
 		seedPrimary        *clustermetadatapb.ReplicationPrimary
 		cachedPos          *clustermetadatapb.PoolerPosition
-		primaryTerm        int64
 		resignedLeaderTerm int64
 		inconsistentGUC    bool
 		expectedAction     remedialAction
@@ -318,7 +317,6 @@ func TestDetermineRemedialAction(t *testing.T) {
 			},
 			poolerType:         clustermetadatapb.PoolerType_PRIMARY,
 			cachedPos:          selfPos(5, selfID),
-			primaryTerm:        5,
 			resignedLeaderTerm: 0,
 			expectedAction:     remedialActionResignLeadership,
 		},
@@ -332,7 +330,6 @@ func TestDetermineRemedialAction(t *testing.T) {
 			},
 			poolerType:         clustermetadatapb.PoolerType_PRIMARY,
 			cachedPos:          selfPos(5, selfID),
-			primaryTerm:        5,
 			resignedLeaderTerm: 5,
 			expectedAction:     remedialActionNone,
 		},
@@ -350,7 +347,6 @@ func TestDetermineRemedialAction(t *testing.T) {
 			},
 			poolerType:         clustermetadatapb.PoolerType_REPLICA,
 			cachedPos:          selfPos(5, selfID),
-			primaryTerm:        5,
 			resignedLeaderTerm: 5,
 			expectedAction:     remedialActionNone,
 		},
@@ -472,7 +468,6 @@ func TestDetermineRemedialAction(t *testing.T) {
 				withResignedLeaderAtTerm(tt.resignedLeaderTerm),
 				withRuleStore(&fakeRuleStore{pos: tt.cachedPos, inconsistentGUC: tt.inconsistentGUC}),
 			)
-			tt.state.primaryTerm = tt.primaryTerm
 
 			// lastAppliedPrimary == state.isPrimary: this table exercises role,
 			// demote, resign and GUC decisions, not physical-primary drift (covered
@@ -729,7 +724,7 @@ func TestStaleStandbyDemoteTarget(t *testing.T) {
 }
 
 // TestIntendedRole verifies that intendedRole() derives the PoolerType from
-// the freshest rule this pooler knows about (latestRule, which merges the
+// the freshest rule this pooler knows about (highestKnownRule, which merges the
 // consensus-recorded replication primary with the rule store's cached
 // position): UNKNOWN when no rule exists, PRIMARY when the freshest rule names
 // this pooler as leader, REPLICA when it names another pooler. The
@@ -885,21 +880,29 @@ func TestTakeRemedialAction_LogDeduplication(t *testing.T) {
 }
 
 func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
+	selfID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "test-pooler"}
 	otherID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "other-pooler"}
+	selfPos := func(term int64) *clustermetadatapb.PoolerPosition {
+		return &clustermetadatapb.PoolerPosition{Rule: &clustermetadatapb.ShardRule{
+			RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: term},
+			LeaderId:   selfID,
+		}}
+	}
 	tests := []struct {
 		name           string
 		action         remedialAction
 		poolerType     clustermetadatapb.PoolerType
-		primaryTerm    int64                             // set in consensus state before action
 		resignedBefore int64                             // set resignedLeaderAtTerm before action (0 = don't set)
-		cachedPos      *clustermetadatapb.PoolerPosition // rule the monitor reads for ReconcileRole
+		cachedPos      *clustermetadatapb.PoolerPosition // rule the monitor reads; the resign term comes from it
 		wantAvStatus   *clustermetadatapb.AvailabilityStatus
 	}{
 		{
-			name:        "ResignLeadership sets resignation at primary_term",
-			action:      remedialActionResignLeadership,
-			poolerType:  clustermetadatapb.PoolerType_PRIMARY,
-			primaryTerm: 5,
+			// The resign term is the highest-known rule's term; seed a rule naming
+			// self at term 5.
+			name:       "ResignLeadership sets resignation at the highest-known term",
+			action:     remedialActionResignLeadership,
+			poolerType: clustermetadatapb.PoolerType_PRIMARY,
+			cachedPos:  selfPos(5),
 			wantAvStatus: &clustermetadatapb.AvailabilityStatus{
 				LeadershipStatus: &clustermetadatapb.LeadershipStatus{
 					LeaderTerm: 5,
@@ -911,10 +914,10 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 			},
 		},
 		{
-			name:        "ResignLeadership sets no resignation when primary_term is zero",
-			action:      remedialActionResignLeadership,
-			poolerType:  clustermetadatapb.PoolerType_PRIMARY,
-			primaryTerm: 0,
+			// No known rule (nil position) -> term 0 -> no resignation signal.
+			name:       "ResignLeadership sets no resignation when no known term",
+			action:     remedialActionResignLeadership,
+			poolerType: clustermetadatapb.PoolerType_PRIMARY,
 			wantAvStatus: &clustermetadatapb.AvailabilityStatus{
 				CohortEligibilityStatus: &clustermetadatapb.CohortEligibilityStatus{
 					Signal: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE,
@@ -951,7 +954,7 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 			ctx := t.Context()
 
 			multipooler := &clustermetadatapb.MultiPooler{
-				Id:   &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "test-pooler"},
+				Id:   selfID,
 				Type: tc.poolerType,
 			}
 			if tc.poolerType == clustermetadatapb.PoolerType_PRIMARY {
@@ -978,7 +981,7 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 				require.NoError(t, pm.consensusMgr.SetResignedLeaderAtTerm(lockCtx, tc.resignedBefore))
 			}
 
-			pm.takeRemedialAction(lockCtx, tc.action, postgresState{primaryTerm: tc.primaryTerm})
+			pm.takeRemedialAction(lockCtx, tc.action, postgresState{})
 
 			assert.Equal(t, tc.wantAvStatus, pm.buildAvailabilityStatus())
 		})
@@ -1268,7 +1271,6 @@ func TestPostgresStateEqual(t *testing.T) {
 		backupsAvailable:         true,
 		isPrimary:                true,
 		bootstrapSentinelPresent: true,
-		primaryTerm:              42,
 	}
 
 	t.Run("equal states", func(t *testing.T) {
@@ -1285,7 +1287,6 @@ func TestPostgresStateEqual(t *testing.T) {
 		{"backupsAvailable", func() postgresState { s := base; s.backupsAvailable = false; return s }()},
 		{"isPrimary", func() postgresState { s := base; s.isPrimary = false; return s }()},
 		{"bootstrapSentinelPresent", func() postgresState { s := base; s.bootstrapSentinelPresent = false; return s }()},
-		{"primaryTerm", func() postgresState { s := base; s.primaryTerm = 99; return s }()},
 	}
 	for _, tc := range tests {
 		t.Run("differs in "+tc.name, func(t *testing.T) {

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -723,14 +723,6 @@ func TestStaleStandbyDemoteTarget(t *testing.T) {
 	})
 }
 
-// TestIntendedRole verifies that intendedRole() derives the PoolerType from
-// the freshest rule this pooler knows about (highestKnownRule, which merges the
-// consensus-recorded replication primary with the rule store's cached
-// position): UNKNOWN when no rule exists, PRIMARY when the freshest rule names
-// this pooler as leader, REPLICA when it names another pooler. The
-// consensus-recorded rule can outrank our cached position — that is the
-// stale-primary signal, where intendedRole() reports REPLICA even though our
-// cached rule still names self.
 func TestTakeRemedialAction_PgctldUnavailable(t *testing.T) {
 	ctx := t.Context()
 

--- a/go/test/endtoend/multipooler/rpc_manager_api_test.go
+++ b/go/test/endtoend/multipooler/rpc_manager_api_test.go
@@ -59,7 +59,7 @@ func TestManagerStatus_NodeIdentityAndConsensus(t *testing.T) {
 		assert.Equal(t, setup.PrimaryMultipooler.Name, resp.GetConsensusStatus().GetId().GetName(), "PoolerId should match")
 		assert.Equal(t, "test-cell", resp.GetConsensusStatus().GetId().GetCell(), "Cell should match")
 		assert.Equal(t, int64(1), resp.GetConsensusStatus().GetTermRevocation().GetRevokedBelowTerm(), "TermNumber should be 1")
-		assert.True(t, consensus.NamesSelfAsLeader(resp.GetConsensusStatus()), "Primary should be consensus primary")
+		assert.Equal(t, consensus.ConsensusRoleLeader, consensus.SelfConsensusRole(resp.GetConsensusStatus()), "Primary should be consensus leader")
 	})
 
 	t.Run("standby", func(t *testing.T) {
@@ -69,7 +69,7 @@ func TestManagerStatus_NodeIdentityAndConsensus(t *testing.T) {
 
 		assert.Equal(t, setup.StandbyMultipooler.Name, resp.GetConsensusStatus().GetId().GetName(), "PoolerId should match")
 		assert.Equal(t, "test-cell", resp.GetConsensusStatus().GetId().GetCell(), "Cell should match")
-		assert.False(t, consensus.NamesSelfAsLeader(resp.GetConsensusStatus()), "Standby should not be consensus primary")
+		assert.NotEqual(t, consensus.ConsensusRoleLeader, consensus.SelfConsensusRole(resp.GetConsensusStatus()), "Standby should not be consensus leader")
 	})
 }
 

--- a/go/tools/ruleguard/rules.go
+++ b/go/tools/ruleguard/rules.go
@@ -215,7 +215,7 @@ func disallowWallClockInConsensus(m dsl.Matcher) {
 // MultiPoolerInfo is disallowed. The postgres recovery-mode role reported in a
 // pooler's health Status (Status.PoolerType) is also a different field.
 //
-// Use consensus instead (GetSelfLeadership() != nil / commonconsensus.NamesSelfAsLeader).
+// Use consensus instead (GetSelfLeadership() != nil / commonconsensus.SelfConsensusRole).
 func disallowMultiPoolerTypeForRouting(m dsl.Matcher) {
 	m.Import("github.com/multigres/multigres/go/pb/clustermetadata")
 	m.Import("github.com/multigres/multigres/go/common/topoclient")


### PR DESCRIPTION
The idea here is to start splitting apart the types for consensus vs routing

## Changes

**1. Introduce `ConsensusRole` and adopt it (`refactor(consensus)`)**
- Add `ConsensusRole` (`leader`/`follower`/`observer`) with `SelfConsensusRole(cs)`
  over a `ConsensusStatus`, plus the `RuleNamesLeader` and
  `IsNonRevokedCommittedLeader` helpers.
- Replace `NamesSelfAsLeader` (a leader-only boolean) with `SelfConsensusRole`
  everywhere; the wrapper is removed. `SelfConsensusRole` keeps follower and
  observer distinct, which `NamesSelfAsLeader` collapsed.
- Retype `PoolerAnalysis.NamesSelfAsLeader bool` -> `SelfConsensusRole ConsensusRole`
  in the multiorch recovery analyzers.

**2. Drop cached `primaryTerm` from `postgresState` (`refactor(multipooler)`)**
- The monitor recomputed `primaryTerm` every tick (an extra consensus read +
  change-detection churn) for a single consumer (the resign path). Compute the
  term on demand from the highest-known rule at that one site.
- Rename `latestRule()` -> `highestKnownRule()` to make the highest-known vs.
  committed distinction explicit; TODO left for a `highestCommittedRule`
  companion that write-safety decisions should use.

**3. Drive monitor role decisions from `SelfConsensusRole` (`refactor(multipooler)`)**
- `determineRoleAction` / `shouldMarkRewindReady` branch on the consensus role
  instead of the `PoolerType` label routed through `intendedRole`/`deriveTypeAndObs`.
- Behavior-preserving: the no-rule wait stays (`highestKnownRule() == nil`), leader
  -> PRIMARY and follower/observer -> REPLICA, and the published-label drift check is
  computed locally. `deriveTypeAndObs` survives only to build the
  `LeaderObservation` for publishing.

## Behavior

No intended behavior change. Existing monitor/recovery/consensus unit tests pass
unchanged (the equivalences `highestKnownRule()==nil <=> UNKNOWN`,
`SelfConsensusRole==Leader <=> rule names self` hold).

