### PR TITLE
fix(grpc): raise client MaxCallRecvMsgSize/SendMsgSize to match server

### DIFF
--- a/go/common/servenv/grpc_server.go
+++ b/go/common/servenv/grpc_server.go
@@ -347,8 +347,10 @@ func (g *GrpcServer) Create() error {
 	// Large messages can occur when users try to insert or fetch very big
 	// rows. If they hit the limit, they'll see the following error:
 	// grpc: received message length XXXXXXX exceeding the max size 4194304
-	// Note: For gRPC 1.0.0 it's sufficient to set the limit on the server only
-	// because it's not enforced on the client side.
+	// The client side must set matching limits too: modern gRPC-Go enforces
+	// MaxCallRecvMsgSize (4 MiB default) on the client independent of the server.
+	// See grpccommon.NewClient, which sets grpc.WithDefaultCallOptions to the same
+	// MaxMessageSize().
 	msgSize := grpccommon.MaxMessageSize()
 	slog.Info("Setting grpc max message size", "msgSize", msgSize)
 	opts = append(opts, grpc.MaxRecvMsgSize(msgSize))

--- a/go/test/endtoend/queryserving/large_result_test.go
+++ b/go/test/endtoend/queryserving/large_result_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestLargeResultThroughGateway is the regression for the gRPC 4 MiB result cap.
+// A query result larger than the gRPC client default (4194304 bytes) must stream
+// back through the pooler->gateway gRPC channel without RESOURCE_EXHAUSTED. The
+// server limit is grpccommon.MaxMessageSize() (16 MiB default); 8 MiB exceeds the
+// old client default but stays under the server limit.
+func TestLargeResultThroughGateway(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 60*time.Second)
+
+	const sizeBytes = 8 * 1024 * 1024 // 8 MiB: > 4 MiB client default, < 16 MiB server limit
+	query := "SELECT repeat('x', 8388608)"
+
+	for _, target := range setup.GetComparisonTargets(t) {
+		t.Run(target.Name, func(t *testing.T) {
+			// Low-level pgprotocol client (simple protocol) — a single 8 MiB row
+			// forces one gRPC message > 4 MiB on the pooler->gateway hop.
+			t.Run("low-level", func(t *testing.T) {
+				conn := connectLowLevelToPort(t, ctx, target.Port)
+				defer conn.Close()
+
+				results, err := conn.Query(ctx, query)
+				require.NoError(t, err, "large result must not error (gRPC recv cap)")
+
+				var got int
+				for _, r := range results {
+					for _, row := range r.Rows {
+						got = len(row.Values[0])
+					}
+				}
+				assert.Equal(t, sizeBytes, got, "full 8 MiB value should come back")
+			})
+
+			// pgx (extended protocol) — mirrors the real Postgrex/Ecto failure mode.
+			t.Run("pgx", func(t *testing.T) {
+				connStr := shardsetup.GetTestUserDSN("localhost", target.Port, "sslmode=disable", "connect_timeout=5")
+				conn, err := pgx.Connect(ctx, connStr)
+				require.NoError(t, err)
+				defer conn.Close(ctx)
+
+				var s string
+				err = conn.QueryRow(ctx, query).Scan(&s)
+				require.NoError(t, err, "large result must not error (gRPC recv cap)")
+				assert.Equal(t, sizeBytes, len(s))
+			})
+		})
+	}
+}

--- a/go/tools/grpccommon/options.go
+++ b/go/tools/grpccommon/options.go
@@ -122,9 +122,18 @@ func NewClient(target string, opts ...ClientOption) (*grpc.ClientConn, error) {
 		opt.apply(cfg)
 	}
 
-	// Create single stats handler with all OTel options
+	// Raise the client-side max message sizes to match the server
+	// (grpc.MaxRecvMsgSize/MaxSendMsgSize in servenv). Modern gRPC-Go enforces a
+	// 4 MiB default MaxCallRecvMsgSize on the CLIENT, independent of the server
+	// limit, so without this a >4 MiB result (e.g. a large row streamed from the
+	// pooler to the gateway) fails with RESOURCE_EXHAUSTED "received message larger
+	// than max".
 	allOpts := append([]grpc.DialOption{
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler(cfg.otelOptions...)),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(maxMessageSize),
+			grpc.MaxCallSendMsgSize(maxMessageSize),
+		),
 	}, cfg.dialOptions...)
 
 	return grpc.NewClient(target, allOpts...)


### PR DESCRIPTION
## Summary

Found while debugging a failing Realtime test: a `RETURNING *` query over ~8 MB triggered `RESOURCE_EXHAUSTED` through the gateway. Root cause: Multigres's gRPC server sets `MaxRecvMsgSize`/`MaxSendMsgSize` to `grpccommon.MaxMessageSize()` (16 MiB default), but no client ever set `MaxCallRecvMsgSize`, so modern gRPC-Go silently capped client receives at gRPC's 4 MiB default — any result over 4 MiB streamed from pooler to gateway failed, surfaced to SQL clients as a transaction rollback.

## Fix

Add matching `MaxCallRecvMsgSize`/`MaxCallSendMsgSize` client call options in the shared client constructor `grpccommon.NewClient`, driven by the same `--grpc-max-message-size` flag/var the server already uses, so every grpccommon client stays in sync with the server limit. Also fixes a stale comment claiming the client side doesn't need matching limits. Includes an end-to-end regression test (`TestLargeResultThroughGateway`) streaming an 8 MiB row through both a direct PostgreSQL target and the multigateway.

Note: this raises the ceiling to match the configured max message size, it doesn't remove it — Postgres allows fields up to ~1 GiB, so results larger than `--grpc-max-message-size` will still fail. A more robust fix (chunking `DataRow`s across multiple gRPC frames) is out of scope here.