### PR TITLE
build: require Go 1.26

### DIFF
--- a/.github/actions/go-version/action.yml
+++ b/.github/actions/go-version/action.yml
@@ -1,0 +1,32 @@
+name: Go version from go.mod
+description: >-
+  Reads the Go version required by go.mod and exposes it as an output, so Docker
+  builds can pin their base image to the same version the code requires without
+  repeating it. Single source of truth: go.mod.
+
+  Prefers the `toolchain goX.Y.Z` directive (the exact toolchain the module
+  pins) when present, otherwise falls back to the `go X.Y[.Z]` directive. Both
+  map directly to an official golang image tag: a bare minor like `1.26` floats
+  to the latest 1.26.x patch, while a full `1.26.3` pins that exact patch.
+outputs:
+  version:
+    description: The Go version required by go.mod (e.g. 1.26 or 1.26.3).
+    value: ${{ steps.read.outputs.version }}
+runs:
+  using: composite
+  steps:
+    - id: read
+      shell: bash
+      run: |
+        # Prefer the toolchain directive (an exact goX.Y.Z pin); strip its `go`
+        # prefix. Fall back to the go directive's version otherwise.
+        version="$(awk '/^toolchain go/{v=$2; sub(/^go/,"",v); print v; exit}' go.mod)"
+        if [ -z "$version" ]; then
+          version="$(awk '/^go /{print $2; exit}' go.mod)"
+        fi
+        if [ -z "$version" ]; then
+          echo "::error::could not read a Go version from go.mod" >&2
+          exit 1
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "go.mod requires Go $version"

--- a/.github/workflows/docker-build-cluster.yml
+++ b/.github/workflows/docker-build-cluster.yml
@@ -64,11 +64,17 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha
 
+      - name: Read Go version from go.mod
+        id: goversion
+        uses: ./.github/actions/go-version
+
       - name: Build and push cluster Docker image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: ./Dockerfile.cluster
+          build-args: |
+            GO_VERSION=${{ steps.goversion.outputs.version }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build-pgctld.yml
+++ b/.github/workflows/docker-build-pgctld.yml
@@ -62,11 +62,17 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
 
+      - name: Read Go version from go.mod
+        id: goversion
+        uses: ./.github/actions/go-version
+
       - name: Build and push pgctld Docker image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: ./Dockerfile.pgctld
+          build-args: |
+            GO_VERSION=${{ steps.goversion.outputs.version }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -60,11 +60,17 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
 
+      - name: Read Go version from go.mod
+        id: goversion
+        uses: ./.github/actions/go-version
+
       - name: Build and push Docker image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: ./Dockerfile
+          build-args: |
+            GO_VERSION=${{ steps.goversion.outputs.version }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -99,12 +99,20 @@ jobs:
         run: |
           echo "Nightly Docker image version: ${VERSION}"
 
+      - name: Read Go version from go.mod
+        id: goversion
+        uses: ./.github/actions/go-version
+
       - name: Build and push nightly image
         id: build
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
+          # GO_VERSION is unused by the Node-based multiadmin-web image (a
+          # harmless build-arg warning); the Go images pin their base to it.
+          build-args: |
+            GO_VERSION=${{ steps.goversion.outputs.version }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,12 +155,20 @@ jobs:
         with:
           cosign-release: v3.0.6
 
+      - name: Read Go version from go.mod
+        id: goversion
+        uses: ./.github/actions/go-version
+
       - name: Build release image
         id: build-release-image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
+          # GO_VERSION is unused by the Node-based multiadmin-web image (a
+          # harmless build-arg warning); the Go images pin their base to it.
+          build-args: |
+            GO_VERSION=${{ steps.goversion.outputs.version }}
           push: ${{ env.PUSH_IMAGE }}
           tags: ${{ env.IMAGE_REF }}:${{ env.RELEASE_TAG }}
           provenance: mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 # =========================================================================
 # Stage 1: The Builder Stage
 # =========================================================================
-FROM golang:1.25-alpine AS builder
+# GO_VERSION is the Go toolchain the build runs on. It defaults to the current
+# go.mod minor for local `docker build`/`make images`; CI overrides it with the
+# exact version read from go.mod, so go.mod is the single source of truth (see
+# .github/actions/go-version). Keep the default's minor in sync with go.mod.
+ARG GO_VERSION=1.26
+FROM golang:${GO_VERSION}-alpine AS builder
 
 WORKDIR /src
 

--- a/Dockerfile.cluster
+++ b/Dockerfile.cluster
@@ -18,7 +18,12 @@
 # =========================================================================
 # Stage 1: Build the multigres binaries
 # =========================================================================
-FROM golang:1.25-alpine AS builder
+# GO_VERSION is the Go toolchain the build runs on. It defaults to the current
+# go.mod minor for local `docker build`/`make images`; CI overrides it with the
+# exact version read from go.mod, so go.mod is the single source of truth (see
+# .github/actions/go-version). Keep the default's minor in sync with go.mod.
+ARG GO_VERSION=1.26
+FROM golang:${GO_VERSION}-alpine AS builder
 
 WORKDIR /src
 

--- a/Dockerfile.pgctld
+++ b/Dockerfile.pgctld
@@ -1,7 +1,12 @@
 # =========================================================================
 # Stage 1: Build pgctld
 # =========================================================================
-FROM golang:1.25-alpine AS builder
+# GO_VERSION is the Go toolchain the build runs on. It defaults to the current
+# go.mod minor for local `docker build`/`make images`; CI overrides it with the
+# exact version read from go.mod, so go.mod is the single source of truth (see
+# .github/actions/go-version). Keep the default's minor in sync with go.mod.
+ARG GO_VERSION=1.26
+FROM golang:${GO_VERSION}-alpine AS builder
 
 WORKDIR /src
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/multigres/multigres
 
-go 1.25.1
+go 1.26
 
 require github.com/stretchr/testify v1.11.1
 

--- a/go/common/eventlog/eventlog_test.go
+++ b/go/common/eventlog/eventlog_test.go
@@ -36,8 +36,6 @@ func (h *testHandler) Handle(_ context.Context, r slog.Record) error {
 func (h *testHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
 func (h *testHandler) WithGroup(string) slog.Handler      { return h }
 
-func ptr[T any](v T) *T { return &v }
-
 // recordAttrs extracts all attributes from a slog.Record into a map.
 func recordAttrs(r slog.Record) map[string]any {
 	attrs := make(map[string]any)
@@ -62,7 +60,7 @@ func TestEmit(t *testing.T) {
 		{
 			name:          "terminal promotion carries new_primary, proposed_term and phase timings",
 			outcome:       Success,
-			event:         PrimaryPromotion{NewPrimary: "pg-1", ProposedTerm: 7, Reason: "ShardInit", RecruitMs: ptr(int64(120)), PromoteMs: ptr(int64(680))},
+			event:         PrimaryPromotion{NewPrimary: "pg-1", ProposedTerm: 7, Reason: "ShardInit", RecruitMs: new(int64(120)), PromoteMs: new(int64(680))},
 			wantLevel:     slog.LevelInfo,
 			wantEventType: "primary.promotion",
 			wantAttrs:     map[string]any{"outcome": "success", "new_primary": "pg-1", "proposed_term": int64(7), "reason": "ShardInit", "recruit_ms": int64(120), "promote_ms": int64(680)},
@@ -70,7 +68,7 @@ func TestEmit(t *testing.T) {
 		{
 			name:          "recruitment failure records recruit_ms but no promote_ms",
 			outcome:       Failed,
-			event:         PrimaryPromotion{ProposedTerm: 7, Reason: "LeaderIsDead", RecruitMs: ptr(int64(4200))},
+			event:         PrimaryPromotion{ProposedTerm: 7, Reason: "LeaderIsDead", RecruitMs: new(int64(4200))},
 			wantLevel:     slog.LevelError,
 			wantEventType: "primary.promotion",
 			wantAttrs:     map[string]any{"outcome": "failed", "proposed_term": int64(7), "reason": "LeaderIsDead", "recruit_ms": int64(4200)},

--- a/go/common/pgprotocol/client/ssl_test.go
+++ b/go/common/pgprotocol/client/ssl_test.go
@@ -123,7 +123,6 @@ func TestBuildTLSConfig_RequireAndPrefer(t *testing.T) {
 		}
 		if cfg == nil {
 			t.Fatalf("BuildTLSConfig(%s) = nil, want non-nil", mode)
-			return // staticcheck SA5011: t.Fatalf isn't modeled as no-return; make it explicit before dereferencing cfg
 		}
 		if !cfg.InsecureSkipVerify {
 			t.Errorf("BuildTLSConfig(%s).InsecureSkipVerify = false, want true (libpq parity)", mode)
@@ -295,7 +294,6 @@ func tlsStateFromPEM(t *testing.T, certPEM, keyPEM []byte) tls.ConnectionState {
 	block, _ := pem.Decode(certPEM)
 	if block == nil {
 		t.Fatal("failed to decode cert PEM")
-		return tls.ConnectionState{} // staticcheck SA5011: t.Fatal isn't modeled as no-return; make it explicit before dereferencing block
 	}
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {

--- a/go/services/multiadmin/proxy.go
+++ b/go/services/multiadmin/proxy.go
@@ -165,18 +165,20 @@ func (ma *MultiAdmin) handleProxy(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to parse target URL", http.StatusInternalServerError)
 		return
 	}
-	proxy := httputil.NewSingleHostReverseProxy(targetURL)
-
-	// Modify the director to strip the proxy prefix from the request path
-	originalDirector := proxy.Director
-	proxy.Director = func(req *http.Request) {
-		originalDirector(req)
-		// Strip the proxy prefix to get the actual path the backend expects
-		req.URL.Path = strings.TrimPrefix(r.URL.Path, target.proxyBasePath)
-		if req.URL.Path == "" {
-			req.URL.Path = "/"
-		}
-		req.Host = targetURL.Host
+	// Use Rewrite to route to the target and strip the proxy prefix from the request
+	// path. SetURL applies the target's scheme/host (what the default director did);
+	// SetXForwarded preserves the X-Forwarded-* headers the Director path added automatically.
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(targetURL)
+			pr.SetXForwarded()
+			// Strip the proxy prefix to get the actual path the backend expects.
+			pr.Out.URL.Path = strings.TrimPrefix(r.URL.Path, target.proxyBasePath)
+			if pr.Out.URL.Path == "" {
+				pr.Out.URL.Path = "/"
+			}
+			pr.Out.Host = targetURL.Host
+		},
 	}
 
 	// Intercept the response to rewrite HTML content

--- a/go/services/multiadmin/proxy_test.go
+++ b/go/services/multiadmin/proxy_test.go
@@ -15,8 +15,20 @@
 package multiadmin
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/topoclient"
+	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
 
 func TestRewriteHTML(t *testing.T) {
@@ -206,4 +218,201 @@ func TestRewriteHTML_EmptyInput(t *testing.T) {
 	if len(got) == 0 {
 		t.Error("rewriteHTML() returned empty output for empty input")
 	}
+}
+
+// newProxyTestAdmin builds a MultiAdmin backed by an in-memory topology for the
+// proxy routing tests. senv is left nil on purpose: the routing methods under
+// test only consult it for the "admin" self-proxy branch and the
+// HTML-rewrite-failure log path, neither of which these tests exercise.
+func newProxyTestAdmin(t *testing.T, cells ...string) (*MultiAdmin, topoclient.Store) {
+	t.Helper()
+	ts := memorytopo.NewServer(t.Context(), cells...)
+	return &MultiAdmin{ts: ts}, ts
+}
+
+func TestParseProxyPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		want    *proxyPathInfo
+		wantErr bool
+	}{
+		{
+			name: "three parts",
+			path: "/proxy/gate/cell1/gw1",
+			want: &proxyPathInfo{serviceType: "gate", cellName: "cell1", serviceName: "gw1"},
+		},
+		{
+			name: "extra path beyond the service name is ignored for routing",
+			path: "/proxy/pool/cell1/p1/metrics/x",
+			want: &proxyPathInfo{serviceType: "pool", cellName: "cell1", serviceName: "p1"},
+		},
+		{
+			name:    "too few parts",
+			path:    "/proxy/gate/cell1",
+			wantErr: true,
+		},
+		{
+			name:    "empty after prefix",
+			path:    "/proxy/",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseProxyPath(tt.path)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLookupCellService(t *testing.T) {
+	ma, ts := newProxyTestAdmin(t, "cell1")
+	ctx := t.Context()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	require.NoError(t, ts.CreateMultiGateway(ctx, &clustermetadatapb.MultiGateway{
+		Id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIGATEWAY, Cell: "cell1", Name: "gw1"},
+		Hostname: "gw.host",
+		PortMap:  map[string]int32{"http": 8080, "grpc": 1},
+	}))
+	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadatapb.MultiPooler{
+		Id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "p1"},
+		Hostname: "pool.host",
+		PortMap:  map[string]int32{"http": 8081},
+	}))
+	require.NoError(t, ts.CreateMultiOrch(ctx, &clustermetadatapb.MultiOrch{
+		Id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIORCH, Cell: "cell1", Name: "o1"},
+		Hostname: "orch.host",
+		PortMap:  map[string]int32{"http": 8082},
+	}))
+	// A gateway that has no http port in its port map.
+	require.NoError(t, ts.CreateMultiGateway(ctx, &clustermetadatapb.MultiGateway{
+		Id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIGATEWAY, Cell: "cell1", Name: "noport"},
+		Hostname: "gw.host",
+		PortMap:  map[string]int32{"grpc": 1},
+	}))
+
+	t.Run("gate", func(t *testing.T) {
+		host, port, err := ma.lookupCellService(req, proxyPathInfo{serviceType: "gate", cellName: "cell1", serviceName: "gw1"})
+		require.NoError(t, err)
+		assert.Equal(t, "gw.host", host)
+		assert.Equal(t, 8080, port)
+	})
+	t.Run("pool", func(t *testing.T) {
+		host, port, err := ma.lookupCellService(req, proxyPathInfo{serviceType: "pool", cellName: "cell1", serviceName: "p1"})
+		require.NoError(t, err)
+		assert.Equal(t, "pool.host", host)
+		assert.Equal(t, 8081, port)
+	})
+	t.Run("orch", func(t *testing.T) {
+		host, port, err := ma.lookupCellService(req, proxyPathInfo{serviceType: "orch", cellName: "cell1", serviceName: "o1"})
+		require.NoError(t, err)
+		assert.Equal(t, "orch.host", host)
+		assert.Equal(t, 8082, port)
+	})
+	t.Run("invalid service type", func(t *testing.T) {
+		_, _, err := ma.lookupCellService(req, proxyPathInfo{serviceType: "bogus", cellName: "cell1", serviceName: "x"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid service type")
+	})
+	t.Run("missing http port", func(t *testing.T) {
+		_, _, err := ma.lookupCellService(req, proxyPathInfo{serviceType: "gate", cellName: "cell1", serviceName: "noport"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "service port not found")
+	})
+	t.Run("service not in topology", func(t *testing.T) {
+		_, _, err := ma.lookupCellService(req, proxyPathInfo{serviceType: "gate", cellName: "cell1", serviceName: "missing"})
+		require.Error(t, err)
+	})
+}
+
+func TestResolveServiceTarget(t *testing.T) {
+	ma, ts := newProxyTestAdmin(t, "cell1")
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	require.NoError(t, ts.CreateMultiGateway(t.Context(), &clustermetadatapb.MultiGateway{
+		Id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIGATEWAY, Cell: "cell1", Name: "gw1"},
+		Hostname: "gw.host",
+		PortMap:  map[string]int32{"http": 8080},
+	}))
+
+	t.Run("cell service builds target and base path", func(t *testing.T) {
+		target, err := ma.resolveServiceTarget(req, proxyPathInfo{serviceType: "gate", cellName: "cell1", serviceName: "gw1"})
+		require.NoError(t, err)
+		assert.Equal(t, "gw.host", target.host)
+		assert.Equal(t, 8080, target.port)
+		assert.Equal(t, "/proxy/gate/cell1/gw1", target.proxyBasePath)
+	})
+	t.Run("invalid service type", func(t *testing.T) {
+		_, err := ma.resolveServiceTarget(req, proxyPathInfo{serviceType: "bogus"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid service type")
+	})
+	t.Run("unknown cell service is not found", func(t *testing.T) {
+		_, err := ma.resolveServiceTarget(req, proxyPathInfo{serviceType: "gate", cellName: "cell1", serviceName: "missing"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "service not found")
+	})
+}
+
+func TestHandleProxy(t *testing.T) {
+	// Backend the proxy target resolves to. It echoes the path it received (so we
+	// can assert the proxy prefix was stripped) and serves HTML on one route (so
+	// we can assert the HTML rewrite ran).
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/htmlpage" {
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = io.WriteString(w, `<html><head><title>t</title></head><body><a href="/foo">x</a></body></html>`)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = io.WriteString(w, "backend saw: "+r.URL.Path)
+	}))
+	defer backend.Close()
+
+	u, err := url.Parse(backend.URL)
+	require.NoError(t, err)
+	port, err := strconv.ParseInt(u.Port(), 10, 32)
+	require.NoError(t, err)
+
+	ma, ts := newProxyTestAdmin(t, "cell1")
+	require.NoError(t, ts.CreateMultiGateway(t.Context(), &clustermetadatapb.MultiGateway{
+		Id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIGATEWAY, Cell: "cell1", Name: "gw1"},
+		Hostname: u.Hostname(),
+		PortMap:  map[string]int32{"http": int32(port)},
+	}))
+
+	t.Run("invalid path returns 400", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		ma.handleProxy(rec, httptest.NewRequest(http.MethodGet, "/proxy/gate/cell1", nil))
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("unknown service returns 404", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		ma.handleProxy(rec, httptest.NewRequest(http.MethodGet, "/proxy/gate/cell1/missing", nil))
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("proxies to the backend and strips the proxy prefix", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		ma.handleProxy(rec, httptest.NewRequest(http.MethodGet, "/proxy/gate/cell1/gw1/somepage", nil))
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "backend saw: /somepage", rec.Body.String())
+	})
+
+	t.Run("rewrites HTML responses to carry the proxy base path", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		ma.handleProxy(rec, httptest.NewRequest(http.MethodGet, "/proxy/gate/cell1/gw1/htmlpage", nil))
+		assert.Equal(t, http.StatusOK, rec.Code)
+		// The rewrite injects a <base>/absolute-URL prefix so the browser keeps
+		// routing subsequent requests through the proxy base path.
+		assert.Contains(t, rec.Body.String(), "/proxy/gate/cell1/gw1")
+	})
 }

--- a/go/services/multigateway/handler/statement_timeout_test.go
+++ b/go/services/multigateway/handler/statement_timeout_test.go
@@ -21,8 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func durationPtr(d time.Duration) *time.Duration { return &d }
-
 func TestResolveStatementTimeout(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -38,13 +36,13 @@ func TestResolveStatementTimeout(t *testing.T) {
 		},
 		{
 			name:      "directive wins over effective",
-			directive: durationPtr(500 * time.Millisecond),
+			directive: new(500 * time.Millisecond),
 			effective: 10 * time.Second,
 			want:      500 * time.Millisecond,
 		},
 		{
 			name:      "directive=0 disables timeout",
-			directive: durationPtr(0),
+			directive: new(time.Duration(0)),
 			effective: 10 * time.Second,
 			want:      0,
 		},
@@ -55,7 +53,7 @@ func TestResolveStatementTimeout(t *testing.T) {
 		},
 		{
 			name:      "directive wins even when larger",
-			directive: durationPtr(60 * time.Second),
+			directive: new(60 * time.Second),
 			effective: 10 * time.Second,
 			want:      60 * time.Second,
 		},

--- a/go/tools/flakyaggregator/main_test.go
+++ b/go/tools/flakyaggregator/main_test.go
@@ -26,8 +26,8 @@ import (
 
 func makeRun(id int64, url string, t time.Time) *github.WorkflowRun {
 	return &github.WorkflowRun{
-		ID:        github.Ptr(id),
-		HTMLURL:   github.Ptr(url),
+		ID:        new(id),
+		HTMLURL:   new(url),
 		CreatedAt: &github.Timestamp{Time: t},
 	}
 }


### PR DESCRIPTION
Bump the go.mod `go` directive from 1.25.1 to 1.26.4; CI installs this via setup-go's go-version-file, so it upgrades the CI analysis toolchain too. Consequences of crossing into 1.26, handled here so lint stays clean:

- multiadmin/proxy.go: migrate off the now-deprecated httputil.ReverseProxy.Director to Rewrite (SA1019). SetURL applies the target's scheme/host and SetXForwarded preserves the X-Forwarded-* headers the Director path added automatically.
- ssl_test.go: drop the SA5011 return workaround — 1.26's staticcheck models t.Fatal/t.Fatalf as no-return, so the nil guards no longer look like derefs.
- eventlog / statement_timeout / flakyaggregator tests: apply the modernize new(expr) simplifications 1.26 enables and drop the now-inlined, unused durationPtr helper.