### PR TITLE
refactor(multipooler): collapse serving state to a derived routing role

### DIFF
--- a/go/common/consensus/pooler.go
+++ b/go/common/consensus/pooler.go
@@ -73,17 +73,21 @@ func SelfConsensusRole(cs *clustermetadatapb.ConsensusStatus) ConsensusRole {
 	return ConsensusRoleObserver
 }
 
-// IsNonRevokedCommittedLeader reports whether cs's committed position names its
-// own pooler as leader and that committed rule has not been revoked. This is the
-// write-safety leadership input: it stays false in the window between pg_promote
-// and the new rule being committed to WAL, so a freshly-promoted pooler is not
-// treated as the writable leader until its leadership is durably committed.
-func IsNonRevokedCommittedLeader(cs *clustermetadatapb.ConsensusStatus) bool {
+// IsActiveLeader reports whether cs names its own pooler as a leader fit to accept
+// write transactions. That means:
+// - Highest leader known to the pooler (it hasn't been asked to replicate from somewhere else)
+// - Highest leader written to the pooler's WAL
+// - The pooler hasn't been recruited to revoke that rule
+func IsActiveLeader(cs *clustermetadatapb.ConsensusStatus) bool {
 	committed := cs.GetCurrentPosition().GetRule()
 	if !RuleNamesLeader(committed, cs.GetId()) {
 		return false
 	}
-	return !IsRuleRevoked(committed, cs.GetTermRevocation())
+	if IsRuleRevoked(committed, cs.GetTermRevocation()) {
+		return false
+	}
+	// Not superseded: still the leader of the highest rule we know about.
+	return SelfConsensusRole(cs) == ConsensusRoleLeader
 }
 
 // LeaderTerm returns the coordinator term of the pooler's current recorded

--- a/go/common/consensus/pooler_test.go
+++ b/go/common/consensus/pooler_test.go
@@ -215,7 +215,7 @@ func TestSelfConsensusRole(t *testing.T) {
 	}
 }
 
-func TestIsNonRevokedCommittedLeader(t *testing.T) {
+func TestIsActiveLeader(t *testing.T) {
 	id := func(cell, name string) *clustermetadatapb.ID {
 		return &clustermetadatapb.ID{Cell: cell, Name: name}
 	}
@@ -285,11 +285,25 @@ func TestIsNonRevokedCommittedLeader(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			// Superseded stale primary: our committed rule still names us and is not
+			// revoked, but we have learned (via the replication primary) of a higher
+			// rule naming another pooler — so we are no longer the active leader.
+			name: "committed self but superseded by higher known rule",
+			cs: &clustermetadatapb.ConsensusStatus{
+				Id:              self,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{Rule: &clustermetadatapb.ShardRule{LeaderId: self, RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5}}},
+				ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
+					Rule: &clustermetadatapb.ShardRule{LeaderId: other, RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 6}},
+				},
+			},
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, IsNonRevokedCommittedLeader(tt.cs))
+			assert.Equal(t, tt.want, IsActiveLeader(tt.cs))
 		})
 	}
 }

--- a/go/services/multigateway/poolergateway/load_balancer.go
+++ b/go/services/multigateway/poolergateway/load_balancer.go
@@ -85,6 +85,9 @@ func (s *shardSummary) leader() *clustermetadatapb.LeaderObservation {
 // mergeLeader installs obs as this shard's leader if it strictly
 // supersedes whatever's there now (or there's nothing there). Returns
 // true if installed. Safe to call concurrently.
+//
+// TODO: rename LeadershipObservation to RoutingState and make sure only active primaries
+// publish routing state.
 func (s *shardSummary) mergeLeader(obs *clustermetadatapb.LeaderObservation) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/go/services/multipooler/grpcpoolerservice/stream_replication_test.go
+++ b/go/services/multipooler/grpcpoolerservice/stream_replication_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/internal/poolerserver"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pools/reserved"
 	"github.com/multigres/multigres/go/services/multipooler/internal/replication"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 // fakeReplStream is a test double for MultiPoolerService_StreamReplicationServer.
@@ -224,10 +225,11 @@ func (f *fakeReplPoolManager) NewLogicalReplicationConn(context.Context, string,
 func servingPooler(t *testing.T, pm connpoolmanager.PoolManager) *poolerserver.QueryPoolerServer {
 	t.Helper()
 	p := poolerserver.NewQueryPoolerServer(slog.Default(), pm, nil, "", "", nil, 0, false)
-	// isConsensusLeader=true so a serving primary admits the stream (#1184/#1194:
-	// admission keys off consensus leadership, not the topology PoolerType label).
+	// SERVING so the pooler admits the stream. These replication requests carry a
+	// nil Target, so admission skips the routing-role gate and keys only off the
+	// serving status; the routing role is therefore immaterial here.
 	require.NoError(t, p.OnStateChange(t.Context(),
-		true, false, clustermetadatapb.PoolerServingStatus_SERVING))
+		servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	return p
 }
 

--- a/go/services/multipooler/internal/heartbeat/repltracker.go
+++ b/go/services/multipooler/internal/heartbeat/repltracker.go
@@ -22,6 +22,7 @@ import (
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 // TODO: add stats for heartbeat reads and writes
@@ -82,12 +83,12 @@ func (rt *ReplTracker) makeNonPrimary() {
 }
 
 // OnStateChange transitions the heartbeat tracker based on the serving state.
-// The writer runs only when this pooler is the consensus leader AND postgres is
-// out of recovery AND serving; otherwise the reader runs. Being the leader does
-// not imply a writable postgres — writing heartbeats to a standby fails every
-// interval and spams the log — so postgresPrimary must gate the writer too.
-func (rt *ReplTracker) OnStateChange(_ context.Context, isConsensusLeader, postgresPrimary bool, servingStatus clustermetadatapb.PoolerServingStatus) error {
-	if isConsensusLeader && postgresPrimary && servingStatus == clustermetadatapb.PoolerServingStatus_SERVING {
+// The writer runs only when this pooler is the writable leader (routing role
+// PRIMARY — out of recovery AND the active consensus leader) AND serving;
+// otherwise the reader runs. Writability already folds in the out-of-recovery
+// requirement, so heartbeats are never written to a standby.
+func (rt *ReplTracker) OnStateChange(_ context.Context, state servingstate.State) error {
+	if state.RoutingRole.Writable() && state.ServingStatus == clustermetadatapb.PoolerServingStatus_SERVING {
 		rt.makePrimary()
 	} else {
 		rt.makeNonPrimary()

--- a/go/services/multipooler/internal/heartbeat/repltracker_test.go
+++ b/go/services/multipooler/internal/heartbeat/repltracker_test.go
@@ -22,6 +22,7 @@ import (
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor/mock"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -128,53 +129,41 @@ func TestReplTrackerEnableHeartbeat(t *testing.T) {
 	assert.Greater(t, rt.Writes(), lastWrites)
 }
 
-// TestReplTrackerOnStateChangeGating verifies the writer (primary mode) runs
-// only when this pooler is the consensus leader AND postgres is out of recovery
-// AND serving. The postgresPrimary gate is the important one: a consensus leader
-// whose postgres is still in recovery must NOT run the heartbeat writer, since
+// TestReplTrackerOnStateChangeGating verifies the writer (primary mode) runs only
+// when this pooler is the writable leader (RoutingRolePrimary) AND serving. The
+// routing role folds in both the consensus-leader and out-of-recovery facts: a
+// pooler that is not the writable leader must NOT run the heartbeat writer, since
 // every write would fail against a read-only standby.
 func TestReplTrackerOnStateChangeGating(t *testing.T) {
 	tests := []struct {
-		name              string
-		isConsensusLeader bool
-		postgresPrimary   bool
-		servingStatus     clustermetadatapb.PoolerServingStatus
-		wantPrimary       bool
+		name          string
+		routingRole   servingstate.RoutingRole
+		servingStatus clustermetadatapb.PoolerServingStatus
+		wantPrimary   bool
 	}{
 		{
-			name:              "leader, writable, serving -> writer runs",
-			isConsensusLeader: true,
-			postgresPrimary:   true,
-			servingStatus:     clustermetadatapb.PoolerServingStatus_SERVING,
-			wantPrimary:       true,
+			name:          "writable leader, serving -> writer runs",
+			routingRole:   servingstate.RoutingRolePrimary,
+			servingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
+			wantPrimary:   true,
 		},
 		{
-			name:              "leader but not yet writable -> writer stays off",
-			isConsensusLeader: true,
-			postgresPrimary:   false,
-			servingStatus:     clustermetadatapb.PoolerServingStatus_SERVING,
-			wantPrimary:       false,
+			name:          "not the writable leader, serving -> writer stays off",
+			routingRole:   servingstate.RoutingRoleReplica,
+			servingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
+			wantPrimary:   false,
 		},
 		{
-			name:              "writable but not leader -> writer stays off",
-			isConsensusLeader: false,
-			postgresPrimary:   true,
-			servingStatus:     clustermetadatapb.PoolerServingStatus_SERVING,
-			wantPrimary:       false,
+			name:          "writable leader but draining -> writer stays off",
+			routingRole:   servingstate.RoutingRolePrimary,
+			servingStatus: clustermetadatapb.PoolerServingStatus_DRAINING,
+			wantPrimary:   false,
 		},
 		{
-			name:              "leader and writable but draining -> writer stays off",
-			isConsensusLeader: true,
-			postgresPrimary:   true,
-			servingStatus:     clustermetadatapb.PoolerServingStatus_DRAINING,
-			wantPrimary:       false,
-		},
-		{
-			name:              "leader and writable but disabled -> writer stays off",
-			isConsensusLeader: true,
-			postgresPrimary:   true,
-			servingStatus:     clustermetadatapb.PoolerServingStatus_DISABLED,
-			wantPrimary:       false,
+			name:          "writable leader but disabled -> writer stays off",
+			routingRole:   servingstate.RoutingRolePrimary,
+			servingStatus: clustermetadatapb.PoolerServingStatus_DISABLED,
+			wantPrimary:   false,
 		},
 	}
 
@@ -190,7 +179,7 @@ func TestReplTrackerOnStateChangeGating(t *testing.T) {
 			rt := NewReplTracker(queryService, slog.Default(), []byte("test-shard"), "test-pooler", 250)
 			defer rt.Close()
 
-			err := rt.OnStateChange(context.Background(), tt.isConsensusLeader, tt.postgresPrimary, tt.servingStatus)
+			err := rt.OnStateChange(context.Background(), servingstate.State{RoutingRole: tt.routingRole, ServingStatus: tt.servingStatus})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantPrimary, rt.IsPrimary())
 			assert.Equal(t, tt.wantPrimary, rt.hw.IsOpen(), "writer open state must match primary mode")

--- a/go/services/multipooler/internal/manager/consensus_manager_test.go
+++ b/go/services/multipooler/internal/manager/consensus_manager_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
 	"github.com/multigres/multigres/go/services/multipooler/internal/poolerserver"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 // forTestOption configures NewMultiPoolerManagerForTesting.
@@ -174,6 +175,15 @@ func (cfg *testManagerConfig) seedLockedState(t *testing.T, pm *MultiPoolerManag
 func newTestManager(t *testing.T, opts ...testManagerOption) *MultiPoolerManager {
 	t.Helper()
 	cfg := resolveTestManagerConfig(t, opts...)
+	if cfg.record == nil {
+		// A non-nil record is required to wire the StateManager (below); default to
+		// a REPLICA/DISABLED record for tests that don't supply their own.
+		cfg.record = newRecordFromProto(&clustermetadatapb.MultiPooler{
+			Id:            cfg.serviceID,
+			Type:          clustermetadatapb.PoolerType_REPLICA,
+			ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED,
+		})
+	}
 	pm := &MultiPoolerManager{
 		logger:       slog.Default(),
 		actionLock:   actionlock.NewActionLock(),
@@ -181,6 +191,27 @@ func newTestManager(t *testing.T, opts ...testManagerOption) *MultiPoolerManager
 		record:       cfg.record,
 		consensusMgr: cfg.consensusManager(t),
 	}
+	// The remedial-action decision path (determineRoleAction) consults
+	// StateManager.hasDrift, so a non-nil StateManager wired to the same record and
+	// live consensus snapshot the manager uses is required.
+	pm.stateManager = NewStateManager(pm.logger, pm.record, pm.consensusMgr.CachedConsensusStatus)
 	cfg.seedLockedState(t, pm)
+	// Prime the StateManager's last-fanned-out state to reflect what components
+	// last saw: the seeded record's own label and serving status, with the physical
+	// recovery flag assumed aligned with that label (PRIMARY <-> primary). This is
+	// the faithful port of the old determineRemedialAction lastAppliedPrimary input
+	// (which the tables passed as state.isPrimary): a freshly-built manager is NOT
+	// drifted relative to its seed, so drift is registered only when the observed
+	// postgresState / consensus diverges from the seeded label.
+	primaryBaseline := pm.record.Type() == clustermetadatapb.PoolerType_PRIMARY
+	pm.stateManager.postgresPrimary = primaryBaseline
+	baseline := servingstate.State{
+		RoutingRole:   servingstate.RoutingRoleReplica,
+		ServingStatus: pm.record.ServingStatus(),
+	}
+	if primaryBaseline {
+		baseline.RoutingRole = servingstate.RoutingRolePrimary
+	}
+	pm.stateManager.lastFannedOut = &baseline
 	return pm
 }

--- a/go/services/multipooler/internal/manager/graceful_shutdown_test.go
+++ b/go/services/multipooler/internal/manager/graceful_shutdown_test.go
@@ -117,7 +117,7 @@ func newGracefulShutdownTestManager(t *testing.T, pgctldClient pgctldpb.PgCtldCl
 		// GracefulShutdown transitions serving state to DISABLED; wire a real
 		// StateManager (fanning out to the healthStreamer) so the shutdown path
 		// runs as in production rather than relying on a nil-check.
-		stateManager: NewStateManager(logger, record, hs),
+		stateManager: NewStateManager(logger, record, nilConsensusStatus, hs),
 	}
 }
 

--- a/go/services/multipooler/internal/manager/health_provider.go
+++ b/go/services/multipooler/internal/manager/health_provider.go
@@ -23,6 +23,7 @@ import (
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/poolerserver"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 const (
@@ -127,35 +128,34 @@ func (hs *healthStreamer) UpdateLeaderObservation(obs *poolerserver.LeaderObserv
 // discovering the new primary before the pooler can actually serve that type.
 // not-serving transitions broadcast immediately so the gateway can start
 // buffering without delay.
-func (hs *healthStreamer) OnStateChange(ctx context.Context, isConsensusLeader, postgresPrimary bool, servingStatus clustermetadatapb.PoolerServingStatus) error {
-	if servingStatus == clustermetadatapb.PoolerServingStatus_SERVING && hs.queryServer != nil {
-		hs.queryServer.AwaitStateChange(ctx, isConsensusLeader, servingStatus)
+func (hs *healthStreamer) OnStateChange(ctx context.Context, state servingstate.State) error {
+	if state.ServingStatus == clustermetadatapb.PoolerServingStatus_SERVING && hs.queryServer != nil {
+		hs.queryServer.AwaitStateChange(ctx, state.RoutingRole, state.ServingStatus)
 	}
 
 	hs.mu.Lock()
 	defer hs.mu.Unlock()
 
 	prev := hs.servingStatus
-	// The health stream still reports the PoolerType routing label to the gateway.
-	// PoolerType tracks the consensus term (leadership), not postgres writability —
-	// a leader can be the term leader before it has finished promoting. Translate
-	// the leader fact to the wire label: a non-leader is a read replica for routing.
-	hs.poolerType = poolerTypeForLeader(isConsensusLeader)
-	// writable is published separately so the gateway gates write traffic on actual
-	// write-readiness (postgres out of recovery), not on leadership.
-	hs.writable = postgresPrimary
-	hs.servingStatus = servingStatus
+	// The health stream reports the routing role to the gateway as a PoolerType
+	// label plus the writable flag. Both derive from the routing role: PRIMARY (and
+	// writable) iff this pooler is the writable leader, REPLICA otherwise. A leader
+	// that has not finished promoting is not yet routing PRIMARY, so the gateway
+	// does not route writes to it until its rule commits.
+	hs.poolerType = poolerTypeForLeader(state.RoutingRole.Writable())
+	hs.writable = state.RoutingRole.Writable()
+	hs.servingStatus = state.ServingStatus
 	hs.broadcastLocked()
-	if prev != servingStatus {
-		hs.metrics.recordTransition(ctx, prev, servingStatus)
+	if prev != state.ServingStatus {
+		hs.metrics.recordTransition(ctx, prev, state.ServingStatus)
 	}
 	return nil
 }
 
-// poolerTypeForLeader maps the consensus-leadership fact to the PoolerType routing
-// label published on the health stream.
-func poolerTypeForLeader(isConsensusLeader bool) clustermetadatapb.PoolerType {
-	if isConsensusLeader {
+// poolerTypeForLeader maps a writable-leader boolean to the PoolerType label
+// (published on the health stream and persisted to the topology record).
+func poolerTypeForLeader(writableLeader bool) clustermetadatapb.PoolerType {
+	if writableLeader {
 		return clustermetadatapb.PoolerType_PRIMARY
 	}
 	return clustermetadatapb.PoolerType_REPLICA

--- a/go/services/multipooler/internal/manager/health_provider_test.go
+++ b/go/services/multipooler/internal/manager/health_provider_test.go
@@ -26,6 +26,7 @@ import (
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/poolerserver"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 func TestHealthStreamer_BroadcastToSubscribers(t *testing.T) {
@@ -44,7 +45,7 @@ func TestHealthStreamer_BroadcastToSubscribers(t *testing.T) {
 	assert.Equal(t, 2, hs.clientCount())
 
 	// Update state (triggers broadcast)
-	require.NoError(t, hs.OnStateChange(context.Background(), false, false, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, hs.OnStateChange(context.Background(), servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// Both clients should receive the state
 	timeout1 := time.After(100 * time.Millisecond)
@@ -75,7 +76,7 @@ func TestHealthStreamer_SubscribeReceivesCurrentState(t *testing.T) {
 	hs := newHealthStreamer(logger, serviceID, "initial", "0")
 
 	// Set initial state via OnStateChange
-	require.NoError(t, hs.OnStateChange(context.Background(), false, false, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, hs.OnStateChange(context.Background(), servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// Subscribe should return current state
 	state, _ := hs.subscribe()
@@ -101,7 +102,7 @@ func TestHealthStreamer_FullBufferClosesChannel(t *testing.T) {
 
 	// Send more than buffer size without draining
 	for range defaultHealthStreamBufferSize + 5 {
-		require.NoError(t, hs.OnStateChange(context.Background(), false, false, clustermetadatapb.PoolerServingStatus_SERVING))
+		require.NoError(t, hs.OnStateChange(context.Background(), servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	}
 
 	// Channel should be closed due to buffer overflow
@@ -139,7 +140,7 @@ func TestHealthStreamer_GetState(t *testing.T) {
 	assert.Equal(t, clustermetadatapb.PoolerServingStatus_DISABLED, got.ServingStatus)
 
 	// Update and verify
-	require.NoError(t, hs.OnStateChange(context.Background(), false, false, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, hs.OnStateChange(context.Background(), servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	got = hs.getState()
 	assert.Equal(t, clustermetadatapb.PoolerServingStatus_SERVING, got.ServingStatus)
 }
@@ -238,7 +239,7 @@ func TestHealthStreamer_OnStateChange(t *testing.T) {
 	_, ch := hs.subscribe()
 
 	// Call OnStateChange — updates both fields atomically with one broadcast
-	err := hs.OnStateChange(context.Background(), true, true, clustermetadatapb.PoolerServingStatus_SERVING)
+	err := hs.OnStateChange(context.Background(), servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING})
 	require.NoError(t, err)
 
 	// Verify subscriber receives a single broadcast with both fields updated
@@ -317,7 +318,7 @@ func TestHealthStreamer_WaitsForQueryServerOnServing(t *testing.T) {
 	// It should block because qps hasn't transitioned yet.
 	hsDone := make(chan struct{})
 	go func() {
-		_ = hs.OnStateChange(t.Context(), true, true, clustermetadatapb.PoolerServingStatus_SERVING)
+		_ = hs.OnStateChange(t.Context(), servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING})
 		close(hsDone)
 	}()
 
@@ -329,7 +330,7 @@ func TestHealthStreamer_WaitsForQueryServerOnServing(t *testing.T) {
 	}
 
 	// Now transition the query server.
-	require.NoError(t, qps.OnStateChange(t.Context(), true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, qps.OnStateChange(t.Context(), servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// Health streamer should unblock and broadcast.
 	select {
@@ -355,7 +356,7 @@ func TestHealthStreamer_DoesNotWaitOnNotServing(t *testing.T) {
 
 	// Create a query server that is PRIMARY/SERVING.
 	qps := poolerserver.NewQueryPoolerServer(logger, nil, nil, "", "", nil, 0, false)
-	require.NoError(t, qps.OnStateChange(t.Context(), true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, qps.OnStateChange(t.Context(), servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	hs.SetQueryServer(qps)
 
 	ch := make(chan *poolerserver.HealthState, 10)
@@ -364,7 +365,7 @@ func TestHealthStreamer_DoesNotWaitOnNotServing(t *testing.T) {
 	// DISABLED should broadcast immediately, even though qps is still PRIMARY/SERVING.
 	hsDone := make(chan struct{})
 	go func() {
-		_ = hs.OnStateChange(t.Context(), false, false, clustermetadatapb.PoolerServingStatus_DISABLED)
+		_ = hs.OnStateChange(t.Context(), servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
 		close(hsDone)
 	}()
 
@@ -388,16 +389,14 @@ func TestHealthStreamer_PublishesWritability(t *testing.T) {
 
 	// Leader, SERVING (can answer reads), but postgres still in recovery: not writable.
 	require.NoError(t, hs.OnStateChange(t.Context(),
-		true /* isConsensusLeader */, false, /* postgresPrimary */
-		clustermetadatapb.PoolerServingStatus_SERVING))
+		servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	st := <-ch
 	assert.Equal(t, clustermetadatapb.PoolerServingStatus_SERVING, st.ServingStatus)
 	assert.False(t, st.Writable, "leader still in recovery must not advertise writable")
 
 	// Promotion completes (out of recovery): now writable.
 	require.NoError(t, hs.OnStateChange(t.Context(),
-		true /* isConsensusLeader */, true, /* postgresPrimary */
-		clustermetadatapb.PoolerServingStatus_SERVING))
+		servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	st = <-ch
 	assert.True(t, st.Writable, "writable once postgres leaves recovery")
 }

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -369,7 +369,7 @@ func newMultiPoolerManager(logger *slog.Logger, multiPooler *clustermetadatapb.M
 
 	// Create the serving state manager with the query service and health streamer as initial components.
 	// The ReplTracker is registered later when heartbeat is started.
-	pm.stateManager = NewStateManager(logger, pm.record, pm.qsc, pm.healthStreamer)
+	pm.stateManager = NewStateManager(logger, pm.record, pm.consensusMgr.CachedConsensusStatus, pm.qsc, pm.healthStreamer)
 
 	// Construct the pgBackRest engine. It owns all pgBackRest interaction and its
 	// own metrics. The pgbackrest.conf path, pgpass file, and repo config are
@@ -841,17 +841,6 @@ func (pm *MultiPoolerManager) getPoolerType() clustermetadatapb.PoolerType {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 	return pm.record.Type()
-}
-
-// leaderObs builds the LeaderObservation this pooler records when it is the
-// leader under rule. The caller supplies the rule it knows names this pooler as
-// leader — the proposed rule on promotion, the recorded rule in the monitor —
-// so the source is explicit rather than read implicitly here.
-func (pm *MultiPoolerManager) leaderObs(rule *clustermetadatapb.ShardRule) *clustermetadatapb.LeaderObservation {
-	return &clustermetadatapb.LeaderObservation{
-		LeaderId:         rule.GetLeaderId(),
-		LeaderRuleNumber: rule.GetRuleNumber(),
-	}
 }
 
 // shardKey returns a ShardKey identifying this pooler's shard.
@@ -1569,14 +1558,14 @@ func (pm *MultiPoolerManager) updateTopologyAfterPromotion(ctx context.Context, 
 		pm.logger.InfoContext(ctx, "Updating pooler type in topology to PRIMARY")
 	}
 
-	// rule is the rule this pooler was just promoted under; it names this pooler
-	// as leader, so the leadership observation built from it is authoritative.
-	// Promotion has already waited for postgres to leave recovery, so set the
-	// writable state in the same Mutate — this lets the heartbeat writer / LISTEN
-	// start immediately rather than waiting for the next monitor tick to observe
-	// it. Mutate is idempotent — if already at this state it short-circuits.
+	// Promotion has already waited for postgres to leave recovery AND for the new
+	// rule to commit (DoUpdateRule blocks on the sync-standby ack before this
+	// runs), so the consensus snapshot now names this pooler the active committed
+	// leader: poking PostgresPrimary here derives routing role PRIMARY and its
+	// leadership observation, letting the heartbeat writer / LISTEN and the gateway
+	// start immediately rather than waiting for the next monitor tick. Mutate is
+	// idempotent — if already at this state it short-circuits.
 	if err := pm.stateManager.Mutate(ctx, func(s *servingStateMutation) {
-		s.SelfLeadership = pm.leaderObs(rule)
 		s.PostgresPrimary = true
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	}); err != nil {

--- a/go/services/multipooler/internal/manager/metrics_test.go
+++ b/go/services/multipooler/internal/manager/metrics_test.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 	"github.com/multigres/multigres/go/tools/telemetry"
 )
 
@@ -83,19 +84,16 @@ func TestServingTransitions(t *testing.T) {
 
 	// DISABLED (initial) → SERVING records one transition.
 	require.NoError(t, hs.OnStateChange(ctx,
-		true /* isConsensusLeader */, true, /* postgresPrimary */
-		clustermetadatapb.PoolerServingStatus_SERVING))
+		servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
-	// SERVING → SERVING is a no-op (role change only, leader/primary → replica):
+	// SERVING → SERVING is a no-op (role change only, primary → replica):
 	// no new transition.
 	require.NoError(t, hs.OnStateChange(ctx,
-		false /* isConsensusLeader */, false, /* postgresPrimary */
-		clustermetadatapb.PoolerServingStatus_SERVING))
+		servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// SERVING → DISABLED records a second transition.
 	require.NoError(t, hs.OnStateChange(ctx,
-		false /* isConsensusLeader */, false, /* postgresPrimary */
-		clustermetadatapb.PoolerServingStatus_DISABLED))
+		servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
 
 	m := findMetric(t, reader, "mg.pooler.serving.transitions")
 	sum, ok := m.Data.(metricdata.Sum[int64])

--- a/go/services/multipooler/internal/manager/pg_multischema_test.go
+++ b/go/services/multipooler/internal/manager/pg_multischema_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
 	"github.com/multigres/multigres/go/services/multipooler/internal/poolerserver"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pubsub"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -43,7 +44,7 @@ func (m *mockPoolerController) Open(context.Context) error { return nil }
 func (m *mockPoolerController) Close() error               { return nil }
 func (m *mockPoolerController) IsHealthy() error           { return nil }
 func (m *mockPoolerController) IsServing() bool            { return true }
-func (m *mockPoolerController) OnStateChange(context.Context, bool, bool, clustermetadatapb.PoolerServingStatus) error {
+func (m *mockPoolerController) OnStateChange(context.Context, servingstate.State) error {
 	return nil
 }
 
@@ -51,7 +52,7 @@ func (m *mockPoolerController) StartRequest(*query.Target, poolerserver.RequestK
 	return nil
 }
 
-func (m *mockPoolerController) AwaitStateChange(context.Context, bool, clustermetadatapb.PoolerServingStatus) {
+func (m *mockPoolerController) AwaitStateChange(context.Context, servingstate.RoutingRole, clustermetadatapb.PoolerServingStatus) {
 }
 func (m *mockPoolerController) Executor() (queryservice.QueryService, error) { return nil, nil }
 func (m *mockPoolerController) InternalQueryService() executor.InternalQueryService {

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	"google.golang.org/protobuf/proto"
-
 	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
 	"github.com/multigres/multigres/go/tools/telemetry"
@@ -30,24 +28,6 @@ import (
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
 )
-
-// deriveTypeAndObs maps a consensus rule to the pooler role it implies and the
-// self-leadership observation to publish. A nil rule (no rule known yet) yields
-// UNKNOWN; a rule naming this pooler yields PRIMARY plus an observation; any
-// other rule yields REPLICA with no observation. This is the single place the
-// rule is translated into a role.
-func deriveTypeAndObs(rule *clustermetadatapb.ShardRule, selfID *clustermetadatapb.ID) (clustermetadatapb.PoolerType, *clustermetadatapb.LeaderObservation) {
-	if rule == nil {
-		return clustermetadatapb.PoolerType_UNKNOWN, nil
-	}
-	if proto.Equal(rule.GetLeaderId(), selfID) {
-		return clustermetadatapb.PoolerType_PRIMARY, &clustermetadatapb.LeaderObservation{
-			LeaderId:         selfID,
-			LeaderRuleNumber: rule.GetRuleNumber(),
-		}
-	}
-	return clustermetadatapb.PoolerType_REPLICA, nil
-}
 
 // highestKnownRule returns the highest-numbered rule this pooler knows of,
 // combining the rule it has applied into its own position with the rule it was
@@ -225,7 +205,7 @@ func (pm *MultiPoolerManager) monitorPostgresIteration(ctx context.Context) (pos
 	}
 
 	// Determine what remediation is needed
-	action := pm.determineRemedialAction(ctx, currentState, pm.stateManager.isPostgresPrimary())
+	action := pm.determineRemedialAction(ctx, currentState)
 	if action == remedialActionNone {
 		// No action needed - just log status
 		if currentState.postgresRunning {
@@ -255,7 +235,7 @@ func (pm *MultiPoolerManager) monitorPostgresIteration(ctx context.Context) (pos
 	}
 
 	// Re-determine action based on current state
-	action = pm.determineRemedialAction(lockCtx, currentState, pm.stateManager.isPostgresPrimary())
+	action = pm.determineRemedialAction(lockCtx, currentState)
 
 	// Take remedial action with lock held
 	pm.takeRemedialAction(lockCtx, action, currentState)
@@ -451,7 +431,7 @@ func (pm *MultiPoolerManager) primaryConnInfoDiffersFromRecorded(ctx context.Con
 // determineRoleAction returns the action needed to align this pooler's role with
 // the rule-derived intended role: demote a stale primary, resign when the rule
 // names us leader but postgres is a standby, etc.
-func (pm *MultiPoolerManager) determineRoleAction(role commonconsensus.ConsensusRole, state postgresState, lastAppliedPrimary bool) remedialAction {
+func (pm *MultiPoolerManager) determineRoleAction(role commonconsensus.ConsensusRole, state postgresState) remedialAction {
 	// Consensus role: not leader (follower/observer)
 	// Postgres: PRIMARY
 	// Diagnosis: Stale primary. We should restart as a replica, but we anticipate
@@ -481,24 +461,13 @@ func (pm *MultiPoolerManager) determineRoleAction(role commonconsensus.Consensus
 		return remedialActionNone
 	}
 
-	// Here we reconcile the StateManager's effective state against what we've
-	// observed and fix any drift:
-	//   - role drift (e.g. an RPC that timed out before republishing the label);
-	//   - physical primary-ness drift that did not trigger a role action (postgres
-	//     entering/leaving recovery while the role is unchanged — the resign window,
-	//     or recovery clearing again), so the heartbeat writer doesn't spam failed
-	//     writes against a standby;
-	//   - DRAINING: serving was disabled transiently for an in-place transition
-	//     (demotion) and is re-enabled here once the node is healthy and role-aligned
-	//     — e.g. after a demote restarts the node as a standby, or a demote that
-	//     errored before completing. DISABLED is deliberately NOT re-enabled (it
-	//     means stopping/paused/operator-drained); the drain that set DRAINING ran
-	//     under the action lock, so an actionable DRAINING means the drain finished
-	//     and restoring SERVING is safe. A resigned leader is handled by the branch
-	//     above.
-	if pm.getPoolerType() != poolerTypeForLeader(role == commonconsensus.ConsensusRoleLeader) ||
-		state.isPrimary != lastAppliedPrimary ||
-		pm.record.ServingStatus() == clustermetadatapb.PoolerServingStatus_DRAINING {
+	// Re-fan the effective state to components if the last-applied one is stale
+	// vs. what we now observe (recovery + the live consensus snapshot -> routing
+	// role, plus serving status). This is what propagates a routing-role flip (the
+	// committed rule landing after pg_promote, or a revocation) to the query
+	// server's write gate, and completes a transient DRAINING. hasDrift reads the
+	// consensus snapshot itself, so it and fixDrift derive from the same inputs.
+	if pm.stateManager.hasDrift(state.isPrimary) {
 		return remedialActionReconcileState
 	}
 
@@ -541,7 +510,7 @@ func (pm *MultiPoolerManager) determineReplicationSettingsAction(ctx context.Con
 
 // determineRemedialAction decides what action to take based on discovered state.
 // This is pure decision logic with no side effects.
-func (pm *MultiPoolerManager) determineRemedialAction(ctx context.Context, currentState postgresState, lastAppliedPrimary bool) remedialAction {
+func (pm *MultiPoolerManager) determineRemedialAction(ctx context.Context, currentState postgresState) remedialAction {
 	// Pgctld unavailable: No action possible
 	if !currentState.pgctldAvailable {
 		return remedialActionNone
@@ -559,7 +528,7 @@ func (pm *MultiPoolerManager) determineRemedialAction(ctx context.Context, curre
 			return remedialActionNone
 		}
 		role := commonconsensus.SelfConsensusRole(pm.consensusMgr.CachedConsensusStatus())
-		if action := pm.determineRoleAction(role, currentState, lastAppliedPrimary); action != remedialActionNone {
+		if action := pm.determineRoleAction(role, currentState); action != remedialActionNone {
 			return action
 		}
 		if action := pm.determineReplicationSettingsAction(ctx, currentState); action != remedialActionNone {
@@ -658,16 +627,13 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to restart stale primary as standby", "error", err)
 			return
 		}
-		// Republish the role label and physical primary-ness immediately so the
-		// gateway and stale-leader analyzer stop treating us as a primary, and the
-		// published writable signal reflects reality, rather than waiting a monitor
-		// cycle for reconcileState. The rule named another leader (that is why we
-		// demoted), so the role resolves to REPLICA (nil self-leadership); we just
-		// restarted as a standby, so postgres is no longer primary. Serving status
-		// is unchanged (a healthy standby keeps serving reads).
-		_, obs := deriveTypeAndObs(pm.highestKnownRule(), pm.serviceID)
+		// Sync physical primary-ness immediately so the gateway and stale-leader
+		// analyzer stop treating us as a primary, rather than waiting a monitor cycle
+		// for reconcile. We just restarted as a standby, so postgres is no longer
+		// primary; that derives routing role REPLICA (clearing the PRIMARY label /
+		// self-leadership and the writable signal). Serving status is unchanged (a
+		// healthy standby keeps serving reads).
 		if err := pm.stateManager.Mutate(ctx, func(s *servingStateMutation) {
-			s.SelfLeadership = obs
 			s.PostgresPrimary = false
 		}); err != nil {
 			pm.logger.WarnContext(ctx, "MonitorPostgres: failed to apply role after demote", "error", err)
@@ -675,33 +641,16 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 
 	case remedialActionReconcileState:
 		pm.setMonitorReason(ctx, reasonPostgresRunning, "MonitorPostgres: PostgreSQL is running")
-		// The StateManager's effective state has drifted (role, physical
-		// primary-ness, and/or a transient drain). Reconcile in one Mutate: the
-		// leadership obs sets the derived role, and the observed isPrimary syncs the
-		// writable state that gates the heartbeat writer / LISTEN. Serving is
-		// re-enabled only out of DRAINING (the transient drain this loop owns); a
-		// DISABLED pooler (stopping/paused/operator-drained) is left not-serving,
-		// since this case also fires for plain role/primary drift.
-		intended, obs := deriveTypeAndObs(pm.highestKnownRule(), pm.serviceID)
-		pm.logger.InfoContext(ctx, "MonitorPostgres: reconciling state from rule",
-			"intended_role", intended.String(), "postgres_primary", state.isPrimary)
-		if err := pm.stateManager.Mutate(ctx, func(s *servingStateMutation) {
-			s.SelfLeadership = obs
-			// TODO: There's a subtle but important bug here. We're currently conflating
-			// being a postgres primary (not in recovery mode) with being able to accept
-			// user transactions. Need to gate user transactions on being a primary, and
-			// also being the leader in the most recent non-revoked committed consensus rule.
-			// SelfLeadership actually holds the highest known rule, not the highest non-revoked
-			// locally-committed rule, so the way we're dealing with state here could cause a bug
-			// if a Promote() RPC times out and then this remedial action ends up telling multigateway
-			// that it's ok to send user traffic when we actually never finished consensus propagation
-			// and establishment.
-			s.PostgresPrimary = state.isPrimary
-			if s.ServingStatus == clustermetadatapb.PoolerServingStatus_DRAINING {
-				s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
-			}
-		}); err != nil {
-			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to reconcile state from rule", "error", err)
+		// The StateManager's effective state has drifted (routing role and/or a
+		// transient drain). fixDrift re-derives the routing role from the freshly
+		// observed recovery flag and the live consensus snapshot and re-fans it out;
+		// the record's PoolerType / self-leadership follow. This is the propagation
+		// path for a committed-rule landing after pg_promote or a revocation reaching
+		// the query server's write gate. Serving is re-enabled only out of DRAINING;
+		// a DISABLED pooler is left not-serving.
+		pm.logger.InfoContext(ctx, "MonitorPostgres: reconciling drifted state", "postgres_primary", state.isPrimary)
+		if err := pm.stateManager.fixDrift(ctx, state.isPrimary); err != nil {
+			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to reconcile drifted state", "error", err)
 		}
 
 	case remedialActionResignLeadership:

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -510,73 +510,13 @@ func TestDetermineRemedialAction(t *testing.T) {
 				withRuleStore(&fakeRuleStore{pos: tt.cachedPos, inconsistentGUC: tt.inconsistentGUC}),
 			)
 
-			// lastAppliedPrimary == state.isPrimary: this table exercises role,
-			// demote, resign and GUC decisions, not physical-primary drift (covered
-			// separately), so pass no drift here.
-			got := pm.determineRemedialAction(t.Context(), tt.state, tt.state.isPrimary)
+			// This table exercises role, demote, resign and GUC decisions, not
+			// physical-primary drift (that moved to StateManager.hasDrift/fixDrift and
+			// is covered separately).
+			got := pm.determineRemedialAction(t.Context(), tt.state)
 			require.Equal(t, tt.expectedAction, got)
 		})
 	}
-}
-
-// TestDetermineRemedialAction_PrimaryDrift covers the physical-primary-drift path:
-// the role is already aligned (rule names self, record says PRIMARY), but the
-// StateManager's last-applied primary-ness differs from what postgres reports.
-// That drift alone must trigger remedialActionReconcileState so the writable-only
-// components (heartbeat writer, LISTEN) re-evaluate — e.g. recovery clearing again
-// after a resign.
-func TestDetermineRemedialAction_PrimaryDrift(t *testing.T) {
-	selfID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "test-cell", Name: "self"}
-	newAlignedPrimaryManager := func(serving clustermetadatapb.PoolerServingStatus) *MultiPoolerManager {
-		// Rule names self, so intendedRole is PRIMARY and the record already agrees:
-		// no role drift, isolating the physical-primary / serving decisions.
-		return newTestManager(t,
-			withServiceID(selfID),
-			withRecord(newRecordFromProto(&clustermetadatapb.MultiPooler{
-				Id:             selfID,
-				Type:           clustermetadatapb.PoolerType_PRIMARY,
-				SelfLeadership: &clustermetadatapb.LeaderObservation{LeaderId: selfID},
-				ServingStatus:  serving,
-			})),
-			withRuleStore(&fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{
-				Rule: &clustermetadatapb.ShardRule{
-					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
-					LeaderId:   selfID,
-				},
-			}}),
-		)
-	}
-
-	runningPrimary := postgresState{pgctldAvailable: true, postgresRunning: true, isPrimary: true}
-
-	t.Run("primary drift reconciles", func(t *testing.T) {
-		pm := newAlignedPrimaryManager(clustermetadatapb.PoolerServingStatus_SERVING)
-		// Components last saw a standby (false) but postgres is now a primary (true).
-		got := pm.determineRemedialAction(t.Context(), runningPrimary, false /* lastAppliedPrimary */)
-		require.Equal(t, remedialActionReconcileState, got)
-	})
-
-	t.Run("draining reconciles", func(t *testing.T) {
-		// Role and primary aligned, but serving was left DRAINING (e.g. a demotion
-		// that errored before re-serving). The monitor re-enables it.
-		pm := newAlignedPrimaryManager(clustermetadatapb.PoolerServingStatus_DRAINING)
-		got := pm.determineRemedialAction(t.Context(), runningPrimary, true /* lastAppliedPrimary */)
-		require.Equal(t, remedialActionReconcileState, got)
-	})
-
-	t.Run("disabled is left alone", func(t *testing.T) {
-		// DISABLED is a deliberate non-serving state (stopping/paused/operator);
-		// the monitor must NOT auto-re-enable it.
-		pm := newAlignedPrimaryManager(clustermetadatapb.PoolerServingStatus_DISABLED)
-		got := pm.determineRemedialAction(t.Context(), runningPrimary, true /* lastAppliedPrimary */)
-		require.Equal(t, remedialActionNone, got)
-	})
-
-	t.Run("no drift is a no-op", func(t *testing.T) {
-		pm := newAlignedPrimaryManager(clustermetadatapb.PoolerServingStatus_SERVING)
-		got := pm.determineRemedialAction(t.Context(), runningPrimary, true /* lastAppliedPrimary */)
-		require.Equal(t, remedialActionNone, got)
-	})
 }
 
 // TestDetermineRemedialAction_StalePrimaryDemote covers the consensus-authoritative
@@ -674,7 +614,7 @@ func TestDetermineRemedialAction_StalePrimaryDemote(t *testing.T) {
 				withRuleStore(&fakeRuleStore{pos: tt.cachedPos}),
 			)
 
-			got := pm.determineRemedialAction(t.Context(), runningPrimary, runningPrimary.isPrimary)
+			got := pm.determineRemedialAction(t.Context(), runningPrimary)
 			require.Equal(t, tt.expectedAction, got)
 		})
 	}

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -680,14 +680,13 @@ func (pm *MultiPoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 	// stale-leader analyzer to keep firing forever. Promote has the same
 	// step on its replica branch for the same reason.
 	// A REPLICA pooler record carries no self leadership observation.
-	// Republish REPLICA (clear any stale PRIMARY self-leadership) so the
-	// stale-leader analyzer stops firing, and sync physical primary-ness: we
-	// just restarted as a standby, so postgres is no longer primary and the
-	// published writable signal must reflect that immediately rather than
-	// waiting a monitor cycle. Serving status is owned by the lifecycle and the
-	// monitor's reconcileState, not by "here is your primary" bookkeeping.
+	// Sync physical primary-ness: we just restarted as a standby, so postgres is
+	// no longer primary. That derives routing role REPLICA, clearing any stale
+	// PRIMARY label/self-leadership (so the stale-leader analyzer stops firing) and
+	// the published writable signal immediately rather than waiting a monitor
+	// cycle. Serving status is owned by the lifecycle and the monitor's reconcile,
+	// not by "here is your primary" bookkeeping.
 	if err := pm.stateManager.Mutate(ctx, func(s *servingStateMutation) {
-		s.SelfLeadership = nil
 		s.PostgresPrimary = false
 	}); err != nil {
 		pm.logger.WarnContext(ctx, "Failed to update pooler type to REPLICA after SetPrimary", "error", err)

--- a/go/services/multipooler/internal/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/internal/manager/rpc_initialization_test.go
@@ -277,9 +277,12 @@ func newRemedialActionTestManager(t *testing.T, multipooler *clustermetadatapb.M
 		record:       record,
 		serviceID:    multipooler.Id,
 		topoClient:   ts,
-		stateManager: NewStateManager(slog.Default(), record),
 		consensusMgr: cfg.consensusManager(t),
 	}
+	// Wire the StateManager to the live consensus snapshot (as production does), so
+	// the derived routing role reflects the promotion rule the test records — a
+	// promotion under a self-naming rule then derives Type=PRIMARY + SelfLeadership.
+	pm.stateManager = NewStateManager(slog.Default(), record, pm.consensusMgr.CachedConsensusStatus)
 	cfg.seedLockedState(t, pm)
 	return pm
 }
@@ -292,17 +295,20 @@ func TestUpdateTopologyAfterPromotion_PublishesSelfLeadership(t *testing.T) {
 		Id:   &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "test-pooler"},
 		Type: clustermetadatapb.PoolerType_REPLICA,
 	}
-	pm := newRemedialActionTestManager(t, multipooler)
-
-	lockCtx, err := pm.actionLock.Acquire(t.Context(), "test")
-	require.NoError(t, err)
-	defer pm.actionLock.Release(lockCtx)
-
 	// The pooler is promoted under this rule, which names it as leader.
 	rule := &clustermetadatapb.ShardRule{
 		RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 7, LeaderSubterm: 2},
 		LeaderId:   multipooler.Id,
 	}
+	// The committed consensus position names self as leader under that rule, so the
+	// StateManager derives routing role PRIMARY (IsActiveLeader) once the promotion
+	// pokes PostgresPrimary.
+	pm := newRemedialActionTestManager(t, multipooler,
+		withRuleStore(&fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Rule: rule}}))
+
+	lockCtx, err := pm.actionLock.Acquire(t.Context(), "test")
+	require.NoError(t, err)
+	defer pm.actionLock.Release(lockCtx)
 	require.NoError(t, pm.updateTopologyAfterPromotion(lockCtx, &promotionState{}, rule))
 
 	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, pm.record.Type())

--- a/go/services/multipooler/internal/manager/rpc_manager_test.go
+++ b/go/services/multipooler/internal/manager/rpc_manager_test.go
@@ -364,9 +364,17 @@ func TestReplicationStatus(t *testing.T) {
 			PgctldAddr: pgctldAddr,
 		}
 		mockQueryService := mock.NewQueryService()
+		// The committed consensus position names self as leader, so the derived
+		// routing role is PRIMARY (with postgres out of recovery below), matching the
+		// seeded PRIMARY label rather than the monitor reconciling it to REPLICA.
 		pm, err := NewMultiPoolerManagerForTesting(t, logger, multipooler, config,
 			withMockController(&mockPoolerController{queryService: mockQueryService}),
-			withFakeRules(&fakeRuleStore{}))
+			withFakeRules(&fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{
+				Rule: &clustermetadatapb.ShardRule{
+					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
+					LeaderId:   serviceID,
+				},
+			}}))
 		require.NoError(t, err)
 		t.Cleanup(func() { pm.ShutdownForTest(context.Background()) })
 
@@ -392,6 +400,15 @@ func TestReplicationStatus(t *testing.T) {
 		require.Eventually(t, func() bool {
 			return pm.GetState() == ManagerStateReady
 		}, 5*time.Second, 100*time.Millisecond, "Manager should reach Ready state")
+
+		// PoolerType is now derived from the live routing role, which the postgres
+		// monitor converges once postgres is probed (running, out of recovery) and the
+		// consensus rule names self. The fast-start monitor tick can race ahead of
+		// Ready, so drive an explicit iteration and wait for the derived PRIMARY.
+		require.Eventually(t, func() bool {
+			_, _ = pm.monitorPostgresIteration(ctx)
+			return pm.getPoolerType() == clustermetadatapb.PoolerType_PRIMARY
+		}, 5*time.Second, 50*time.Millisecond, "monitor should derive PRIMARY routing role")
 
 		// Call ReplicationStatus
 		status, err := pm.Status(ctx)
@@ -569,8 +586,12 @@ func TestReplicationStatus(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, status)
 
-		// PoolerType from topology says PRIMARY, but status shows standby state
-		assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, status.Status.PoolerType)
+		// The record is seeded PRIMARY, but PoolerType is now derived from the live
+		// routing role: postgres reports recovery (standby), so the routing role is
+		// REPLICA and the monitor reconciles the label to REPLICA. Status therefore
+		// reports REPLICA with a populated ReplicationStatus (not a lasting
+		// PRIMARY-label / standby-postgres mismatch, which the derived model prevents).
+		assert.Equal(t, clustermetadatapb.PoolerType_REPLICA, status.Status.PoolerType)
 		assert.Nil(t, status.Status.PrimaryStatus, "PrimaryStatus should be nil since PostgreSQL is a standby")
 		assert.NotNil(t, status.Status.ReplicationStatus, "ReplicationStatus should be populated since PostgreSQL is a standby")
 	})

--- a/go/services/multipooler/internal/manager/state_manager.go
+++ b/go/services/multipooler/internal/manager/state_manager.go
@@ -21,8 +21,10 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 // StateAware is implemented by components that need to react to serving state changes.
@@ -31,15 +33,11 @@ import (
 // and serving, while a query service component adjusts which queries it accepts.
 type StateAware interface {
 	// OnStateChange is called when the effective serving state changes; the
-	// component transitions to match it.
-	//
-	// isConsensusLeader reports whether this pooler is the consensus-elected
-	// leader (the shard's write target). postgresPrimary reports the physical
-	// recovery state (!pg_is_in_recovery): being the leader does NOT imply
-	// postgres is out of recovery, so components that need a writable backend
-	// (heartbeat writer, LISTEN/NOTIFY) must require both. servingStatus is the
-	// serving intent.
-	OnStateChange(ctx context.Context, isConsensusLeader, postgresPrimary bool, servingStatus clustermetadatapb.PoolerServingStatus) error
+	// component transitions to match it. The state carries the derived routing
+	// role (writability) and the serving intent — see servingstate.State. A
+	// component that needs consensus leadership reads it from the consensus
+	// snapshot directly; the serving layer does not carry it.
+	OnStateChange(ctx context.Context, state servingstate.State) error
 }
 
 // StateManager coordinates serving state transitions across components.
@@ -64,36 +62,68 @@ type StateManager struct {
 	// Type/ServingStatus it is local-only and never published to topology. Guarded by mu.
 	postgresPrimary bool
 
+	// consensusStatus returns this pooler's live consensus snapshot (e.g.
+	// ConsensusManager.CachedConsensusStatus). Injected — queried live, not stored —
+	// so the derived routing role (write-safety) reflects a revocation or a new
+	// committed/known-rule observation without any explicit set. See deriveRoutingRole.
+	consensusStatus func() *clustermetadatapb.ConsensusStatus
+
 	// lastFannedOut is the effective state most recently delivered to components,
-	// or nil if none has been yet. Used to skip redundant fan-outs: components
-	// react to the (leader, postgresPrimary, servingStatus) tuple, and distinct
-	// PoolerTypes (REPLICA vs UNKNOWN) collapse to the same tuple, so a record-only
-	// change that leaves the tuple identical must not re-notify components.
-	lastFannedOut *effectiveState
+	// or nil if none has been yet. Used to skip redundant fan-outs: a record-only
+	// change (e.g. an obs rule-number bump) that leaves the {routingRole,
+	// servingStatus} tuple identical must not re-notify components.
+	lastFannedOut *servingstate.State
 
 	// Registered components that react to state changes.
 	components []StateAware
 }
 
-// effectiveState is what registered components react to, distinct from the
-// topology record's PoolerType/ServingStatus: leader is the consensus-leadership
-// fact, postgresPrimary the physical recovery state.
-type effectiveState struct {
-	leader          bool
-	postgresPrimary bool
-	servingStatus   clustermetadatapb.PoolerServingStatus
+// deriveRoutingRole computes the write-safety routing role from the physical
+// recovery state and the live consensus snapshot: PRIMARY iff postgres is out of
+// recovery AND this pooler is the active consensus leader (committed, non-revoked,
+// not superseded by a higher known rule — see commonconsensus.IsActiveLeader);
+// REPLICA otherwise. cs may be nil (treated as not a leader). This is the single
+// place the base facts (recovery, consensus) become the effective routing role.
+func deriveRoutingRole(postgresPrimary bool, cs *clustermetadatapb.ConsensusStatus) servingstate.RoutingRole {
+	if postgresPrimary && commonconsensus.IsActiveLeader(cs) {
+		return servingstate.RoutingRolePrimary
+	}
+	return servingstate.RoutingRoleReplica
 }
 
-// NewStateManager creates a new StateManager.
+// routingLeadershipObs builds the self-leadership observation persisted to the
+// record to reflect the routing role: non-nil (naming self at the committed rule)
+// when routing PRIMARY, nil otherwise. It intentionally reads the *committed*
+// rule — a routing PRIMARY is by definition the active committed leader
+// (IsActiveLeader), so this both matches the routing role and carries write
+// authority, never a not-yet-committed rule. Returns nil when not PRIMARY so the
+// record's Type ⇔ SelfLeadership invariant holds (Type PRIMARY ⇔ obs present ⇔
+// routing PRIMARY).
+func routingLeadershipObs(routingRole servingstate.RoutingRole, cs *clustermetadatapb.ConsensusStatus) *clustermetadatapb.LeaderObservation {
+	if routingRole != servingstate.RoutingRolePrimary {
+		return nil
+	}
+	committed := cs.GetCurrentPosition().GetRule()
+	return &clustermetadatapb.LeaderObservation{
+		LeaderId:         cs.GetId(),
+		LeaderRuleNumber: committed.GetRuleNumber(),
+	}
+}
+
+// NewStateManager creates a new StateManager. consensusStatus returns the live
+// consensus snapshot (e.g. ConsensusManager.CachedConsensusStatus), combined with
+// the cached recovery state to derive the routing role / write-safety live.
 func NewStateManager(
 	logger *slog.Logger,
 	record *poolerRecord,
+	consensusStatus func() *clustermetadatapb.ConsensusStatus,
 	components ...StateAware,
 ) *StateManager {
 	return &StateManager{
-		logger:     logger,
-		record:     record,
-		components: components,
+		logger:          logger,
+		record:          record,
+		consensusStatus: consensusStatus,
+		components:      components,
 	}
 }
 
@@ -114,16 +144,15 @@ func (ssm *StateManager) RegisterAndSync(ctx context.Context, component StateAwa
 	ssm.mu.Lock()
 	defer ssm.mu.Unlock()
 	ssm.components = append(ssm.components, component)
-	return component.OnStateChange(ctx, ssm.record.SelfLeadership() != nil, ssm.postgresPrimary, ssm.record.ServingStatus())
+	return component.OnStateChange(ctx, servingstate.State{
+		RoutingRole:   deriveRoutingRole(ssm.postgresPrimary, ssm.consensusStatus()),
+		ServingStatus: ssm.record.ServingStatus(),
+	})
 }
 
 // fanOutLocked notifies every registered component of the target effective state
 // in parallel and waits for them to converge. Caller must hold mu.
-//
-// Leadership — whether this pooler is the consensus-elected write target — is the
-// self-leadership observation being non-nil, the consensus fact from which the
-// PoolerType routing label is derived. Components react to that fact, not the label.
-func (ssm *StateManager) fanOutLocked(ctx context.Context, target effectiveState) error {
+func (ssm *StateManager) fanOutLocked(ctx context.Context, target servingstate.State) error {
 	if ssm.lastFannedOut != nil && *ssm.lastFannedOut == target {
 		// Components are already at this effective state; nothing to notify.
 		return nil
@@ -131,7 +160,7 @@ func (ssm *StateManager) fanOutLocked(ctx context.Context, target effectiveState
 	g, ctx := errgroup.WithContext(ctx)
 	for _, c := range ssm.components {
 		g.Go(func() error {
-			return c.OnStateChange(ctx, target.leader, target.postgresPrimary, target.servingStatus)
+			return c.OnStateChange(ctx, target)
 		})
 	}
 	if err := g.Wait(); err != nil {
@@ -146,14 +175,20 @@ func (ssm *StateManager) fanOutLocked(ctx context.Context, target effectiveState
 
 // servingStateMutation is the mutable view passed to Mutate. A callback changes
 // any subset of fields and sees the previous values; fields it leaves alone are
-// carried forward. SelfLeadership and ServingStatus are topology-backed (persisted
-// to the poolerRecord); PostgresPrimary is local-only physical state.
+// carried forward. These are the base facts callers poke: PostgresPrimary is the
+// physical recovery state (local-only); ServingStatus is the serving intent
+// (topology-backed).
 //
-// There is deliberately no PoolerType field: the consensus-leadership observation
-// is the source of truth, and PoolerType (PRIMARY iff a self-leadership obs is
-// held, REPLICA otherwise) is derived from it when persisting the record.
+// There is deliberately no leadership or PoolerType field. The routing role, the
+// record's SelfLeadership observation, and PoolerType are all *derived* from the
+// live consensus snapshot plus PostgresPrimary — see deriveRoutingRole /
+// routingLeadershipObs. Callers change consensus (via the rule store) and poke
+// recovery/serving here; leadership follows.
 type servingStateMutation struct {
-	SelfLeadership  *clustermetadatapb.LeaderObservation
+	// PostgresPrimary is the physical recovery state (!pg_is_in_recovery).
+	// TODO: flip to an InRecovery field (invert the sense) so callers state the
+	// base fact postgres reports directly, removing the double-negative ambiguity
+	// ("primary" is overloaded; "in recovery" is what pg_is_in_recovery() means).
 	PostgresPrimary bool
 	ServingStatus   clustermetadatapb.PoolerServingStatus
 }
@@ -180,45 +215,57 @@ func (ssm *StateManager) Mutate(ctx context.Context, fn func(s *servingStateMuta
 	defer ssm.mu.Unlock()
 
 	cur := servingStateMutation{
-		SelfLeadership:  ssm.record.SelfLeadership(),
 		PostgresPrimary: ssm.postgresPrimary,
 		ServingStatus:   ssm.record.ServingStatus(),
 	}
 	next := cur
 	fn(&next)
 
-	// Leadership drives the derived PoolerType, so the record changes when
-	// leader-ness flips or serving changes. An obs-only change (same leader-ness,
-	// new rule number) is published via UpdateLeaderObservation, not here.
-	leaderChanged := (next.SelfLeadership != nil) != (cur.SelfLeadership != nil)
-	servingChanged := next.ServingStatus != cur.ServingStatus
-	primaryChanged := next.PostgresPrimary != cur.PostgresPrimary
-	if !leaderChanged && !servingChanged && !primaryChanged {
+	// The effective state components react to. routingRole is derived live from
+	// recovery + the consensus snapshot, so it can change (the committed rule
+	// lands, a revocation arrives) even when serving/recovery have not — comparing
+	// the whole target against the last fan-out is what ensures OnStateChange fires
+	// on ANY effective-state change.
+	cs := ssm.consensusStatus()
+	target := servingstate.State{
+		RoutingRole:   deriveRoutingRole(next.PostgresPrimary, cs),
+		ServingStatus: next.ServingStatus,
+	}
+	if ssm.lastFannedOut != nil && *ssm.lastFannedOut == target {
+		// Nothing components react to changed; no fan-out, no record write. (An
+		// obs rule-number bump that keeps the same routing role is published via
+		// the health stream, not the record.)
 		return nil
 	}
 
 	ssm.logger.InfoContext(ctx, "Applying serving state",
-		"leader", next.SelfLeadership != nil, "status", next.ServingStatus, "postgres_primary", next.PostgresPrimary,
-		"prev_leader", cur.SelfLeadership != nil, "prev_status", cur.ServingStatus, "prev_postgres_primary", cur.PostgresPrimary)
+		"routing_role", target.RoutingRole, "status", target.ServingStatus, "postgres_primary", next.PostgresPrimary,
+		"prev_status", cur.ServingStatus, "prev_postgres_primary", cur.PostgresPrimary)
 
-	// Fan out first so a failed transition leaves the record untouched. The
-	// fan-out dedups on the effective tuple, so a primary-only or record-only
-	// change that leaves the tuple identical does not re-notify.
-	if err := ssm.fanOutLocked(ctx, effectiveState{
-		leader:          next.SelfLeadership != nil,
-		postgresPrimary: next.PostgresPrimary,
-		servingStatus:   next.ServingStatus,
-	}); err != nil {
+	// Fan out first so a failed transition leaves the record untouched.
+	if err := ssm.fanOutLocked(ctx, target); err != nil {
 		return err
 	}
 	// Components converged — keep the local physical state in step with what they
 	// received before the (fallible) record write.
 	ssm.postgresPrimary = next.PostgresPrimary
 
-	if leaderChanged || servingChanged {
+	// Project the routing role onto the topology record: Type PRIMARY and a
+	// self-leadership observation iff routing PRIMARY (writable). Type and obs move
+	// together, preserving the record's Type ⇔ SelfLeadership invariant. Write only
+	// when the projected Type or serving status actually differs from the record.
+	//
+	// TODO: this record projection could itself be a StateAware — give poolerRecord
+	// an OnStateChange(State) that projects routing role onto Type/SelfLeadership and
+	// register it as a component, so Mutate just fans out and owns no special-case
+	// record write. It would need the ServingStatus (already on State) and to be
+	// ordered so the record write follows component convergence.
+	obs := routingLeadershipObs(target.RoutingRole, cs)
+	nextType := poolerTypeForLeader(obs != nil)
+	if nextType != ssm.record.Type() || next.ServingStatus != cur.ServingStatus {
 		if err := ssm.record.Mutate(ctx, func(s *MutablePoolerRecordState) {
-			s.Type = poolerTypeForLeader(next.SelfLeadership != nil)
-			s.SelfLeadership = next.SelfLeadership
+			s.Type = nextType
+			s.SelfLeadership = obs
 			s.ServingStatus = next.ServingStatus
 		}); err != nil {
 			return err
@@ -227,11 +274,42 @@ func (ssm *StateManager) Mutate(ctx context.Context, fn func(s *servingStateMuta
 	return nil
 }
 
-// isPostgresPrimary returns the physical recovery state last applied to
-// components. The monitor compares its fresh observation against this (lock-free)
-// to decide whether a sync under the action lock is needed.
-func (ssm *StateManager) isPostgresPrimary() bool {
+// hasDrift reports whether the effective state last fanned out to components is
+// stale relative to freshly-observed inputs — postgres recovery (postgresPrimary)
+// and the live consensus snapshot, from which the routing role is derived, plus
+// the record's serving status. When true, the monitor calls fixDrift to
+// re-derive and re-fan-out under the action lock, so components (notably the
+// query server's write gate) never lag a committed-rule, revocation, recovery,
+// or serving change. hasDrift (detect) and fixDrift (correct) derive the routing
+// role from the same inputs, so a drift can never be detected but not corrected.
+//
+// A never-fanned state and DRAINING both always report drift: DRAINING is a
+// transient drain this loop owns, and reconciling re-verifies it (completing the
+// DRAINING->SERVING transition once the node is healthy and role-aligned).
+func (ssm *StateManager) hasDrift(postgresPrimary bool) bool {
 	ssm.mu.Lock()
 	defer ssm.mu.Unlock()
-	return ssm.postgresPrimary
+	if ssm.lastFannedOut == nil || ssm.record.ServingStatus() == clustermetadatapb.PoolerServingStatus_DRAINING {
+		return true
+	}
+	observed := servingstate.State{
+		RoutingRole:   deriveRoutingRole(postgresPrimary, ssm.consensusStatus()),
+		ServingStatus: ssm.record.ServingStatus(),
+	}
+	return *ssm.lastFannedOut != observed
+}
+
+// fixDrift re-applies the effective state from a freshly-observed recovery flag
+// (and the live consensus snapshot, read inside Mutate): it re-fans-out to
+// components and re-projects the record. It is the correction paired with
+// hasDrift's detection. A DRAINING status is completed to SERVING (the transient
+// drain the monitor owns); any other status is preserved (DISABLED stays
+// not-serving). Requires the action lock (asserted by Mutate).
+func (ssm *StateManager) fixDrift(ctx context.Context, postgresPrimary bool) error {
+	return ssm.Mutate(ctx, func(s *servingStateMutation) {
+		s.PostgresPrimary = postgresPrimary
+		if s.ServingStatus == clustermetadatapb.PoolerServingStatus_DRAINING {
+			s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
+		}
+	})
 }

--- a/go/services/multipooler/internal/manager/state_manager.go
+++ b/go/services/multipooler/internal/manager/state_manager.go
@@ -235,6 +235,14 @@ func (ssm *StateManager) Mutate(ctx context.Context, fn func(s *servingStateMuta
 		// Nothing components react to changed; no fan-out, no record write. (An
 		// obs rule-number bump that keeps the same routing role is published via
 		// the health stream, not the record.)
+		//
+		// Still refresh the cached recovery fact: postgres may have left/entered
+		// recovery without flipping the derived routing role (e.g. while this
+		// pooler is not the active leader, so it stays REPLICA either way). The
+		// cache is a physical observation independent of the fan-out, and
+		// RegisterAndSync reads it to derive the role for a late-registered
+		// component — leaving it stale could hand that component the wrong role.
+		ssm.postgresPrimary = next.PostgresPrimary
 		return nil
 	}
 

--- a/go/services/multipooler/internal/manager/state_manager_test.go
+++ b/go/services/multipooler/internal/manager/state_manager_test.go
@@ -495,3 +495,98 @@ func selfLeaderConsensusStatus() *clustermetadatapb.ConsensusStatus {
 		},
 	}
 }
+
+// TestDeriveRoutingRole pins the write-safety boundary: routing role is PRIMARY
+// only when postgres is out of recovery AND the pooler is the active committed
+// consensus leader (commonconsensus.IsActiveLeader). Every other combination is
+// REPLICA — most importantly the pg_promote()->WAL-commit window, where postgres
+// is already out of recovery but the pooler's committed rule does not yet name it,
+// which must stay REPLICA so no write is admitted on a not-yet-committed term.
+func TestDeriveRoutingRole(t *testing.T) {
+	otherPoolerID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      testPoolerID.GetCell(),
+		Name:      "other-pooler",
+	}
+
+	tests := []struct {
+		name            string
+		postgresPrimary bool
+		cs              *clustermetadatapb.ConsensusStatus
+		want            servingstate.RoutingRole
+	}{
+		{
+			name:            "out of recovery and active leader is primary",
+			postgresPrimary: true,
+			cs:              selfLeaderConsensusStatus(),
+			want:            servingstate.RoutingRolePrimary,
+		},
+		{
+			name:            "in recovery is replica even as active leader",
+			postgresPrimary: false,
+			cs:              selfLeaderConsensusStatus(),
+			want:            servingstate.RoutingRoleReplica,
+		},
+		{
+			// pg_promote() has flipped postgres out of recovery, but the new rule has
+			// not committed to this pooler's WAL yet, so its committed rule still names
+			// the previous leader. Admitting writes here would land them on a
+			// not-yet-committed term — this is the window the routing role closes.
+			name:            "primary but committed rule names another is replica",
+			postgresPrimary: true,
+			cs: &clustermetadatapb.ConsensusStatus{
+				Id: testPoolerID,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{
+					Rule: &clustermetadatapb.ShardRule{
+						RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
+						LeaderId:   otherPoolerID,
+					},
+				},
+			},
+			want: servingstate.RoutingRoleReplica,
+		},
+		{
+			name:            "primary with no consensus snapshot is replica",
+			postgresPrimary: true,
+			cs:              nil,
+			want:            servingstate.RoutingRoleReplica,
+		},
+		{
+			// Self's committed rule (term 1) is revoked below term 2: the pooler was
+			// recruited into a higher term's reconfiguration, so the rule no longer
+			// carries write authority.
+			name:            "primary but committed rule revoked is replica",
+			postgresPrimary: true,
+			cs: func() *clustermetadatapb.ConsensusStatus {
+				cs := selfLeaderConsensusStatus()
+				cs.TermRevocation = &clustermetadatapb.TermRevocation{RevokedBelowTerm: 2}
+				return cs
+			}(),
+			want: servingstate.RoutingRoleReplica,
+		},
+		{
+			// Self's committed rule (term 1) names self, but a higher rule (term 2)
+			// naming another pooler is known via ReplicationPrimary — self has been
+			// superseded, so it is no longer the active leader.
+			name:            "primary but superseded by higher known rule is replica",
+			postgresPrimary: true,
+			cs: func() *clustermetadatapb.ConsensusStatus {
+				cs := selfLeaderConsensusStatus()
+				cs.ReplicationPrimary = &clustermetadatapb.ReplicationPrimary{
+					Rule: &clustermetadatapb.ShardRule{
+						RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2},
+						LeaderId:   otherPoolerID,
+					},
+				}
+				return cs
+			}(),
+			want: servingstate.RoutingRoleReplica,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, deriveRoutingRole(tt.postgresPrimary, tt.cs))
+		})
+	}
+}

--- a/go/services/multipooler/internal/manager/state_manager_test.go
+++ b/go/services/multipooler/internal/manager/state_manager_test.go
@@ -25,26 +25,27 @@ import (
 	"github.com/stretchr/testify/require"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 // testComponent records state transitions for testing.
 type testComponent struct {
-	lastType    clustermetadatapb.PoolerType
-	lastPrimary bool
-	lastStatus  clustermetadatapb.PoolerServingStatus
-	callCount   int
-	err         error // if set, OnStateChange returns this error
+	lastType   clustermetadatapb.PoolerType
+	lastRole   servingstate.RoutingRole
+	lastStatus clustermetadatapb.PoolerServingStatus
+	callCount  int
+	err        error // if set, OnStateChange returns this error
 }
 
-func (c *testComponent) OnStateChange(_ context.Context, isConsensusLeader, postgresPrimary bool, servingStatus clustermetadatapb.PoolerServingStatus) error {
+func (c *testComponent) OnStateChange(_ context.Context, state servingstate.State) error {
 	c.callCount++
 	if c.err != nil {
 		return c.err
 	}
 	// Record the derived PoolerType so existing assertions keep reading lastType.
-	c.lastType = poolerTypeForLeader(isConsensusLeader)
-	c.lastPrimary = postgresPrimary
-	c.lastStatus = servingStatus
+	c.lastType = poolerTypeForLeader(state.RoutingRole.Writable())
+	c.lastRole = state.RoutingRole
+	c.lastStatus = state.ServingStatus
 	return nil
 }
 
@@ -53,7 +54,7 @@ type slowComponent struct {
 	called atomic.Bool
 }
 
-func (c *slowComponent) OnStateChange(_ context.Context, _, _ bool, _ clustermetadatapb.PoolerServingStatus) error {
+func (c *slowComponent) OnStateChange(_ context.Context, _ servingstate.State) error {
 	c.called.Store(true)
 	return nil
 }
@@ -105,10 +106,10 @@ func TestStateManager_SetState_PrimaryServing(t *testing.T) {
 	comp := &testComponent{}
 	r := newTestRecord(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED)
 
-	ssm := NewStateManager(newTestLogger(), r, comp)
+	ssm := NewStateManager(newTestLogger(), r, selfLeaderConsensusStatus, comp)
 
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
-		s.SelfLeadership = primaryObs()
+		s.PostgresPrimary = true
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	})
 	require.NoError(t, err)
@@ -127,10 +128,10 @@ func TestStateManager_SetState_NotServing(t *testing.T) {
 	comp := &testComponent{}
 	r := newTestRecord(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
 
-	ssm := NewStateManager(newTestLogger(), r, comp)
+	ssm := NewStateManager(newTestLogger(), r, selfLeaderConsensusStatus, comp)
 
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
-		s.SelfLeadership = primaryObs()
+		s.PostgresPrimary = true
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_DISABLED
 	})
 	require.NoError(t, err)
@@ -146,10 +147,10 @@ func TestStateManager_SetState_ComponentError(t *testing.T) {
 	comp := &testComponent{err: errors.New("transition failed")}
 	r := newTestRecord(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
 
-	ssm := NewStateManager(newTestLogger(), r, comp)
+	ssm := NewStateManager(newTestLogger(), r, nilConsensusStatus, comp)
 
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
-		s.SelfLeadership = nil
+		s.PostgresPrimary = false
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	})
 	require.Error(t, err)
@@ -167,11 +168,11 @@ func TestStateManager_DemotionFlow(t *testing.T) {
 	comp := &testComponent{}
 	r := newTestRecord(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
 
-	ssm := NewStateManager(newTestLogger(), r, comp)
+	ssm := NewStateManager(newTestLogger(), r, selfLeaderConsensusStatus, comp)
 
-	// Step 1: Stop serving
+	// Step 1: Stop serving (still the writable leader, so routing stays PRIMARY)
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
-		s.SelfLeadership = primaryObs()
+		s.PostgresPrimary = true
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_DISABLED
 	})
 	require.NoError(t, err)
@@ -181,7 +182,7 @@ func TestStateManager_DemotionFlow(t *testing.T) {
 
 	// Step 1b: Retry DISABLED (idempotent — should be a no-op)
 	err = ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
-		s.SelfLeadership = primaryObs()
+		s.PostgresPrimary = true
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_DISABLED
 	})
 	require.NoError(t, err)
@@ -189,9 +190,9 @@ func TestStateManager_DemotionFlow(t *testing.T) {
 	assert.Equal(t, clustermetadatapb.PoolerServingStatus_DISABLED, r.ServingStatus())
 	assert.Equal(t, 1, comp.callCount) // no additional call
 
-	// Step 2: Transition to replica serving
+	// Step 2: Transition to replica serving (recovery -> not the writable leader)
 	err = ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
-		s.SelfLeadership = nil
+		s.PostgresPrimary = false
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	})
 	require.NoError(t, err)
@@ -205,10 +206,10 @@ func TestStateManager_MultipleComponents(t *testing.T) {
 	comp2 := &testComponent{}
 	r := newTestRecord(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED)
 
-	ssm := NewStateManager(newTestLogger(), r, comp1, comp2)
+	ssm := NewStateManager(newTestLogger(), r, selfLeaderConsensusStatus, comp1, comp2)
 
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
-		s.SelfLeadership = primaryObs()
+		s.PostgresPrimary = true
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	})
 	require.NoError(t, err)
@@ -225,10 +226,10 @@ func TestStateManager_MultipleComponents_OneError(t *testing.T) {
 	comp2 := &testComponent{err: errors.New("comp2 failed")}
 	r := newTestRecord(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
 
-	ssm := NewStateManager(newTestLogger(), r, comp1, comp2)
+	ssm := NewStateManager(newTestLogger(), r, nilConsensusStatus, comp1, comp2)
 
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
-		s.SelfLeadership = nil
+		s.PostgresPrimary = false
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	})
 	require.Error(t, err)
@@ -244,13 +245,13 @@ func TestStateManager_Register(t *testing.T) {
 	comp2 := &testComponent{}
 	r := newTestRecord(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED)
 
-	ssm := NewStateManager(newTestLogger(), r, comp1)
+	ssm := NewStateManager(newTestLogger(), r, selfLeaderConsensusStatus, comp1)
 
 	// Register a second component after creation.
 	ssm.Register(comp2)
 
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
-		s.SelfLeadership = primaryObs()
+		s.PostgresPrimary = true
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	})
 	require.NoError(t, err)
@@ -264,9 +265,9 @@ func TestStateManager_RegisterAndSync(t *testing.T) {
 	r := newTestRecord(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
 
 	// Create manager with no components, then transition state.
-	ssm := NewStateManager(newTestLogger(), r)
+	ssm := NewStateManager(newTestLogger(), r, selfLeaderConsensusStatus)
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
-		s.SelfLeadership = primaryObs()
+		s.PostgresPrimary = true
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	})
 	require.NoError(t, err)
@@ -286,7 +287,7 @@ func TestStateManager_RegisterAndSync(t *testing.T) {
 	// A subsequent SetState should notify both the constructor components and the late one.
 	ssm2 := NewStateManager(newTestLogger(),
 		newTestRecord(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED),
-		comp1)
+		nilConsensusStatus, comp1)
 	comp3 := &testComponent{}
 	err = ssm2.RegisterAndSync(context.Background(), comp3)
 	require.NoError(t, err)
@@ -296,7 +297,7 @@ func TestStateManager_RegisterAndSync(t *testing.T) {
 
 func TestStateManager_RegisterAndSync_Error(t *testing.T) {
 	r := newTestRecord(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
-	ssm := NewStateManager(newTestLogger(), r)
+	ssm := NewStateManager(newTestLogger(), r, nilConsensusStatus)
 
 	comp := &testComponent{err: errors.New("sync failed")}
 	err := ssm.RegisterAndSync(context.Background(), comp)
@@ -307,10 +308,10 @@ func TestStateManager_RegisterAndSync_Error(t *testing.T) {
 func TestStateManager_NoComponents(t *testing.T) {
 	r := newTestRecord(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED)
 
-	ssm := NewStateManager(newTestLogger(), r)
+	ssm := NewStateManager(newTestLogger(), r, selfLeaderConsensusStatus)
 
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
-		s.SelfLeadership = primaryObs()
+		s.PostgresPrimary = true
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	})
 	require.NoError(t, err)
@@ -333,13 +334,13 @@ func TestStateManager_HealthStreamerIntegration(t *testing.T) {
 	comp := &testComponent{}
 	r := newTestRecord(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED)
 
-	ssm := NewStateManager(logger, r, comp, hs)
+	ssm := NewStateManager(logger, r, selfLeaderConsensusStatus, comp, hs)
 
 	// Subscribe to health stream before state change
 	_, ch := hs.subscribe()
 
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
-		s.SelfLeadership = primaryObs()
+		s.PostgresPrimary = true
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	})
 	require.NoError(t, err)
@@ -369,10 +370,10 @@ func TestStateManager_ParallelExecution(t *testing.T) {
 	comp2 := &slowComponent{}
 	r := newTestRecord(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED)
 
-	ssm := NewStateManager(newTestLogger(), r, comp1, comp2)
+	ssm := NewStateManager(newTestLogger(), r, selfLeaderConsensusStatus, comp1, comp2)
 
 	err := ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
-		s.SelfLeadership = primaryObs()
+		s.PostgresPrimary = true
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	})
 	require.NoError(t, err)
@@ -384,11 +385,11 @@ func TestStateManager_ParallelExecution(t *testing.T) {
 func TestStateManager_SetState_RequiresActionLock(t *testing.T) {
 	comp := &testComponent{}
 	r := newTestRecord(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED)
-	ssm := NewStateManager(newTestLogger(), r, comp)
+	ssm := NewStateManager(newTestLogger(), r, nilConsensusStatus, comp)
 
 	// No action lock on the context: SetState must reject before doing anything.
 	err := ssm.Mutate(t.Context(), func(s *servingStateMutation) {
-		s.SelfLeadership = primaryObs()
+		s.PostgresPrimary = true
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	})
 	require.Error(t, err)
@@ -397,4 +398,100 @@ func TestStateManager_SetState_RequiresActionLock(t *testing.T) {
 	assert.Equal(t, 0, comp.callCount, "components must not transition without the action lock")
 	assert.Equal(t, clustermetadatapb.PoolerType_REPLICA, r.Type())
 	assert.Equal(t, clustermetadatapb.PoolerServingStatus_DISABLED, r.ServingStatus())
+}
+
+// TestStateManager_HasDrift covers the physical-primary / serving drift detection
+// that the postgres monitor uses to decide whether to reconcile (fixDrift). The
+// role facts are held fixed as the active writable leader (self-leader consensus +
+// PostgresPrimary=true) so this isolates the recovery-flag / serving-status inputs,
+// matching the old determineRemedialAction primary-drift coverage that moved here.
+func TestStateManager_HasDrift(t *testing.T) {
+	// newFannedOut builds a manager whose last-fanned-out effective state is
+	// (PRIMARY, serving): the active writable leader currently in `serving`.
+	newFannedOut := func(t *testing.T, serving clustermetadatapb.PoolerServingStatus) *StateManager {
+		r := newTestRecord(clustermetadatapb.PoolerType_PRIMARY, serving)
+		ssm := NewStateManager(newTestLogger(), r, selfLeaderConsensusStatus)
+		// Establish lastFannedOut = (PRIMARY, serving) as the active writable leader.
+		require.NoError(t, ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
+			s.PostgresPrimary = true
+			s.ServingStatus = serving
+		}))
+		return ssm
+	}
+
+	t.Run("primary drift reconciles", func(t *testing.T) {
+		// Last fanned out as the writable leader (PostgresPrimary true), but postgres
+		// now reports recovery (postgresPrimary=false): the routing role would flip,
+		// so this is drift.
+		ssm := newFannedOut(t, clustermetadatapb.PoolerServingStatus_SERVING)
+		assert.True(t, ssm.hasDrift(false /* postgresPrimary */))
+	})
+
+	t.Run("draining always reconciles", func(t *testing.T) {
+		// DRAINING is a transient drain the monitor owns; hasDrift always reports it
+		// so fixDrift completes DRAINING->SERVING once healthy and role-aligned.
+		ssm := newFannedOut(t, clustermetadatapb.PoolerServingStatus_DRAINING)
+		assert.True(t, ssm.hasDrift(true /* postgresPrimary */))
+	})
+
+	t.Run("disabled is left alone", func(t *testing.T) {
+		// DISABLED is a deliberate non-serving state; with the recovery flag and role
+		// unchanged there is no drift, so the monitor must not auto-reconcile it.
+		ssm := newFannedOut(t, clustermetadatapb.PoolerServingStatus_DISABLED)
+		assert.False(t, ssm.hasDrift(true /* postgresPrimary */))
+	})
+
+	t.Run("no drift is a no-op", func(t *testing.T) {
+		// Recovery flag and serving status match what was last fanned out: no drift.
+		ssm := newFannedOut(t, clustermetadatapb.PoolerServingStatus_SERVING)
+		assert.False(t, ssm.hasDrift(true /* postgresPrimary */))
+	})
+}
+
+// TestStateManager_FixDrift verifies fixDrift re-derives and re-applies the
+// effective state: a recovery flip re-projects the record to REPLICA, and a
+// DRAINING status is completed to SERVING.
+func TestStateManager_FixDrift(t *testing.T) {
+	t.Run("recovery flip demotes to replica", func(t *testing.T) {
+		r := newTestRecord(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
+		ssm := NewStateManager(newTestLogger(), r, selfLeaderConsensusStatus)
+		require.NoError(t, ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
+			s.PostgresPrimary = true
+			s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
+		}))
+		require.Equal(t, clustermetadatapb.PoolerType_PRIMARY, r.Type())
+
+		require.NoError(t, ssm.fixDrift(newActionLockedCtx(t), false /* postgresPrimary */))
+		assert.Equal(t, clustermetadatapb.PoolerType_REPLICA, r.Type())
+		assert.Equal(t, clustermetadatapb.PoolerServingStatus_SERVING, r.ServingStatus())
+	})
+
+	t.Run("draining completes to serving", func(t *testing.T) {
+		r := newTestRecord(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_DRAINING)
+		ssm := NewStateManager(newTestLogger(), r, selfLeaderConsensusStatus)
+
+		require.NoError(t, ssm.fixDrift(newActionLockedCtx(t), true /* postgresPrimary */))
+		assert.Equal(t, clustermetadatapb.PoolerServingStatus_SERVING, r.ServingStatus())
+		assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, r.Type())
+	})
+}
+
+// nilConsensusStatus is a StateManager consensus-snapshot injector for tests that
+// don't exercise the derived routing role (nil -> not the active leader -> REPLICA).
+func nilConsensusStatus() *clustermetadatapb.ConsensusStatus { return nil }
+
+// selfLeaderConsensusStatus is a StateManager consensus-snapshot injector in
+// which testPoolerID is the active committed leader (commonconsensus.IsActiveLeader
+// is true): the committed rule names self and is not revoked or superseded.
+// Combined with s.PostgresPrimary = true it yields routing role PRIMARY.
+func selfLeaderConsensusStatus() *clustermetadatapb.ConsensusStatus {
+	return &clustermetadatapb.ConsensusStatus{
+		Id: testPoolerID,
+		CurrentPosition: &clustermetadatapb.PoolerPosition{
+			Rule: &clustermetadatapb.ShardRule{
+				RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
+				LeaderId:   testPoolerID,
+			},
+		},
+	}
 }

--- a/go/services/multipooler/internal/manager/state_manager_test.go
+++ b/go/services/multipooler/internal/manager/state_manager_test.go
@@ -476,6 +476,54 @@ func TestStateManager_FixDrift(t *testing.T) {
 	})
 }
 
+// TestStateManager_RegisterAndSyncAfterDedupedRecoveryChange is a regression test
+// for the cached recovery fact going stale across a deduped (early-return) Mutate.
+// A postgresPrimary change that does not flip the routing role — because this
+// pooler is not yet the active consensus leader, so it stays REPLICA either way —
+// must still refresh ssm.postgresPrimary. Otherwise a component registered later,
+// once consensus does name this pooler the active leader, would derive REPLICA
+// from the stale recovery flag instead of the correct PRIMARY.
+func TestStateManager_RegisterAndSyncAfterDedupedRecoveryChange(t *testing.T) {
+	r := newTestRecord(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_SERVING)
+
+	// A consensus snapshot the test flips from "not the active leader" to "active
+	// leader". While not the leader the routing role is REPLICA regardless of
+	// recovery mode; once the leader, recovery mode decides PRIMARY vs REPLICA.
+	var activeLeader atomic.Bool
+	consensusStatus := func() *clustermetadatapb.ConsensusStatus {
+		if activeLeader.Load() {
+			return selfLeaderConsensusStatus()
+		}
+		return nilConsensusStatus()
+	}
+	ssm := NewStateManager(newTestLogger(), r, consensusStatus)
+
+	// Baseline fan-out: REPLICA/SERVING with postgres in recovery.
+	require.NoError(t, ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
+		s.PostgresPrimary = false
+		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
+	}))
+
+	// Postgres leaves recovery, but this pooler is not yet the active leader, so
+	// the derived routing role stays REPLICA and Mutate early-returns without a
+	// fan-out. The cached recovery fact must still advance to true.
+	require.NoError(t, ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
+		s.PostgresPrimary = true
+		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
+	}))
+
+	// Consensus now names this pooler the active leader.
+	activeLeader.Store(true)
+
+	// A component registered now must see PRIMARY: postgres is out of recovery
+	// (cached true) AND this pooler is the active leader. A stale cached false
+	// would derive REPLICA.
+	comp := &testComponent{}
+	require.NoError(t, ssm.RegisterAndSync(t.Context(), comp))
+	assert.Equal(t, servingstate.RoutingRolePrimary, comp.lastRole,
+		"late-registered component must derive PRIMARY from the refreshed recovery cache")
+}
+
 // nilConsensusStatus is a StateManager consensus-snapshot injector for tests that
 // don't exercise the derived routing role (nil -> not the active leader -> REPLICA).
 func nilConsensusStatus() *clustermetadatapb.ConsensusStatus { return nil }

--- a/go/services/multipooler/internal/poolerserver/controller.go
+++ b/go/services/multipooler/internal/poolerserver/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/multigres/multigres/go/pb/query"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pubsub"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 // PoolerController defines the control interface for query serving.
@@ -39,20 +40,17 @@ type PoolerController interface {
 	// OnStateChange transitions the query service to match the new serving state.
 	// This is called by StateManager during state transitions.
 	//
-	// isConsensusLeader determines query behavior:
-	//   - leader: Accept reads + writes
-	//   - non-leader (replica): Accept reads only
+	// state.RoutingRole is the write-safety role. The query server admits leader-
+	// bound traffic (WRITABLE and CONSISTENT) only when it is PRIMARY (out of
+	// recovery AND the non-revoked committed + highest-known leader), which closes
+	// the window between pg_promote() and the new rule committing to WAL.
 	//
-	// postgresPrimary reports the physical recovery state; the query server does
-	// not gate admission on it today (writability surfaces via the leader role and
-	// serving status), but it is part of the uniform StateAware signature.
-	//
-	// The servingStatus determines whether queries are accepted at all:
+	// state.ServingStatus determines whether queries are accepted at all:
 	//   - SERVING: Accept queries
 	//   - not-serving: Reject all queries
 	//
 	// Returns error if the transition fails.
-	OnStateChange(ctx context.Context, isConsensusLeader, postgresPrimary bool, servingStatus clustermetadatapb.PoolerServingStatus) error
+	OnStateChange(ctx context.Context, state servingstate.State) error
 
 	// StartRequest checks whether a request should be admitted, based on its
 	// RequestKind and the pooler's drain phase. It returns MTF01 (which the
@@ -63,10 +61,10 @@ type PoolerController interface {
 	// throughout. See StartRequest for the full admission matrix.
 	StartRequest(target *query.Target, kind RequestKind) error
 
-	// AwaitStateChange blocks until the pooler's leader role and serving status
+	// AwaitStateChange blocks until the pooler's routing role and serving status
 	// match the given targets, or ctx is cancelled. Used by the health streamer to
 	// ensure the query server is ready before broadcasting the new state.
-	AwaitStateChange(ctx context.Context, isConsensusLeader bool, servingStatus clustermetadatapb.PoolerServingStatus)
+	AwaitStateChange(ctx context.Context, routingRole servingstate.RoutingRole, servingStatus clustermetadatapb.PoolerServingStatus)
 
 	// IsServing returns true if the query service is currently serving requests.
 	IsServing() bool

--- a/go/services/multipooler/internal/poolerserver/metrics_test.go
+++ b/go/services/multipooler/internal/poolerserver/metrics_test.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 	"github.com/multigres/multigres/go/tools/telemetry"
 )
 
@@ -117,9 +118,9 @@ func TestDrainMetricGracefulOutcome(t *testing.T) {
 	pooler.gracePeriod = 5 * time.Second
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	// No in-flight connections → WaitForDrain returns immediately.
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_DISABLED))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
 
 	assert.Equal(t, int64(1), readCounterByOutcome(t, reader, "mg.pooler.drain.outcome", "graceful"))
 	assert.Equal(t, int64(0), readCounterByOutcome(t, reader, "mg.pooler.drain.outcome", "force_close"))
@@ -141,11 +142,11 @@ func TestDrainMetricForceCloseOutcome(t *testing.T) {
 	pooler.gracePeriod = 50 * time.Millisecond
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// Simulate an in-flight connection that never returns → WaitForDrain blocks until grace period.
 	mock.regularAdd(1)
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_DISABLED))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
 
 	assert.Equal(t, int64(0), readCounterByOutcome(t, reader, "mg.pooler.drain.outcome", "graceful"))
 	assert.Equal(t, int64(1), readCounterByOutcome(t, reader, "mg.pooler.drain.outcome", "force_close"))
@@ -168,8 +169,8 @@ func TestDrainMetricDurationBuckets(t *testing.T) {
 	pooler.gracePeriod = 50 * time.Millisecond
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_DISABLED))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
 
 	hist := readHistogramFloat64(t, reader, "mg.pooler.drain.duration")
 	require.NotNil(t, hist)

--- a/go/services/multipooler/internal/poolerserver/pooler.go
+++ b/go/services/multipooler/internal/poolerserver/pooler.go
@@ -30,6 +30,7 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pubsub"
 	"github.com/multigres/multigres/go/services/multipooler/internal/replication"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 // QueryPoolerServer is the core pooler implementation for query serving.
@@ -54,12 +55,14 @@ type QueryPoolerServer struct {
 	shard      string
 
 	mu sync.Mutex
-	// isConsensusLeader reports whether this pooler is the consensus-elected
-	// leader (the shard's write target). Set from OnStateChange; replaces the
-	// PoolerType label, which the gateway no longer routes on.
-	isConsensusLeader bool
-	servingStatus     clustermetadatapb.PoolerServingStatus
-	healthProvider    HealthProvider
+	// routingRole is the write-safety role from OnStateChange: PRIMARY iff this
+	// pooler is the writable leader (out of recovery AND the active — committed,
+	// non-revoked, highest-known — consensus leader). Both leader-bound query
+	// modes (WRITABLE and CONSISTENT) gate on it: writes and read-your-writes reads
+	// route to the writable leader, closing the pg_promote()→WAL-commit window.
+	routingRole    servingstate.RoutingRole
+	servingStatus  clustermetadatapb.PoolerServingStatus
+	healthProvider HealthProvider
 
 	// pubsubListener is the shared LISTEN/NOTIFY listener, set by MultiPoolerManager.
 	pubsubListener *pubsub.Listener
@@ -182,15 +185,17 @@ func (s *QueryPoolerServer) ReplicationMetrics() *replication.Metrics {
 // any still-running single queries are killed by the postgres demotion that
 // follows. On timeout, errors are acceptable — that is what the grace period
 // bounds.
-func (s *QueryPoolerServer) OnStateChange(ctx context.Context, isConsensusLeader, _ bool, servingStatus clustermetadatapb.PoolerServingStatus) error {
+func (s *QueryPoolerServer) OnStateChange(ctx context.Context, state servingstate.State) error {
+	routingRole := state.RoutingRole
+	servingStatus := state.ServingStatus
 	s.mu.Lock()
 
 	s.logger.InfoContext(ctx, "Transitioning serving type",
-		"leader_from", s.isConsensusLeader, "leader_to", isConsensusLeader,
+		"routing_from", s.routingRole, "routing_to", routingRole,
 		"status_from", s.servingStatus, "status_to", servingStatus)
 
 	if servingStatus == clustermetadatapb.PoolerServingStatus_SERVING {
-		s.isConsensusLeader = isConsensusLeader
+		s.routingRole = routingRole
 		s.servingStatus = servingStatus
 		s.drainPhase = drainNone
 		s.notifyStateChangedLocked()
@@ -199,7 +204,7 @@ func (s *QueryPoolerServer) OnStateChange(ctx context.Context, isConsensusLeader
 	}
 
 	// not-serving: begin stage 1 of the graceful drain.
-	// The leader role is NOT updated yet — in-flight requests on reserved
+	// The routing role is NOT updated yet — in-flight requests on reserved
 	// connections (e.g., COMMIT after a demotion) must still see the old role
 	// so that checkTargetLocked allows them to complete.
 	s.drainPhase = drainReserved
@@ -246,10 +251,10 @@ func (s *QueryPoolerServer) OnStateChange(ctx context.Context, isConsensusLeader
 		s.drainStats.recordDrain(ctx, time.Since(drainStart).Seconds(), outcome)
 	}
 
-	// Complete the transition. The leader role is set here (after drain) so that
+	// Complete the transition. The routing role is set here (after drain) so that
 	// in-flight requests saw the old role throughout the drain phase.
 	s.mu.Lock()
-	s.isConsensusLeader = isConsensusLeader
+	s.routingRole = routingRole
 	s.servingStatus = servingStatus
 	s.drainPhase = drainNone
 	s.notifyStateChangedLocked()
@@ -365,15 +370,18 @@ func (s *QueryPoolerServer) checkTargetLocked(target *query.Target, existingRese
 		return nil
 	}
 
-	// A leader-bound request (WRITABLE / CONSISTENT) hitting a non-leader means the
-	// gateway thinks this pooler is still the primary, but it was demoted. Return
-	// MTF01 to trigger buffering. Target side uses the Mode enum (#1183); pooler
-	// side uses the consensus-leadership observation, not the topology PoolerType
-	// label (PR 1184 — the gateway derives role from consensus observations).
-	mode := target.GetMode()
-	if (mode == query.Mode_MODE_WRITABLE || mode == query.Mode_MODE_CONSISTENT) &&
-		!s.isConsensusLeader {
-		return mterrors.MTF01.New()
+	// A leader-bound request (WRITABLE / CONSISTENT) hitting a non-writable pooler
+	// means the gateway thinks this pooler is still the primary, but it is not the
+	// writable leader (demoted, or not yet done promoting). Return MTF01 to trigger
+	// buffering. Both modes gate on the routing role: writes must not land on an
+	// older consensus timeline, and read-your-writes reads must not be served by a
+	// not-yet-writable (still promoting) or superseded/deposed leader — they buffer
+	// until a writable leader exists rather than returning a stale read.
+	switch target.GetMode() {
+	case query.Mode_MODE_WRITABLE, query.Mode_MODE_CONSISTENT:
+		if s.routingRole != servingstate.RoutingRolePrimary {
+			return mterrors.MTF01.New()
+		}
 	}
 
 	return nil
@@ -387,13 +395,13 @@ func (s *QueryPoolerServer) notifyStateChangedLocked() {
 	s.stateChanged = make(chan struct{})
 }
 
-// AwaitStateChange blocks until the pooler's type and serving status match
-// the given targets, or ctx is cancelled. Used by the health streamer to
+// AwaitStateChange blocks until the pooler's routing role and serving status
+// match the given targets, or ctx is cancelled. Used by the health streamer to
 // ensure the query server is ready before broadcasting the new state.
-func (s *QueryPoolerServer) AwaitStateChange(ctx context.Context, isConsensusLeader bool, servingStatus clustermetadatapb.PoolerServingStatus) {
+func (s *QueryPoolerServer) AwaitStateChange(ctx context.Context, routingRole servingstate.RoutingRole, servingStatus clustermetadatapb.PoolerServingStatus) {
 	for {
 		s.mu.Lock()
-		if s.isConsensusLeader == isConsensusLeader && s.servingStatus == servingStatus {
+		if s.routingRole == routingRole && s.servingStatus == servingStatus {
 			s.mu.Unlock()
 			return
 		}
@@ -439,15 +447,6 @@ func (s *QueryPoolerServer) IsHealthy() error {
 // Implements PoolerController interface.
 func (s *QueryPoolerServer) RegisterGRPCServices() {
 	s.registerGRPCServices()
-}
-
-// StartServiceForTests is a convenience method for tests to initialize and start the pooler.
-// Following Vitess pattern: "StartService is only used for testing."
-// It sets the serving type to PRIMARY + SERVING.
-func (s *QueryPoolerServer) StartServiceForTests() error {
-	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
-	defer cancel()
-	return s.OnStateChange(ctx, true /* isConsensusLeader */, true /* postgresPrimary */, clustermetadatapb.PoolerServingStatus_SERVING)
 }
 
 // Executor returns the executor instance for use by gRPC service handlers.

--- a/go/services/multipooler/internal/poolerserver/pooler_test.go
+++ b/go/services/multipooler/internal/poolerserver/pooler_test.go
@@ -30,6 +30,7 @@ import (
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/pb/query"
 	"github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 func TestNewQueryPoolerServer_NilPoolManager(t *testing.T) {
@@ -153,7 +154,7 @@ func TestStartRequest_DrainRegular_RejectsSingleQueries(t *testing.T) {
 func TestStartRequest_PrimaryOpOnReplica_ReservedConnAllowed(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_DISABLED
-	s.isConsensusLeader = false
+	s.routingRole = servingstate.RoutingRoleReplica
 
 	target := &query.Target{Mode: query.Mode_MODE_WRITABLE}
 	// A fresh PRIMARY-targeted request on a demoted (REPLICA) pooler is rejected
@@ -169,7 +170,7 @@ func TestStartRequest_PrimaryOpOnReplica_ReservedConnAllowed(t *testing.T) {
 func TestStartRequest_PrimaryQueryOnReplica_Rejected(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
-	s.isConsensusLeader = false
+	s.routingRole = servingstate.RoutingRoleReplica
 
 	// PRIMARY query hitting a REPLICA pooler should be rejected with MTF01.
 	target := &query.Target{Mode: query.Mode_MODE_WRITABLE}
@@ -179,16 +180,38 @@ func TestStartRequest_PrimaryQueryOnReplica_Rejected(t *testing.T) {
 func TestStartRequest_PrimaryQueryOnPrimary_Allowed(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
-	s.isConsensusLeader = true
+	s.routingRole = servingstate.RoutingRolePrimary // writable leader
 
 	target := &query.Target{Mode: query.Mode_MODE_WRITABLE}
 	require.NoError(t, s.StartRequest(target, RequestSingleQuery))
 }
 
+// TestStartRequest_WritableGatesOnRoutingRole is the write-safety regression:
+// both leader-bound query modes (WRITABLE and CONSISTENT) gate on the same
+// write-safety routing role. A pooler that is NOT yet writable (routingRole !=
+// PRIMARY — e.g. the pg_promote()→WAL-commit window) must reject BOTH with MTF01
+// so the gateway buffers; once it is the writable leader (RoutingRolePrimary)
+// both are admitted.
+func TestStartRequest_WritableGatesOnRoutingRole(t *testing.T) {
+	s := newStartRequestTestServer()
+	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
+	s.routingRole = servingstate.RoutingRoleReplica // not yet the writable leader
+
+	// Not writable: both leader-bound modes are rejected. Leadership alone no
+	// longer admits either — routing role (write-safety) is the single gate.
+	requireMTF01(t, s.StartRequest(&query.Target{Mode: query.Mode_MODE_WRITABLE}, RequestSingleQuery))
+	requireMTF01(t, s.StartRequest(&query.Target{Mode: query.Mode_MODE_CONSISTENT}, RequestSingleQuery))
+
+	// Once the writable leader, both modes are admitted.
+	s.routingRole = servingstate.RoutingRolePrimary
+	require.NoError(t, s.StartRequest(&query.Target{Mode: query.Mode_MODE_WRITABLE}, RequestSingleQuery))
+	require.NoError(t, s.StartRequest(&query.Target{Mode: query.Mode_MODE_CONSISTENT}, RequestSingleQuery))
+}
+
 func TestStartRequest_ReplicaQueryOnPrimary_Allowed(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
-	s.isConsensusLeader = true
+	s.routingRole = servingstate.RoutingRolePrimary
 
 	// PRIMARY pooler can serve REPLICA traffic.
 	target := &query.Target{Mode: query.Mode_MODE_INCONSISTENT}
@@ -198,7 +221,7 @@ func TestStartRequest_ReplicaQueryOnPrimary_Allowed(t *testing.T) {
 func TestStartRequest_NilTarget_Skipped(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
-	s.isConsensusLeader = false
+	s.routingRole = servingstate.RoutingRoleReplica
 
 	// Nil target should skip target validation (e.g., GetAuthCredentials).
 	require.NoError(t, s.StartRequest(nil, RequestSingleQuery))
@@ -207,7 +230,7 @@ func TestStartRequest_NilTarget_Skipped(t *testing.T) {
 func TestStartRequest_TableGroupMismatch_Bug(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
-	s.isConsensusLeader = true
+	s.routingRole = servingstate.RoutingRolePrimary
 	s.tableGroup = "tg1"
 	s.shard = "0"
 
@@ -223,7 +246,7 @@ func TestStartRequest_TableGroupMismatch_Bug(t *testing.T) {
 func TestStartRequest_ShardMismatch_Bug(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
-	s.isConsensusLeader = true
+	s.routingRole = servingstate.RoutingRolePrimary
 	s.tableGroup = "tg1"
 	s.shard = "0"
 
@@ -238,7 +261,7 @@ func TestStartRequest_ShardMismatch_Bug(t *testing.T) {
 func TestStartRequest_FullTargetMatch_Allowed(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
-	s.isConsensusLeader = true
+	s.routingRole = servingstate.RoutingRolePrimary // writable leader
 	s.tableGroup = "tg1"
 	s.shard = "0"
 
@@ -377,7 +400,7 @@ func TestOnStateChange_TwoStageDrain(t *testing.T) {
 	pooler.gracePeriod = 5 * time.Second
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// One in-flight transaction (reserved) and one in-flight single query (regular).
 	mock.reservedAdd(1)
@@ -386,7 +409,7 @@ func TestOnStateChange_TwoStageDrain(t *testing.T) {
 	drainDone := make(chan struct{})
 	go func() {
 		defer close(drainDone)
-		_ = pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_DISABLED)
+		_ = pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
 	}()
 
 	// Stage 1: blocked on the in-flight transaction. Single queries are served,
@@ -424,13 +447,13 @@ func TestOnStateChange_GracePeriodExpiresInStage1(t *testing.T) {
 	pooler.gracePeriod = 100 * time.Millisecond
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// A transaction that never commits — stage 1 (WaitForReservedDrain) blocks.
 	mock.reservedAdd(1)
 
 	start := time.Now()
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_DISABLED))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
 	elapsed := time.Since(start)
 
 	assert.GreaterOrEqual(t, elapsed, 80*time.Millisecond, "should block ~grace period waiting on the held transaction")
@@ -449,7 +472,7 @@ func TestOnStateChange_WaitsForInflightRequests(t *testing.T) {
 	pooler.gracePeriod = 5 * time.Second
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// Simulate two in-flight connections
 	mock.regularAdd(1)
@@ -458,7 +481,7 @@ func TestOnStateChange_WaitsForInflightRequests(t *testing.T) {
 	drainDone := make(chan struct{})
 	go func() {
 		defer close(drainDone)
-		_ = pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_DISABLED)
+		_ = pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
 	}()
 
 	// Drain should not complete while connections are in-flight
@@ -491,7 +514,7 @@ func TestOnStateChange_GracePeriodExpires(t *testing.T) {
 	pooler.gracePeriod = 100 * time.Millisecond
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// Simulate a connection that will never return
 	mock.regularAdd(1)
@@ -500,7 +523,7 @@ func TestOnStateChange_GracePeriodExpires(t *testing.T) {
 	drainDone := make(chan struct{})
 	go func() {
 		defer close(drainDone)
-		_ = pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_DISABLED)
+		_ = pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
 	}()
 
 	select {
@@ -527,14 +550,14 @@ func TestOnStateChange_BackToServing(t *testing.T) {
 	ctx := t.Context()
 
 	// SERVING → DISABLED → SERVING
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	assert.True(t, pooler.IsServing())
 
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_DISABLED))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
 	assert.False(t, pooler.IsServing())
 
 	// Transition back to SERVING
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	assert.True(t, pooler.IsServing())
 
 	// Requests should work again
@@ -550,7 +573,7 @@ func TestOnStateChange_ConcurrentRequests(t *testing.T) {
 	pooler.gracePeriod = 2 * time.Second
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	const numRequests = 50
 	var wg sync.WaitGroup
@@ -576,7 +599,7 @@ func TestOnStateChange_ConcurrentRequests(t *testing.T) {
 	drainDone := make(chan struct{})
 	go func() {
 		defer close(drainDone)
-		_ = pooler.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_DISABLED)
+		_ = pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
 	}()
 
 	// Wait for all goroutines and drain to complete
@@ -595,12 +618,12 @@ func TestAwaitStateChange_AlreadyMatches(t *testing.T) {
 	ctx := t.Context()
 
 	// Transition to PRIMARY/SERVING
-	require.NoError(t, s.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, s.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// AwaitStateChange should return immediately when state already matches
 	done := make(chan struct{})
 	go func() {
-		s.AwaitStateChange(ctx, true, clustermetadatapb.PoolerServingStatus_SERVING)
+		s.AwaitStateChange(ctx, servingstate.RoutingRolePrimary, clustermetadatapb.PoolerServingStatus_SERVING)
 		close(done)
 	}()
 
@@ -618,7 +641,7 @@ func TestAwaitStateChange_BlocksUntilTransition(t *testing.T) {
 	// Start as DISABLED (default)
 	done := make(chan struct{})
 	go func() {
-		s.AwaitStateChange(ctx, true, clustermetadatapb.PoolerServingStatus_SERVING)
+		s.AwaitStateChange(ctx, servingstate.RoutingRolePrimary, clustermetadatapb.PoolerServingStatus_SERVING)
 		close(done)
 	}()
 
@@ -630,7 +653,7 @@ func TestAwaitStateChange_BlocksUntilTransition(t *testing.T) {
 	}
 
 	// Transition to the awaited state
-	require.NoError(t, s.OnStateChange(ctx, true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, s.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	select {
 	case <-done:
@@ -646,7 +669,7 @@ func TestAwaitStateChange_RespectsContextCancellation(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		// Wait for a state that will never happen
-		s.AwaitStateChange(ctx, true, clustermetadatapb.PoolerServingStatus_SERVING)
+		s.AwaitStateChange(ctx, servingstate.RoutingRolePrimary, clustermetadatapb.PoolerServingStatus_SERVING)
 		close(done)
 	}()
 

--- a/go/services/multipooler/internal/pubsub/listener.go
+++ b/go/services/multipooler/internal/pubsub/listener.go
@@ -31,6 +31,7 @@ import (
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pools/reserved"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
 
 // request types for the serialized event loop.
@@ -112,12 +113,13 @@ func (l *Listener) Stop() {
 }
 
 // OnStateChange implements manager.StateAware. The listener runs only when this
-// pooler is the consensus leader AND postgres is out of recovery AND serving; it
-// is stopped on any other state transition. LISTEN/NOTIFY only carries
-// notifications on the actual postgres primary — standbys never receive them — so
-// postgresPrimary must gate it in addition to leadership.
-func (l *Listener) OnStateChange(_ context.Context, isConsensusLeader bool, postgresPrimary bool, servingStatus clustermetadatapb.PoolerServingStatus) error {
-	if isConsensusLeader && postgresPrimary && servingStatus == clustermetadatapb.PoolerServingStatus_SERVING {
+// pooler is the writable leader (routing role PRIMARY — out of recovery AND the
+// active consensus leader) AND serving; it is stopped on any other state
+// transition. LISTEN/NOTIFY only carries notifications on the actual postgres
+// primary, and writability already requires out-of-recovery, so a standby never
+// starts the listener.
+func (l *Listener) OnStateChange(_ context.Context, state servingstate.State) error {
+	if state.RoutingRole.Writable() && state.ServingStatus == clustermetadatapb.PoolerServingStatus_SERVING {
 		//nolint:gocritic // Long-lived background listener; must not use the transient state-change ctx.
 		l.Start(context.Background())
 	} else {

--- a/go/services/multipooler/internal/pubsub/listener_test.go
+++ b/go/services/multipooler/internal/pubsub/listener_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -43,59 +44,47 @@ func newTestListener(t *testing.T) *Listener {
 }
 
 // TestListenerOnStateChangeGating verifies the LISTEN/NOTIFY listener runs only
-// when this pooler is the consensus leader AND postgres is out of recovery AND
-// serving. postgresPrimary is the key gate: LISTEN/NOTIFY only delivers on the
-// actual postgres primary, so a leader whose postgres is still in recovery must
-// not run the listener.
+// when this pooler is the writable leader (RoutingRolePrimary) AND serving. The
+// routing role folds in both the consensus-leader and out-of-recovery facts:
+// LISTEN/NOTIFY only delivers on the actual postgres primary, so a pooler that is
+// not the writable leader must not run the listener.
 func TestListenerOnStateChangeGating(t *testing.T) {
 	tests := []struct {
-		name              string
-		isConsensusLeader bool
-		postgresPrimary   bool
-		servingStatus     clustermetadatapb.PoolerServingStatus
-		wantRunning       bool
+		name          string
+		routingRole   servingstate.RoutingRole
+		servingStatus clustermetadatapb.PoolerServingStatus
+		wantRunning   bool
 	}{
 		{
-			name:              "leader, writable, serving -> listener runs",
-			isConsensusLeader: true,
-			postgresPrimary:   true,
-			servingStatus:     clustermetadatapb.PoolerServingStatus_SERVING,
-			wantRunning:       true,
+			name:          "writable leader, serving -> listener runs",
+			routingRole:   servingstate.RoutingRolePrimary,
+			servingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
+			wantRunning:   true,
 		},
 		{
-			name:              "leader but not yet writable -> listener stays off",
-			isConsensusLeader: true,
-			postgresPrimary:   false,
-			servingStatus:     clustermetadatapb.PoolerServingStatus_SERVING,
-			wantRunning:       false,
+			name:          "not the writable leader, serving -> listener stays off",
+			routingRole:   servingstate.RoutingRoleReplica,
+			servingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
+			wantRunning:   false,
 		},
 		{
-			name:              "writable but not leader -> listener stays off",
-			isConsensusLeader: false,
-			postgresPrimary:   true,
-			servingStatus:     clustermetadatapb.PoolerServingStatus_SERVING,
-			wantRunning:       false,
+			name:          "writable leader but draining -> listener stays off",
+			routingRole:   servingstate.RoutingRolePrimary,
+			servingStatus: clustermetadatapb.PoolerServingStatus_DRAINING,
+			wantRunning:   false,
 		},
 		{
-			name:              "leader and writable but draining -> listener stays off",
-			isConsensusLeader: true,
-			postgresPrimary:   true,
-			servingStatus:     clustermetadatapb.PoolerServingStatus_DRAINING,
-			wantRunning:       false,
-		},
-		{
-			name:              "leader and writable but disabled -> listener stays off",
-			isConsensusLeader: true,
-			postgresPrimary:   true,
-			servingStatus:     clustermetadatapb.PoolerServingStatus_DISABLED,
-			wantRunning:       false,
+			name:          "writable leader but disabled -> listener stays off",
+			routingRole:   servingstate.RoutingRolePrimary,
+			servingStatus: clustermetadatapb.PoolerServingStatus_DISABLED,
+			wantRunning:   false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			l := newTestListener(t)
-			err := l.OnStateChange(context.Background(), tt.isConsensusLeader, tt.postgresPrimary, tt.servingStatus)
+			err := l.OnStateChange(context.Background(), servingstate.State{RoutingRole: tt.routingRole, ServingStatus: tt.servingStatus})
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantRunning, running(l))
 		})
@@ -108,11 +97,11 @@ func TestListenerOnStateChangeGating(t *testing.T) {
 func TestListenerOnStateChangeStopsOnDemotion(t *testing.T) {
 	l := newTestListener(t)
 
-	require.NoError(t, l.OnStateChange(context.Background(), true, true, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, l.OnStateChange(context.Background(), servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	require.True(t, running(l), "listener should run while leader+writable+serving")
 
 	// Postgres falls back into recovery (demoted to standby) while still nominally
 	// the leader: the listener must stop.
-	require.NoError(t, l.OnStateChange(context.Background(), true, false, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, l.OnStateChange(context.Background(), servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	assert.False(t, running(l), "listener must stop once postgres is no longer writable")
 }

--- a/go/services/multipooler/internal/servingstate/servingstate.go
+++ b/go/services/multipooler/internal/servingstate/servingstate.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package servingstate defines the effective serving state that the multipooler
+// manager's StateManager delivers to components via OnStateChange.
+//
+// It lives in its own leaf package because the components that react to state
+// changes (heartbeat, query server) satisfy the manager's interface structurally
+// and cannot import the manager package back.
+package servingstate
+
+import clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+
+// State is the effective serving state the StateManager delivers to components
+// via OnStateChange. It carries a single derived role concept — the routing role
+// (writability) — plus the serving intent. Consensus leadership is deliberately
+// absent: it is a consensus-layer fact, derived from the ConsensusStatus by
+// whoever needs it, not something the serving layer traffics in. Both leader-
+// bound query modes (WRITABLE and CONSISTENT) gate on RoutingRole.
+type State struct {
+	// RoutingRole reports whether this pooler is the writable leader — see
+	// RoutingRole / Writable. Derived from postgres recovery mode and the live
+	// consensus snapshot; the single authority the query gates, heartbeat writer,
+	// and LISTEN/NOTIFY react to.
+	RoutingRole RoutingRole
+
+	// ServingStatus is the serving intent (SERVING / DISABLED / DRAINING).
+	ServingStatus clustermetadatapb.PoolerServingStatus
+}
+
+// RoutingRole is a pooler's role for query ROUTING and HA purposes. It is about
+// WRITABILITY, not consensus leadership: PRIMARY means this pooler is the
+// writable leader (postgres out of recovery AND it is the highest non-revoked
+// committed leader), REPLICA means it is not. It is deliberately distinct from
+// consensus role (leader/follower/observer, from ConsensusStatus) and from
+// postgres recovery mode (primary/standby).
+//
+// It is an enum rather than a bool so the write-safety meaning travels with the
+// value as it flows through OnStateChange rather than eroding into an anonymous
+// boolean. This Go type is the internal carrier; when writability is published
+// to the gateway (health stream + topology record) it migrates to the
+// clustermetadata.RoutingRole proto enum, whose values line up 1:1.
+type RoutingRole int
+
+const (
+	// RoutingRoleUnknown is the zero value: the routing role has not been
+	// established yet (cold start). Treated as not-writable — never routed writes.
+	RoutingRoleUnknown RoutingRole = iota
+	// RoutingRolePrimary means this pooler is the writable leader: it may admit
+	// user transactions (see Writable for the exact conjunction). Writes route here.
+	RoutingRolePrimary
+	// RoutingRoleReplica means this pooler is not the writable leader.
+	RoutingRoleReplica
+)
+
+// String returns a human-readable name for the routing role.
+func (r RoutingRole) String() string {
+	switch r {
+	case RoutingRolePrimary:
+		return "primary"
+	case RoutingRoleReplica:
+		return "replica"
+	case RoutingRoleUnknown:
+		return "unknown"
+	default:
+		return "invalid"
+	}
+}
+
+// Writable reports whether this pooler may accept user transactions (writes) —
+// true iff the routing role is PRIMARY. "Writable" is specifically about user
+// write traffic, and PRIMARY means, in practice:
+//
+//   - postgres is not in recovery mode, AND
+//   - the pooler is the active consensus leader (commonconsensus.IsActiveLeader):
+//     its current-term rule is committed in its own WAL, is not revoked, and is
+//     not superseded by a higher rule it knows of.
+//
+// We key on the *committed* rule: a just-pg_promote()'d pooler is not marked
+// PRIMARY until its new rule commits — we do not mark it primary early — and a
+// deposed leader whose rule was revoked or superseded is not PRIMARY. The
+// property this buys is that an admitted write can never land on an older
+// consensus timeline.
+//
+// (Even the edge case where an uncommitted rule's writes become visible — e.g.
+// crash recovery surfacing them as phantom transactions — is not a correctness
+// bug: such writes hang on the unmet durability quorum rather than corrupting.
+// That is not the expected path, just reassurance that the boundary is safe.)
+func (r RoutingRole) Writable() bool {
+	return r == RoutingRolePrimary
+}


### PR DESCRIPTION
De-conflate "leader" in the pooler serving layer into a single derived concept — the routing role (writability) — closing a write-safety hole where MODE_WRITABLE traffic was admitted based on highest-known leadership, i.e. during the pg_promote()->WAL-commit window before the new rule committed to consensus.

- servingstate.State{RoutingRole, ServingStatus}: the one effective signal fanned to components via OnStateChange. Consensus leadership stays a consensus-layer fact, read from the ConsensusStatus by whoever needs it.
- StateManager derives the routing role from postgres recovery mode plus the live consensus snapshot (commonconsensus.IsActiveLeader) and projects it onto the record's Type/SelfLeadership. servingStateMutation drops SelfLeadership — callers poke recovery/serving; leadership follows.
- Query server gates both WRITABLE and CONSISTENT on RoutingRole==PRIMARY.
- Health stream PoolerType and writable are both derived from the routing role.
- Monitor reduced to drift detection/repair via StateManager.hasDrift and fixDrift; dead deriveTypeAndObs, leaderObs, and StartServiceForTests removed.