### PR TITLE
fix(parser): preserve OPERATOR(schema.op) in ANY/ALL deparse

### DIFF
--- a/go/common/parser/ast/parse_infrastructure.go
+++ b/go/common/parser/ast/parse_infrastructure.go
@@ -162,6 +162,34 @@ func unwrapLikeEscape(expr Node, wrapper string) (pattern string, escape string)
 	return pattern, escape
 }
 
+// opNameOrOperatorSyntax formats an operator Name list, using the bare symbol
+// for a simple operator and OPERATOR(schema.op) syntax when the name is
+// schema-qualified (i.e. has more than one item).
+func opNameOrOperatorSyntax(name *NodeList) (op string, qualified bool) {
+	if name == nil || name.Len() == 0 {
+		return "", false
+	}
+	if name.Len() == 1 {
+		if str, ok := name.Items[0].(*String); ok {
+			return str.SVal, false
+		}
+		return name.Items[0].String(), false
+	}
+
+	// Qualified operator - format as OPERATOR(schema.op). The leading parts
+	// are schema identifiers (quote them); the final part is the operator
+	// symbol (emit verbatim).
+	var parts []string
+	for _, item := range name.Items {
+		if str, ok := item.(*String); ok {
+			parts = append(parts, QuoteIdentifierOrOperator(str.SVal))
+		} else {
+			parts = append(parts, item.String())
+		}
+	}
+	return fmt.Sprintf("OPERATOR(%s)", strings.Join(parts, ".")), true
+}
+
 // SqlString returns the SQL representation of the A_Expr
 func (a *A_Expr) SqlString() string {
 	switch a.Kind {
@@ -173,29 +201,17 @@ func (a *A_Expr) SqlString() string {
 		// Check if this is a qualified operator (OPERATOR(schema.op) syntax)
 		// Qualified operators have multiple items in the Name list
 		if a.Name.Len() > 1 {
-			// This is a qualified operator - format as OPERATOR(schema.op).
-			// The leading parts are schema identifiers (quote them); the final
-			// part is the operator symbol (emit verbatim).
-			var parts []string
-			for _, item := range a.Name.Items {
-				if str, ok := item.(*String); ok {
-					parts = append(parts, QuoteIdentifierOrOperator(str.SVal))
-				} else {
-					parts = append(parts, item.String())
-				}
-			}
-			// Join the parts with dots (e.g., "pg_catalog" "+" becomes "pg_catalog.+")
-			qualifiedOp := strings.Join(parts, ".")
+			qualifiedOp, _ := opNameOrOperatorSyntax(a.Name)
 
 			// Format the expression with OPERATOR syntax
 			if a.Lexpr != nil && a.Rexpr != nil {
 				leftStr := a.Lexpr.SqlString()
 				rightStr := a.Rexpr.SqlString()
-				return fmt.Sprintf("%s OPERATOR(%s) %s", leftStr, qualifiedOp, rightStr)
+				return fmt.Sprintf("%s %s %s", leftStr, qualifiedOp, rightStr)
 			}
 			// Unary qualified operator (rare but possible)
 			if a.Lexpr == nil && a.Rexpr != nil {
-				return fmt.Sprintf("OPERATOR(%s) %s", qualifiedOp, a.Rexpr.SqlString())
+				return fmt.Sprintf("%s %s", qualifiedOp, a.Rexpr.SqlString())
 			}
 			return "UNKNOWN_EXPR"
 		}
@@ -296,12 +312,9 @@ func (a *A_Expr) SqlString() string {
 			leftStr := a.Lexpr.SqlString()
 			rightStr := a.Rexpr.SqlString()
 
-			// Get the operator
-			op := "=" // Default operator
-			if a.Name != nil && len(a.Name.Items) > 0 {
-				if str, ok := a.Name.Items[0].(*String); ok {
-					op = str.SVal
-				}
+			op, _ := opNameOrOperatorSyntax(a.Name)
+			if op == "" {
+				op = "="
 			}
 			return fmt.Sprintf("%s %s ANY (%s)", leftStr, op, rightStr)
 		}
@@ -313,12 +326,9 @@ func (a *A_Expr) SqlString() string {
 			leftStr := a.Lexpr.SqlString()
 			rightStr := a.Rexpr.SqlString()
 
-			// Get the operator
-			op := "=" // Default operator
-			if a.Name != nil && len(a.Name.Items) > 0 {
-				if str, ok := a.Name.Items[0].(*String); ok {
-					op = str.SVal
-				}
+			op, _ := opNameOrOperatorSyntax(a.Name)
+			if op == "" {
+				op = "="
 			}
 			return fmt.Sprintf("%s %s ALL (%s)", leftStr, op, rightStr)
 		}

--- a/go/common/parser/ast/parse_infrastructure.go
+++ b/go/common/parser/ast/parse_infrastructure.go
@@ -165,20 +165,13 @@ func unwrapLikeEscape(expr Node, wrapper string) (pattern string, escape string)
 // opNameOrOperatorSyntax formats an operator Name list, using the bare symbol
 // for a simple operator and OPERATOR(schema.op) syntax when the name is
 // schema-qualified (i.e. has more than one item).
-func opNameOrOperatorSyntax(name *NodeList) (op string, qualified bool) {
+func opNameOrOperatorSyntax(name *NodeList) string {
 	if name == nil || name.Len() == 0 {
-		return "", false
-	}
-	if name.Len() == 1 {
-		if str, ok := name.Items[0].(*String); ok {
-			return str.SVal, false
-		}
-		return name.Items[0].String(), false
+		return ""
 	}
 
-	// Qualified operator - format as OPERATOR(schema.op). The leading parts
-	// are schema identifiers (quote them); the final part is the operator
-	// symbol (emit verbatim).
+	// The leading parts are schema identifiers (quote them); the final part is
+	// the operator symbol (QuoteIdentifierOrOperator emits it verbatim).
 	var parts []string
 	for _, item := range name.Items {
 		if str, ok := item.(*String); ok {
@@ -187,7 +180,13 @@ func opNameOrOperatorSyntax(name *NodeList) (op string, qualified bool) {
 			parts = append(parts, item.String())
 		}
 	}
-	return fmt.Sprintf("OPERATOR(%s)", strings.Join(parts, ".")), true
+
+	// A single, unqualified operator is emitted as the bare symbol; a
+	// schema-qualified operator needs the OPERATOR(schema.op) wrapper.
+	if len(parts) == 1 {
+		return parts[0]
+	}
+	return fmt.Sprintf("OPERATOR(%s)", strings.Join(parts, "."))
 }
 
 // SqlString returns the SQL representation of the A_Expr
@@ -201,7 +200,7 @@ func (a *A_Expr) SqlString() string {
 		// Check if this is a qualified operator (OPERATOR(schema.op) syntax)
 		// Qualified operators have multiple items in the Name list
 		if a.Name.Len() > 1 {
-			qualifiedOp, _ := opNameOrOperatorSyntax(a.Name)
+			qualifiedOp := opNameOrOperatorSyntax(a.Name)
 
 			// Format the expression with OPERATOR syntax
 			if a.Lexpr != nil && a.Rexpr != nil {
@@ -312,7 +311,7 @@ func (a *A_Expr) SqlString() string {
 			leftStr := a.Lexpr.SqlString()
 			rightStr := a.Rexpr.SqlString()
 
-			op, _ := opNameOrOperatorSyntax(a.Name)
+			op := opNameOrOperatorSyntax(a.Name)
 			if op == "" {
 				op = "="
 			}
@@ -326,7 +325,7 @@ func (a *A_Expr) SqlString() string {
 			leftStr := a.Lexpr.SqlString()
 			rightStr := a.Rexpr.SqlString()
 
-			op, _ := opNameOrOperatorSyntax(a.Name)
+			op := opNameOrOperatorSyntax(a.Name)
 			if op == "" {
 				op = "="
 			}

--- a/go/common/parser/testdata/select_cases.json
+++ b/go/common/parser/testdata/select_cases.json
@@ -1527,6 +1527,14 @@
     "query": "SELECT a OPERATOR(public.@@) b"
   },
   {
+    "comment": "qualified operator with ANY",
+    "query": "SELECT a OPERATOR(pg_catalog.=) ANY (ARRAY[1,2,3])"
+  },
+  {
+    "comment": "qualified operator with ALL",
+    "query": "SELECT a OPERATOR(pg_catalog.=) ALL (ARRAY[1,2,3])"
+  },
+  {
     "comment": "bit type casting",
     "query": "SELECT value::bit",
     "expected": "SELECT CAST(value AS bit)"


### PR DESCRIPTION
While testing multigres against the supabase storage repo's migration idempotency check ([supabase/storage#1155 CI run](https://github.com/supabase/storage/actions/runs/28593651310/job/84783455746?pr=1155)), `pg_dump` failed with:

```
pg_dump: error: query failed: ERROR:  syntax error at or near "pg_catalog"
LINE 5: WHERE c.relkind OPERATOR(pg_catalog.=) ANY
                          ^
pg_dump: detail: Query was: SELECT c.oid
FROM pg_catalog.pg_class c
     LEFT JOIN pg_catalog.pg_namespace n
     ON n.oid OPERATOR(pg_catalog.=) c.relnamespace
WHERE c.relkind OPERATOR(pg_catalog.=) ANY
    (array['r', 'S', 'v', 'm', 'f', 'p'])
  AND c.relname OPERATOR(pg_catalog.~) '^(migrations)$' COLLATE pg_catalog.default
  AND n.nspname OPERATOR(pg_catalog.~) '^(storage)$' COLLATE pg_catalog.defaultlt
```

`pg_dump` uses `OPERATOR(schema.op) ANY (...)` / `ALL (...)` syntax in its own introspection queries. When multigateway parses and re-serializes a query like this, it was dropping the `OPERATOR(pg_catalog.=)` part and rewriting it as just `pg_catalog`, which is invalid SQL.

The fix makes the query re-serialization handle this `OPERATOR(schema.op)` form correctly for `ANY`/`ALL` expressions, the same way it was already handled for plain comparisons.