### PR TITLE
fix(pgprotocol): preserve RowDescription for zero-column results

### DIFF
--- a/go/common/sqltypes/sqltypes.go
+++ b/go/common/sqltypes/sqltypes.go
@@ -211,6 +211,25 @@ func ResultFromProto(pr *query.QueryResult) *Result {
 	}
 }
 
+// SetStatementDescriptionHasFields records, on desc.HasFields, whether desc.Fields
+// was non-nil before crossing a gRPC boundary. Protobuf encodes both nil and empty
+// repeated fields identically (as absent), so this flag preserves the
+// RowDescription(0 fields) vs NoData distinction. Mirrors Result.ToProto.
+func SetStatementDescriptionHasFields(desc *query.StatementDescription) {
+	if desc != nil {
+		desc.HasFields = desc.GetFields() != nil
+	}
+}
+
+// RestoreStatementDescriptionFields restores the non-nil empty Fields slice that
+// protobuf collapsed to nil on the wire, using HasFields to distinguish "no result
+// set" from "zero-column result". Mirrors ResultFromProto.
+func RestoreStatementDescriptionFields(desc *query.StatementDescription) {
+	if desc != nil && desc.GetHasFields() && desc.GetFields() == nil {
+		desc.Fields = []*query.Field{}
+	}
+}
+
 // ToProto converts Row to proto format (lengths+values) for gRPC serialization.
 // Encoding: -1 = NULL, 0 = empty string, >0 = actual length.
 func (r *Row) ToProto() *query.Row {

--- a/go/common/sqltypes/sqltypes_test.go
+++ b/go/common/sqltypes/sqltypes_test.go
@@ -241,6 +241,57 @@ func TestResultToProtoNil(t *testing.T) {
 	assert.Nil(t, r.ToProto())
 }
 
+func TestSetStatementDescriptionHasFields(t *testing.T) {
+	t.Run("nil desc is a no-op", func(t *testing.T) {
+		SetStatementDescriptionHasFields(nil)
+	})
+
+	t.Run("nil fields (DML) sets HasFields false", func(t *testing.T) {
+		desc := &query.StatementDescription{Fields: nil}
+		SetStatementDescriptionHasFields(desc)
+		assert.False(t, desc.GetHasFields())
+	})
+
+	t.Run("non-nil empty fields (zero-column SELECT) sets HasFields true", func(t *testing.T) {
+		desc := &query.StatementDescription{Fields: []*query.Field{}}
+		SetStatementDescriptionHasFields(desc)
+		assert.True(t, desc.GetHasFields())
+	})
+
+	t.Run("non-nil non-empty fields sets HasFields true", func(t *testing.T) {
+		desc := &query.StatementDescription{Fields: []*query.Field{{Name: "col1"}}}
+		SetStatementDescriptionHasFields(desc)
+		assert.True(t, desc.GetHasFields())
+	})
+}
+
+func TestRestoreStatementDescriptionFields(t *testing.T) {
+	t.Run("nil desc is a no-op", func(t *testing.T) {
+		RestoreStatementDescriptionFields(nil)
+	})
+
+	t.Run("HasFields true and nil Fields restores a non-nil empty slice", func(t *testing.T) {
+		desc := &query.StatementDescription{HasFields: true, Fields: nil}
+		RestoreStatementDescriptionFields(desc)
+		assert.NotNil(t, desc.Fields)
+		assert.Empty(t, desc.Fields)
+	})
+
+	t.Run("HasFields false and nil Fields stays nil (NoData)", func(t *testing.T) {
+		desc := &query.StatementDescription{HasFields: false, Fields: nil}
+		RestoreStatementDescriptionFields(desc)
+		assert.Nil(t, desc.Fields)
+	})
+
+	t.Run("HasFields true with already non-nil Fields is unchanged", func(t *testing.T) {
+		fields := []*query.Field{{Name: "col1"}}
+		desc := &query.StatementDescription{HasFields: true, Fields: fields}
+		RestoreStatementDescriptionFields(desc)
+		require.Len(t, desc.Fields, 1)
+		assert.Equal(t, "col1", desc.Fields[0].GetName())
+	})
+}
+
 func TestParamsToProtoAndBack(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -722,7 +722,15 @@ type StatementDescription struct {
 	Parameters []*ParameterDescription `protobuf:"bytes,1,rep,name=parameters,proto3" json:"parameters,omitempty"`
 	// fields describes the result columns
 	// Nil if the statement doesn't return rows.
-	Fields        []*Field `protobuf:"bytes,2,rep,name=fields,proto3" json:"fields,omitempty"`
+	Fields []*Field `protobuf:"bytes,2,rep,name=fields,proto3" json:"fields,omitempty"`
+	// has_fields distinguishes "no result set" (false, fields is nil — the
+	// backend answered Describe with NoData, e.g. a DML statement) from a
+	// row-returning statement with zero result columns (true, fields is a
+	// non-nil empty slice — the backend answered with RowDescription carrying 0
+	// fields, e.g. `SELECT FROM t`). protobuf serializes both an empty and a nil
+	// `repeated fields` identically, so this flag carries the distinction across
+	// the wire. Mirror of QueryResult.has_fields.
+	HasFields     bool `protobuf:"varint,3,opt,name=has_fields,json=hasFields,proto3" json:"has_fields,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -769,6 +777,13 @@ func (x *StatementDescription) GetFields() []*Field {
 		return x.Fields
 	}
 	return nil
+}
+
+func (x *StatementDescription) GetHasFields() bool {
+	if x != nil {
+		return x.HasFields
+	}
+	return false
 }
 
 // ParameterDescription describes a parameter in a prepared statement.
@@ -1575,12 +1590,14 @@ const file_query_proto_rawDesc = "" +
 	"\x0ePgNotification\x12\x10\n" +
 	"\x03pid\x18\x01 \x01(\x05R\x03pid\x12\x18\n" +
 	"\achannel\x18\x02 \x01(\tR\achannel\x12\x18\n" +
-	"\apayload\x18\x03 \x01(\tR\apayload\"y\n" +
+	"\apayload\x18\x03 \x01(\tR\apayload\"\x98\x01\n" +
 	"\x14StatementDescription\x12;\n" +
 	"\n" +
 	"parameters\x18\x01 \x03(\v2\x1b.query.ParameterDescriptionR\n" +
 	"parameters\x12$\n" +
-	"\x06fields\x18\x02 \x03(\v2\f.query.FieldR\x06fields\":\n" +
+	"\x06fields\x18\x02 \x03(\v2\f.query.FieldR\x06fields\x12\x1d\n" +
+	"\n" +
+	"has_fields\x18\x03 \x01(\bR\thasFields\":\n" +
 	"\x14ParameterDescription\x12\"\n" +
 	"\rdata_type_oid\x18\x01 \x01(\rR\vdataTypeOid\"a\n" +
 	"\x06Target\x126\n" +

--- a/go/services/multigateway/poolergateway/grpc_query_service.go
+++ b/go/services/multigateway/poolergateway/grpc_query_service.go
@@ -305,6 +305,13 @@ func (g *grpcQueryService) Describe(
 	}
 
 	g.logger.DebugContext(ctx, "describe completed successfully", "pooler_id", g.poolerID)
+
+	// protobuf deserializes an empty `repeated fields` as nil. Restore the
+	// non-nil empty slice for a zero-column row-returning statement so the
+	// wire layer sends RowDescription(0 fields) instead of NoData. nil +
+	// HasFields == zero-column SELECT.
+	sqltypes.RestoreStatementDescriptionFields(response.Description)
+
 	return response.Description, nil
 }
 

--- a/go/services/multigateway/poolergateway/grpc_query_service_test.go
+++ b/go/services/multigateway/poolergateway/grpc_query_service_test.go
@@ -100,6 +100,10 @@ type mockMultiPoolerServiceClient struct {
 	// ConcludeTransaction behavior
 	concludeResponse *multipoolerservice.ConcludeTransactionResponse
 	concludeErr      error
+
+	// Describe behavior
+	describeResponse *multipoolerservice.DescribeResponse
+	describeErr      error
 }
 
 func (m *mockMultiPoolerServiceClient) CopyBidiExecute(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[multipoolerservice.CopyBidiExecuteRequest, multipoolerservice.CopyBidiExecuteResponse], error) {
@@ -127,7 +131,10 @@ func (m *mockMultiPoolerServiceClient) PortalStreamExecute(ctx context.Context, 
 }
 
 func (m *mockMultiPoolerServiceClient) Describe(ctx context.Context, in *multipoolerservice.DescribeRequest, opts ...grpc.CallOption) (*multipoolerservice.DescribeResponse, error) {
-	return nil, nil
+	if m.describeErr != nil {
+		return nil, m.describeErr
+	}
+	return m.describeResponse, nil
 }
 
 func (m *mockMultiPoolerServiceClient) GetAuthCredentials(ctx context.Context, in *multipoolerservice.GetAuthCredentialsRequest, opts ...grpc.CallOption) (*multipoolerservice.GetAuthCredentialsResponse, error) {
@@ -821,4 +828,68 @@ func TestConcludeTransaction_Error(t *testing.T) {
 	// underlying PostgreSQL diagnostic surfaces unwrapped. For a generic mock
 	// error we keep its original message instead of an internal RPC prefix.
 	require.Contains(t, err.Error(), "conclude failed")
+}
+
+func TestDescribe_RestoresEmptyFieldsForZeroColumnRowDescription(t *testing.T) {
+	mockClient := &mockMultiPoolerServiceClient{
+		describeResponse: &multipoolerservice.DescribeResponse{
+			Description: &query.StatementDescription{HasFields: true, Fields: nil},
+		},
+	}
+
+	svc := newTestGRPCQueryService(mockClient)
+
+	desc, err := svc.Describe(
+		context.Background(),
+		protoutil.NewTarget("", "test", "", query.Mode_MODE_UNSPECIFIED),
+		&query.PreparedStatement{},
+		nil,
+		&query.ExecuteOptions{},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, desc)
+	require.NotNil(t, desc.Fields, "zero-column row-returning statement must restore a non-nil Fields slice")
+	require.Empty(t, desc.Fields)
+}
+
+func TestDescribe_LeavesNilFieldsForNoData(t *testing.T) {
+	mockClient := &mockMultiPoolerServiceClient{
+		describeResponse: &multipoolerservice.DescribeResponse{
+			Description: &query.StatementDescription{HasFields: false, Fields: nil},
+		},
+	}
+
+	svc := newTestGRPCQueryService(mockClient)
+
+	desc, err := svc.Describe(
+		context.Background(),
+		protoutil.NewTarget("", "test", "", query.Mode_MODE_UNSPECIFIED),
+		&query.PreparedStatement{},
+		nil,
+		&query.ExecuteOptions{},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, desc)
+	require.Nil(t, desc.Fields, "DML statement must stay NoData (nil Fields)")
+}
+
+func TestDescribe_Error(t *testing.T) {
+	mockClient := &mockMultiPoolerServiceClient{
+		describeErr: errors.New("describe failed"),
+	}
+
+	svc := newTestGRPCQueryService(mockClient)
+
+	_, err := svc.Describe(
+		context.Background(),
+		protoutil.NewTarget("", "test", "", query.Mode_MODE_UNSPECIFIED),
+		&query.PreparedStatement{},
+		nil,
+		&query.ExecuteOptions{},
+	)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "describe failed")
 }

--- a/go/services/multipooler/grpcpoolerservice/service.go
+++ b/go/services/multipooler/grpcpoolerservice/service.go
@@ -310,6 +310,12 @@ func (s *poolerService) Describe(ctx context.Context, req *multipoolerpb.Describ
 		return nil, mterrors.ToGRPC(err)
 	}
 
+	// protobuf collapses an empty `repeated fields` to nil on the wire, losing
+	// the RowDescription(0 fields) vs NoData distinction. Record it explicitly
+	// so the gateway can restore it. nil Fields => NoData (no result set);
+	// non-nil (incl. empty) => RowDescription.
+	sqltypes.SetStatementDescriptionHasFields(desc)
+
 	return &multipoolerpb.DescribeResponse{
 		Description: desc,
 	}, nil

--- a/go/test/endtoend/queryserving/extended_query_protocol_test.go
+++ b/go/test/endtoend/queryserving/extended_query_protocol_test.go
@@ -904,3 +904,77 @@ func TestExtendedQueryProtocol_CommentOnlyStatement(t *testing.T) {
 		})
 	}
 }
+
+// TestZeroColumnDescribeExtended is the regression for the zero-column result
+// bug: a row-returning statement with zero result columns must answer Describe
+// with RowDescription (non-nil, empty Fields), NOT NoData. Postgrex/Ecto rely
+// on this; pgx tolerates the wrong sequence, so TestZeroColumnResults misses it.
+func TestZeroColumnDescribeExtended(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	const zeroColQuery = "SELECT FROM generate_series(1, 3)" // 0 columns, 3 rows
+
+	for _, target := range setup.GetComparisonTargets(t) {
+		t.Run(target.Name, func(t *testing.T) {
+			t.Run("statement describe returns empty RowDescription not NoData", func(t *testing.T) {
+				conn := connectLowLevelToPort(t, ctx, target.Port)
+				defer conn.Close()
+
+				require.NoError(t, conn.Parse(ctx, "zc_s", zeroColQuery, nil))
+
+				desc, err := conn.DescribePrepared(ctx, "zc_s")
+				require.NoError(t, err)
+				require.NotNil(t, desc)
+				// The crux: non-nil (RowDescription was sent) but empty (0 columns).
+				// Before the fix the gateway sends NoData -> Fields is nil here.
+				require.NotNil(t, desc.Fields,
+					"zero-column row-returning statement must send RowDescription, not NoData")
+				assert.Empty(t, desc.Fields, "zero-column statement has 0 fields")
+
+				require.NoError(t, conn.CloseStatement(ctx, "zc_s"))
+			})
+
+			t.Run("portal describe returns empty RowDescription not NoData", func(t *testing.T) {
+				conn := connectLowLevelToPort(t, ctx, target.Port)
+				defer conn.Close()
+
+				require.NoError(t, conn.Parse(ctx, "zc_p", zeroColQuery, nil))
+
+				desc, err := conn.BindAndDescribe(ctx, "zc_p", nil, nil, nil)
+				require.NoError(t, err)
+				require.NotNil(t, desc)
+				require.NotNil(t, desc.Fields,
+					"zero-column portal must send RowDescription, not NoData")
+				assert.Empty(t, desc.Fields)
+
+				require.NoError(t, conn.CloseStatement(ctx, "zc_p"))
+			})
+
+			t.Run("bind+execute streams the rows", func(t *testing.T) {
+				conn := connectLowLevelToPort(t, ctx, target.Port)
+				defer conn.Close()
+
+				require.NoError(t, conn.Parse(ctx, "zc_e", zeroColQuery, nil))
+
+				var rows int
+				_, err := conn.BindAndExecute(ctx, "", "zc_e", nil, nil, nil, 0,
+					func(ctx context.Context, result *sqltypes.Result) error {
+						rows += len(result.Rows)
+						return nil
+					})
+				require.NoError(t, err)
+				assert.Equal(t, 3, rows, "should stream 3 zero-column rows")
+
+				require.NoError(t, conn.CloseStatement(ctx, "zc_e"))
+			})
+		})
+	}
+}

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -179,6 +179,15 @@ message StatementDescription {
   // fields describes the result columns
   // Nil if the statement doesn't return rows.
   repeated Field fields = 2;
+
+  // has_fields distinguishes "no result set" (false, fields is nil — the
+  // backend answered Describe with NoData, e.g. a DML statement) from a
+  // row-returning statement with zero result columns (true, fields is a
+  // non-nil empty slice — the backend answered with RowDescription carrying 0
+  // fields, e.g. `SELECT FROM t`). protobuf serializes both an empty and a nil
+  // `repeated fields` identically, so this flag carries the distinction across
+  // the wire. Mirror of QueryResult.has_fields.
+  bool has_fields = 3;
 }
 
 // ParameterDescription describes a parameter in a prepared statement.


### PR DESCRIPTION
## Summary

- A row-returning statement with zero result columns (e.g. `SELECT FROM generate_series(1,3)`) must answer the extended-protocol Describe with `RowDescription` (0 fields), not `NoData` — strict clients like Postgrex/Ecto crash decoding the `DataRow`s that follow an incorrect `NoData`.
- The distinction was lost at the pooler→multigateway gRPC boundary: protobuf collapses an empty `repeated Field fields` and a nil one to the same wire representation, so a zero-column `RowDescription` indistinguishable from a `NoData` response once it crosses gRPC.
- Adds `StatementDescription.has_fields` (mirroring the existing `QueryResult.has_fields` pattern used for the same problem on the streaming `Execute` path), set on the pooler side and used to restore the non-nil empty `Fields` slice on the gateway side.
- Adds `TestZeroColumnDescribeExtended`, a regression that drives Parse → Describe → Bind → Execute directly and asserts both statement and portal Describe return `RowDescription` with empty (not nil) `Fields` against both real PostgreSQL and the gateway.

## Problem

Multigres' extended-query protocol returned `NoData` instead of `RowDescription` for a row-returning statement with zero result columns. This broke strict clients (Postgrex/Ecto) that rely on the wire-protocol distinction between "no result set" and "result set with zero columns" — they crashed decoding subsequent `DataRow` messages. The existing `TestZeroColumnResults` test didn't catch this because its pgx subtest only counts rows; pgx tolerates the malformed sequence.

## Solution

Mirror the fix already applied to `QueryResult` for the simple-query path: add a `has_fields` boolean to the `StatementDescription` proto message, set it on the pooler (`true` iff the original `Fields` slice was non-nil), and on the gateway side, restore a non-nil empty `Fields` slice whenever `has_fields` is true but the slice arrived as nil after the gRPC round-trip. The wire-layer code that decides `RowDescription` vs `NoData` already gates correctly on `Fields != nil`, so no change was needed there.

Validated end-to-end against the real Supabase Realtime test harness (`replication_connection_test.exs` run against a Multigres gateway cluster built from a worktree with this fix cherry-picked on top of the replication-tunnel branch): with the harness's `storage_up!` no-op temporarily reverted to exercise the real zero-column existence probe, results matched the documented pre-fix baseline (32/35 passing) with no crashes, confirming the fix resolves the original issue with no regressions.