### PR TITLE
refactor(multigateway): route by writable routing role, not consensus role

### DIFF
--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -1868,13 +1868,32 @@ func (x *PoolerPosition) GetLsn() string {
 	return ""
 }
 
-// LeaderObservation represents a pooler's view of who the consensus leader is.
-// It is carried in two places:
-//   - the leader's own MultiPooler topology record (self_leadership field), so
-//     multigateway can bootstrap leader routing from etcd at discovery time
-//     without relying on MultiPooler.type as a hint; and
+// LeaderObservation is a pooler's report of the writable routing primary — in
+// practice a pooler reporting itself once it is the active, writable leader. It
+// is carried in two places:
 //   - the multipooler health stream
-//     (StreamPoolerHealthResponse.leader_observation).
+//     (StreamPoolerHealthResponse.leader_observation), which multigateway uses as
+//     the live, authoritative signal for routing writes; and
+//   - the leader's own MultiPooler topology record (self_leadership field), a
+//     projection of the same fact. NOTE: multigateway no longer consults the
+//     topology record for leader identity — routing is driven purely by the live
+//     health stream.
+//
+// TODO(routing-state, fast-follow): the gateway now reasons about *routing*
+// (which pooler is the writable primary), not consensus leadership, so this
+// message should evolve into
+//
+//	message RoutingState { RoutingRole role = 1; RuleNumber rule = 2; }
+//
+// with a new prefixed proto3 enum
+//
+//	enum RoutingRole { ROUTING_ROLE_UNKNOWN = 0; ROUTING_ROLE_PRIMARY = 1;
+//	                   ROUTING_ROLE_REPLICA = 2; }
+//
+// leader_id then drops out: a pooler only reports its own routing state, so the
+// identity is contextual. This mirrors the internal servingstate.RoutingRole /
+// State.Leadership pair. Keep RoutingState off the orch-facing consensus-fitness
+// path — orch derives writability from consensus state, not this routing label.
 type LeaderObservation struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// leader_id is the ID of the pooler this node believes is the consensus leader.

--- a/go/pb/multipoolerservice/multipoolerservice.pb.go
+++ b/go/pb/multipoolerservice/multipoolerservice.pb.go
@@ -2187,13 +2187,8 @@ type StreamPoolerHealthResponse struct {
 	// replication_lag_ns is the current replication lag in nanoseconds,
 	// measured via heartbeat timestamps. Zero on a leader or when unknown.
 	ReplicationLagNs int64 `protobuf:"varint,6,opt,name=replication_lag_ns,json=replicationLagNs,proto3" json:"replication_lag_ns,omitempty"`
-	// writable reports whether this pooler can accept writes — i.e. postgres is
-	// out of recovery (!pg_is_in_recovery). A consensus leader mid-promotion is
-	// SERVING (can answer reads) but not yet writable, so clients must gate write
-	// traffic on this rather than on pooler_type/serving_status alone.
-	Writable      bool `protobuf:"varint,7,opt,name=writable,proto3" json:"writable,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *StreamPoolerHealthResponse) Reset() {
@@ -2259,13 +2254,6 @@ func (x *StreamPoolerHealthResponse) GetReplicationLagNs() int64 {
 		return x.ReplicationLagNs
 	}
 	return 0
-}
-
-func (x *StreamPoolerHealthResponse) GetWritable() bool {
-	if x != nil {
-		return x.Writable
-	}
-	return false
 }
 
 // StreamNotificationsRequest subscribes to or unsubscribes from PG notification channels.
@@ -2503,14 +2491,13 @@ const file_multipoolerservice_proto_rawDesc = "" +
 	"\tcaller_id\x18\x02 \x01(\v2\x0f.mtrpc.CallerIDR\bcallerId\x12/\n" +
 	"\aoptions\x18\x03 \x01(\v2\x15.query.ExecuteOptionsR\aoptions\"#\n" +
 	"!ReleaseReservedConnectionResponse\"\x1b\n" +
-	"\x19StreamPoolerHealthRequest\"\x97\x03\n" +
+	"\x19StreamPoolerHealthRequest\"\xfb\x02\n" +
 	"\x1aStreamPoolerHealthResponse\x120\n" +
 	"\tpooler_id\x18\x02 \x01(\v2\x13.clustermetadata.IDR\bpoolerId\x12K\n" +
 	"\x0eserving_status\x18\x03 \x01(\x0e2$.clustermetadata.PoolerServingStatusR\rservingStatus\x12Q\n" +
 	"\x12leader_observation\x18\x04 \x01(\v2\".clustermetadata.LeaderObservationR\x11leaderObservation\x12]\n" +
 	"\x1drecommended_staleness_timeout\x18\x05 \x01(\v2\x19.google.protobuf.DurationR\x1brecommendedStalenessTimeout\x12,\n" +
-	"\x12replication_lag_ns\x18\x06 \x01(\x03R\x10replicationLagNs\x12\x1a\n" +
-	"\bwritable\x18\a \x01(\bR\bwritable\"_\n" +
+	"\x12replication_lag_ns\x18\x06 \x01(\x03R\x10replicationLagNs\"_\n" +
 	"\x1aStreamNotificationsRequest\x12%\n" +
 	"\x06target\x18\x01 \x01(\v2\r.query.TargetR\x06target\x12\x1a\n" +
 	"\bchannels\x18\x02 \x03(\tR\bchannels\"X\n" +

--- a/go/services/multigateway/poolergateway/load_balancer.go
+++ b/go/services/multigateway/poolergateway/load_balancer.go
@@ -144,6 +144,17 @@ func (s *shardSummary) clearPrimary(poolerID topoclient.ComponentID) bool {
 	return !sameObservation(before, s.primaries.highest())
 }
 
+// hasPrimary reports whether poolerID currently claims to be a routing primary
+// for this shard — i.e. its latest health observation named itself. This is the
+// single authority for "believes itself the writable primary": both stale-leader
+// detection and replica-read exclusion read it, rather than re-deriving the same
+// signal from each connection's live health.
+func (s *shardSummary) hasPrimary(poolerID topoclient.ComponentID) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.primaries.has(poolerID)
+}
+
 // sameObservation reports whether two leader observations name the same elected
 // leader at the same rule (both nil counts as same).
 func sameObservation(a, b *clustermetadatapb.LeaderObservation) bool {
@@ -156,29 +167,27 @@ func sameObservation(a, b *clustermetadatapb.LeaderObservation) bool {
 // constructs the connection, and OnGone closes it. loadBalancer owns no
 // per-pooler registry of its own.
 //
-// Per-shard state is tracked via the shards map, populated from two sources
-// that both carry a rule number: a pooler's self_leadership in its topology
-// record (folded in when the hook calls mergeTopologyLeader) and
-// LeaderObservation messages on health streams (delivered via
-// onPoolerHealthUpdate). The most-authoritative observation (highest rule
-// number) wins, regardless of source. The pooler.Type field from etcd
-// topology is never consulted for leader identity — only self_leadership is.
-// A shardSummary survives connection lifecycle events except when the last
-// pooler in the shard leaves (see onPoolerGone): removing one pooler does
-// not erase consensus's choice of leader.
+// Per-shard state is tracked via the shards map. Each shardSummary holds the
+// SET of poolers currently claiming to be the writable routing primary, fed
+// entirely by live health-stream observations (via onPoolerHealthUpdate): a
+// pooler is added when its own observation names itself and retracted when it
+// stops claiming or leaves. The etcd topology — pooler.Type and self_leadership
+// alike — is never consulted for leader identity; only a live, self-attested
+// health observation counts. A shardSummary survives connection lifecycle
+// events until the last pooler in the shard leaves (see onPoolerGone).
 //
 // Concurrency: a two-lock model is in play.
 //   - lb.mu protects ONLY the lb.shards map (lookups, inserts, deletes).
-//   - Each *shardSummary has its own mu protecting its leader field; reads
-//     go through leader(), mutations through mergeLeader().
+//   - Each *shardSummary has its own mu protecting its routing-primary set;
+//     reads go through leader()/hasPrimary(), mutations through
+//     setPrimary/clearPrimary.
 //
 // Lock ordering: take lb.mu first (if needed), then summary.mu. No method
 // holds both at once — summaryForPooler() releases lb.mu before returning the
 // *shardSummary, and callers then invoke summary methods which self-lock.
 // Cache reads happen after lb.mu has been released, so the cache OnLive/
-// OnGone hooks (which call mergeTopologyLeader / notifyIfLeaderServing →
-// lb.mu) can never deadlock against an LB method holding lb.mu and waiting
-// on the cache.
+// OnGone hooks (which call onPoolerHealthUpdate / onPoolerGone → lb.mu) can
+// never deadlock against an LB method holding lb.mu and waiting on the cache.
 type loadBalancer struct {
 	// localCell is the cell where this gateway is running
 	localCell string
@@ -192,15 +201,13 @@ type loadBalancer struct {
 	// mu protects shards.
 	mu sync.Mutex
 
-	// shards maps shard key to the gateway's per-shard summary (currently the
-	// most-authoritative LeaderObservation seen for that shard). Populated
-	// from a pooler's self_leadership topology record (via
-	// mergeTopologyLeader) and from LeaderObservation messages on health
-	// streams (via onPoolerHealthUpdate). The leader_id field of the
-	// observation may name a pooler we are not currently connected to —
-	// GetConnection handles that case at read time by consulting the cache.
-	// Entries are auto-cleared by onPoolerGone once no poolers remain in the
-	// shard.
+	// shards maps shard key to the gateway's per-shard summary — the set of
+	// poolers currently claiming to be the writable routing primary for that
+	// shard. Populated solely from LeaderObservation messages on health streams
+	// (via onPoolerHealthUpdate); the elected leader (highest-rule claimant) may
+	// name a pooler we are not currently connected to — GetConnection handles
+	// that at read time by consulting the cache. Entries are auto-cleared by
+	// onPoolerGone once no poolers remain in the shard.
 	shards map[shardKey]*shardSummary
 
 	// cache is the pooler cache that owns the per-pooler *poolerConnection
@@ -428,7 +435,7 @@ func (lb *loadBalancer) getConnection(target *query.Target) (*poolerConnection, 
 			if conn == nil {
 				continue
 			}
-			if matchesReplicaTarget(conn, target) {
+			if lb.matchesReplicaTarget(conn, target) {
 				candidates = append(candidates, conn)
 			}
 		}
@@ -653,26 +660,48 @@ func matchesShardTarget(conn *poolerConnection, target *query.Target) bool {
 }
 
 // matchesReplicaTarget reports whether conn is eligible to serve REPLICA
-// traffic for target: it is in the shard and does not believe itself the shard
-// leader. Leadership is judged per-connection from the better of the pooler's
-// etcd self_leadership and its health-stream observation (see
-// believesSelfLeader), never from the topology Type label.
+// traffic for target: it is in the shard and does not claim to be a routing
+// primary. Leadership is judged from the shard summary's routing-primary set
+// (fed by health-stream observations, see claimsPrimary), never from the
+// topology Type label.
 //
-// Excluding self-believed leaders covers both the current leader and a stale
-// leader — a pooler whose own view still names it the leader even though a
-// newer leader has been observed. Either would serve reads as a primary or from
-// a diverged timeline, so neither is a replica candidate.
+// Any primary claimant is excluded, not just the elected one. The reason is
+// forward-looking, not about stale timelines: a pooler that claims primary but
+// is not (or is no longer) the winning leader is headed for demotion, and
+// demoting it back to a replica restarts postgres — often with a pg_rewind to
+// discard diverged WAL. That restart drains gracefully (in-flight queries get a
+// grace period to finish), so it is not an abrupt kill; but any query slow
+// enough to outlast the grace period is interrupted. Sending fresh replica reads
+// to a pooler we expect to restart soon needlessly exposes them to that risk, so
+// a lower-rule (stale) claimant is excluded too, until it stops claiming primary.
 //
 // TODO(replica-quality): eligibility is otherwise binary. Longer term, treat a
 // replica as degraded when it is not actively replicating or has fallen behind,
 // and prefer non-degraded replicas when several are available. That belongs in
 // selectReplicaConnection (which already tiers by lag), with the per-pooler
 // signal carried on the health observation.
-func matchesReplicaTarget(conn *poolerConnection, target *query.Target) bool {
+func (lb *loadBalancer) matchesReplicaTarget(conn *poolerConnection, target *query.Target) bool {
 	if !matchesShardTarget(conn, target) {
 		return false
 	}
-	return !conn.believesSelfLeader()
+	return !lb.claimsPrimary(conn)
+}
+
+// claimsPrimary reports whether conn currently claims to be a routing primary
+// for its shard, per the shard summary's routing-primary set. It is the single
+// authority for the "believes itself the writable primary" signal — the same
+// signal onPoolerHealthUpdate folds into the summary — consulted by both
+// leadershipFor (stale-leader label) and matchesReplicaTarget (replica
+// exclusion).
+func (lb *loadBalancer) claimsPrimary(conn *poolerConnection) bool {
+	if conn == nil {
+		return false
+	}
+	key := shardKeyOf(conn.PoolerInfo().GetShardKey())
+	lb.mu.Lock()
+	summary := lb.shards[key]
+	lb.mu.Unlock()
+	return summary != nil && summary.hasPrimary(conn.ID())
 }
 
 // connectionCount returns the number of active connections, sourced from the
@@ -698,10 +727,9 @@ const (
 )
 
 // leadershipFor returns the consensus leadership role of a single connected
-// pooler for the admin/status page. The role reflects the gateway's merged
-// view — the shard's shardSummary (self_leadership combined with
-// health-stream observations) and the pooler's own belief — never the
-// topology Type label.
+// pooler for the admin/status page. The role reflects the gateway's live view —
+// the shard's shardSummary routing-primary set, fed by health-stream
+// observations — never the topology Type label.
 func (lb *loadBalancer) leadershipFor(conn *poolerConnection) string {
 	if conn == nil {
 		return leadershipFollower
@@ -712,19 +740,19 @@ func (lb *loadBalancer) leadershipFor(conn *poolerConnection) string {
 	lb.mu.Lock()
 	summary := lb.shards[key]
 	lb.mu.Unlock()
-	var leader *clustermetadatapb.LeaderObservation
-	if summary != nil {
-		leader = summary.leader()
+	if summary == nil {
+		return leadershipFollower
 	}
+	leader := summary.leader()
 
-	// The shard's consensus leader (merged across every pooler's
-	// self_leadership and health-stream reports) takes precedence, so a
-	// leader whose own record lags is still reported as the leader.
-	// Otherwise a pooler that still believes itself leader is stale.
+	// The shard's elected routing primary (highest-rule claimant across all
+	// health-stream reports) takes precedence. A pooler that still claims to be
+	// a routing primary but is not the elected one is stale — consensus has
+	// moved on to a higher rule.
 	switch {
 	case leader != nil && topoclient.ComponentIDString(leader.LeaderId) == conn.ID():
 		return leadershipLeader
-	case conn.believesSelfLeader():
+	case summary.hasPrimary(conn.ID()):
 		return leadershipStaleLeader
 	}
 	return leadershipFollower

--- a/go/services/multigateway/poolergateway/load_balancer.go
+++ b/go/services/multigateway/poolergateway/load_balancer.go
@@ -52,51 +52,102 @@ func shardKeyOf(sk *clustermetadatapb.ShardKey) shardKey {
 	}
 }
 
-// shardSummary holds the gateway's per-shard consensus state.
+// shardSummary holds the gateway's per-shard routing state.
 // One shardSummary exists per (tableGroup, shard) pair while any pooler
 // from that shard is tracked in the cache. It is auto-created on the
 // first observation for the shard and auto-cleared once no poolers from
 // the shard remain.
 //
-// Concurrency: leader is protected by mu. Read via leader(), mutate via
-// mergeLeader(). The shardKey field is immutable after construction and
-// safe to read without holding mu.
+// The state is the SET of poolers currently claiming to be the writable
+// (routing) primary — membership means "this pooler is a routing primary right
+// now," keyed by pooler id. This is distinct from consensus: orch reasons about
+// the highest-known rule over consensus statuses; the gateway only cares which
+// pooler(s) are writable primaries. The observation's rule number is used only
+// as a tiebreaker to pick among members during the brief failover-overlap window
+// when two poolers both claim primary. A pooler is added when it advertises
+// itself as a writable primary and removed when it stops (demoted, no longer
+// writable) or leaves — so a stale primary retracts rather than sticking.
+//
+// Concurrency: primaries is protected by mu. Read the elected leader via
+// leader(), mutate via setPrimary/clearPrimary. shardKey is immutable.
 type shardSummary struct {
 	// shardKey identifies the shard — database, tablegroup, shard.
 	shardKey *clustermetadatapb.ShardKey
 
-	mu sync.Mutex
-	// leaderObs is the most-authoritative LeaderObservation seen across this
-	// shard's poolers — merged across self_leadership topology records
-	// (folded in at mergeTopologyLeader time) and LeaderObservation
-	// messages on health streams (folded in via onPoolerHealthUpdate).
-	// May be nil if no leader has been observed yet.
-	leaderObs *clustermetadatapb.LeaderObservation
+	mu        sync.Mutex
+	primaries primarySet
 }
 
-// leader returns a snapshot of the current leader observation, or nil
-// if no leader has been observed yet. Safe to call concurrently.
+// primarySet is the set of poolers currently claiming to be the writable
+// routing primary for a shard, keyed by pooler id, each carrying the rule under
+// which it claimed. It exposes only what the gateway needs — add/remove by id
+// and "the highest-rule member" — behind a named type so the storage can change
+// without touching callers. No heap or sorted structure is warranted: the number
+// of simultaneous primary claims per shard is expected to be very low in practice
+// (normally one, briefly two during a failover overlap), so a plain map with a
+// linear highest() scan is the right call. Not safe for concurrent use —
+// shardSummary.mu guards it.
+type primarySet struct {
+	byID map[topoclient.ComponentID]*clustermetadatapb.LeaderObservation
+}
+
+func (p *primarySet) set(id topoclient.ComponentID, obs *clustermetadatapb.LeaderObservation) {
+	if p.byID == nil {
+		p.byID = make(map[topoclient.ComponentID]*clustermetadatapb.LeaderObservation)
+	}
+	p.byID[id] = obs
+}
+
+func (p *primarySet) clear(id topoclient.ComponentID) { delete(p.byID, id) }
+
+func (p *primarySet) has(id topoclient.ComponentID) bool { _, ok := p.byID[id]; return ok }
+
+// highest returns the member with the highest rule, or nil if the set is empty.
+func (p *primarySet) highest() *clustermetadatapb.LeaderObservation {
+	var best *clustermetadatapb.LeaderObservation
+	for _, obs := range p.byID {
+		if best == nil || commonconsensus.CompareRuleNumbers(obs.GetLeaderRuleNumber(), best.GetLeaderRuleNumber()) > 0 {
+			best = obs
+		}
+	}
+	return best
+}
+
+// leader returns the routing primary with the highest rule, or nil if the shard
+// currently has no writable leader. Safe to call concurrently.
 func (s *shardSummary) leader() *clustermetadatapb.LeaderObservation {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.leaderObs
+	return s.primaries.highest()
 }
 
-// mergeLeader installs obs as this shard's leader if it strictly
-// supersedes whatever's there now (or there's nothing there). Returns
-// true if installed. Safe to call concurrently.
-//
-// TODO: rename LeadershipObservation to RoutingState and make sure only active primaries
-// publish routing state.
-func (s *shardSummary) mergeLeader(obs *clustermetadatapb.LeaderObservation) bool {
+// setPrimary records poolerID as a routing primary at obs's rule (adds it to the
+// set or updates its rule). Returns true if the elected leader changed.
+func (s *shardSummary) setPrimary(poolerID topoclient.ComponentID, obs *clustermetadatapb.LeaderObservation) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	merged := commonconsensus.MostAuthoritativeObservation(s.leaderObs, obs)
-	if merged == s.leaderObs {
+	before := s.primaries.highest()
+	s.primaries.set(poolerID, obs)
+	return !sameObservation(before, s.primaries.highest())
+}
+
+// clearPrimary removes poolerID from the routing-primary set (retraction).
+// Returns true if the elected leader changed. Safe on an absent pooler.
+func (s *shardSummary) clearPrimary(poolerID topoclient.ComponentID) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.primaries.has(poolerID) {
 		return false
 	}
-	s.leaderObs = merged
-	return true
+	before := s.primaries.highest()
+	s.primaries.clear(poolerID)
+	return !sameObservation(before, s.primaries.highest())
+}
+
+// sameObservation reports whether two leader observations name the same elected
+// leader at the same rule (both nil counts as same).
+func sameObservation(a, b *clustermetadatapb.LeaderObservation) bool {
+	return proto.Equal(a, b)
 }
 
 // loadBalancer selects poolerConnections for queries. The set of tracked
@@ -227,33 +278,6 @@ func newLoadBalancer(opts loadBalancerOpts) *loadBalancer {
 	}
 }
 
-// mergeTopologyLeader folds a pooler's self_leadership observation (from its
-// topology record) into the shard's shardSummary, keeping whichever
-// observation has the higher rule number. A pooler that is not the leader
-// carries no self_leadership, so this is a no-op for it — it never clears an
-// existing entry, since a higher observation from any source is what
-// supersedes a leader.
-//
-// Called by the pooler cache's OnLive and OnUpdate hooks. Acquires lb.mu and
-// the summary's mu internally (in that order, non-overlapping); must not be
-// called while holding either.
-func (lb *loadBalancer) mergeTopologyLeader(pooler *clustermetadatapb.MultiPooler) {
-	obs := pooler.GetSelfLeadership()
-	if obs == nil {
-		return
-	}
-	summary := lb.summaryForPooler(pooler)
-	if !summary.mergeLeader(obs) {
-		return
-	}
-
-	lb.logger.Debug("leader observation from topology self_leadership",
-		"pooler_id", topoclient.ComponentIDString(pooler.Id),
-		"tablegroup", pooler.GetShardKey().GetTableGroup(),
-		"shard", pooler.GetShardKey().GetShard(),
-		"rule", commonconsensus.FormatRuleNumber(obs.GetLeaderRuleNumber()))
-}
-
 // shardSummary returns the existing summary for the shard, creating one if
 // absent. The returned *shardSummary is owned by the cache; callers mutate
 // via its methods (which self-lock). Briefly holds lb.mu; releases it before
@@ -315,17 +339,12 @@ func (lb *loadBalancer) notifyLeaderServingFromSummary(summary *shardSummary, co
 	if health == nil || !health.isServing() {
 		return
 	}
-	// The pooler's own broadcast LeaderObservation must name itself as
-	// leader.
+	// The pooler's own broadcast observation must name itself as leader — it is
+	// the elected routing primary and it is attesting to that itself. That
+	// observation implies writability (a pooler advertises leadership only once it
+	// is the writable routing primary), so draining the failover buffer toward it
+	// is safe without a separate writability check.
 	if !proto.Equal(health.LeaderObservation.GetLeaderId(), connID) {
-		return
-	}
-	// Gate write-resume on writability, not just leadership. A leader can answer
-	// reads (CONSISTENT) and report SERVING before it has finished promoting,
-	// while postgres is still in recovery. Draining the failover buffer then would
-	// route buffered writes to a read-only node ("cannot ... during recovery" /
-	// read-only transaction). isWritable() reflects postgres being out of recovery.
-	if !health.isWritable() {
 		return
 	}
 	lb.onLeaderServing(summary.shardKey)
@@ -573,27 +592,35 @@ func (lb *loadBalancer) selectReplicaConnection(candidates []*poolerConnection) 
 // release healthMu before invoking this callback.
 func (lb *loadBalancer) onPoolerHealthUpdate(conn *poolerConnection) {
 	health := conn.Health()
-	if health == nil || health.LeaderObservation == nil {
+	if health == nil {
 		return
 	}
 
-	obs := health.LeaderObservation
+	poolerID := topoclient.ComponentIDString(conn.PoolerInfo().GetId())
 	summary := lb.summaryForPooler(conn.PoolerInfo().MultiPooler)
-	if summary.mergeLeader(obs) {
-		lb.logger.Debug("leader observation recorded",
-			"tablegroup", summary.shardKey.GetTableGroup(),
-			"shard", summary.shardKey.GetShard(),
-			"leader_id", topoclient.ComponentIDString(obs.LeaderId),
-			"rule", commonconsensus.FormatRuleNumber(obs.GetLeaderRuleNumber()))
+
+	// A pooler is a routing primary iff its broadcast observation names itself.
+	// The observation implies writability: a pooler only advertises itself as the
+	// leader once it is the writable routing primary (out of recovery and the
+	// active committed leader), so the gateway needs no separate writability
+	// check. Anything else — a follower naming another leader, or no observation —
+	// retracts any prior claim (demotion / no-longer-primary).
+	obs := health.LeaderObservation
+	if obs != nil && proto.Equal(obs.GetLeaderId(), conn.PoolerInfo().GetId()) {
+		if summary.setPrimary(poolerID, obs) {
+			lb.logger.Debug("routing primary recorded",
+				"tablegroup", summary.shardKey.GetTableGroup(),
+				"shard", summary.shardKey.GetShard(),
+				"leader_id", poolerID,
+				"rule", commonconsensus.FormatRuleNumber(obs.GetLeaderRuleNumber()))
+		}
+	} else {
+		summary.clearPrimary(poolerID)
 	}
 
-	// Whether or not the observation was newly installed, re-check the
-	// SERVING-leader notification. A stale-rule observation can be ignored
-	// here entirely (mergeLeader returned false and the existing leader is
-	// unrelated), but for the "same rule, leader has just become SERVING"
-	// case we still need to notify. notifyIfLeaderServing's checks are
-	// idempotent and cheap, so always calling it is simpler than retaining
-	// the cmp>0 / cmp==0 / cmp<0 split.
+	// Re-check the SERVING-leader notification: if the elected routing primary is
+	// this (or any) connected pooler and it is serving, drain the failover buffer.
+	// Idempotent and cheap, so always calling it is simpler than tracking deltas.
 	leader := summary.leader()
 	if leader == nil || lb.cache == nil {
 		return
@@ -727,11 +754,23 @@ func (lb *loadBalancer) onPoolerGone(p *clustermetadatapb.MultiPooler) {
 		return
 	}
 	sk := p.GetShardKey()
+	key := shardKeyOf(sk)
+
+	lb.mu.Lock()
+	summary := lb.shards[key]
+	lb.mu.Unlock()
+
+	// Retract the departing pooler's routing-primary claim even when other
+	// poolers remain — otherwise a leader that left the topology would stick in
+	// the set as a phantom primary.
+	if summary != nil {
+		summary.clearPrimary(topoclient.ComponentIDString(p.GetId()))
+	}
+
+	// Drop the summary entirely once no poolers remain in the shard.
 	if len(lb.cache.GetByShard(sk.GetDatabase(), sk.GetTableGroup(), sk.GetShard())) > 0 {
 		return
 	}
-	key := shardKeyOf(sk)
-
 	lb.mu.Lock()
 	delete(lb.shards, key)
 	lb.mu.Unlock()

--- a/go/services/multigateway/poolergateway/load_balancer_test.go
+++ b/go/services/multigateway/poolergateway/load_balancer_test.go
@@ -21,9 +21,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/common/topoclient"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	"github.com/multigres/multigres/go/pb/multipoolerservice"
 	"github.com/multigres/multigres/go/pb/query"
 )
@@ -164,11 +166,15 @@ func TestLoadBalancer_GetConnection_NilTarget(t *testing.T) {
 func TestLoadBalancer_GetConnection_NoMatch(t *testing.T) {
 	lb := newTestLB(t, "zone1")
 
-	// Add a primary (a real PRIMARY record carries self_leadership).
-	primary := withSelfLeadership(createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY), 1)
+	// Add a primary that self-attests as leader on its health stream, so it is
+	// excluded from replica reads.
+	primary := createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
 	addPoolerForTest(t, lb, primary)
+	simulateHealthUpdate(connForTest(t, lb, primary), clustermetadatapb.PoolerServingStatus_SERVING,
+		&clustermetadatapb.LeaderObservation{LeaderId: primary.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
 
-	// Request a replica - should not find one
+	// Request a replica - should not find one (only the primary exists, and a
+	// self-attesting leader is excluded from replica reads).
 	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "", query.Mode_MODE_INCONSISTENT)
 	_, err := lb.getConnection(target)
 	require.Error(t, err)
@@ -247,6 +253,48 @@ func TestLoadBalancer_WriteResumeWaitsForServingSelfNamedLeader(t *testing.T) {
 	simulateHealthUpdate(conn, clustermetadatapb.PoolerServingStatus_SERVING,
 		&clustermetadatapb.LeaderObservation{LeaderId: p.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5}})
 	assert.Equal(t, 1, resumed, "resume once the leader observes itself as the serving primary")
+}
+
+// TestLoadBalancer_ConsistentBuffersUntilLeaderWritable verifies that CONSISTENT
+// reads route to the writable leader, not to an appointed-but-not-yet-established
+// one. A pooler appointed leader by consensus does not advertise itself until it
+// is actually writable (out of recovery and its committed rule is active), so it
+// carries no routing-primary claim. Until then CONSISTENT (like WRITABLE) has no
+// leader to route to and returns UNAVAILABLE — the gateway buffers rather than
+// serving read-your-writes traffic from a leader that may not yet have replayed
+// the latest commits. Once the leader self-reports writable, CONSISTENT routes to
+// it.
+func TestLoadBalancer_ConsistentBuffersUntilLeaderWritable(t *testing.T) {
+	lb := newTestLB(t, "zone1")
+
+	p := createTestMultiPooler("appointee", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+	addPoolerForTest(t, lb, p)
+	conn := connForTest(t, lb, p)
+
+	// Appointed leader, SERVING, but still establishing: its broadcast names the
+	// prior leader (not yet writable itself), so it makes no routing-primary claim.
+	oldLeaderID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "zone1",
+		Name:      "old-leader",
+	}
+	simulateHealthUpdate(conn, clustermetadatapb.PoolerServingStatus_SERVING,
+		&clustermetadatapb.LeaderObservation{LeaderId: oldLeaderID, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4}})
+
+	consistent := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_CONSISTENT)
+	_, err := lb.getConnection(consistent)
+	require.Error(t, err, "CONSISTENT must not route while no leader is writable")
+	assert.Equal(t, mtrpcpb.Code_UNAVAILABLE, mterrors.Code(err),
+		"a not-yet-established leader must buffer, not serve CONSISTENT reads")
+
+	// The appointee establishes itself: out of recovery and active committed
+	// leader, so it now advertises itself as the writable primary.
+	simulateHealthUpdate(conn, clustermetadatapb.PoolerServingStatus_SERVING,
+		&clustermetadatapb.LeaderObservation{LeaderId: p.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5}})
+
+	got, err := lb.getConnection(consistent)
+	require.NoError(t, err, "CONSISTENT routes once the leader is writable")
+	assert.Equal(t, poolerID(p), got.ID())
 }
 
 func TestLoadBalancer_PrimaryCaching(t *testing.T) {
@@ -723,44 +771,6 @@ func TestLoadBalancer_StaleLeaderExcludedFromReplicas(t *testing.T) {
 		assert.Equal(t, poolerID(replica), conn.ID(),
 			"reads must avoid both the leader and the stale leader")
 	}
-}
-
-// TestLoadBalancer_CentrallyKnownLeaderUnknownToItselfEligibleAsReplica
-// documents the inverse of the stale-leader case: a pooler the central leaders
-// map knows to be the leader — populated by a peer's health-stream observation
-// — is still eligible for replica reads when its own view does not yet name it
-// the leader (etcd self_leadership absent and its own health stream not yet
-// reported). matchesReplicaTarget consults only the per-connection
-// believesSelfLeader, never the central map, so the leader is not excluded here.
-//
-// This is benign: a read served by the actual current leader sees the most
-// up-to-date data, so it cannot violate read consistency. The window is also
-// narrow — it closes the moment the leader's own health stream reports or its
-// etcd record gains self_leadership. The dangerous direction (serving from a
-// stale leader on an older rule) is covered by the test above.
-func TestLoadBalancer_CentrallyKnownLeaderUnknownToItselfEligibleAsReplica(t *testing.T) {
-	lb := newTestLB(t, "zone1")
-
-	// leader's etcd record lags: discovered without self_leadership, and its own
-	// health stream has not reported, so believesSelfLeader(leader) is false.
-	leader := createTestMultiPooler("leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
-	addPoolerForTest(t, lb, leader)
-
-	// A peer's health stream has already named `leader` the shard leader at rule
-	// 2, recorded in the central map. Set it directly rather than wiring a second
-	// connection, mirroring how onPoolerHealthUpdate would populate it.
-	setLeaderForTest(t, lb, constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", &clustermetadatapb.LeaderObservation{
-		LeaderId:         leader.Id,
-		LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2},
-	})
-
-	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_INCONSISTENT)
-	// `leader` is the only connection and is eligible despite the central map
-	// naming it the leader, so it is returned rather than erroring as no-candidate.
-	conn, err := lb.getConnection(target)
-	require.NoError(t, err)
-	assert.Equal(t, poolerID(leader), conn.ID(),
-		"a centrally-known leader unaware of its own leadership is eligible for replica reads")
 }
 
 // TestLoadBalancer_LeadershipFor verifies the three roles reported for the

--- a/go/services/multigateway/poolergateway/load_balancer_test.go
+++ b/go/services/multigateway/poolergateway/load_balancer_test.go
@@ -214,12 +214,14 @@ func simulateHealthUpdate(conn *poolerConnection, status clustermetadatapb.Poole
 	})
 }
 
-// TestLoadBalancer_WriteResumeWaitsForWritable verifies the buffer-drain gate
-// (notifyLeaderServingFromSummary → onLeaderServing) does NOT resume write
-// traffic for a leader that is the observed leader and SERVING but not yet
-// writable (still in recovery mid-promotion). It resumes only once the leader
-// reports writable.
-func TestLoadBalancer_WriteResumeWaitsForWritable(t *testing.T) {
+// TestLoadBalancer_WriteResumeWaitsForServingSelfNamedLeader verifies the
+// buffer-drain gate (notifyLeaderServingFromSummary → onLeaderServing) does NOT
+// resume write traffic while the leader's own broadcast names a different leader
+// (pre-promotion), and DOES resume once the elected primary's own health
+// snapshot self-identifies as leader AND is SERVING. Under the new model a
+// self-naming LeaderObservation implies writability, so there is no separate
+// writable gate — obs-presence is the writable signal.
+func TestLoadBalancer_WriteResumeWaitsForServingSelfNamedLeader(t *testing.T) {
 	lb := newTestLB(t, "zone1")
 
 	var resumed int
@@ -229,26 +231,22 @@ func TestLoadBalancer_WriteResumeWaitsForWritable(t *testing.T) {
 	addPoolerForTest(t, lb, p)
 	conn := connForTest(t, lb, p)
 
-	obs := &clustermetadatapb.LeaderObservation{
-		LeaderId:         p.Id,
-		LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
+	// SERVING, but the broadcast still names the OLD leader (pre-promotion):
+	// no primary claim for this pooler → hold the buffer.
+	oldLeaderID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "zone1",
+		Name:      "old-leader",
 	}
-	injectHealth := func(writable bool) {
-		conn.processHealthResponse(&multipoolerservice.StreamPoolerHealthResponse{
-			PoolerId:          p.Id,
-			ServingStatus:     clustermetadatapb.PoolerServingStatus_SERVING,
-			LeaderObservation: obs,
-			Writable:          writable,
-		})
-	}
+	simulateHealthUpdate(conn, clustermetadatapb.PoolerServingStatus_SERVING,
+		&clustermetadatapb.LeaderObservation{LeaderId: oldLeaderID, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5}})
+	assert.Equal(t, 0, resumed, "write traffic must stay buffered while the broadcast names a different leader")
 
-	// Observed leader, SERVING, but still in recovery: hold.
-	injectHealth(false)
-	assert.Equal(t, 0, resumed, "write traffic must stay buffered until the leader is writable")
-
-	// Out of recovery: writable → resume.
-	injectHealth(true)
-	assert.Equal(t, 1, resumed, "resume once the leader reports writable")
+	// The pooler's own broadcast now names itself as leader and is SERVING.
+	// A self-naming observation implies writability → resume.
+	simulateHealthUpdate(conn, clustermetadatapb.PoolerServingStatus_SERVING,
+		&clustermetadatapb.LeaderObservation{LeaderId: p.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5}})
+	assert.Equal(t, 1, resumed, "resume once the leader observes itself as the serving primary")
 }
 
 func TestLoadBalancer_PrimaryCaching(t *testing.T) {
@@ -324,70 +322,83 @@ func TestLoadBalancer_PrimaryCaching(t *testing.T) {
 		assert.Equal(t, poolerID(primary1), conn.ID(), "Should trust replica's observation with highest term")
 	})
 
-	t.Run("no observations uses topology self_leadership", func(t *testing.T) {
+	t.Run("no health observation means no writable leader", func(t *testing.T) {
 		lb := newTestLB(t, "zone1")
 
+		// A PRIMARY topology record with self_leadership no longer seeds routing:
+		// the primary set is driven purely by live health. With no self-naming
+		// health observation, the shard has no writable leader and WRITABLE
+		// routing must buffer.
 		primary := withSelfLeadership(createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY), 1)
 		replica := createTestMultiPooler("replica1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
 
 		addPoolerForTest(t, lb, primary)
 		addPoolerForTest(t, lb, replica)
 
-		// No health updates — but the primary's self_leadership record names it
-		// the leader, so the gateway can route before any health stream connects.
 		target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
-		conn, err := lb.getConnection(target)
-		require.NoError(t, err)
-		assert.Equal(t, poolerID(primary), conn.ID(),
-			"Should return the self_leadership-named primary before health stream connects")
+		_, err := lb.getConnection(target)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no leader observed yet",
+			"self_leadership topology alone must not seed a writable leader")
 	})
 
-	t.Run("leader identity preserved while another pooler remains in shard", func(t *testing.T) {
+	t.Run("removing the elected primary falls back to the other overlapping primary", func(t *testing.T) {
 		lb := newTestLB(t, "zone1")
 
-		primary := createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
-		replica := createTestMultiPooler("replica1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
-		addPoolerForTest(t, lb, primary)
-		addPoolerForTest(t, lb, replica)
+		// Failover overlap: two poolers both currently claim primary via their
+		// own health streams, at different rules. The higher-rule one is elected.
+		primary1 := createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+		primary2 := createTestMultiPooler("primary2", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+		addPoolerForTest(t, lb, primary1)
+		addPoolerForTest(t, lb, primary2)
 
-		connPrimary := connForTest(t, lb, primary)
+		connPrimary1 := connForTest(t, lb, primary1)
+		connPrimary2 := connForTest(t, lb, primary2)
 
-		// Health update populates the leader entry with a real (term > 0)
-		// observation.
-		simulateHealthUpdate(connPrimary,
+		simulateHealthUpdate(connPrimary1,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&clustermetadatapb.LeaderObservation{LeaderId: primary.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
+			&clustermetadatapb.LeaderObservation{LeaderId: primary1.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
+		simulateHealthUpdate(connPrimary2,
+			clustermetadatapb.PoolerServingStatus_SERVING,
+			&clustermetadatapb.LeaderObservation{LeaderId: primary2.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}})
 
-		// Verify routing
 		target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
 		conn, err := lb.getConnection(target)
 		require.NoError(t, err)
-		assert.Equal(t, poolerID(primary), conn.ID())
+		assert.Equal(t, poolerID(primary2), conn.ID(), "highest-rule primary is elected")
 
-		// Remove the primary pooler — leader identity must persist as long as
-		// some pooler from the shard remains in the cache. GetConnection
-		// distinguishes "known but not connected" (transient, after removal)
-		// from "no leader observed yet" (operational, never saw consensus).
-		removePoolerForTest(t, lb, poolerID(primary))
+		// The elected primary leaves: onPoolerGone retracts its claim, and the
+		// remaining overlapping primary takes over rather than the shard going
+		// leaderless.
+		removePoolerForTest(t, lb, poolerID(primary2))
 
-		_, err = lb.getConnection(target)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not connected",
-			"Leader identity must persist while another pooler remains in the shard")
+		conn, err = lb.getConnection(target)
+		require.NoError(t, err)
+		assert.Equal(t, poolerID(primary1), conn.ID(),
+			"retracting the elected primary must fall back to the other overlapping primary")
 	})
 }
 
-func TestLoadBalancer_PrimaryCachedFromDiscovery(t *testing.T) {
+// TestLoadBalancer_PrimaryLearnedFromHealth verifies that the writable leader is
+// learned from a live self-naming health observation (not from topology
+// discovery / self_leadership, which no longer seeds routing under the new
+// model). Once the primary attests to itself on its health stream, WRITABLE
+// routing resolves to it.
+func TestLoadBalancer_PrimaryLearnedFromHealth(t *testing.T) {
 	lb := newTestLB(t, "zone1")
 
-	// AddPooler with a self_leadership record seeds the cache — no health update needed
-	primary := withSelfLeadership(createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY), 1)
+	primary := createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
 	addPoolerForTest(t, lb, primary)
+
+	connPrimary := connForTest(t, lb, primary)
+	simulateHealthUpdate(connPrimary,
+		clustermetadatapb.PoolerServingStatus_SERVING,
+		&clustermetadatapb.LeaderObservation{LeaderId: primary.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
 
 	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
 	conn, err := lb.getConnection(target)
 	require.NoError(t, err)
-	assert.Equal(t, poolerID(primary), conn.ID(), "Should find primary seeded from self_leadership")
+	assert.Equal(t, poolerID(primary), conn.ID(), "Should route to the primary learned from its health observation")
 }
 
 func TestLoadBalancer_KnownLeaderSurvivesTopologyDemotion(t *testing.T) {
@@ -439,23 +450,24 @@ func TestLoadBalancer_UnknownTypePrimarySelection(t *testing.T) {
 			"Should not fall back to UNKNOWN type poolers")
 	})
 
-	t.Run("UNKNOWN poolers with observation cached via health callback", func(t *testing.T) {
-		// Both UNKNOWN poolers point to each other (pathological case)
+	t.Run("routing follows the self-naming health observation regardless of Type", func(t *testing.T) {
+		// unknown2 attests to ITSELF as the writable primary on its health
+		// stream; unknown1 (a peer) reports unknown2 as leader, which does not
+		// make unknown1 a primary. Routing follows the self-naming observation
+		// even though the topology Type is UNKNOWN — Type is irrelevant to
+		// routing now.
 		simulateHealthUpdate(connUnknown1,
 			clustermetadatapb.PoolerServingStatus_SERVING,
 			&clustermetadatapb.LeaderObservation{LeaderId: unknown2.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 10}})
 		simulateHealthUpdate(connUnknown2,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&clustermetadatapb.LeaderObservation{LeaderId: unknown1.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5}})
+			&clustermetadatapb.LeaderObservation{LeaderId: unknown2.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 10}})
 
 		target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
-		// The health callback caches the observed primary with highest term (unknown2 at term 10).
-		// The cache returns the identified pooler regardless of type —
-		// the observation is authoritative.
 		conn, err := lb.getConnection(target)
 		require.NoError(t, err)
 		assert.Equal(t, poolerID(unknown2), conn.ID(),
-			"Observation takes precedence over pooler type")
+			"routing follows the self-naming primary regardless of topology Type")
 	})
 }
 
@@ -513,40 +525,40 @@ func TestLoadBalancer_SelectReplicaByLocalityAndServingStatus(t *testing.T) {
 	})
 }
 
-// TestLoadBalancer_LeaderObservationBeforeConnection covers the silent-drop
-// race from the failover archive: a higher-term LeaderObservation arrives for
-// pooler X before X has been added via AddPooler. With the old shape, the
-// observation was dropped because the connection didn't exist yet. With the
-// new shape, leader identity is recorded regardless and routing works the
-// moment X is added.
+// TestLoadBalancer_LeaderObservationBeforeConnection covers the "known but not
+// connected" routing case: a pooler is known to be the writable primary for a
+// shard, but the gateway does not yet hold a connection to it. WRITABLE routing
+// must distinguish "known but unreachable" (buffer, transient) from "no leader
+// observed yet". Under the new model the primary set is keyed by the
+// self-naming pooler, so we seed the future leader's own claim directly (as
+// onPoolerHealthUpdate would once its health stream connects); once the pooler
+// is added, routing resolves to it.
 func TestLoadBalancer_LeaderObservationBeforeConnection(t *testing.T) {
 	lb := newTestLB(t, "zone1")
 
-	// observer is in the shard but is NOT the leader; we use its health stream
-	// to deliver an observation naming a pooler we have not added yet.
+	// observer is in the shard but is NOT the leader; it keeps a shardSummary
+	// alive so the shard is tracked before the leader connects.
 	observer := createTestMultiPooler("observer", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
 	addPoolerForTest(t, lb, observer)
-
-	connObserver := connForTest(t, lb, observer)
 
 	// The future leader exists in topology but has not been added yet.
 	futureLeader := createTestMultiPooler("future-leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
 
-	// observer reports that future-leader is the consensus leader at term 7.
-	simulateHealthUpdate(connObserver,
-		clustermetadatapb.PoolerServingStatus_SERVING,
+	// future-leader's own primary claim (rule 7) is recorded before we hold a
+	// connection to it — the identity the gateway must not drop.
+	setLeaderForTest(t, lb, constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0",
 		&clustermetadatapb.LeaderObservation{LeaderId: futureLeader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 7}})
 
 	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
 
-	// Leader identity must be recorded even though we have no connection.
+	// Leader identity is recorded even though we have no connection.
 	_, err := lb.getConnection(target)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not connected",
 		"Identity must be recorded; the gateway should distinguish 'known but unreachable' from 'unknown'")
 
-	// AddPooler the leader. No additional observation needed — routing must
-	// work immediately, proving identity was not dropped at observation time.
+	// Add the leader. No additional observation needed — routing must work
+	// immediately, proving identity was not dropped.
 	addPoolerForTest(t, lb, futureLeader)
 	conn, err := lb.getConnection(target)
 	require.NoError(t, err)
@@ -596,30 +608,52 @@ func TestLoadBalancer_StalePrimaryTypeDoesNotEvict(t *testing.T) {
 		"Stale topology must not redirect PRIMARY traffic away from the consensus-elected leader")
 }
 
-// TestLoadBalancer_TopologySelfLeadershipMergesByRule verifies that
-// self_leadership observations read from topology are reconciled by rule
-// number: a higher rule supersedes the known leader, while a stale lower rule
-// is ignored.
-func TestLoadBalancer_TopologySelfLeadershipMergesByRule(t *testing.T) {
+// TestLoadBalancer_HealthObservationsMergeByRule verifies that concurrent
+// self-naming primary claims delivered on health streams are reconciled by rule
+// number: during a failover overlap two poolers both claim primary, and the
+// higher-rule one is elected. When the elected primary stops naming itself
+// (demoted — its next health snapshot names another leader) the set falls back
+// to the remaining primary; when that one goes away too, the shard has no
+// writable leader.
+func TestLoadBalancer_HealthObservationsMergeByRule(t *testing.T) {
 	lb := newTestLB(t, "zone1")
 
-	oldLeader := withSelfLeadership(createTestMultiPooler("old-leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY), 1)
-	newLeader := withSelfLeadership(createTestMultiPooler("new-leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY), 2)
+	oldLeader := createTestMultiPooler("old-leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+	newLeader := createTestMultiPooler("new-leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
 	addPoolerForTest(t, lb, oldLeader)
 	addPoolerForTest(t, lb, newLeader)
 
-	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
+	connOld := connForTest(t, lb, oldLeader)
+	connNew := connForTest(t, lb, newLeader)
 
-	// new-leader's self_leadership (rule 2) supersedes old-leader's (rule 1).
+	// Both poolers currently claim primary via their own health streams; the
+	// higher rule (new-leader at rule 2) is elected over old-leader at rule 1.
+	simulateHealthUpdate(connOld, clustermetadatapb.PoolerServingStatus_SERVING,
+		&clustermetadatapb.LeaderObservation{LeaderId: oldLeader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
+	simulateHealthUpdate(connNew, clustermetadatapb.PoolerServingStatus_SERVING,
+		&clustermetadatapb.LeaderObservation{LeaderId: newLeader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}})
+
+	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
 	conn, err := lb.getConnection(target)
 	require.NoError(t, err)
-	assert.Equal(t, poolerID(newLeader), conn.ID(), "higher-rule self_leadership should win")
+	assert.Equal(t, poolerID(newLeader), conn.ID(), "higher-rule self-naming observation should win")
 
-	// Re-discovering old-leader's stale rule-1 record must not move the leader back.
-	addPoolerForTest(t, lb, withSelfLeadership(createTestMultiPooler("old-leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY), 1))
+	// new-leader retracts: its next health snapshot names old-leader instead of
+	// itself, so its primary claim is cleared and routing falls back to
+	// old-leader, the only remaining self-naming primary.
+	simulateHealthUpdate(connNew, clustermetadatapb.PoolerServingStatus_SERVING,
+		&clustermetadatapb.LeaderObservation{LeaderId: oldLeader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}})
 	conn, err = lb.getConnection(target)
 	require.NoError(t, err)
-	assert.Equal(t, poolerID(newLeader), conn.ID(), "stale lower-rule self_leadership must be ignored")
+	assert.Equal(t, poolerID(oldLeader), conn.ID(), "retracting the elected primary falls back to the remaining primary")
+
+	// old-leader goes away too: onPoolerGone retracts its claim and the shard
+	// has no writable leader, so WRITABLE routing buffers.
+	removePoolerForTest(t, lb, poolerID(oldLeader))
+	_, err = lb.getConnection(target)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no leader observed yet",
+		"with no self-naming primary left, the shard has no writable leader")
 }
 
 // TestLoadBalancer_ReplicaCandidatesExcludeLeader verifies that REPLICA
@@ -735,7 +769,7 @@ func TestLoadBalancer_CentrallyKnownLeaderUnknownToItselfEligibleAsReplica(t *te
 func TestLoadBalancer_LeadershipFor(t *testing.T) {
 	lb := newTestLB(t, "zone1")
 
-	leader := withSelfLeadership(createTestMultiPooler("leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY), 2)
+	leader := createTestMultiPooler("leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
 	stale := createTestMultiPooler("stale", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
 	follower := createTestMultiPooler("follower", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
 	addPoolerForTest(t, lb, leader)
@@ -746,8 +780,11 @@ func TestLoadBalancer_LeadershipFor(t *testing.T) {
 	connStale := connForTest(t, lb, stale)
 	connFollower := connForTest(t, lb, follower)
 
-	// stale still believes it leads at the old rule 1; follower already tracks
-	// the new leader at rule 2.
+	// leader's own health stream names itself as the writable primary at rule 2,
+	// electing it into the shard's primary set; stale still believes it leads at
+	// the old rule 1; follower tracks the new leader at rule 2.
+	simulateHealthUpdate(connLeader, clustermetadatapb.PoolerServingStatus_SERVING,
+		&clustermetadatapb.LeaderObservation{LeaderId: leader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}})
 	simulateHealthUpdate(connStale, clustermetadatapb.PoolerServingStatus_SERVING,
 		&clustermetadatapb.LeaderObservation{LeaderId: stale.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
 	simulateHealthUpdate(connFollower, clustermetadatapb.PoolerServingStatus_SERVING,
@@ -763,18 +800,27 @@ func TestLoadBalancer_LeadershipFor(t *testing.T) {
 func TestLoadBalancer_ShardSummaryAutoClear(t *testing.T) {
 	lb := newTestLB(t, "zone1")
 
-	primary := withSelfLeadership(createTestMultiPooler("primary", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY), 1)
+	primary := createTestMultiPooler("primary", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
 	addPoolerForTest(t, lb, primary)
 
+	// A shardSummary is created from the first live health observation, not from
+	// topology add — the primary set is driven purely by health under the new
+	// model. Deliver a self-naming observation so the shard is tracked.
+	connPrimary := connForTest(t, lb, primary)
+	simulateHealthUpdate(connPrimary, clustermetadatapb.PoolerServingStatus_SERVING,
+		&clustermetadatapb.LeaderObservation{LeaderId: primary.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
+
 	lb.mu.Lock()
-	require.Len(t, lb.shards, 1, "shard should be tracked after adding a pooler")
+	shardCount := len(lb.shards)
 	lb.mu.Unlock()
+	require.Equal(t, 1, shardCount, "shard should be tracked after a health observation")
 
 	removePoolerForTest(t, lb, poolerID(primary))
 
 	lb.mu.Lock()
-	assert.Empty(t, lb.shards, "shardSummary should be cleared once no poolers remain in the shard")
+	shardCount = len(lb.shards)
 	lb.mu.Unlock()
+	assert.Zero(t, shardCount, "shardSummary should be cleared once no poolers remain in the shard")
 }
 
 // TestLoadBalancer_OnLeaderServingRequiresSelfNamedLeader is the regression
@@ -819,7 +865,6 @@ func TestLoadBalancer_OnLeaderServingRequiresSelfNamedLeader(t *testing.T) {
 		PoolerId:          leader.Id,
 		ServingStatus:     clustermetadatapb.PoolerServingStatus_SERVING,
 		LeaderObservation: &clustermetadatapb.LeaderObservation{LeaderId: leader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}},
-		Writable:          true,
 	})
 	require.Len(t, calls, 1, "OnLeaderServing must fire once the pooler self-identifies as leader")
 	assert.Equal(t, constants.DefaultTableGroup, calls[0].GetTableGroup())

--- a/go/services/multigateway/poolergateway/load_balancer_test_helpers_test.go
+++ b/go/services/multigateway/poolergateway/load_balancer_test_helpers_test.go
@@ -62,7 +62,6 @@ func newTestLBWithLeaderServing(t *testing.T, localCell string, onLeaderServing 
 				t.Errorf("newPoolerConnection failed: %v", err)
 				return nil
 			}
-			lb.mergeTopologyLeader(p)
 			lb.notifyIfLeaderServing(p, conn)
 			return conn
 		},
@@ -71,7 +70,6 @@ func newTestLBWithLeaderServing(t *testing.T, localCell string, onLeaderServing 
 				return
 			}
 			conn.UpdatePoolerInfo(curr)
-			lb.mergeTopologyLeader(curr)
 			lb.notifyIfLeaderServing(curr, conn)
 		},
 		OnGone: func(p *clustermetadatapb.MultiPooler, conn *poolerConnection, _ poolerwatch.GoneReason) {
@@ -111,9 +109,10 @@ func connForTest(t *testing.T, lb *loadBalancer, p *clustermetadatapb.MultiPoole
 	return conn
 }
 
-// setLeaderForTest installs a LeaderObservation directly into the LB's
-// per-shard leader map. Used by tests that need to model a peer observation
-// without wiring a second connection.
+// setLeaderForTest installs a routing-primary claim directly into the LB's
+// per-shard summary. Used by tests that need to model a peer observation
+// without wiring a second connection. The observation's LeaderId is the pooler
+// claiming primary.
 func setLeaderForTest(t *testing.T, lb *loadBalancer, database, tableGroup, shard string, obs *clustermetadatapb.LeaderObservation) {
 	t.Helper()
 	sk := &clustermetadatapb.ShardKey{
@@ -121,10 +120,11 @@ func setLeaderForTest(t *testing.T, lb *loadBalancer, database, tableGroup, shar
 		TableGroup: tableGroup,
 		Shard:      shard,
 	}
+	summary := &shardSummary{shardKey: sk}
+	if obs != nil {
+		summary.setPrimary(topoclient.ComponentIDString(obs.GetLeaderId()), obs)
+	}
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
-	lb.shards[shardKeyOf(sk)] = &shardSummary{
-		shardKey:  sk,
-		leaderObs: obs,
-	}
+	lb.shards[shardKeyOf(sk)] = summary
 }

--- a/go/services/multigateway/poolergateway/pooler_connection.go
+++ b/go/services/multigateway/poolergateway/pooler_connection.go
@@ -62,11 +62,6 @@ type poolerHealth struct {
 	// Zero on the primary or when not yet measured.
 	ReplicationLagNs int64
 
-	// Writable reports whether the pooler can accept writes (postgres out of
-	// recovery). A consensus leader mid-promotion is SERVING (reads) but not yet
-	// Writable; the failover buffer holds write traffic until this is true.
-	Writable bool
-
 	// LastError is the most recent error from the health stream.
 	LastError error
 
@@ -80,12 +75,6 @@ func (h *poolerHealth) isServing() bool {
 		return false
 	}
 	return h.ServingStatus == clustermetadatapb.PoolerServingStatus_SERVING
-}
-
-// isWritable returns true if the pooler can accept writes (postgres out of
-// recovery). The failover buffer drains write traffic only once this is true.
-func (h *poolerHealth) isWritable() bool {
-	return h != nil && h.Writable
 }
 
 // simpleCopy returns a shallow copy of the poolerHealth.
@@ -102,7 +91,6 @@ func (h *poolerHealth) simpleCopy() *poolerHealth {
 		ServingStatus:     h.ServingStatus,
 		LeaderObservation: h.LeaderObservation,
 		ReplicationLagNs:  h.ReplicationLagNs,
-		Writable:          h.Writable,
 		LastError:         h.LastError,
 		LastResponse:      h.LastResponse,
 	}
@@ -440,7 +428,6 @@ func (pc *poolerConnection) processHealthResponse(response *multipoolerservice.S
 		ServingStatus:     response.ServingStatus,
 		LeaderObservation: response.LeaderObservation,
 		ReplicationLagNs:  response.ReplicationLagNs,
-		Writable:          response.Writable,
 		LastError:         nil,
 		LastResponse:      time.Now(),
 	}

--- a/go/services/multigateway/poolergateway/pooler_connection.go
+++ b/go/services/multigateway/poolergateway/pooler_connection.go
@@ -24,7 +24,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/queryservice"
 	"github.com/multigres/multigres/go/common/rpcclient"
@@ -231,20 +230,6 @@ func (pc *poolerConnection) ID() topoclient.ComponentID {
 // Cell returns the cell where this pooler is located.
 func (pc *poolerConnection) Cell() string {
 	return pc.poolerInfo.Load().Id.GetCell()
-}
-
-// believesSelfLeader reports whether this pooler considers itself the shard
-// leader, judged from the better of its topology self_leadership (read at
-// discovery) and its latest health-stream observation. A pooler in this state
-// is either the current leader or a stale leader that has not yet learned of a
-// newer one; either way it must not be selected for replica reads.
-func (pc *poolerConnection) believesSelfLeader() bool {
-	var healthObs *clustermetadatapb.LeaderObservation
-	if h := pc.Health(); h != nil {
-		healthObs = h.LeaderObservation
-	}
-	obs := commonconsensus.MostAuthoritativeObservation(pc.poolerInfo.Load().GetSelfLeadership(), healthObs)
-	return obs != nil && topoclient.ComponentIDString(obs.GetLeaderId()) == pc.ID()
 }
 
 // UpdatePoolerInfo refreshes the pooler metadata (hostname, ports, shard) from

--- a/go/services/multigateway/poolergateway/pooler_gateway.go
+++ b/go/services/multigateway/poolergateway/pooler_gateway.go
@@ -179,7 +179,6 @@ func NewPoolerGateway(opts PoolerGatewayOpts) *PoolerGateway {
 					"pooler_id", topoclient.ComponentIDString(p.Id), "error", err)
 				return nil
 			}
-			lb.mergeTopologyLeader(p)
 			lb.notifyIfLeaderServing(p, conn)
 			return conn
 		},
@@ -188,7 +187,6 @@ func NewPoolerGateway(opts PoolerGatewayOpts) *PoolerGateway {
 				return
 			}
 			conn.UpdatePoolerInfo(curr)
-			lb.mergeTopologyLeader(curr)
 			lb.notifyIfLeaderServing(curr, conn)
 		},
 		OnGone: func(p *clustermetadatapb.MultiPooler, conn *poolerConnection, _ poolerwatch.GoneReason) {

--- a/go/services/multigateway/status_test.go
+++ b/go/services/multigateway/status_test.go
@@ -164,13 +164,20 @@ func TestCollectCellStatuses_MultipleCellsSortedAlphabetically(t *testing.T) {
 	assert.Equal(t, "active", statuses[0].Poolers[0].Lifecycle)
 }
 
-func TestCollectCellStatuses_LeaderReportsLeader(t *testing.T) {
+// TestCollectCellStatuses_EtcdSelfLeadershipDoesNotImplyLeader verifies that a
+// pooler's topology self_leadership record does NOT make the gateway report it
+// as a leader. Leadership is derived only from live health-stream observations
+// now — the gateway deliberately no longer trusts etcd for leader identity (see
+// the load balancer's move off topology for routing). Since this test's poolers
+// have no reachable health stream, they render as plain followers even though
+// their etcd record names them leader.
+//
+// The positive leader / stale-leader / follower derivation is exercised where
+// live health can be simulated: poolergateway.TestLoadBalancer_LeadershipFor.
+func TestCollectCellStatuses_EtcdSelfLeadershipDoesNotImplyLeader(t *testing.T) {
 	mg, ts := newTestGateway(t, "zone1")
 	ctx := t.Context()
 
-	// The pooler's own self_leadership names itself as leader; the gateway
-	// folds this into the shard summary on OnLive, so leadershipFor will
-	// return "leader" for it.
 	leader := withSelfLeader(
 		newTestPooler("zone1", "leader1", "tg", "0", clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE),
 		1,
@@ -180,49 +187,8 @@ func TestCollectCellStatuses_LeaderReportsLeader(t *testing.T) {
 
 	statuses := mg.collectCellStatuses()
 	ps := findPoolerStatus(t, statuses, "zone1", "leader1")
-	assert.Equal(t, "leader", ps.Leadership)
-}
-
-func TestCollectCellStatuses_StaleLeader(t *testing.T) {
-	mg, ts := newTestGateway(t, "zone1")
-	ctx := t.Context()
-
-	// Two poolers in the same shard. `oldLeader` has self_leadership at term 1.
-	// `newLeader` has self_leadership at term 2 — its higher rule number wins
-	// when the shard summary is built. From the gateway's view:
-	//   - newLeader is the consensus leader (reported as "leader"),
-	//   - oldLeader still believes itself the leader (its own self_leadership
-	//     names itself) but consensus has moved on — reported as "stale-leader".
-	oldLeader := withSelfLeader(
-		newTestPooler("zone1", "old", "tg", "0", clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE),
-		1,
-	)
-	newLeader := withSelfLeader(
-		newTestPooler("zone1", "new", "tg", "0", clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE),
-		2,
-	)
-	require.NoError(t, ts.CreateMultiPooler(ctx, oldLeader))
-	require.NoError(t, ts.CreateMultiPooler(ctx, newLeader))
-	waitForPoolerCount(t, mg, 2)
-
-	// Wait for both to be reflected in the shard summary; the LB merges each
-	// self_leadership observation on OnLive synchronously, so by the time
-	// PoolerCount=2 the summary is up to date.
-	require.Eventually(t, func() bool {
-		statuses := mg.collectCellStatuses()
-		var newRole, oldRole string
-		for _, cs := range statuses {
-			for _, p := range cs.Poolers {
-				if p.Name == "new" {
-					newRole = p.Leadership
-				}
-				if p.Name == "old" {
-					oldRole = p.Leadership
-				}
-			}
-		}
-		return newRole == "leader" && oldRole == "stale-leader"
-	}, 2*time.Second, 5*time.Millisecond, "expected new=leader, old=stale-leader")
+	assert.Equal(t, "follower", ps.Leadership,
+		"etcd self_leadership must not make the gateway report a leader; only live health does")
 }
 
 // TestCollectCellStatuses_TombstoneHasEmptyLeadership verifies that a pooler

--- a/go/services/multipooler/grpcpoolerservice/service.go
+++ b/go/services/multipooler/grpcpoolerservice/service.go
@@ -864,7 +864,6 @@ func healthStateToProto(state *poolerserver.HealthState) *multipoolerpb.StreamPo
 	resp := &multipoolerpb.StreamPoolerHealthResponse{
 		PoolerId:      state.PoolerID,
 		ServingStatus: state.ServingStatus,
-		Writable:      state.Writable,
 	}
 
 	if state.LeaderObservation != nil {

--- a/go/services/multipooler/internal/manager/consensus/rule_store.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store.go
@@ -472,6 +472,17 @@ func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clus
 //
 // Returns an error if postgres is unreachable or if the current_rule sentinel
 // row is missing (which indicates the tables are not initialized).
+//
+// TODO: a position observation is how a node first learns its committed rule was
+// superseded by a higher one — a consensus change that flips the routing role
+// with no revoke/promote to carry it. Ideally observing such a change would
+// trigger a state recalc here too (like the revoke path does), so the routing
+// role converges immediately instead of on the monitor's next drift tick. The
+// obstacle is layering + locking: ObservePosition is a hot read path called
+// without the action lock, and it lives below the manager's StateManager, so it
+// cannot call Recalc directly. Figure out if/how to surface "the observed rule
+// moved" to the StateManager (a lock-free recalc, or an observer the manager
+// wires up) without coupling this layer to serving state.
 func (rs *ruleStore) ObservePosition(ctx context.Context) (*clustermetadatapb.PoolerPosition, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, timeouts.RuleReadTimeout)
 	defer cancel()

--- a/go/services/multipooler/internal/manager/fake_rule_store_test.go
+++ b/go/services/multipooler/internal/manager/fake_rule_store_test.go
@@ -137,7 +137,28 @@ func (f *fakeRuleStore) UpdateRule(ctx context.Context, update *consensus.RuleUp
 	if updateErrAfterHook != nil {
 		return nil, updateErrAfterHook
 	}
-	return pos, nil
+
+	// Mirror the real rule store: a successful write makes the written rule the
+	// new observable current position. Consumers derive from CachedPosition (e.g.
+	// CachedConsensusStatus, which the StateManager reads to compute the routing
+	// role after a promote), so the fake must advance it or the derived state
+	// would never reflect the new rule. The LSN is carried over from the prior
+	// position (the write does not move the WAL cursor here).
+	newPos := &clustermetadatapb.PoolerPosition{
+		Rule: &clustermetadatapb.ShardRule{
+			LeaderId:      update.GetLeaderID(),
+			CoordinatorId: update.GetCoordinatorID(),
+			RuleNumber:    &clustermetadatapb.RuleNumber{CoordinatorTerm: update.GetTermNumber()},
+			CohortMembers: update.GetCohortMembers(),
+		},
+	}
+	if pos != nil {
+		newPos.Lsn = pos.GetLsn()
+	}
+	f.mu.Lock()
+	f.pos = newPos
+	f.mu.Unlock()
+	return newPos, nil
 }
 
 func (f *fakeRuleStore) HasInconsistentGUC(_ context.Context) bool {

--- a/go/services/multipooler/internal/manager/health_provider.go
+++ b/go/services/multipooler/internal/manager/health_provider.go
@@ -60,12 +60,6 @@ type healthStreamer struct {
 	poolerType        clustermetadatapb.PoolerType
 	leaderObservation *poolerserver.LeaderObservation
 
-	// writable reports whether postgres can accept writes (!pg_is_in_recovery).
-	// Published separately from poolerType (which tracks the consensus term, not
-	// writability) so the gateway can hold write traffic for a leader that is
-	// SERVING but still mid-promotion.
-	writable bool
-
 	// Client management
 	clients map[chan *poolerserver.HealthState]struct{}
 
@@ -109,26 +103,32 @@ func (hs *healthStreamer) SetQueryServer(qs poolerserver.PoolerController) {
 	hs.queryServer = qs
 }
 
-// UpdateLeaderObservation updates the primary observation (term + primary ID)
-// and broadcasts to clients.
-func (hs *healthStreamer) UpdateLeaderObservation(obs *poolerserver.LeaderObservation) {
-	hs.mu.Lock()
-	defer hs.mu.Unlock()
-
-	hs.leaderObservation = obs
-	hs.broadcastLocked()
-}
-
-// OnStateChange updates both poolerType and servingStatus atomically with a single
-// broadcast. This implements the StateAware interface so the healthStreamer can be
-// registered with StateManager.
+// OnStateChange updates the health stream's poolerType, leader observation, and
+// servingStatus atomically with a single broadcast. This implements the
+// StateAware interface so the healthStreamer can be registered with StateManager.
 //
-// For SERVING transitions, it waits for the query server (via queryReadyGate)
-// to finish updating before broadcasting. This prevents the gateway from
-// discovering the new primary before the pooler can actually serve that type.
-// not-serving transitions broadcast immediately so the gateway can start
-// buffering without delay.
+// The leader observation is DERIVED from the fanned routing state — non-nil
+// (naming self) iff routing PRIMARY — rather than pushed by callers. So a pooler
+// advertises itself as leader to the gateway exactly when it is the writable
+// routing primary, and clears it on demotion, automatically. Followers never
+// advertise a leader.
+//
+// For SERVING transitions, it waits for the query server to finish transitioning
+// before broadcasting. This prevents the gateway from discovering the new primary
+// before the pooler can actually serve that type. not-serving transitions
+// broadcast immediately so the gateway can start buffering without delay.
 func (hs *healthStreamer) OnStateChange(ctx context.Context, state servingstate.State) error {
+	// We wait so we don't advertise SERVING before the query server can actually
+	// serve the new role. This is a rendezvous with a sibling component in the
+	// same (concurrent) fan-out.
+	//
+	// TODO: this explicit wait could go away if StateManager grew multi-phase
+	// fan-out — deliver an "after applied" phase to advertise-style components
+	// once the transition-style components (the query server) have converged, so
+	// ordering lives in the orchestrator instead of a per-component wait. Note
+	// the required order is direction-dependent (serving: ready-then-advertise;
+	// not-serving: advertise-then-drain), so the phases would need to account for
+	// that. Low priority: the SERVING transition waited on here is fast.
 	if state.ServingStatus == clustermetadatapb.PoolerServingStatus_SERVING && hs.queryServer != nil {
 		hs.queryServer.AwaitStateChange(ctx, state.RoutingRole, state.ServingStatus)
 	}
@@ -137,19 +137,31 @@ func (hs *healthStreamer) OnStateChange(ctx context.Context, state servingstate.
 	defer hs.mu.Unlock()
 
 	prev := hs.servingStatus
-	// The health stream reports the routing role to the gateway as a PoolerType
-	// label plus the writable flag. Both derive from the routing role: PRIMARY (and
-	// writable) iff this pooler is the writable leader, REPLICA otherwise. A leader
-	// that has not finished promoting is not yet routing PRIMARY, so the gateway
-	// does not route writes to it until its rule commits.
+	// PoolerType and the leader observation both derive from the routing role:
+	// PRIMARY / self-naming observation iff this pooler is the writable leader,
+	// REPLICA / nil otherwise. A leader mid-promotion is not yet routing PRIMARY,
+	// so it does not advertise itself until its rule commits.
 	hs.poolerType = poolerTypeForLeader(state.RoutingRole.Writable())
-	hs.writable = state.RoutingRole.Writable()
+	hs.leaderObservation = leaderObsFromState(state)
 	hs.servingStatus = state.ServingStatus
 	hs.broadcastLocked()
 	if prev != state.ServingStatus {
 		hs.metrics.recordTransition(ctx, prev, state.ServingStatus)
 	}
 	return nil
+}
+
+// leaderObsFromState converts the fanned self-leadership observation into the
+// health-stream form (self id + coordinator term), or nil when this pooler is
+// not the writable routing primary.
+func leaderObsFromState(state servingstate.State) *poolerserver.LeaderObservation {
+	if state.Leadership == nil {
+		return nil
+	}
+	return &poolerserver.LeaderObservation{
+		LeaderID:   state.Leadership.GetLeaderId(),
+		LeaderTerm: state.Leadership.GetLeaderRuleNumber().GetCoordinatorTerm(),
+	}
 }
 
 // poolerTypeForLeader maps a writable-leader boolean to the PoolerType label
@@ -185,7 +197,6 @@ func (hs *healthStreamer) buildStateLocked() *poolerserver.HealthState {
 		LeaderObservation:           hs.leaderObservation,
 		RecommendedStalenessTimeout: hs.recommendedStalenessTimeout,
 		ReplicationLagNs:            hs.replicationLagNs.Load(),
-		Writable:                    hs.writable,
 	}
 }
 

--- a/go/services/multipooler/internal/manager/health_provider_test.go
+++ b/go/services/multipooler/internal/manager/health_provider_test.go
@@ -197,35 +197,6 @@ func TestHealthProvider_SubscribeHealthReturnsNilWhenNoStreamer(t *testing.T) {
 	assert.Nil(t, ch)
 }
 
-func TestHealthStreamer_UpdateLeaderObservation(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	serviceID := &clustermetadatapb.ID{
-		Component: clustermetadatapb.ID_MULTIPOOLER,
-		Cell:      "zone1",
-		Name:      "test-pooler",
-	}
-	hs := newHealthStreamer(logger, serviceID, "tg1", "0")
-
-	// Subscribe
-	_, ch := hs.subscribe()
-
-	// Update primary observation
-	obs := &poolerserver.LeaderObservation{
-		LeaderTerm: 42,
-	}
-	hs.UpdateLeaderObservation(obs)
-
-	// Verify subscriber receives the updated state
-	select {
-	case received := <-ch:
-		require.NotNil(t, received)
-		require.NotNil(t, received.LeaderObservation)
-		assert.Equal(t, int64(42), received.LeaderObservation.LeaderTerm)
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("subscriber did not receive health broadcast")
-	}
-}
-
 func TestHealthStreamer_OnStateChange(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	serviceID := &clustermetadatapb.ID{
@@ -376,27 +347,44 @@ func TestHealthStreamer_DoesNotWaitOnNotServing(t *testing.T) {
 	}
 }
 
-// TestHealthStreamer_PublishesWritability verifies the health stream publishes
-// Writable from postgresPrimary, independent of PoolerType/serving: a consensus
-// leader still in recovery is PRIMARY + SERVING but not yet Writable, and flips to
-// Writable only once postgres leaves recovery. This is what lets the gateway hold
-// write traffic for a leader mid-promotion.
-func TestHealthStreamer_PublishesWritability(t *testing.T) {
+// TestHealthStreamer_AdvertisesLeaderWhenWritable verifies the health stream
+// advertises a self-naming leader observation exactly when this pooler is the
+// writable routing primary. A consensus leader still in recovery is SERVING (can
+// answer reads) but routes REPLICA and carries no Leadership, so it advertises no
+// leader; once postgres leaves recovery it routes PRIMARY and advertises itself.
+// The presence of the observation is what lets the gateway route (and unbuffer)
+// writes — replacing the old separate Writable bool.
+func TestHealthStreamer_AdvertisesLeaderWhenWritable(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	hs := newHealthStreamer(logger, nil, "tg1", "0")
+	self := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "zone1",
+		Name:      "test-pooler",
+	}
+	hs := newHealthStreamer(logger, self, "tg1", "0")
 	ch := make(chan *poolerserver.HealthState, 10)
 	hs.clients[ch] = struct{}{}
 
-	// Leader, SERVING (can answer reads), but postgres still in recovery: not writable.
+	// Leader, SERVING (can answer reads), but postgres still in recovery: routes
+	// REPLICA and carries no Leadership, so it advertises no leader.
 	require.NoError(t, hs.OnStateChange(t.Context(),
 		servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	st := <-ch
 	assert.Equal(t, clustermetadatapb.PoolerServingStatus_SERVING, st.ServingStatus)
-	assert.False(t, st.Writable, "leader still in recovery must not advertise writable")
+	assert.Nil(t, st.LeaderObservation, "leader still in recovery must not advertise itself")
 
-	// Promotion completes (out of recovery): now writable.
+	// Promotion completes (out of recovery): routes PRIMARY and carries a
+	// self-naming Leadership at the committed rule, so it advertises itself.
 	require.NoError(t, hs.OnStateChange(t.Context(),
-		servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+		servingstate.State{
+			RoutingRole:   servingstate.RoutingRolePrimary,
+			ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
+			Leadership: &clustermetadatapb.LeaderObservation{
+				LeaderId:         self,
+				LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 42},
+			},
+		}))
 	st = <-ch
-	assert.True(t, st.Writable, "writable once postgres leaves recovery")
+	require.NotNil(t, st.LeaderObservation, "writable primary must advertise itself")
+	assert.Equal(t, int64(42), st.LeaderObservation.LeaderTerm)
 }

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/multigres/multigres/go/common/backup"
-	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
@@ -965,21 +964,6 @@ func (pm *MultiPoolerManager) checkAndSetReady() {
 			// Already closed
 		default:
 			close(pm.readyChan)
-		}
-
-		// Set initial leader observation from the highest known rule.
-		// commonconsensus.LeaderTerm returns 0 unless the rule names us as the
-		// leader, so publishing serviceID here is safe. Fall back to the cached
-		// position if postgres is unreachable.
-		cs, err := pm.consensusMgr.InconsistentConsensusStatus(pm.ctx)
-		if err != nil {
-			cs = pm.consensusMgr.CachedConsensusStatus()
-		}
-		if primaryTerm := commonconsensus.LeaderTerm(cs); primaryTerm > 0 {
-			pm.healthStreamer.UpdateLeaderObservation(&poolerserver.LeaderObservation{
-				LeaderID:   pm.serviceID,
-				LeaderTerm: primaryTerm,
-			})
 		}
 	}
 }

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -1525,40 +1525,6 @@ func (pm *MultiPoolerManager) waitForPromotionComplete(ctx context.Context) erro
 	}
 }
 
-// updateTopologyAfterPromotion updates the pooler type in topology to PRIMARY
-// and transitions the serving state to SERVING.
-//
-// The serving-state transition must always run, even when the topology already
-// reports PRIMARY. That can happen on re-promotion of the same pooler at a
-// higher term: demoteToStandbyLocked left the topology Type=PRIMARY (only
-// stale-primary demote updates topology) but transitioned serving status to
-// DRAINING. Skipping the Mutate call left the pooler stuck at
-// PRIMARY/DRAINING, which prevented the multigateway buffer from draining
-// after the failover.
-func (pm *MultiPoolerManager) updateTopologyAfterPromotion(ctx context.Context, state *promotionState, rule *clustermetadatapb.ShardRule) error {
-	if state.isPrimaryInTopology {
-		pm.logger.InfoContext(ctx, "Topology type already PRIMARY; ensuring serving status is SERVING")
-	} else {
-		pm.logger.InfoContext(ctx, "Updating pooler type in topology to PRIMARY")
-	}
-
-	// Promotion has already waited for postgres to leave recovery AND for the new
-	// rule to commit (DoUpdateRule blocks on the sync-standby ack before this
-	// runs), so the consensus snapshot now names this pooler the active committed
-	// leader: poking PostgresPrimary here derives routing role PRIMARY and its
-	// leadership observation, letting the heartbeat writer / LISTEN and the gateway
-	// start immediately rather than waiting for the next monitor tick. Mutate is
-	// idempotent — if already at this state it short-circuits.
-	if err := pm.stateManager.Mutate(ctx, func(s *servingStateMutation) {
-		s.PostgresPrimary = true
-		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
-	}); err != nil {
-		return mterrors.Wrap(err, "failed to set serving state for promotion")
-	}
-
-	return nil
-}
-
 // ReplicationLag returns the current replication lag from the heartbeat reader
 func (pm *MultiPoolerManager) ReplicationLag(ctx context.Context) (time.Duration, error) {
 	if err := pm.checkReady(); err != nil {

--- a/go/services/multipooler/internal/manager/rpc_backup.go
+++ b/go/services/multipooler/internal/manager/rpc_backup.go
@@ -353,14 +353,6 @@ func (pm *MultiPoolerManager) restoreFromBackupLocked(ctx context.Context, backu
 		return err
 	}
 
-	// Clear the in-memory leader observation. The restored PGDATA may have been
-	// from a different point in time, so the previously observed leader may no
-	// longer be accurate. The term revocation is intentionally preserved: it is
-	// monotonically increasing and the restore does not change who is allowed to
-	// lead — only a coordinator with a term >= the revocation term may configure
-	// this node, which is exactly the right safety property.
-	pm.healthStreamer.UpdateLeaderObservation(nil)
-
 	if err := telemetry.WithSpan(ctx, "restore/reopen-pooler", func(ctx context.Context) error {
 		return pm.reopenPoolerManager(ctx)
 	}); err != nil {

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -444,11 +444,27 @@ func (pm *MultiPoolerManager) promoteLocked(ctx context.Context, req *consensusd
 	if _, err = pm.DoUpdateRule(ctx, ruleUpdate); err != nil {
 		return nil, mterrors.Wrap(err, "promote failed: could not write rule")
 	}
-	// IMPORTANT: updateTopologyAfterPromotion must only be called after UpdateRule
-	// succeeds. It advertises PRIMARY + SERVING to the gateway, opening write traffic.
-	// UpdateRule is the durability gate: it waits for sync-standby acknowledgment.
-	if err := pm.updateTopologyAfterPromotion(ctx, state, proposedRule); err != nil {
-		pm.logger.WarnContext(ctx, "Failed to update topology after promote", "error", err)
+	// Advertise PRIMARY + SERVING now that the rule has committed — this opens the
+	// gateway to write traffic, so it must run only after UpdateRule succeeds
+	// (UpdateRule is the durability gate: it waits for sync-standby acknowledgment).
+	//
+	// Promotion has already waited for postgres to leave recovery AND for the new
+	// rule to commit, so the consensus snapshot now names this pooler the active
+	// committed leader: poking PostgresPrimary here derives routing role PRIMARY
+	// and its leadership observation, starting the heartbeat writer / LISTEN and
+	// opening the gateway immediately rather than waiting for the next monitor tick.
+	//
+	// The serving transition must run even when topology already reports PRIMARY:
+	// on re-promotion of the same pooler at a higher term, demoteToStandbyLocked
+	// left Type=PRIMARY but serving=DRAINING, and skipping this would strand the
+	// pooler at PRIMARY/DRAINING and prevent the gateway buffer from draining.
+	if err := pm.stateManager.Mutate(ctx, func(s *servingStateMutation) {
+		s.PostgresPrimary = true
+		if s.ServingStatus == clustermetadatapb.PoolerServingStatus_DRAINING {
+			s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
+		}
+	}); err != nil {
+		pm.logger.WarnContext(ctx, "Failed to update serving state after promote", "error", err)
 	}
 
 	// Record the (rule, primary) — this pooler IS now the primary. Stamping

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -29,7 +29,6 @@ import (
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
-	"github.com/multigres/multigres/go/services/multipooler/internal/poolerserver"
 	"github.com/multigres/multigres/go/tools/telemetry"
 )
 
@@ -224,6 +223,18 @@ func (pm *MultiPoolerManager) Recruit(ctx context.Context, req *consensusdatapb.
 
 	eventlog.Emit(ctx, pm.logger, eventlog.Success, termEvent)
 	pm.logger.InfoContext(ctx, "Recruit complete", "revoked_below_term", revokedBelowTerm)
+
+	// The revocation persisted: this pooler's term is now revoked, so it is no
+	// longer the active leader even if postgres has not yet left recovery. Recalc
+	// re-derives the routing role (PRIMARY -> REPLICA) and re-fans it, clearing the
+	// writable signal and self-leadership advertisement immediately rather than
+	// waiting for the monitor's next drift tick. Kept next to the revoke that
+	// causes it. Lock-safe: the action lock is held (acquired at the top of
+	// Recruit) and AcceptRevocation has released the consensus lock, so reading the
+	// consensus snapshot inside Recalc cannot deadlock.
+	if err := pm.stateManager.Recalc(ctx); err != nil {
+		pm.logger.WarnContext(ctx, "Recruit: failed to recalc serving state after revocation", "error", err)
+	}
 
 	// Step 5: Return ConsensusStatus with the stable post-revoke position.
 	// Uses the cached position warmed by the getConsensusStatus call in step 3.
@@ -439,16 +450,6 @@ func (pm *MultiPoolerManager) promoteLocked(ctx context.Context, req *consensusd
 	if err := pm.updateTopologyAfterPromotion(ctx, state, proposedRule); err != nil {
 		pm.logger.WarnContext(ctx, "Failed to update topology after promote", "error", err)
 	}
-	// UpdateLeaderObservation broadcasts (leader = self). Issue it AFTER
-	// updateTopologyAfterPromotion's SetState(PRIMARY, SERVING) so the
-	// broadcast that names this pooler as leader is also the first that
-	// reports PRIMARY+SERVING — keeping the gateway's buffer-drain check
-	// (serving && broadcast-names-self) from firing before the queryServer
-	// has finished transitioning to PRIMARY.
-	pm.healthStreamer.UpdateLeaderObservation(&poolerserver.LeaderObservation{
-		LeaderID:   pm.serviceID,
-		LeaderTerm: revokedBelowTerm,
-	})
 
 	// Record the (rule, primary) — this pooler IS now the primary. Stamping
 	// the published ReplicationPrimary lets the health stream advertise the
@@ -618,12 +619,6 @@ func (pm *MultiPoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 		return nil, mterrors.Wrap(err, "failed to check recovery status")
 	}
 
-	// Reported to the gateway as the new leader's term. Not term validation —
-	// the rule compare above is the gate. SetPrimary does not bump the local
-	// revocation: revocations are authored by coordinators via Recruit, and
-	// an SetPrimary is a notification, not a revoke.
-	consensusTerm := rule.GetRuleNumber().GetCoordinatorTerm()
-
 	if isPrimary {
 		if _, err := pm.consensusMgr.SetSuspectedDivergence(ctx, true); err != nil {
 			pm.logger.ErrorContext(ctx, "failed to set suspected divergence in SetPrimary", "error", err)
@@ -691,18 +686,6 @@ func (pm *MultiPoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 	}); err != nil {
 		pm.logger.WarnContext(ctx, "Failed to update pooler type to REPLICA after SetPrimary", "error", err)
 	}
-
-	// Advertise the new leader to the health stream so the gateway can route
-	// reads/writes against it. The stale-primary branch gets this for free
-	// via demoteStalePrimaryLocked; the standby branch must do it explicitly.
-	// TODO: LeaderObservation is redundant with the (rule, primary) tuple
-	// already recorded in consensusPromises.replicationPrimary. Plan to make
-	// RecordTermPrimary (or its successor) drive the health-stream
-	// observation directly, so callers don't have to remember to do both.
-	pm.healthStreamer.UpdateLeaderObservation(&poolerserver.LeaderObservation{
-		LeaderID:   leader.GetId(),
-		LeaderTerm: consensusTerm,
-	})
 
 	if err := pm.consensusMgr.ClearResignedLeaderAtTerm(ctx); err != nil {
 		pm.logger.WarnContext(ctx, "Failed to clear resigned leader term after promote", "error", err)

--- a/go/services/multipooler/internal/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/internal/manager/rpc_initialization_test.go
@@ -287,10 +287,11 @@ func newRemedialActionTestManager(t *testing.T, multipooler *clustermetadatapb.M
 	return pm
 }
 
-// TestUpdateTopologyAfterPromotion_PublishesSelfLeadership verifies the
-// promotion path records a self-leadership observation naming this pooler under
-// the rule it was promoted under, alongside Type=PRIMARY + SERVING.
-func TestUpdateTopologyAfterPromotion_PublishesSelfLeadership(t *testing.T) {
+// TestPromotion_PublishesSelfLeadership verifies the promotion serving-state
+// transition records a self-leadership observation naming this pooler under the
+// rule it was promoted under, alongside Type=PRIMARY + SERVING. It exercises the
+// Mutate that promoteLocked performs after the rule commits.
+func TestPromotion_PublishesSelfLeadership(t *testing.T) {
 	multipooler := &clustermetadatapb.MultiPooler{
 		Id:   &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "test-pooler"},
 		Type: clustermetadatapb.PoolerType_REPLICA,
@@ -309,7 +310,15 @@ func TestUpdateTopologyAfterPromotion_PublishesSelfLeadership(t *testing.T) {
 	lockCtx, err := pm.actionLock.Acquire(t.Context(), "test")
 	require.NoError(t, err)
 	defer pm.actionLock.Release(lockCtx)
-	require.NoError(t, pm.updateTopologyAfterPromotion(lockCtx, &promotionState{}, rule))
+	// Mirror the Mutate promoteLocked performs after DoUpdateRule commits the rule:
+	// postgres is now primary and any drain completes, so the routing role derives
+	// PRIMARY and the record projects the self-leadership observation.
+	require.NoError(t, pm.stateManager.Mutate(lockCtx, func(s *servingStateMutation) {
+		s.PostgresPrimary = true
+		if s.ServingStatus == clustermetadatapb.PoolerServingStatus_DRAINING {
+			s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
+		}
+	}))
 
 	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, pm.record.Type())
 	assert.Equal(t, clustermetadatapb.PoolerServingStatus_SERVING, pm.record.ServingStatus())

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -527,6 +527,19 @@ func (pm *MultiPoolerManager) UpdateConsensusRule(ctx context.Context, operation
 		"new_cohort", updatedStandbyIDs,
 		"expected_outgoing_rule", expectedOutgoingRule)
 
+	// The committed rule changed, so recalc the routing role from the fresh
+	// consensus snapshot. Today this is a no-op: UpdateConsensusRule only amends
+	// the cohort and keeps this pooler the leader (WithLeader above), so the
+	// routing role does not flip. It is here as a guard — if a rule write through
+	// this path ever changes the leader, the routing role and advertised
+	// observation re-derive immediately instead of waiting for the monitor's next
+	// drift tick. Runs after DoUpdateRule returns (outside the rule-store lock)
+	// and under the action lock, so it cannot deadlock. Precedes broadcastHealth
+	// so the pushed snapshot reflects any re-derived state.
+	if err := pm.stateManager.Recalc(ctx); err != nil {
+		pm.logger.WarnContext(ctx, "UpdateConsensusRule: failed to recalc serving state", "error", err)
+	}
+
 	// Push an immediate health snapshot so orchestrators learn about the changed
 	// synchronous standby list without waiting for the next 30-second heartbeat.
 	pm.broadcastHealth()

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -745,8 +745,6 @@ func (pm *MultiPoolerManager) demoteToStandbyLocked(ctx context.Context, consens
 		return err
 	}
 
-	pm.healthStreamer.UpdateLeaderObservation(nil)
-
 	// Mark the WAL as rewind-suspect: this node was just demoted, so the next
 	// restart-as-standby (the coordinator's RewindToSource, or the monitor's own
 	// demote path) must run pg_rewind before trusting local WAL.

--- a/go/services/multipooler/internal/manager/rpc_set_primary_test.go
+++ b/go/services/multipooler/internal/manager/rpc_set_primary_test.go
@@ -360,11 +360,15 @@ func TestSetPrimary_StalePrimaryDemotes(t *testing.T) {
 	assert.True(t, ruleStore.clearSyncCalled,
 		"stale-primary demotion should clear sync standby names via ClearSyncStandby")
 
-	// Gateway leader observation should reflect the new primary.
+	// A demoted pooler advertises no leader observation. The health-stream
+	// observation is derived from this pooler's own routing role: non-nil
+	// (naming self) only while it is the writable routing primary, and nil once
+	// demoted to a standby. A follower never advertises another pooler as the
+	// leader — the gateway learns the new primary from that primary's own health
+	// stream, not from this demoted node.
 	healthState := pm.healthStreamer.getState()
-	require.NotNil(t, healthState.LeaderObservation)
-	assert.Equal(t, "new-primary", healthState.LeaderObservation.LeaderID.Name)
-	assert.Equal(t, int64(10), healthState.LeaderObservation.LeaderTerm)
+	assert.Nil(t, healthState.LeaderObservation,
+		"a demoted pooler must not advertise a leader observation")
 }
 
 // TestSetPrimary_IgnoresRevokedRule verifies that when the incoming rule is

--- a/go/services/multipooler/internal/manager/state_manager.go
+++ b/go/services/multipooler/internal/manager/state_manager.go
@@ -272,9 +272,18 @@ func (ssm *StateManager) Mutate(ctx context.Context, fn func(s *servingStateMuta
 		return nil
 	}
 
-	ssm.logger.InfoContext(ctx, "Applying serving state",
-		"routing_role", target.RoutingRole, "status", target.ServingStatus, "postgres_primary", next.PostgresPrimary,
-		"prev_status", cur.ServingStatus, "prev_postgres_primary", cur.PostgresPrimary)
+	// This point is only reached when the effective state actually changed (the
+	// dedup above returned otherwise), so log it as a transition with prev -> new
+	// for each field. prev_routing_role comes from the last fan-out; it is unknown
+	// on the first transition (nil lastFannedOut).
+	prevRoutingRole := servingstate.RoutingRoleUnknown
+	if ssm.lastFannedOut != nil {
+		prevRoutingRole = ssm.lastFannedOut.RoutingRole
+	}
+	ssm.logger.InfoContext(ctx, "Serving state changed",
+		"routing_role", target.RoutingRole, "prev_routing_role", prevRoutingRole,
+		"status", target.ServingStatus, "prev_status", cur.ServingStatus,
+		"postgres_primary", next.PostgresPrimary, "prev_postgres_primary", cur.PostgresPrimary)
 
 	// Fan out first so a failed transition leaves the record untouched.
 	if err := ssm.fanOutLocked(ctx, target); err != nil {

--- a/go/services/multipooler/internal/manager/state_manager.go
+++ b/go/services/multipooler/internal/manager/state_manager.go
@@ -37,6 +37,14 @@ type StateAware interface {
 	// role (writability) and the serving intent — see servingstate.State. A
 	// component that needs consensus leadership reads it from the consensus
 	// snapshot directly; the serving layer does not carry it.
+	//
+	// INVARIANT — OnStateChange must be a pure sink: it consumes the state
+	// (transition, publish, project) and must NOT initiate a state change.
+	// Specifically it must not call StateManager.Mutate/Recalc (they assert the
+	// action lock and re-enter ssm.mu, which is held across the fan-out —
+	// deadlock) nor trigger a consensus mutation that would loop back into a
+	// recalc. Handlers run concurrently under ssm.mu; keep them non-blocking
+	// beyond waiting on their own subsystem.
 	OnStateChange(ctx context.Context, state servingstate.State) error
 }
 
@@ -150,10 +158,21 @@ func (ssm *StateManager) RegisterAndSync(ctx context.Context, component StateAwa
 	})
 }
 
+// sameFanout reports whether two states are equivalent for fan-out dedup. It
+// compares only RoutingRole and ServingStatus — the facts components react to —
+// and deliberately ignores Leadership: that observation is derived from
+// RoutingRole, and a same-leader rule bump (RoutingRole unchanged) need not
+// re-fan, while a rule change that matters (supersession) flips RoutingRole and
+// re-fans anyway. Comparing the pointer-valued Leadership here would also defeat
+// dedup, since Mutate builds a fresh observation each call.
+func sameFanout(a, b servingstate.State) bool {
+	return a.RoutingRole == b.RoutingRole && a.ServingStatus == b.ServingStatus
+}
+
 // fanOutLocked notifies every registered component of the target effective state
 // in parallel and waits for them to converge. Caller must hold mu.
 func (ssm *StateManager) fanOutLocked(ctx context.Context, target servingstate.State) error {
-	if ssm.lastFannedOut != nil && *ssm.lastFannedOut == target {
+	if ssm.lastFannedOut != nil && sameFanout(*ssm.lastFannedOut, target) {
 		// Components are already at this effective state; nothing to notify.
 		return nil
 	}
@@ -227,14 +246,21 @@ func (ssm *StateManager) Mutate(ctx context.Context, fn func(s *servingStateMuta
 	// the whole target against the last fan-out is what ensures OnStateChange fires
 	// on ANY effective-state change.
 	cs := ssm.consensusStatus()
+	routingRole := deriveRoutingRole(next.PostgresPrimary, cs)
 	target := servingstate.State{
-		RoutingRole:   deriveRoutingRole(next.PostgresPrimary, cs),
+		RoutingRole:   routingRole,
 		ServingStatus: next.ServingStatus,
+		// The self-leadership observation is derived here, so components that
+		// advertise it (the health streamer, the record projection below) publish
+		// it as a pure function of the fanned state — no explicit push. Non-nil
+		// (naming self at the committed rule) iff routing PRIMARY.
+		Leadership: routingLeadershipObs(routingRole, cs),
 	}
-	if ssm.lastFannedOut != nil && *ssm.lastFannedOut == target {
-		// Nothing components react to changed; no fan-out, no record write. (An
-		// obs rule-number bump that keeps the same routing role is published via
-		// the health stream, not the record.)
+	if ssm.lastFannedOut != nil && sameFanout(*ssm.lastFannedOut, target) {
+		// Nothing components react to changed; no fan-out, no record write. Dedup
+		// ignores Leadership: it is derived from RoutingRole, and a same-leader
+		// rule bump need not re-fan — a rule change that matters (supersession by
+		// a higher rule) flips RoutingRole to REPLICA and re-fans anyway.
 		//
 		// Still refresh the cached recovery fact: postgres may have left/entered
 		// recovery without flipping the derived routing role (e.g. while this
@@ -258,7 +284,7 @@ func (ssm *StateManager) Mutate(ctx context.Context, fn func(s *servingStateMuta
 	// received before the (fallible) record write.
 	ssm.postgresPrimary = next.PostgresPrimary
 
-	// Project the routing role onto the topology record: Type PRIMARY and a
+	// Project the routing role onto the topology record: Type PRIMARY and the
 	// self-leadership observation iff routing PRIMARY (writable). Type and obs move
 	// together, preserving the record's Type ⇔ SelfLeadership invariant. Write only
 	// when the projected Type or serving status actually differs from the record.
@@ -266,9 +292,8 @@ func (ssm *StateManager) Mutate(ctx context.Context, fn func(s *servingStateMuta
 	// TODO: this record projection could itself be a StateAware — give poolerRecord
 	// an OnStateChange(State) that projects routing role onto Type/SelfLeadership and
 	// register it as a component, so Mutate just fans out and owns no special-case
-	// record write. It would need the ServingStatus (already on State) and to be
-	// ordered so the record write follows component convergence.
-	obs := routingLeadershipObs(target.RoutingRole, cs)
+	// record write.
+	obs := target.Leadership
 	nextType := poolerTypeForLeader(obs != nil)
 	if nextType != ssm.record.Type() || next.ServingStatus != cur.ServingStatus {
 		if err := ssm.record.Mutate(ctx, func(s *MutablePoolerRecordState) {
@@ -304,7 +329,11 @@ func (ssm *StateManager) hasDrift(postgresPrimary bool) bool {
 		RoutingRole:   deriveRoutingRole(postgresPrimary, ssm.consensusStatus()),
 		ServingStatus: ssm.record.ServingStatus(),
 	}
-	return *ssm.lastFannedOut != observed
+	// Compare with sameFanout, not raw struct equality: the fanned-out state
+	// carries a derived Leadership pointer that `observed` intentionally leaves
+	// nil, and Mutate itself dedups on sameFanout (RoutingRole + ServingStatus).
+	// Using != here would treat the derived pointer as drift and re-fan forever.
+	return !sameFanout(*ssm.lastFannedOut, observed)
 }
 
 // fixDrift re-applies the effective state from a freshly-observed recovery flag
@@ -320,4 +349,20 @@ func (ssm *StateManager) fixDrift(ctx context.Context, postgresPrimary bool) err
 			s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 		}
 	})
+}
+
+// Recalc re-derives the effective state from the live consensus snapshot and the
+// last-known postgres recovery mode, fanning out only if something components
+// react to changed (deduped like any other Mutate). It exists for consensus-only
+// transitions — a revocation, a superseding committed rule — that flip the
+// routing role with no recovery or serving event to carry them, so components
+// (the query gate, the health stream advertising writable) converge immediately
+// instead of waiting for the monitor's next drift tick.
+//
+// It reuses the stored postgresPrimary rather than taking a fresh one: a pure
+// consensus change does not move postgres recovery mode, and any transition that
+// does move it already flows through Mutate. Like Mutate it requires the action
+// lock; today it is only called from consensus RPC handlers that already hold it.
+func (ssm *StateManager) Recalc(ctx context.Context) error {
+	return ssm.Mutate(ctx, func(*servingStateMutation) {})
 }

--- a/go/services/multipooler/internal/manager/state_manager_test.go
+++ b/go/services/multipooler/internal/manager/state_manager_test.go
@@ -524,6 +524,74 @@ func TestStateManager_RegisterAndSyncAfterDedupedRecoveryChange(t *testing.T) {
 		"late-registered component must derive PRIMARY from the refreshed recovery cache")
 }
 
+// TestStateManager_Recalc verifies Recalc re-derives the effective state from
+// the live consensus snapshot with no explicit recovery/serving change: when a
+// revocation makes this pooler no longer the active leader, Recalc flips the
+// fanned routing role PRIMARY->REPLICA and clears the self-leadership
+// observation immediately, rather than leaving it stale until the next monitor
+// drift tick. This is the behavior the Recruit path relies on after
+// AcceptRevocation persists.
+func TestStateManager_Recalc(t *testing.T) {
+	comp := &testComponent{}
+	r := newTestRecord(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
+
+	// A consensus snapshot the test flips from "self is the active leader" to
+	// "self's term is revoked", simulating a revocation arriving between the
+	// initial promotion and the Recalc. selfLeaderConsensusStatus names self at
+	// term 1; revoking below term 2 makes IsActiveLeader false.
+	var revoked atomic.Bool
+	consensusStatus := func() *clustermetadatapb.ConsensusStatus {
+		cs := selfLeaderConsensusStatus()
+		if revoked.Load() {
+			cs.TermRevocation = &clustermetadatapb.TermRevocation{RevokedBelowTerm: 2}
+		}
+		return cs
+	}
+
+	ssm := NewStateManager(newTestLogger(), r, consensusStatus, comp)
+
+	// Baseline: the writable leader — PRIMARY + self-naming observation.
+	require.NoError(t, ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
+		s.PostgresPrimary = true
+		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
+	}))
+	require.Equal(t, servingstate.RoutingRolePrimary, comp.lastRole)
+	require.Equal(t, clustermetadatapb.PoolerType_PRIMARY, r.Type())
+	require.NotNil(t, r.SelfLeadership())
+	callsAfterMutate := comp.callCount
+
+	// A revocation arrives: this pooler's term is revoked, so it is no longer the
+	// active leader even though postgres is still out of recovery. Recalc, with no
+	// recovery/serving mutation, must re-fan the flipped routing role.
+	revoked.Store(true)
+	require.NoError(t, ssm.Recalc(newActionLockedCtx(t)))
+
+	assert.Greater(t, comp.callCount, callsAfterMutate,
+		"Recalc should re-fan on the consensus-only change")
+	assert.Equal(t, servingstate.RoutingRoleReplica, comp.lastRole,
+		"revoked leader routes as REPLICA")
+	assert.Equal(t, clustermetadatapb.PoolerType_REPLICA, r.Type())
+	assert.Nil(t, r.SelfLeadership(),
+		"revoked leader must clear its self-leadership observation immediately")
+}
+
+// TestStateManager_Recalc_NoChangeIsNoOp verifies Recalc does not re-fan when the
+// derived state is unchanged (it dedups like any other Mutate).
+func TestStateManager_Recalc_NoChangeIsNoOp(t *testing.T) {
+	comp := &testComponent{}
+	r := newTestRecord(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
+	ssm := NewStateManager(newTestLogger(), r, selfLeaderConsensusStatus, comp)
+
+	require.NoError(t, ssm.Mutate(newActionLockedCtx(t), func(s *servingStateMutation) {
+		s.PostgresPrimary = true
+		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
+	}))
+	calls := comp.callCount
+
+	require.NoError(t, ssm.Recalc(newActionLockedCtx(t)))
+	assert.Equal(t, calls, comp.callCount, "Recalc with no derived change must not re-fan")
+}
+
 // nilConsensusStatus is a StateManager consensus-snapshot injector for tests that
 // don't exercise the derived routing role (nil -> not the active leader -> REPLICA).
 func nilConsensusStatus() *clustermetadatapb.ConsensusStatus { return nil }

--- a/go/services/multipooler/internal/poolerserver/health_provider.go
+++ b/go/services/multipooler/internal/poolerserver/health_provider.go
@@ -45,10 +45,6 @@ type HealthState struct {
 	// ReplicationLagNs is the current replication lag in nanoseconds,
 	// measured via heartbeat timestamps. Zero on the primary or when unknown.
 	ReplicationLagNs int64
-
-	// Writable reports whether postgres can accept writes (!pg_is_in_recovery).
-	// A consensus leader mid-promotion is SERVING (reads) but not yet Writable.
-	Writable bool
 }
 
 // LeaderObservation represents a pooler's view of who the consensus leader is.

--- a/go/services/multipooler/internal/servingstate/servingstate.go
+++ b/go/services/multipooler/internal/servingstate/servingstate.go
@@ -37,6 +37,20 @@ type State struct {
 
 	// ServingStatus is the serving intent (SERVING / DISABLED / DRAINING).
 	ServingStatus clustermetadatapb.PoolerServingStatus
+
+	// Leadership is the self-leadership observation to advertise while this pooler
+	// is the writable routing primary: non-nil (naming self at the committed rule)
+	// iff RoutingRole is PRIMARY, else nil. It is derived alongside RoutingRole so
+	// consumers publish "I am the writable primary at rule N" as a pure function of
+	// the fanned state — the topology record projects it onto Type/SelfLeadership,
+	// and the health streamer publishes it to the gateway — with no explicit
+	// push. A follower carries nil and therefore advertises no leader.
+	//
+	// TODO: RoutingRole and Leadership are two fields carrying one fact — a PRIMARY
+	// role always pairs with a self-naming observation, a REPLICA with nil. They
+	// collapse into a single RoutingState{role, rule} once the proto is evolved
+	// (see the RoutingState plan); this struct should follow suit then.
+	Leadership *clustermetadatapb.LeaderObservation
 }
 
 // RoutingRole is a pooler's role for query ROUTING and HA purposes. It is about

--- a/go/tools/ruleguard/rules.go
+++ b/go/tools/ruleguard/rules.go
@@ -216,6 +216,12 @@ func disallowWallClockInConsensus(m dsl.Matcher) {
 // pooler's health Status (Status.PoolerType) is also a different field.
 //
 // Use consensus instead (GetSelfLeadership() != nil / commonconsensus.SelfConsensusRole).
+//
+// TODO: broaden this to also ban reading MultiPooler.ServingStatus (and Type
+// generally) off the etcd topology record anywhere in the repo.
+// Add a companion rule reporting reads of $x.ServingStatus / $x.GetServingStatus()
+// on *clustermetadata.MultiPooler / *topoclient.MultiPoolerInfo outside the
+// pooler that owns the record.
 func disallowMultiPoolerTypeForRouting(m dsl.Matcher) {
 	m.Import("github.com/multigres/multigres/go/pb/clustermetadata")
 	m.Import("github.com/multigres/multigres/go/common/topoclient")

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -465,13 +465,28 @@ message PoolerPosition {
   string lsn = 2;
 }
 
-// LeaderObservation represents a pooler's view of who the consensus leader is.
-// It is carried in two places:
-//   - the leader's own MultiPooler topology record (self_leadership field), so
-//     multigateway can bootstrap leader routing from etcd at discovery time
-//     without relying on MultiPooler.type as a hint; and
+// LeaderObservation is a pooler's report of the writable routing primary — in
+// practice a pooler reporting itself once it is the active, writable leader. It
+// is carried in two places:
 //   - the multipooler health stream
-//     (StreamPoolerHealthResponse.leader_observation).
+//     (StreamPoolerHealthResponse.leader_observation), which multigateway uses as
+//     the live, authoritative signal for routing writes; and
+//   - the leader's own MultiPooler topology record (self_leadership field), a
+//     projection of the same fact. NOTE: multigateway no longer consults the
+//     topology record for leader identity — routing is driven purely by the live
+//     health stream.
+//
+// TODO(routing-state, fast-follow): the gateway now reasons about *routing*
+// (which pooler is the writable primary), not consensus leadership, so this
+// message should evolve into
+//     message RoutingState { RoutingRole role = 1; RuleNumber rule = 2; }
+// with a new prefixed proto3 enum
+//     enum RoutingRole { ROUTING_ROLE_UNKNOWN = 0; ROUTING_ROLE_PRIMARY = 1;
+//                        ROUTING_ROLE_REPLICA = 2; }
+// leader_id then drops out: a pooler only reports its own routing state, so the
+// identity is contextual. This mirrors the internal servingstate.RoutingRole /
+// State.Leadership pair. Keep RoutingState off the orch-facing consensus-fitness
+// path — orch derives writability from consensus state, not this routing label.
 message LeaderObservation {
   // leader_id is the ID of the pooler this node believes is the consensus leader.
   // May be this pooler's own ID if it believes itself to be leader.

--- a/proto/multipoolerservice.proto
+++ b/proto/multipoolerservice.proto
@@ -570,12 +570,6 @@ message StreamPoolerHealthResponse {
   // replication_lag_ns is the current replication lag in nanoseconds,
   // measured via heartbeat timestamps. Zero on a leader or when unknown.
   int64 replication_lag_ns = 6;
-
-  // writable reports whether this pooler can accept writes — i.e. postgres is
-  // out of recovery (!pg_is_in_recovery). A consensus leader mid-promotion is
-  // SERVING (can answer reads) but not yet writable, so clients must gate write
-  // traffic on this rather than on pooler_type/serving_status alone.
-  bool writable = 7;
 }
 
 // StreamNotificationsRequest subscribes to or unsubscribes from PG notification channels.

--- a/web/multiadmin/lib/api/generated/clustermetadata_pb.ts
+++ b/web/multiadmin/lib/api/generated/clustermetadata_pb.ts
@@ -1562,13 +1562,28 @@ export class PoolerPosition extends Message<PoolerPosition> {
 }
 
 /**
- * LeaderObservation represents a pooler's view of who the consensus leader is.
- * It is carried in two places:
- *   - the leader's own MultiPooler topology record (self_leadership field), so
- *     multigateway can bootstrap leader routing from etcd at discovery time
- *     without relying on MultiPooler.type as a hint; and
+ * LeaderObservation is a pooler's report of the writable routing primary — in
+ * practice a pooler reporting itself once it is the active, writable leader. It
+ * is carried in two places:
  *   - the multipooler health stream
- *     (StreamPoolerHealthResponse.leader_observation).
+ *     (StreamPoolerHealthResponse.leader_observation), which multigateway uses as
+ *     the live, authoritative signal for routing writes; and
+ *   - the leader's own MultiPooler topology record (self_leadership field), a
+ *     projection of the same fact. NOTE: multigateway no longer consults the
+ *     topology record for leader identity — routing is driven purely by the live
+ *     health stream.
+ *
+ * TODO(routing-state, fast-follow): the gateway now reasons about *routing*
+ * (which pooler is the writable primary), not consensus leadership, so this
+ * message should evolve into
+ *     message RoutingState { RoutingRole role = 1; RuleNumber rule = 2; }
+ * with a new prefixed proto3 enum
+ *     enum RoutingRole { ROUTING_ROLE_UNKNOWN = 0; ROUTING_ROLE_PRIMARY = 1;
+ *                        ROUTING_ROLE_REPLICA = 2; }
+ * leader_id then drops out: a pooler only reports its own routing state, so the
+ * identity is contextual. This mirrors the internal servingstate.RoutingRole /
+ * State.Leadership pair. Keep RoutingState off the orch-facing consensus-fitness
+ * path — orch derives writability from consensus state, not this routing label.
  *
  * @generated from message clustermetadata.LeaderObservation
  */


### PR DESCRIPTION
## Summary

The multigateway is a **gate**: for routing and buffering, all that matters is *is there a writable primary for this shard, and which pooler is it*. This PR leans fully into that — the gateway routes by a **routing role** that each pooler derives and self-reports on its live health stream, rather than inferring leadership from consensus role or the etcd topology record.

The key shift: **a pooler advertises a leader observation only when it is the writable routing primary** (postgres out of recovery AND the active, non-revoked, highest-known committed leader). So the *presence* of the observation now implies writability — the gateway deals only in "writable primary present → route writes here; absent → buffer," with the rule number as a tiebreaker during a brief failover overlap.

## What changed

- **Route by a live routing-primary set, not etcd / highest-known** — the gateway's per-shard summary is the set of poolers currently claiming to be the writable primary, fed purely by health-stream observations. Dropped `mergeTopologyLeader`: etcd is not consulted for leader identity. We need a gRPC connection to send queries anyway, so that seems like the authoritative place to learn about pooler health
- **Derive the leader observation from routing state** — it is now a pure function of the fanned serving state (non-nil, naming self, iff routing PRIMARY; nil otherwise). Deleted the imperative `UpdateLeaderObservation` and all its callers; followers and demoted poolers advertise nil automatically. Added `StateManager.Recalc` so a revocation flips routing to REPLICA (and clears the advertisement) immediately instead of on the next monitor tick.
- **Dropped the `writable` health field** — presence of the observation implies writability, so the separate bool is redundant (proto + health state + gateway-facing conversion).
- **Shard summary is the sole authority for primary claims** — dropped `believesSelfLeader`; both stale-leader reporting and replica-read exclusion read the summary. Any primary claimant is excluded from replica reads: a claimant headed for demotion will restart / `pg_rewind` postgres, interrupting reads that outlast the drain grace period.

## Behavior changes worth calling out

- **CONSISTENT reads buffer until a writable leader exists**, rather than being served by a not-yet-writable appointed leader — more correct for read-your-writes, at the cost of buffering during the promotion window.
- The gateway discovers a new primary from its **health stream**, not etcd — slightly later than an etcd write, but live and authoritative.
- A demoted / stale primary is excluded from replica reads until it stops claiming primary.

## Potential follow-ups

- Evolve `LeaderObservation` → `RoutingState {role, rule}` with a prefixed `RoutingRole` proto3 enum. Kept out of this PR to stay reviewable.
- Lock-free recalc so `ObservePosition` can trigger a re-fan on a superseding committed rule (today: monitor tick).
- Multi-phase fan-out to retire the `AwaitStateChange` rendezvous.

