### PR TITLE
fix(multipooler): keep reserved conn alive on SQL error in extended protocol

### DIFF
--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -926,8 +926,19 @@ func (e *Executor) portalExecuteWithReserved(
 		completed, err = reservedConn.BindAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, maxRows, callback)
 	}
 	if err != nil {
-		reservedConn.Release(reserved.ReleaseError, nil)
-		return nil, wrapQueryError(err)
+		// A PostgreSQL statement error (division_by_zero, a constraint violation,
+		// an RLS WITH CHECK denial, …) only ABORTS the transaction; the backend
+		// stays usable for ROLLBACK [TO SAVEPOINT]. Destroy the reserved conn only
+		// on a genuine connection failure, or when THIS call created the
+		// reservation (newlyReserved) — matching the sibling error sites above and
+		// the COPY path. Otherwise keep the session-owned reservation and return
+		// its state so the gateway keeps tracking it; releasing here would make the
+		// client's next statement fail with 40001 "reserved connection not found".
+		if newlyReserved || mterrors.IsConnectionError(err) {
+			reservedConn.Release(reserved.ReleaseError, nil)
+			return nil, wrapQueryError(err)
+		}
+		return e.buildReservedState(reservedConn), wrapQueryError(err)
 	}
 
 	if reservationOptions.GetMarkSessionStateUntrusted() {

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -1262,3 +1262,83 @@ func TestCopyAbort_NilOptionsAndNoCopyReason(t *testing.T) {
 		require.Nil(t, state)
 	})
 }
+
+// TestPortalStreamExecute_ExistingReservationStatementErrorKeepsConnection is
+// the regression test for the reserved connection being destroyed on a plain
+// SQL error (e.g. division_by_zero, an RLS WITH CHECK denial). Such an error
+// only aborts the transaction — PostgreSQL keeps the backend alive — so a
+// session-owned reservation must survive the failed portal and stay usable for
+// ROLLBACK [TO SAVEPOINT].
+func TestPortalStreamExecute_ExistingReservationStatementErrorKeepsConnection(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+	server.AddRejectedQuery("select 1/0", mterrors.NewPgError("ERROR", "22012", "division by zero", ""))
+
+	pool := reserved.NewPool(context.Background(), &reserved.PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig: server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{
+				Capacity:     2,
+				MaxIdleCount: 2,
+			},
+		},
+	})
+	defer pool.Close()
+
+	ctx := context.Background()
+	rconn, err := pool.NewConn(ctx, nil)
+	require.NoError(t, err)
+
+	e := NewExecutor(slog.Default(), &stubPoolManager{reservedConn: rconn, reservedConnOK: true}, &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"}, false)
+
+	state, err := e.PortalStreamExecute(ctx, &query.Target{},
+		&query.PreparedStatement{Name: "stmt0", Query: "SELECT 1/0"},
+		&query.Portal{Name: "p0"},
+		&query.ExecuteOptions{User: "postgres", ReservedConnectionId: uint64(rconn.ConnID())},
+		nil, nil, noopCallback)
+
+	require.Error(t, err)
+	require.NotNil(t, state, "gateway must keep tracking the session-owned reservation")
+	assert.Equal(t, uint64(rconn.ConnID()), state.GetReservedConnectionId())
+	assert.False(t, rconn.IsReleased(), "a plain statement error must not destroy the reserved connection")
+}
+
+// TestPortalStreamExecute_ExistingReservationConnectionErrorReleases verifies
+// that a genuine connection failure (unlike a plain statement error) still
+// destroys the reserved connection, since the backend is actually gone.
+func TestPortalStreamExecute_ExistingReservationConnectionErrorReleases(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+	server.AddRejectedQuery("select 1", mterrors.NewPgError("FATAL", "57P01", "terminating connection due to administrator command", ""))
+
+	pool := reserved.NewPool(context.Background(), &reserved.PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig: server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{
+				Capacity:     2,
+				MaxIdleCount: 2,
+			},
+		},
+	})
+	defer pool.Close()
+
+	ctx := context.Background()
+	rconn, err := pool.NewConn(ctx, nil)
+	require.NoError(t, err)
+
+	e := NewExecutor(slog.Default(), &stubPoolManager{reservedConn: rconn, reservedConnOK: true}, &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"}, false)
+
+	state, err := e.PortalStreamExecute(ctx, &query.Target{},
+		&query.PreparedStatement{Name: "stmt0", Query: "SELECT 1"},
+		&query.Portal{Name: "p0"},
+		&query.ExecuteOptions{User: "postgres", ReservedConnectionId: uint64(rconn.ConnID())},
+		nil, nil, noopCallback)
+
+	require.Error(t, err)
+	require.Nil(t, state)
+	assert.True(t, rconn.IsReleased(), "a genuine connection failure must still destroy the reserved connection")
+}

--- a/go/test/endtoend/queryserving/reserved_conn_error_recovery_test.go
+++ b/go/test/endtoend/queryserving/reserved_conn_error_recovery_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestReservedConnRecoversFromStatementError is the regression for the reserved
+// connection being destroyed on a plain SQL error. A runtime statement error inside
+// a transaction must only ABORT the transaction (PostgreSQL keeps the backend alive);
+// the client must be able to ROLLBACK / ROLLBACK TO SAVEPOINT and keep using the
+// connection. Before the fix, the multigateway destroyed the reserved backend and the
+// recovery statement returned SQLSTATE 40001.
+func TestReservedConnRecoversFromStatementError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping end-to-end tests in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 60*time.Second)
+
+	for _, target := range setup.GetComparisonTargets(t) {
+		t.Run(target.Name, func(t *testing.T) {
+			connect := func(t *testing.T) *pgx.Conn {
+				dsn := shardsetup.GetTestUserDSN("localhost", target.Port, "sslmode=disable", "connect_timeout=5")
+				conn, err := pgx.Connect(ctx, dsn)
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = conn.Close(ctx) })
+				return conn
+			}
+
+			// A prior successful statement establishes the reserved connection, then a
+			// runtime error aborts the txn; plain ROLLBACK must recover.
+			t.Run("ROLLBACK after runtime error", func(t *testing.T) {
+				conn := connect(t)
+
+				_, err := conn.Exec(ctx, "BEGIN")
+				require.NoError(t, err)
+				_, err = conn.Exec(ctx, "SELECT 1") // establishes the reservation
+				require.NoError(t, err)
+
+				// QueryRow forces the extended protocol (Parse/Bind/Execute), which is
+				// the path PortalStreamExecute runs on and where the bug lives.
+				var divResult int
+				err = conn.QueryRow(ctx, "SELECT 1/0").Scan(&divResult) // runtime error (division_by_zero)
+				require.Error(t, err, "division by zero should error")
+
+				_, err = conn.Exec(ctx, "ROLLBACK")
+				require.NoError(t, err, "ROLLBACK after a statement error must recover the transaction")
+
+				var n int
+				require.NoError(t, conn.QueryRow(ctx, "SELECT 42").Scan(&n))
+				assert.Equal(t, 42, n, "connection must be usable after recovery")
+			})
+
+			// Mirrors Postgrex/Ecto `mode: :savepoint` (Realtime authorization uses this):
+			// SAVEPOINT, erroring statement, ROLLBACK TO SAVEPOINT, continue.
+			t.Run("ROLLBACK TO SAVEPOINT after runtime error", func(t *testing.T) {
+				conn := connect(t)
+
+				_, err := conn.Exec(ctx, "BEGIN")
+				require.NoError(t, err)
+				_, err = conn.Exec(ctx, "SAVEPOINT sp1") // establishes the reservation
+				require.NoError(t, err)
+
+				// QueryRow forces the extended protocol (Parse/Bind/Execute), which is
+				// the path PortalStreamExecute runs on and where the bug lives.
+				var divResult int
+				err = conn.QueryRow(ctx, "SELECT 1/0").Scan(&divResult)
+				require.Error(t, err)
+
+				_, err = conn.Exec(ctx, "ROLLBACK TO SAVEPOINT sp1")
+				require.NoError(t, err, "ROLLBACK TO SAVEPOINT after a statement error must recover")
+
+				var n int
+				require.NoError(t, conn.QueryRow(ctx, "SELECT 42").Scan(&n))
+				assert.Equal(t, 42, n)
+
+				_, _ = conn.Exec(ctx, "ROLLBACK")
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Problem

A runtime statement error inside a transaction should only abort the transaction, not destroy the backend — PostgreSQL keeps it alive for `ROLLBACK`/`ROLLBACK TO SAVEPOINT`. The extended-protocol Bind/Execute path in the reserved connection code released the connection anyway on any error, so any recovery attempt after an in-flight-portal error hit SQLSTATE 40001 ("reserved connection terminated") instead of succeeding. This broke Realtime broadcast-authorization tests, which use Postgrex/Ecto's `mode: :savepoint` recovery pattern around RLS `WITH CHECK` failures.

## Solution

Match the existing pattern used elsewhere in the same function (and the COPY path): only tear down the reserved connection for a fresh reservation or an actual connection failure; a session-owned reservation survives a single failed portal so the client can recover normally. Added an end-to-end regression test that reproduces the bug via extended protocol (`ROLLBACK TO SAVEPOINT` after a runtime error) and fails with 40001 before the fix, passes after.