### PR TITLE
fix(multipooler): re-prepare on 0A000 cached-plan error in regular execute path

### DIFF
--- a/go/common/mterrors/error_helpers.go
+++ b/go/common/mterrors/error_helpers.go
@@ -33,6 +33,20 @@ func ExtractSQLSTATE(err error) string {
 	return PgSSInternalError // "XX000"
 }
 
+// IsCachedPlanError reports whether err is PostgreSQL's SQLSTATE 0A000
+// "cached plan must not change result type" — raised when a cached prepared
+// statement's result columns changed (e.g. after DDL) and the statement must be
+// re-prepared. Matched on both the SQLSTATE and the (stable) message text so that
+// other 0A000 (feature_not_supported) errors are not treated as re-preparable.
+func IsCachedPlanError(err error) bool {
+	var diag *PgDiagnostic
+	if !errors.As(err, &diag) {
+		return false
+	}
+	return diag.Code == PgSSFeatureNotSupported &&
+		strings.Contains(diag.Message, "cached plan must not change result type")
+}
+
 // ClassifyErrorSource categorises the origin of an error for metric attribution.
 // Returns one of:
 //   - "backend"  — real PostgreSQL SQLSTATE (not MT-prefixed)

--- a/go/common/mterrors/error_helpers_test.go
+++ b/go/common/mterrors/error_helpers_test.go
@@ -69,6 +69,26 @@ func TestExtractSQLSTATE(t *testing.T) {
 	}
 }
 
+func TestIsCachedPlanError(t *testing.T) {
+	cachedPlan := &PgDiagnostic{
+		MessageType: 'E', Severity: "ERROR",
+		Code:    PgSSFeatureNotSupported, // "0A000"
+		Message: "cached plan must not change result type",
+	}
+	otherFeature := &PgDiagnostic{
+		MessageType: 'E', Severity: "ERROR",
+		Code: PgSSFeatureNotSupported, Message: "cannot insert multiple commands into a prepared statement",
+	}
+	syntax := &PgDiagnostic{MessageType: 'E', Code: "42601", Message: "syntax error"}
+
+	require.True(t, IsCachedPlanError(cachedPlan))
+	require.True(t, IsCachedPlanError(fmt.Errorf("wrapped: %w", cachedPlan)))
+	require.False(t, IsCachedPlanError(otherFeature), "other 0A000 errors are not cached-plan")
+	require.False(t, IsCachedPlanError(syntax))
+	require.False(t, IsCachedPlanError(nil))
+	require.False(t, IsCachedPlanError(errors.New("plain")))
+}
+
 func TestClassifyErrorSource(t *testing.T) {
 	tests := []struct {
 		name string

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -985,21 +985,41 @@ func (e *Executor) portalExecuteWithRegular(
 	// Stamp multigres_vpid on this pooled regular conn for lock-detection.
 	e.stampVpidOnRegular(ctx, conn.Conn, options)
 
-	// Ensure the statement is prepared on this connection (with consolidation)
+	// Bind and execute, healing a stale cached plan transparently. If a DDL has
+	// changed the result type of the cached plan, PostgreSQL returns 0A000
+	// "cached plan must not change result type". Because prepared statements are
+	// shared by canonical name, the client cannot recover by re-preparing (a new
+	// client name maps back to the same stale backend statement), so we do it
+	// here: close the stale backend statement, drop the per-connection cache
+	// entry, re-Parse against the current schema, and retry once.
+	params := sqltypes.ParamsFromProto(portal.ParamLengths, portal.ParamValues)
+
+	bindExecute := func(canonicalName string) error {
+		if includeDescribe {
+			_, e := conn.Conn.BindDescribeAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, 0, callback)
+			return e
+		}
+		_, e := conn.Conn.BindAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, 0, callback)
+		return e
+	}
+
 	canonicalName, err := e.ensurePrepared(ctx, conn.Conn, preparedStatement)
 	if err != nil {
 		return nil, err
 	}
 
-	// Bind and execute with maxRows=0 (fetch all) using the portal's own name and canonical statement name.
-	// When the protocol layer folded Describe('P') into Execute, fuse the
-	// backend round trip too so the portal description rides on the Execute
-	// response.
-	params := sqltypes.ParamsFromProto(portal.ParamLengths, portal.ParamValues)
-	if includeDescribe {
-		_, err = conn.Conn.BindDescribeAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, 0, callback)
-	} else {
-		_, err = conn.Conn.BindAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, 0, callback)
+	err = bindExecute(canonicalName)
+	if err != nil && mterrors.IsCachedPlanError(err) {
+		// 0A000 is raised during plan revalidation, before any row is streamed, so
+		// no partial results reached the callback — retrying is safe.
+		_ = conn.Conn.CloseStatement(ctx, canonicalName)
+		conn.Conn.State().DeletePreparedStatement(canonicalName)
+
+		canonicalName, err = e.ensurePrepared(ctx, conn.Conn, preparedStatement)
+		if err != nil {
+			return nil, err
+		}
+		err = bindExecute(canonicalName)
 	}
 	if err != nil {
 		return nil, wrapQueryError(err)

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -996,11 +996,11 @@ func (e *Executor) portalExecuteWithRegular(
 
 	bindExecute := func(canonicalName string) error {
 		if includeDescribe {
-			_, e := conn.Conn.BindDescribeAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, 0, callback)
-			return e
+			_, err := conn.Conn.BindDescribeAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, 0, callback)
+			return err
 		}
-		_, e := conn.Conn.BindAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, 0, callback)
-		return e
+		_, err := conn.Conn.BindAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, 0, callback)
+		return err
 	}
 
 	canonicalName, err := e.ensurePrepared(ctx, conn.Conn, preparedStatement)

--- a/go/test/endtoend/queryserving/cached_plan_ddl_test.go
+++ b/go/test/endtoend/queryserving/cached_plan_ddl_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/sqltypes"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestCachedPlanReprepareAfterDDL is the regression for SQLSTATE 0A000
+// "cached plan must not change result type" getting stuck through the gateway.
+// After a DDL changes a query's result columns, a subsequent extended-protocol
+// execution (re-Parsed under a fresh statement name, as PG drivers do after 0A000)
+// must succeed with the new columns — the gateway must re-prepare on the backend
+// rather than reuse the stale cached plan.
+func TestCachedPlanReprepareAfterDDL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping end-to-end tests in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 60*time.Second)
+
+	// collectFirstResult returns the first Result carrying field metadata.
+	// Uses the fused Bind+Describe+Execute path so the portal's RowDescription
+	// rides back through the callback (plain BindAndExecute never sends one).
+	exec := func(t *testing.T, conn interface {
+		BindDescribeAndExecute(context.Context, string, string, [][]byte, []int16, []int16, int32, func(context.Context, *sqltypes.Result) error) (bool, error)
+	}, stmtName string,
+	) *sqltypes.Result {
+		t.Helper()
+		var got *sqltypes.Result
+		_, err := conn.BindDescribeAndExecute(ctx, "", stmtName, nil, nil, nil, 0,
+			func(_ context.Context, r *sqltypes.Result) error {
+				if got == nil && r.Fields != nil {
+					got = r
+				}
+				return nil
+			})
+		require.NoError(t, err)
+		return got
+	}
+
+	for _, target := range setup.GetComparisonTargets(t) {
+		t.Run(target.Name, func(t *testing.T) {
+			conn := connectLowLevelToPort(t, ctx, target.Port)
+			defer conn.Close()
+
+			_, err := conn.Query(ctx, "DROP TABLE IF EXISTS cptest")
+			require.NoError(t, err)
+			_, err = conn.Query(ctx, "CREATE TABLE cptest (a int, b int)")
+			require.NoError(t, err)
+			_, err = conn.Query(ctx, "INSERT INTO cptest VALUES (1, 2)")
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				c := connectLowLevelToPort(t, context.Background(), target.Port)
+				defer c.Close()
+				_, _ = c.Query(context.Background(), "DROP TABLE IF EXISTS cptest")
+			})
+
+			// Warm a prepared statement (2 columns).
+			require.NoError(t, conn.Parse(ctx, "cp_s1", "SELECT * FROM cptest", nil))
+			r1 := exec(t, conn, "cp_s1")
+			require.NotNil(t, r1)
+			assert.Len(t, r1.Fields, 2, "before DDL: two columns")
+
+			// DDL changes the result type.
+			_, err = conn.Query(ctx, "ALTER TABLE cptest DROP COLUMN b")
+			require.NoError(t, err)
+
+			// Re-Parse under a FRESH client statement name (same text) and execute.
+			// Direct PG: fresh plan → OK. Gateway pre-fix: maps to stale canonical → 0A000.
+			require.NoError(t, conn.Parse(ctx, "cp_s2", "SELECT * FROM cptest", nil))
+			r2 := exec(t, conn, "cp_s2")
+			require.NotNil(t, r2, "re-execute after DDL must succeed (no stuck 0A000)")
+			assert.Len(t, r2.Fields, 1, "after DDL: one column")
+			assert.Equal(t, "a", r2.Fields[0].Name)
+
+			require.NoError(t, conn.CloseStatement(ctx, "cp_s1"))
+			require.NoError(t, conn.CloseStatement(ctx, "cp_s2"))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

After a DDL changes a query's result columns (e.g. `ALTER TABLE ... DROP COLUMN`), every subsequent extended-protocol execution of that query text through the gateway fails with SQLSTATE `0A000` "cached plan must not change result type" — for any client, not just the one that prepared it — with no way to recover. Real PostgreSQL treats this as transient and per-connection; through multigres it persists until the affected pooled connection happens to get recycled.

This surfaced as an intermittent failure in Realtime's CDC/RLS subscription test whenever a subscription-table migration landed while a pooled connection still held a stale prepared plan for that query.

## Root cause

The multipooler caches one backend prepared statement per pooled connection by `(query, paramTypes)` and reuses it without re-Parsing as long as the text matches. After a result-type-changing DDL, PostgreSQL invalidates the plan and expects a re-Parse; reusing it instead raises `0A000`, which the pooler forwards verbatim. Because statements are shared by canonical name, even a client-side re-prepare can't help — it maps back to the same stale statement.

## Solution

Self-heal `0A000` transparently in the pooler's regular (autocommit) execute path: detect the error (new `mterrors.IsCachedPlanError` helper), close the stale backend statement, drop the per-connection cache entry, re-Parse, and retry the Bind/Execute once — the same recovery a normal PG driver performs, done on the client's behalf.

The reserved/transaction path is out of scope: an in-transaction `0A000` aborts the transaction, so healing it needs the client's rollback (separate follow-up, also overlapping an in-flight savepoint-40001 fix).