### PR TITLE
fix(multipooler): bump current_rule read timeout to reduce CI flakes

### DIFF
--- a/go/common/timeouts/rpc.go
+++ b/go/common/timeouts/rpc.go
@@ -64,3 +64,11 @@ const ReadyDialTimeout = 500 * time.Millisecond
 // etcd round-trips are network calls. 4s fits within a probe "timeoutSeconds: 5"
 // while still detecting a genuinely unreachable etcd quickly.
 const ReadyTopoCheckTimeout = 4 * time.Second
+
+// RuleReadTimeout bounds a current_rule read, including the CAS-guarded
+// SELECT ... FOR UPDATE NOWAIT used before a rule write. NOWAIT fails
+// immediately on real row-lock contention, so this budget only needs to
+// absorb ordinary query latency (connection acquisition, a loaded postgres
+// instance), not lock waits. 500ms proved too tight under CI contention
+// (multiple postgres instances plus etcd and services sharing one runner).
+const RuleReadTimeout = 2 * time.Second

--- a/go/services/multipooler/internal/manager/consensus/rule_store.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store.go
@@ -473,7 +473,7 @@ func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clus
 // Returns an error if postgres is unreachable or if the current_rule sentinel
 // row is missing (which indicates the tables are not initialized).
 func (rs *ruleStore) ObservePosition(ctx context.Context) (*clustermetadatapb.PoolerPosition, error) {
-	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	queryCtx, cancel := context.WithTimeout(ctx, timeouts.RuleReadTimeout)
 	defer cancel()
 	pos, err := rs.readCurrentRule(queryCtx, false)
 	if err != nil {
@@ -495,7 +495,7 @@ func (rs *ruleStore) ObservePosition(ctx context.Context) (*clustermetadatapb.Po
 // When inRecovery is true (standby/promotion path): omits FOR UPDATE since the
 // node is read-only and no concurrent writes to current_rule are possible.
 func (rs *ruleStore) readCurrentRuleLocked(ctx context.Context, inRecovery bool) (*clustermetadatapb.PoolerPosition, context.Context, error) {
-	readCtx, readCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	readCtx, readCancel := context.WithTimeout(ctx, timeouts.RuleReadTimeout)
 	defer readCancel()
 	pos, err := rs.readCurrentRule(readCtx, !inRecovery)
 	if err != nil {
@@ -864,7 +864,7 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 // queryRuleHistory returns the most recent rule history records in descending
 // order by (coordinator_term, leader_subterm). Returns at most limit records.
 func (rs *ruleStore) queryRuleHistory(ctx context.Context, limit int) ([]ruleHistoryRecord, error) {
-	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	queryCtx, cancel := context.WithTimeout(ctx, timeouts.RuleReadTimeout)
 	defer cancel()
 
 	result, err := rs.queryService.QueryArgs(queryCtx, `


### PR DESCRIPTION
500ms was too tight under CI contention, causing intermittent TestFixReplication failures.