### PR TITLE
fix(multipooler): clean error on dead reserved-conn Describe (MTD06)

### DIFF
--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -1009,6 +1009,22 @@ func (e *Executor) portalExecuteWithRegular(
 	return nil, nil
 }
 
+// reservedDescribeError converts an error from an operation on an EXISTING reserved
+// connection into a client-actionable result. On a connection-level failure (dead
+// backend socket — broken pipe, ECONNRESET, EOF, server shutdown) the reserved backend
+// is gone and its session state (e.g. a temporary logical replication slot) cannot be
+// recreated on a fresh socket, so release the reservation and return a clean, retryable
+// "reserved connection terminated" error (the same signal returned when the reservation
+// is already gone) instead of wrapping the raw broken pipe into an opaque MTD06. Other
+// errors are wrapped with the given context.
+func (e *Executor) reservedDescribeError(rc *reserved.Conn, connID uint64, wrap string, err error) error {
+	if mterrors.IsConnectionError(err) {
+		rc.Release(reserved.ReleaseError, nil)
+		return mterrors.NewReservedConnectionTerminated(connID)
+	}
+	return fmt.Errorf("%s: %w", wrap, err)
+}
+
 // Describe returns metadata about a prepared statement or portal.
 func (e *Executor) Describe(
 	ctx context.Context,
@@ -1041,14 +1057,15 @@ func (e *Executor) Describe(
 
 	// Acquire the connection: reserved (transactional) or regular (pooled).
 	var conn *regular.Conn
+	var reservedConn *reserved.Conn // non-nil iff using an existing reserved connection
 	if options != nil && options.ReservedConnectionId > 0 {
-		reservedConn, _ := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
+		reservedConn, _ = e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 		if reservedConn == nil {
 			return nil, mterrors.NewReservedConnectionTerminated(options.ReservedConnectionId)
 		}
 
 		if err := e.applyReservedSessionSettingsIfNeeded(ctx, reservedConn, options); err != nil {
-			return nil, fmt.Errorf("failed to prepare reserved connection: %w", err)
+			return nil, e.reservedDescribeError(reservedConn, options.ReservedConnectionId, "failed to prepare reserved connection", err)
 		}
 
 		conn = reservedConn.Conn()
@@ -1066,6 +1083,9 @@ func (e *Executor) Describe(
 	// Ensure the statement is prepared on this connection
 	canonicalName, err := e.ensurePrepared(ctx, conn, preparedStatement)
 	if err != nil {
+		if reservedConn != nil {
+			return nil, e.reservedDescribeError(reservedConn, options.ReservedConnectionId, "failed to ensure prepared statement", err)
+		}
 		return nil, err
 	}
 
@@ -1075,6 +1095,9 @@ func (e *Executor) Describe(
 		params := sqltypes.ParamsFromProto(portal.ParamLengths, portal.ParamValues)
 		desc, err := conn.BindAndDescribe(ctx, canonicalName, params, paramFormats, resultFormats)
 		if err != nil {
+			if reservedConn != nil {
+				return nil, e.reservedDescribeError(reservedConn, options.ReservedConnectionId, "failed to describe portal", err)
+			}
 			return nil, fmt.Errorf("failed to describe portal: %w", err)
 		}
 		return desc, nil
@@ -1083,6 +1106,9 @@ func (e *Executor) Describe(
 	// Describe prepared using canonical name
 	desc, err := conn.DescribePrepared(ctx, canonicalName)
 	if err != nil {
+		if reservedConn != nil {
+			return nil, e.reservedDescribeError(reservedConn, options.ReservedConnectionId, "failed to describe prepared statement", err)
+		}
 		return nil, fmt.Errorf("failed to describe prepared statement: %w", err)
 	}
 	return desc, nil

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -1262,3 +1262,136 @@ func TestCopyAbort_NilOptionsAndNoCopyReason(t *testing.T) {
 		require.Nil(t, state)
 	})
 }
+
+// newDeadReservedConnTestExecutor spins up a reserved connection backed by a
+// fake PostgreSQL server and returns the executor, the pool, and the conn.
+// Callers force-close the connection's raw socket to simulate a silently dead
+// backend (the same failure mode as a killed/crashed PostgreSQL process),
+// then exercise Describe against it.
+func newDeadReservedConnTestExecutor(t *testing.T) (*Executor, *reserved.Pool, *reserved.Conn) {
+	t.Helper()
+
+	server := fakepgserver.New(t)
+	t.Cleanup(server.Close)
+	server.SetNeverFail(true)
+
+	pool := reserved.NewPool(context.Background(), &reserved.PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig: server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{
+				Capacity:     2,
+				MaxIdleCount: 2,
+			},
+		},
+	})
+	t.Cleanup(pool.Close)
+
+	rconn, err := pool.NewConn(context.Background(), nil)
+	require.NoError(t, err)
+
+	e := NewExecutor(slog.Default(), &stubPoolManager{reservedConn: rconn, reservedConnOK: true},
+		&clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"}, false)
+
+	return e, pool, rconn
+}
+
+// TestDescribeReservedConnDeadSocket_EnsurePreparedError is the regression for
+// MTD06 "describe failed ... broken pipe": when the reserved backend socket
+// is already dead and the statement has never been prepared on it,
+// ensurePrepared's Parse write fails first. Describe must release the
+// reservation and return a clean, retryable "reserved connection terminated"
+// error instead of wrapping the raw connection error.
+func TestDescribeReservedConnDeadSocket_EnsurePreparedError(t *testing.T) {
+	e, pool, rconn := newDeadReservedConnTestExecutor(t)
+	connID := rconn.ConnID()
+
+	// Simulate the backend socket having silently died: force-close without a
+	// graceful Terminate, so the next write fails like a real broken pipe.
+	rconn.Conn().RawConn().ForceClose()
+
+	desc, err := e.Describe(context.Background(), &query.Target{},
+		&query.PreparedStatement{Name: "s1", Query: "SELECT 1"}, nil,
+		&query.ExecuteOptions{ReservedConnectionId: uint64(connID)})
+
+	require.Nil(t, desc)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "failed to ensure prepared statement",
+		"must not leak the raw wrap/connection error")
+	assert.Equal(t, mterrors.NewReservedConnectionTerminated(uint64(connID)), err)
+
+	_, stillActive := pool.Get(connID)
+	assert.False(t, stillActive, "dead reserved connection must be released, not left dangling")
+}
+
+// TestDescribeReservedConnDeadSocket_DescribePreparedError covers the case
+// where the statement is already prepared on the reserved connection (so
+// ensurePrepared is a no-op) and the backend dies before a subsequent
+// Describe. The DescribePrepared write must fail cleanly.
+func TestDescribeReservedConnDeadSocket_DescribePreparedError(t *testing.T) {
+	e, pool, rconn := newDeadReservedConnTestExecutor(t)
+	connID := rconn.ConnID()
+	options := &query.ExecuteOptions{ReservedConnectionId: uint64(connID)}
+	stmt := &query.PreparedStatement{Name: "s1", Query: "SELECT 1"}
+
+	// Prepare the statement while the backend is still alive.
+	_, err := e.Describe(context.Background(), &query.Target{}, stmt, nil, options)
+	require.NoError(t, err)
+
+	// The backend socket dies silently; the reserved conn stays held (no
+	// background health check), same as the real MTD06 scenario.
+	rconn.Conn().RawConn().ForceClose()
+
+	desc, err := e.Describe(context.Background(), &query.Target{}, stmt, nil, options)
+	require.Nil(t, desc)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "failed to describe prepared statement",
+		"must not leak the raw wrap/connection error")
+	assert.Equal(t, mterrors.NewReservedConnectionTerminated(uint64(connID)), err)
+
+	_, stillActive := pool.Get(connID)
+	assert.False(t, stillActive, "dead reserved connection must be released, not left dangling")
+}
+
+// TestDescribeReservedConnDeadSocket_BindAndDescribeError covers the portal
+// describe path (Describe called with a bound portal rather than just a
+// prepared statement name).
+func TestDescribeReservedConnDeadSocket_BindAndDescribeError(t *testing.T) {
+	e, pool, rconn := newDeadReservedConnTestExecutor(t)
+	connID := rconn.ConnID()
+	options := &query.ExecuteOptions{ReservedConnectionId: uint64(connID)}
+	stmt := &query.PreparedStatement{Name: "s1", Query: "SELECT 1"}
+
+	// Prepare the statement while the backend is still alive.
+	_, err := e.Describe(context.Background(), &query.Target{}, stmt, nil, options)
+	require.NoError(t, err)
+
+	rconn.Conn().RawConn().ForceClose()
+
+	desc, err := e.Describe(context.Background(), &query.Target{}, stmt, &query.Portal{}, options)
+	require.Nil(t, desc)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "failed to describe portal",
+		"must not leak the raw wrap/connection error")
+	assert.Equal(t, mterrors.NewReservedConnectionTerminated(uint64(connID)), err)
+
+	_, stillActive := pool.Get(connID)
+	assert.False(t, stillActive, "dead reserved connection must be released, not left dangling")
+}
+
+// TestReservedDescribeError_NonConnectionErrorIsWrappedNotReleased verifies
+// that reservedDescribeError only treats connection-level failures as a
+// signal to release the reservation. An ordinary (non-connection) error, such
+// as a syntax error, must be wrapped with the given context and must leave
+// the reservation intact for the client to keep using.
+func TestReservedDescribeError_NonConnectionErrorIsWrappedNotReleased(t *testing.T) {
+	e, pool, rconn := newDeadReservedConnTestExecutor(t)
+	connID := rconn.ConnID()
+
+	err := e.reservedDescribeError(rconn, uint64(connID), "failed to ensure prepared statement", errors.New("syntax error"))
+
+	require.EqualError(t, err, "failed to ensure prepared statement: syntax error")
+
+	_, stillActive := pool.Get(connID)
+	assert.True(t, stillActive, "a non-connection error must not release the reservation")
+}

--- a/go/test/endtoend/queryserving/reserved_describe_deadconn_test.go
+++ b/go/test/endtoend/queryserving/reserved_describe_deadconn_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestReservedDescribeDeadConnReturnsCleanError is the regression for MTD06
+// "describe failed … broken pipe". When the backend behind a reserved connection is
+// gone, a Describe must return a clean, retryable "reserved connection terminated"
+// error (SQLSTATE 40001) — not an opaque MTD06 broken-pipe — so the client reconnects
+// (and recreates any temp replication slot) rather than seeing an internal failure.
+func TestReservedDescribeDeadConnReturnsCleanError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping end-to-end tests in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 60*time.Second)
+
+	// This is a gateway/pooler-specific path (reserved connections); run against the
+	// multigateway target.
+	var port int
+	for _, target := range setup.GetComparisonTargets(t) {
+		if target.Name == "multigateway" {
+			port = target.Port
+		}
+	}
+	require.NotZero(t, port, "multigateway target port")
+
+	conn := connectLowLevelToPort(t, ctx, port)
+	defer conn.Close()
+	killer := connectLowLevelToPort(t, ctx, port)
+	defer killer.Close()
+
+	// Reserve the connection with a transaction and prepare a statement on its backend.
+	_, err := conn.Query(ctx, "BEGIN")
+	require.NoError(t, err)
+	require.NoError(t, conn.Parse(ctx, "mtd06_d1", "SELECT $1::int", []uint32{23}))
+
+	// Identify the reserved backend pid, then terminate it from another session.
+	res, err := conn.Query(ctx, "SELECT pg_backend_pid()")
+	require.NoError(t, err)
+	require.NotEmpty(t, res)
+	pid := string(res[0].Rows[0].Values[0])
+
+	_, err = killer.Query(ctx, "SELECT pg_terminate_backend("+pid+")")
+	require.NoError(t, err)
+
+	// Let the socket fully close; the reserved conn stays held (no background health check).
+	time.Sleep(1 * time.Second)
+
+	// Describe on the now-dead reserved connection.
+	_, err = conn.DescribePrepared(ctx, "mtd06_d1")
+	require.Error(t, err, "describe on a dead reserved connection must error")
+
+	msg := err.Error()
+	assert.NotContains(t, msg, "MTD06", "must not be the opaque describe-failed code")
+	assert.NotContains(t, msg, "broken pipe", "must not surface the raw write error")
+	assert.True(t,
+		strings.Contains(msg, "reserved connection terminated") || strings.Contains(msg, "40001"),
+		"expected a clean retryable reserved-connection-terminated error, got: %s", msg)
+}


### PR DESCRIPTION
## Summary
- `Describe`'s reserved-connection branch reused an existing reserved conn with no liveness check; writing a Describe to a silently-closed backend socket failed with a broken pipe that got wrapped into an opaque `MTD06` "describe failed" error.
- A reserved connection holds session state (e.g. a temporary logical replication slot) that can't be recreated on a fresh socket, so the correct recovery is graceful failure, not a transparent reconnect: on a connection-level error from any reserved operation in `Describe` (session settings apply, `ensurePrepared`, `BindAndDescribe`, `DescribePrepared`), release the reservation and return the existing `mterrors.NewReservedConnectionTerminated` (SQLSTATE 40001, retryable) — the same clean signal already returned when `GetReservedConn` finds the reservation already gone.
- Fixes a flaky `MTD06` seen in Realtime's Postgres Changes poller (persistent reserved conn + temp slot).

## Test plan
- New end-to-end regression test `TestReservedDescribeDeadConnReturnsCleanError` (`go/test/endtoend/queryserving/reserved_describe_deadconn_test.go`): reserves a connection, prepares a statement, kills the backend from another session, waits for the socket to close, and asserts `Describe` returns a clean retryable "reserved connection terminated" error rather than `MTD06` / "broken pipe". Confirmed it fails pre-fix and passes post-fix.