### PR TITLE
refactor: replace LeaderObservation with RoutingState{role, rule}

### DIFF
--- a/go/common/consensus/compare.go
+++ b/go/common/consensus/compare.go
@@ -66,24 +66,6 @@ func FormatRuleNumber(rn *clustermetadatapb.RuleNumber) string {
 	return fmt.Sprintf("%d.%d", rn.GetCoordinatorTerm(), rn.GetLeaderSubterm())
 }
 
-// MostAuthoritativeObservation returns the LeaderObservation with the highest
-// rule number among those given (nil entries are skipped). Used to merge leader
-// observations from different sources — a topology record's self_leadership and
-// a health-stream report — choosing the one made under the newest rule. Returns
-// nil if all inputs are nil.
-func MostAuthoritativeObservation(obs ...*clustermetadatapb.LeaderObservation) *clustermetadatapb.LeaderObservation {
-	var best *clustermetadatapb.LeaderObservation
-	for _, o := range obs {
-		if o == nil {
-			continue
-		}
-		if best == nil || CompareRuleNumbers(o.GetLeaderRuleNumber(), best.GetLeaderRuleNumber()) > 0 {
-			best = o
-		}
-	}
-	return best
-}
-
 // MostAdvancedPosition returns the highest-ranked PoolerPosition among the
 // given statuses. Rule number takes precedence; LSN breaks ties within the
 // same rule. Returns nil if no status has a parseable LSN.

--- a/go/common/consensus/compare_test.go
+++ b/go/common/consensus/compare_test.go
@@ -268,38 +268,6 @@ func TestComparePosition(t *testing.T) {
 	}
 }
 
-func obs(name string, term, subterm int64) *clustermetadatapb.LeaderObservation {
-	return &clustermetadatapb.LeaderObservation{
-		LeaderId:         &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: name},
-		LeaderRuleNumber: rn(term, subterm),
-	}
-}
-
-func TestMostAuthoritativeObservation(t *testing.T) {
-	a := obs("a", 5, 0)
-	b := obs("b", 6, 0)
-	c := obs("c", 6, 1)
-
-	t.Run("all nil returns nil", func(t *testing.T) {
-		assert.Nil(t, MostAuthoritativeObservation(nil, nil))
-		assert.Nil(t, MostAuthoritativeObservation())
-	})
-
-	t.Run("skips nil entries", func(t *testing.T) {
-		assert.Same(t, a, MostAuthoritativeObservation(nil, a, nil))
-	})
-
-	t.Run("highest rule number wins", func(t *testing.T) {
-		assert.Same(t, b, MostAuthoritativeObservation(a, b))
-		assert.Same(t, c, MostAuthoritativeObservation(a, b, c)) // subterm breaks the term tie
-	})
-
-	t.Run("first wins on an exact rule tie", func(t *testing.T) {
-		tie := obs("tie", 6, 1)
-		assert.Same(t, c, MostAuthoritativeObservation(c, tie))
-	})
-}
-
 func leaderID(name string) *clustermetadatapb.ID {
 	return &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: name}
 }

--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -289,6 +289,67 @@ func (QuorumType) EnumDescriptor() ([]byte, []int) {
 	return file_clustermetadata_proto_rawDescGZIP(), []int{3}
 }
 
+// RoutingRole is a pooler's role for query ROUTING and HA purposes. It is about
+// WRITABILITY, not consensus: PRIMARY means this pooler is the writable leader,
+// REPLICA means it is not. This is deliberately distinct from consensus
+// leadership (leader/follower, tracked in ConsensusStatus and rule history) and
+// from postgres recovery mode (primary/standby). Consensus consumers
+// (multiorch) must NOT read this — they read consensus state directly.
+type RoutingRole int32
+
+const (
+	// ROUTING_ROLE_UNKNOWN is the proto3 zero value: the routing role has not been
+	// established yet (cold start) or comes from a record predating this field.
+	// Treated as "not the writable leader" — never routed writes.
+	RoutingRole_ROUTING_ROLE_UNKNOWN RoutingRole = 0
+	// ROUTING_ROLE_PRIMARY: this pooler is the writable leader. Postgres is out of
+	// recovery AND it is the highest non-revoked committed leader. Writes route here.
+	RoutingRole_ROUTING_ROLE_PRIMARY RoutingRole = 1
+	// ROUTING_ROLE_REPLICA: this pooler is not the writable leader.
+	RoutingRole_ROUTING_ROLE_REPLICA RoutingRole = 2
+)
+
+// Enum value maps for RoutingRole.
+var (
+	RoutingRole_name = map[int32]string{
+		0: "ROUTING_ROLE_UNKNOWN",
+		1: "ROUTING_ROLE_PRIMARY",
+		2: "ROUTING_ROLE_REPLICA",
+	}
+	RoutingRole_value = map[string]int32{
+		"ROUTING_ROLE_UNKNOWN": 0,
+		"ROUTING_ROLE_PRIMARY": 1,
+		"ROUTING_ROLE_REPLICA": 2,
+	}
+)
+
+func (x RoutingRole) Enum() *RoutingRole {
+	p := new(RoutingRole)
+	*p = x
+	return p
+}
+
+func (x RoutingRole) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RoutingRole) Descriptor() protoreflect.EnumDescriptor {
+	return file_clustermetadata_proto_enumTypes[4].Descriptor()
+}
+
+func (RoutingRole) Type() protoreflect.EnumType {
+	return &file_clustermetadata_proto_enumTypes[4]
+}
+
+func (x RoutingRole) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RoutingRole.Descriptor instead.
+func (RoutingRole) EnumDescriptor() ([]byte, []int) {
+	return file_clustermetadata_proto_rawDescGZIP(), []int{4}
+}
+
 // LeadershipSignal describes a leader's self-reported status for its current term.
 // Only published by nodes that are or were the consensus leader (leader_term != 0).
 // 0 (UNKNOWN) means the field was not intentionally set.
@@ -335,11 +396,11 @@ func (x LeadershipSignal) String() string {
 }
 
 func (LeadershipSignal) Descriptor() protoreflect.EnumDescriptor {
-	return file_clustermetadata_proto_enumTypes[4].Descriptor()
+	return file_clustermetadata_proto_enumTypes[5].Descriptor()
 }
 
 func (LeadershipSignal) Type() protoreflect.EnumType {
-	return &file_clustermetadata_proto_enumTypes[4]
+	return &file_clustermetadata_proto_enumTypes[5]
 }
 
 func (x LeadershipSignal) Number() protoreflect.EnumNumber {
@@ -348,7 +409,7 @@ func (x LeadershipSignal) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use LeadershipSignal.Descriptor instead.
 func (LeadershipSignal) EnumDescriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{4}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{5}
 }
 
 // CohortEligibilitySignal describes a pooler's self-reported willingness to
@@ -392,11 +453,11 @@ func (x CohortEligibilitySignal) String() string {
 }
 
 func (CohortEligibilitySignal) Descriptor() protoreflect.EnumDescriptor {
-	return file_clustermetadata_proto_enumTypes[5].Descriptor()
+	return file_clustermetadata_proto_enumTypes[6].Descriptor()
 }
 
 func (CohortEligibilitySignal) Type() protoreflect.EnumType {
-	return &file_clustermetadata_proto_enumTypes[5]
+	return &file_clustermetadata_proto_enumTypes[6]
 }
 
 func (x CohortEligibilitySignal) Number() protoreflect.EnumNumber {
@@ -405,7 +466,7 @@ func (x CohortEligibilitySignal) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CohortEligibilitySignal.Descriptor instead.
 func (CohortEligibilitySignal) EnumDescriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{5}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{6}
 }
 
 // ComponentType represents the type of Multigres component
@@ -449,11 +510,11 @@ func (x ID_ComponentType) String() string {
 }
 
 func (ID_ComponentType) Descriptor() protoreflect.EnumDescriptor {
-	return file_clustermetadata_proto_enumTypes[6].Descriptor()
+	return file_clustermetadata_proto_enumTypes[7].Descriptor()
 }
 
 func (ID_ComponentType) Type() protoreflect.EnumType {
-	return &file_clustermetadata_proto_enumTypes[6]
+	return &file_clustermetadata_proto_enumTypes[7]
 }
 
 func (x ID_ComponentType) Number() protoreflect.EnumNumber {
@@ -1051,18 +1112,14 @@ type MultiPooler struct {
 	// readiness). Recorded in topology so the orchestrator can observe terminal
 	// lifecycle states even on cold start, not only over the health stream.
 	LifecycleStatus *PoolerLifecycle `protobuf:"bytes,12,opt,name=lifecycle_status,json=lifecycleStatus,proto3" json:"lifecycle_status,omitempty"`
-	// self_leadership is set ONLY when this pooler currently considers itself
-	// the leader of its shard (it names this pooler). Replicas leave it empty —
-	// a replica has no self-leadership — which avoids high-volume etcd writes by
+	// routing_state advertises this pooler's routing/HA role. It is set ONLY when
+	// this pooler is the writable PRIMARY (postgres out of recovery AND highest
+	// non-revoked committed leader). Replicas — including a consensus leader that
+	// is not yet writable — leave it empty, which avoids high-volume etcd writes by
 	// every replica during failovers.
-	//
-	// Consumers (multigateway) will read this on discovery to bootstrap leader
-	// routing without relying on `type` as a hint. Best-effort: empty until the
-	// pooler has been told (via SetTermPrimary / Propose / Recruit) that it is
-	// the leader; cleared again on demotion.
-	SelfLeadership *LeaderObservation `protobuf:"bytes,13,opt,name=self_leadership,json=selfLeadership,proto3" json:"self_leadership,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	RoutingState  *RoutingState `protobuf:"bytes,13,opt,name=routing_state,json=routingState,proto3" json:"routing_state,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *MultiPooler) Reset() {
@@ -1165,9 +1222,9 @@ func (x *MultiPooler) GetLifecycleStatus() *PoolerLifecycle {
 	return nil
 }
 
-func (x *MultiPooler) GetSelfLeadership() *LeaderObservation {
+func (x *MultiPooler) GetRoutingState() *RoutingState {
 	if x != nil {
-		return x.SelfLeadership
+		return x.RoutingState
 	}
 	return nil
 }
@@ -1868,59 +1925,46 @@ func (x *PoolerPosition) GetLsn() string {
 	return ""
 }
 
-// LeaderObservation is a pooler's report of the writable routing primary — in
-// practice a pooler reporting itself once it is the active, writable leader. It
-// is carried in two places:
-//   - the multipooler health stream
-//     (StreamPoolerHealthResponse.leader_observation), which multigateway uses as
-//     the live, authoritative signal for routing writes; and
-//   - the leader's own MultiPooler topology record (self_leadership field), a
-//     projection of the same fact. NOTE: multigateway no longer consults the
-//     topology record for leader identity — routing is driven purely by the live
-//     health stream.
+// RoutingState is a pooler's self-reported routing/HA state: its writability
+// role plus the rule that qualifies it. The pooler's identity is contextual (the
+// enclosing MultiPooler.id, or StreamPoolerHealthResponse.pooler_id) — a REPLICA
+// never points at "the leader", so there is no leader_id here.
 //
-// TODO(routing-state, fast-follow): the gateway now reasons about *routing*
-// (which pooler is the writable primary), not consensus leadership, so this
-// message should evolve into
-//
-//	message RoutingState { RoutingRole role = 1; RuleNumber rule = 2; }
-//
-// with a new prefixed proto3 enum
-//
-//	enum RoutingRole { ROUTING_ROLE_UNKNOWN = 0; ROUTING_ROLE_PRIMARY = 1;
-//	                   ROUTING_ROLE_REPLICA = 2; }
-//
-// leader_id then drops out: a pooler only reports its own routing state, so the
-// identity is contextual. This mirrors the internal servingstate.RoutingRole /
-// State.Leadership pair. Keep RoutingState off the orch-facing consensus-fitness
-// path — orch derives writability from consensus state, not this routing label.
-type LeaderObservation struct {
+// It is carried in two places:
+//   - the writable leader's own MultiPooler topology record (routing_state field,
+//     set only when PRIMARY), so multigateway can bootstrap write routing from
+//     etcd at discovery time without relying on MultiPooler.type as a hint; and
+//   - the multipooler health stream (StreamPoolerHealthResponse.routing_state),
+//     always populated, where role == PRIMARY is the writable signal.
+type RoutingState struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// leader_id is the ID of the pooler this node believes is the consensus leader.
-	// May be this pooler's own ID if it believes itself to be leader.
-	LeaderId *ID `protobuf:"bytes,1,opt,name=leader_id,json=leaderId,proto3" json:"leader_id,omitempty"`
-	// leader_rule_number identifies the rule under which this observation was
-	// made. Lexicographic comparison over (coordinator_term, leader_subterm)
-	// disambiguates concurrent observations during stand-in promotion windows.
-	LeaderRuleNumber *RuleNumber `protobuf:"bytes,2,opt,name=leader_rule_number,json=leaderRuleNumber,proto3" json:"leader_rule_number,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// role is the writability routing role. role == PRIMARY is the writable signal.
+	Role RoutingRole `protobuf:"varint,1,opt,name=role,proto3,enum=clustermetadata.RoutingRole" json:"role,omitempty"`
+	// rule qualifies the role, compared lexicographically over
+	// (coordinator_term, leader_subterm). For PRIMARY it is the committed,
+	// non-revoked rule naming this pooler (write authority; the gateway ranks
+	// competing PRIMARYs by it during the brief overlapping-failover window). For
+	// REPLICA it is the highest rule this pooler has known (advisory) — for a
+	// self-demoting stale primary, its last-known leadership rule.
+	Rule          *RuleNumber `protobuf:"bytes,2,opt,name=rule,proto3" json:"rule,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
-func (x *LeaderObservation) Reset() {
-	*x = LeaderObservation{}
+func (x *RoutingState) Reset() {
+	*x = RoutingState{}
 	mi := &file_clustermetadata_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *LeaderObservation) String() string {
+func (x *RoutingState) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*LeaderObservation) ProtoMessage() {}
+func (*RoutingState) ProtoMessage() {}
 
-func (x *LeaderObservation) ProtoReflect() protoreflect.Message {
+func (x *RoutingState) ProtoReflect() protoreflect.Message {
 	mi := &file_clustermetadata_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1932,21 +1976,21 @@ func (x *LeaderObservation) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use LeaderObservation.ProtoReflect.Descriptor instead.
-func (*LeaderObservation) Descriptor() ([]byte, []int) {
+// Deprecated: Use RoutingState.ProtoReflect.Descriptor instead.
+func (*RoutingState) Descriptor() ([]byte, []int) {
 	return file_clustermetadata_proto_rawDescGZIP(), []int{19}
 }
 
-func (x *LeaderObservation) GetLeaderId() *ID {
+func (x *RoutingState) GetRole() RoutingRole {
 	if x != nil {
-		return x.LeaderId
+		return x.Role
 	}
-	return nil
+	return RoutingRole_ROUTING_ROLE_UNKNOWN
 }
 
-func (x *LeaderObservation) GetLeaderRuleNumber() *RuleNumber {
+func (x *RoutingState) GetRule() *RuleNumber {
 	if x != nil {
-		return x.LeaderRuleNumber
+		return x.Rule
 	}
 	return nil
 }
@@ -2537,7 +2581,7 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\rPoolerAddress\x12#\n" +
 	"\x02id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\x02id\x12\x12\n" +
 	"\x04host\x18\x02 \x01(\tR\x04host\x12#\n" +
-	"\rpostgres_port\x18\x03 \x01(\x05R\fpostgresPort\"\x97\x05\n" +
+	"\rpostgres_port\x18\x03 \x01(\x05R\fpostgresPort\"\x8e\x05\n" +
 	"\vMultiPooler\x12#\n" +
 	"\x02id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\x02id\x126\n" +
 	"\tshard_key\x18\x02 \x01(\v2\x19.clustermetadata.ShardKeyR\bshardKey\x126\n" +
@@ -2550,8 +2594,8 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"pooler_dir\x18\n" +
 	" \x01(\tR\tpoolerDir\x12\x1e\n" +
 	"\vpg_data_dir\x18\v \x01(\tR\tpgDataDir\x12K\n" +
-	"\x10lifecycle_status\x18\f \x01(\v2 .clustermetadata.PoolerLifecycleR\x0flifecycleStatus\x12K\n" +
-	"\x0fself_leadership\x18\r \x01(\v2\".clustermetadata.LeaderObservationR\x0eselfLeadership\x1a:\n" +
+	"\x10lifecycle_status\x18\f \x01(\v2 .clustermetadata.PoolerLifecycleR\x0flifecycleStatus\x12B\n" +
+	"\rrouting_state\x18\r \x01(\v2\x1d.clustermetadata.RoutingStateR\froutingState\x1a:\n" +
 	"\fPortMapEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"\xf1\x01\n" +
@@ -2614,10 +2658,10 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\rcreation_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\fcreationTime\"R\n" +
 	"\x0ePoolerPosition\x12.\n" +
 	"\x04rule\x18\x01 \x01(\v2\x1a.clustermetadata.ShardRuleR\x04rule\x12\x10\n" +
-	"\x03lsn\x18\x02 \x01(\tR\x03lsn\"\x90\x01\n" +
-	"\x11LeaderObservation\x120\n" +
-	"\tleader_id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\bleaderId\x12I\n" +
-	"\x12leader_rule_number\x18\x02 \x01(\v2\x1b.clustermetadata.RuleNumberR\x10leaderRuleNumber\"\xa1\x01\n" +
+	"\x03lsn\x18\x02 \x01(\tR\x03lsn\"q\n" +
+	"\fRoutingState\x120\n" +
+	"\x04role\x18\x01 \x01(\x0e2\x1c.clustermetadata.RoutingRoleR\x04role\x12/\n" +
+	"\x04rule\x18\x02 \x01(\v2\x1b.clustermetadata.RuleNumberR\x04rule\"\xa1\x01\n" +
 	"\x12ReplicationPrimary\x12.\n" +
 	"\x04rule\x18\x01 \x01(\v2\x1a.clustermetadata.ShardRuleR\x04rule\x128\n" +
 	"\aprimary\x18\x02 \x01(\v2\x1e.clustermetadata.PoolerAddressR\aprimary\x12!\n" +
@@ -2666,7 +2710,11 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"QuorumType\x12\x17\n" +
 	"\x13QUORUM_TYPE_UNKNOWN\x10\x00\x12\x1a\n" +
 	"\x16QUORUM_TYPE_AT_LEAST_N\x10\x03\x12%\n" +
-	"!QUORUM_TYPE_MULTI_CELL_AT_LEAST_N\x10\x04*z\n" +
+	"!QUORUM_TYPE_MULTI_CELL_AT_LEAST_N\x10\x04*[\n" +
+	"\vRoutingRole\x12\x18\n" +
+	"\x14ROUTING_ROLE_UNKNOWN\x10\x00\x12\x18\n" +
+	"\x14ROUTING_ROLE_PRIMARY\x10\x01\x12\x18\n" +
+	"\x14ROUTING_ROLE_REPLICA\x10\x02*z\n" +
 	"\x10LeadershipSignal\x12\x1d\n" +
 	"\x19LEADERSHIP_SIGNAL_UNKNOWN\x10\x00\x12\x1c\n" +
 	"\x18LEADERSHIP_SIGNAL_ACTIVE\x10\x01\x12)\n" +
@@ -2688,95 +2736,96 @@ func file_clustermetadata_proto_rawDescGZIP() []byte {
 	return file_clustermetadata_proto_rawDescData
 }
 
-var file_clustermetadata_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
+var file_clustermetadata_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
 var file_clustermetadata_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_clustermetadata_proto_goTypes = []any{
 	(PoolerType)(0),                       // 0: clustermetadata.PoolerType
 	(PoolerLifecycleStatus)(0),            // 1: clustermetadata.PoolerLifecycleStatus
 	(PoolerServingStatus)(0),              // 2: clustermetadata.PoolerServingStatus
 	(QuorumType)(0),                       // 3: clustermetadata.QuorumType
-	(LeadershipSignal)(0),                 // 4: clustermetadata.LeadershipSignal
-	(CohortEligibilitySignal)(0),          // 5: clustermetadata.CohortEligibilitySignal
-	(ID_ComponentType)(0),                 // 6: clustermetadata.ID.ComponentType
-	(*GlobalTopoConfig)(nil),              // 7: clustermetadata.GlobalTopoConfig
-	(*Cell)(nil),                          // 8: clustermetadata.Cell
-	(*Database)(nil),                      // 9: clustermetadata.Database
-	(*ShardInitClaim)(nil),                // 10: clustermetadata.ShardInitClaim
-	(*BackupLocation)(nil),                // 11: clustermetadata.BackupLocation
-	(*FilesystemBackup)(nil),              // 12: clustermetadata.FilesystemBackup
-	(*S3Backup)(nil),                      // 13: clustermetadata.S3Backup
-	(*PoolerAddress)(nil),                 // 14: clustermetadata.PoolerAddress
-	(*MultiPooler)(nil),                   // 15: clustermetadata.MultiPooler
-	(*MultiGateway)(nil),                  // 16: clustermetadata.MultiGateway
-	(*ShardKey)(nil),                      // 17: clustermetadata.ShardKey
-	(*MultiOrch)(nil),                     // 18: clustermetadata.MultiOrch
-	(*ID)(nil),                            // 19: clustermetadata.ID
-	(*KeyRange)(nil),                      // 20: clustermetadata.KeyRange
-	(*PoolerLifecycle)(nil),               // 21: clustermetadata.PoolerLifecycle
-	(*DurabilityPolicy)(nil),              // 22: clustermetadata.DurabilityPolicy
-	(*RuleNumber)(nil),                    // 23: clustermetadata.RuleNumber
-	(*ShardRule)(nil),                     // 24: clustermetadata.ShardRule
-	(*PoolerPosition)(nil),                // 25: clustermetadata.PoolerPosition
-	(*LeaderObservation)(nil),             // 26: clustermetadata.LeaderObservation
-	(*ReplicationPrimary)(nil),            // 27: clustermetadata.ReplicationPrimary
-	(*TermRevocation)(nil),                // 28: clustermetadata.TermRevocation
-	(*ExternallyCertifiedRevocation)(nil), // 29: clustermetadata.ExternallyCertifiedRevocation
-	(*ConsensusStatus)(nil),               // 30: clustermetadata.ConsensusStatus
-	(*LeadershipStatus)(nil),              // 31: clustermetadata.LeadershipStatus
-	(*AvailabilityStatus)(nil),            // 32: clustermetadata.AvailabilityStatus
-	(*CohortEligibilityStatus)(nil),       // 33: clustermetadata.CohortEligibilityStatus
-	nil,                                   // 34: clustermetadata.MultiPooler.PortMapEntry
-	nil,                                   // 35: clustermetadata.MultiGateway.PortMapEntry
-	nil,                                   // 36: clustermetadata.MultiOrch.PortMapEntry
-	(*timestamppb.Timestamp)(nil),         // 37: google.protobuf.Timestamp
+	(RoutingRole)(0),                      // 4: clustermetadata.RoutingRole
+	(LeadershipSignal)(0),                 // 5: clustermetadata.LeadershipSignal
+	(CohortEligibilitySignal)(0),          // 6: clustermetadata.CohortEligibilitySignal
+	(ID_ComponentType)(0),                 // 7: clustermetadata.ID.ComponentType
+	(*GlobalTopoConfig)(nil),              // 8: clustermetadata.GlobalTopoConfig
+	(*Cell)(nil),                          // 9: clustermetadata.Cell
+	(*Database)(nil),                      // 10: clustermetadata.Database
+	(*ShardInitClaim)(nil),                // 11: clustermetadata.ShardInitClaim
+	(*BackupLocation)(nil),                // 12: clustermetadata.BackupLocation
+	(*FilesystemBackup)(nil),              // 13: clustermetadata.FilesystemBackup
+	(*S3Backup)(nil),                      // 14: clustermetadata.S3Backup
+	(*PoolerAddress)(nil),                 // 15: clustermetadata.PoolerAddress
+	(*MultiPooler)(nil),                   // 16: clustermetadata.MultiPooler
+	(*MultiGateway)(nil),                  // 17: clustermetadata.MultiGateway
+	(*ShardKey)(nil),                      // 18: clustermetadata.ShardKey
+	(*MultiOrch)(nil),                     // 19: clustermetadata.MultiOrch
+	(*ID)(nil),                            // 20: clustermetadata.ID
+	(*KeyRange)(nil),                      // 21: clustermetadata.KeyRange
+	(*PoolerLifecycle)(nil),               // 22: clustermetadata.PoolerLifecycle
+	(*DurabilityPolicy)(nil),              // 23: clustermetadata.DurabilityPolicy
+	(*RuleNumber)(nil),                    // 24: clustermetadata.RuleNumber
+	(*ShardRule)(nil),                     // 25: clustermetadata.ShardRule
+	(*PoolerPosition)(nil),                // 26: clustermetadata.PoolerPosition
+	(*RoutingState)(nil),                  // 27: clustermetadata.RoutingState
+	(*ReplicationPrimary)(nil),            // 28: clustermetadata.ReplicationPrimary
+	(*TermRevocation)(nil),                // 29: clustermetadata.TermRevocation
+	(*ExternallyCertifiedRevocation)(nil), // 30: clustermetadata.ExternallyCertifiedRevocation
+	(*ConsensusStatus)(nil),               // 31: clustermetadata.ConsensusStatus
+	(*LeadershipStatus)(nil),              // 32: clustermetadata.LeadershipStatus
+	(*AvailabilityStatus)(nil),            // 33: clustermetadata.AvailabilityStatus
+	(*CohortEligibilityStatus)(nil),       // 34: clustermetadata.CohortEligibilityStatus
+	nil,                                   // 35: clustermetadata.MultiPooler.PortMapEntry
+	nil,                                   // 36: clustermetadata.MultiGateway.PortMapEntry
+	nil,                                   // 37: clustermetadata.MultiOrch.PortMapEntry
+	(*timestamppb.Timestamp)(nil),         // 38: google.protobuf.Timestamp
 }
 var file_clustermetadata_proto_depIdxs = []int32{
-	11, // 0: clustermetadata.Database.backup_location:type_name -> clustermetadata.BackupLocation
-	22, // 1: clustermetadata.Database.bootstrap_durability_policy:type_name -> clustermetadata.DurabilityPolicy
-	19, // 2: clustermetadata.ShardInitClaim.claimer_id:type_name -> clustermetadata.ID
-	19, // 3: clustermetadata.ShardInitClaim.cohort_members:type_name -> clustermetadata.ID
-	12, // 4: clustermetadata.BackupLocation.filesystem:type_name -> clustermetadata.FilesystemBackup
-	13, // 5: clustermetadata.BackupLocation.s3:type_name -> clustermetadata.S3Backup
-	19, // 6: clustermetadata.PoolerAddress.id:type_name -> clustermetadata.ID
-	19, // 7: clustermetadata.MultiPooler.id:type_name -> clustermetadata.ID
-	17, // 8: clustermetadata.MultiPooler.shard_key:type_name -> clustermetadata.ShardKey
-	20, // 9: clustermetadata.MultiPooler.key_range:type_name -> clustermetadata.KeyRange
+	12, // 0: clustermetadata.Database.backup_location:type_name -> clustermetadata.BackupLocation
+	23, // 1: clustermetadata.Database.bootstrap_durability_policy:type_name -> clustermetadata.DurabilityPolicy
+	20, // 2: clustermetadata.ShardInitClaim.claimer_id:type_name -> clustermetadata.ID
+	20, // 3: clustermetadata.ShardInitClaim.cohort_members:type_name -> clustermetadata.ID
+	13, // 4: clustermetadata.BackupLocation.filesystem:type_name -> clustermetadata.FilesystemBackup
+	14, // 5: clustermetadata.BackupLocation.s3:type_name -> clustermetadata.S3Backup
+	20, // 6: clustermetadata.PoolerAddress.id:type_name -> clustermetadata.ID
+	20, // 7: clustermetadata.MultiPooler.id:type_name -> clustermetadata.ID
+	18, // 8: clustermetadata.MultiPooler.shard_key:type_name -> clustermetadata.ShardKey
+	21, // 9: clustermetadata.MultiPooler.key_range:type_name -> clustermetadata.KeyRange
 	0,  // 10: clustermetadata.MultiPooler.type:type_name -> clustermetadata.PoolerType
 	2,  // 11: clustermetadata.MultiPooler.serving_status:type_name -> clustermetadata.PoolerServingStatus
-	34, // 12: clustermetadata.MultiPooler.port_map:type_name -> clustermetadata.MultiPooler.PortMapEntry
-	21, // 13: clustermetadata.MultiPooler.lifecycle_status:type_name -> clustermetadata.PoolerLifecycle
-	26, // 14: clustermetadata.MultiPooler.self_leadership:type_name -> clustermetadata.LeaderObservation
-	19, // 15: clustermetadata.MultiGateway.id:type_name -> clustermetadata.ID
-	35, // 16: clustermetadata.MultiGateway.port_map:type_name -> clustermetadata.MultiGateway.PortMapEntry
-	19, // 17: clustermetadata.MultiOrch.id:type_name -> clustermetadata.ID
-	36, // 18: clustermetadata.MultiOrch.port_map:type_name -> clustermetadata.MultiOrch.PortMapEntry
-	6,  // 19: clustermetadata.ID.component:type_name -> clustermetadata.ID.ComponentType
+	35, // 12: clustermetadata.MultiPooler.port_map:type_name -> clustermetadata.MultiPooler.PortMapEntry
+	22, // 13: clustermetadata.MultiPooler.lifecycle_status:type_name -> clustermetadata.PoolerLifecycle
+	27, // 14: clustermetadata.MultiPooler.routing_state:type_name -> clustermetadata.RoutingState
+	20, // 15: clustermetadata.MultiGateway.id:type_name -> clustermetadata.ID
+	36, // 16: clustermetadata.MultiGateway.port_map:type_name -> clustermetadata.MultiGateway.PortMapEntry
+	20, // 17: clustermetadata.MultiOrch.id:type_name -> clustermetadata.ID
+	37, // 18: clustermetadata.MultiOrch.port_map:type_name -> clustermetadata.MultiOrch.PortMapEntry
+	7,  // 19: clustermetadata.ID.component:type_name -> clustermetadata.ID.ComponentType
 	1,  // 20: clustermetadata.PoolerLifecycle.status:type_name -> clustermetadata.PoolerLifecycleStatus
-	37, // 21: clustermetadata.PoolerLifecycle.updated:type_name -> google.protobuf.Timestamp
+	38, // 21: clustermetadata.PoolerLifecycle.updated:type_name -> google.protobuf.Timestamp
 	3,  // 22: clustermetadata.DurabilityPolicy.quorum_type:type_name -> clustermetadata.QuorumType
-	23, // 23: clustermetadata.ShardRule.rule_number:type_name -> clustermetadata.RuleNumber
-	19, // 24: clustermetadata.ShardRule.leader_id:type_name -> clustermetadata.ID
-	19, // 25: clustermetadata.ShardRule.cohort_members:type_name -> clustermetadata.ID
-	22, // 26: clustermetadata.ShardRule.durability_policy:type_name -> clustermetadata.DurabilityPolicy
-	19, // 27: clustermetadata.ShardRule.coordinator_id:type_name -> clustermetadata.ID
-	37, // 28: clustermetadata.ShardRule.creation_time:type_name -> google.protobuf.Timestamp
-	24, // 29: clustermetadata.PoolerPosition.rule:type_name -> clustermetadata.ShardRule
-	19, // 30: clustermetadata.LeaderObservation.leader_id:type_name -> clustermetadata.ID
-	23, // 31: clustermetadata.LeaderObservation.leader_rule_number:type_name -> clustermetadata.RuleNumber
-	24, // 32: clustermetadata.ReplicationPrimary.rule:type_name -> clustermetadata.ShardRule
-	14, // 33: clustermetadata.ReplicationPrimary.primary:type_name -> clustermetadata.PoolerAddress
-	19, // 34: clustermetadata.TermRevocation.accepted_coordinator_id:type_name -> clustermetadata.ID
-	37, // 35: clustermetadata.TermRevocation.coordinator_initiated_at:type_name -> google.protobuf.Timestamp
-	23, // 36: clustermetadata.TermRevocation.outgoing_rule:type_name -> clustermetadata.RuleNumber
-	28, // 37: clustermetadata.ExternallyCertifiedRevocation.term_revocation:type_name -> clustermetadata.TermRevocation
-	28, // 38: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
-	25, // 39: clustermetadata.ConsensusStatus.current_position:type_name -> clustermetadata.PoolerPosition
-	27, // 40: clustermetadata.ConsensusStatus.replication_primary:type_name -> clustermetadata.ReplicationPrimary
-	19, // 41: clustermetadata.ConsensusStatus.id:type_name -> clustermetadata.ID
-	4,  // 42: clustermetadata.LeadershipStatus.signal:type_name -> clustermetadata.LeadershipSignal
-	31, // 43: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
-	33, // 44: clustermetadata.AvailabilityStatus.cohort_eligibility_status:type_name -> clustermetadata.CohortEligibilityStatus
-	5,  // 45: clustermetadata.CohortEligibilityStatus.signal:type_name -> clustermetadata.CohortEligibilitySignal
+	24, // 23: clustermetadata.ShardRule.rule_number:type_name -> clustermetadata.RuleNumber
+	20, // 24: clustermetadata.ShardRule.leader_id:type_name -> clustermetadata.ID
+	20, // 25: clustermetadata.ShardRule.cohort_members:type_name -> clustermetadata.ID
+	23, // 26: clustermetadata.ShardRule.durability_policy:type_name -> clustermetadata.DurabilityPolicy
+	20, // 27: clustermetadata.ShardRule.coordinator_id:type_name -> clustermetadata.ID
+	38, // 28: clustermetadata.ShardRule.creation_time:type_name -> google.protobuf.Timestamp
+	25, // 29: clustermetadata.PoolerPosition.rule:type_name -> clustermetadata.ShardRule
+	4,  // 30: clustermetadata.RoutingState.role:type_name -> clustermetadata.RoutingRole
+	24, // 31: clustermetadata.RoutingState.rule:type_name -> clustermetadata.RuleNumber
+	25, // 32: clustermetadata.ReplicationPrimary.rule:type_name -> clustermetadata.ShardRule
+	15, // 33: clustermetadata.ReplicationPrimary.primary:type_name -> clustermetadata.PoolerAddress
+	20, // 34: clustermetadata.TermRevocation.accepted_coordinator_id:type_name -> clustermetadata.ID
+	38, // 35: clustermetadata.TermRevocation.coordinator_initiated_at:type_name -> google.protobuf.Timestamp
+	24, // 36: clustermetadata.TermRevocation.outgoing_rule:type_name -> clustermetadata.RuleNumber
+	29, // 37: clustermetadata.ExternallyCertifiedRevocation.term_revocation:type_name -> clustermetadata.TermRevocation
+	29, // 38: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
+	26, // 39: clustermetadata.ConsensusStatus.current_position:type_name -> clustermetadata.PoolerPosition
+	28, // 40: clustermetadata.ConsensusStatus.replication_primary:type_name -> clustermetadata.ReplicationPrimary
+	20, // 41: clustermetadata.ConsensusStatus.id:type_name -> clustermetadata.ID
+	5,  // 42: clustermetadata.LeadershipStatus.signal:type_name -> clustermetadata.LeadershipSignal
+	32, // 43: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
+	34, // 44: clustermetadata.AvailabilityStatus.cohort_eligibility_status:type_name -> clustermetadata.CohortEligibilityStatus
+	6,  // 45: clustermetadata.CohortEligibilityStatus.signal:type_name -> clustermetadata.CohortEligibilitySignal
 	46, // [46:46] is the sub-list for method output_type
 	46, // [46:46] is the sub-list for method input_type
 	46, // [46:46] is the sub-list for extension type_name
@@ -2798,7 +2847,7 @@ func file_clustermetadata_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_clustermetadata_proto_rawDesc), len(file_clustermetadata_proto_rawDesc)),
-			NumEnums:      7,
+			NumEnums:      8,
 			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/go/pb/multipoolerservice/multipoolerservice.pb.go
+++ b/go/pb/multipoolerservice/multipoolerservice.pb.go
@@ -2177,9 +2177,13 @@ type StreamPoolerHealthResponse struct {
 	PoolerId *clustermetadata.ID `protobuf:"bytes,2,opt,name=pooler_id,json=poolerId,proto3" json:"pooler_id,omitempty"`
 	// serving_status is the current serving state of the pooler.
 	ServingStatus clustermetadata.PoolerServingStatus `protobuf:"varint,3,opt,name=serving_status,json=servingStatus,proto3,enum=clustermetadata.PoolerServingStatus" json:"serving_status,omitempty"`
-	// leader_observation contains this pooler's view of who the consensus leader is.
-	// Used by clients to identify the true leader when multiple poolers exist.
-	LeaderObservation *clustermetadata.LeaderObservation `protobuf:"bytes,4,opt,name=leader_observation,json=leaderObservation,proto3" json:"leader_observation,omitempty"`
+	// routing_state is this pooler's self-reported routing/HA role plus the rule
+	// that qualifies it. It is always populated: role == PRIMARY means this pooler
+	// is the writable leader (the signal clients gate write traffic on, replacing
+	// the former separate leader_observation + writable fields), role == REPLICA
+	// means it is not. Clients route writes to the PRIMARY and buffer when there
+	// is none. This is a routing/writability signal, not a consensus signal.
+	RoutingState *clustermetadata.RoutingState `protobuf:"bytes,4,opt,name=routing_state,json=routingState,proto3" json:"routing_state,omitempty"`
 	// recommended_staleness_timeout is the duration clients should use
 	// to detect a stale/dead health stream. If no message is received within
 	// this duration, clients should mark the pooler as unhealthy.
@@ -2235,9 +2239,9 @@ func (x *StreamPoolerHealthResponse) GetServingStatus() clustermetadata.PoolerSe
 	return clustermetadata.PoolerServingStatus(0)
 }
 
-func (x *StreamPoolerHealthResponse) GetLeaderObservation() *clustermetadata.LeaderObservation {
+func (x *StreamPoolerHealthResponse) GetRoutingState() *clustermetadata.RoutingState {
 	if x != nil {
-		return x.LeaderObservation
+		return x.RoutingState
 	}
 	return nil
 }
@@ -2491,11 +2495,11 @@ const file_multipoolerservice_proto_rawDesc = "" +
 	"\tcaller_id\x18\x02 \x01(\v2\x0f.mtrpc.CallerIDR\bcallerId\x12/\n" +
 	"\aoptions\x18\x03 \x01(\v2\x15.query.ExecuteOptionsR\aoptions\"#\n" +
 	"!ReleaseReservedConnectionResponse\"\x1b\n" +
-	"\x19StreamPoolerHealthRequest\"\xfb\x02\n" +
+	"\x19StreamPoolerHealthRequest\"\xec\x02\n" +
 	"\x1aStreamPoolerHealthResponse\x120\n" +
 	"\tpooler_id\x18\x02 \x01(\v2\x13.clustermetadata.IDR\bpoolerId\x12K\n" +
-	"\x0eserving_status\x18\x03 \x01(\x0e2$.clustermetadata.PoolerServingStatusR\rservingStatus\x12Q\n" +
-	"\x12leader_observation\x18\x04 \x01(\v2\".clustermetadata.LeaderObservationR\x11leaderObservation\x12]\n" +
+	"\x0eserving_status\x18\x03 \x01(\x0e2$.clustermetadata.PoolerServingStatusR\rservingStatus\x12B\n" +
+	"\rrouting_state\x18\x04 \x01(\v2\x1d.clustermetadata.RoutingStateR\froutingState\x12]\n" +
 	"\x1drecommended_staleness_timeout\x18\x05 \x01(\v2\x19.google.protobuf.DurationR\x1brecommendedStalenessTimeout\x12,\n" +
 	"\x12replication_lag_ns\x18\x06 \x01(\x03R\x10replicationLagNs\"_\n" +
 	"\x1aStreamNotificationsRequest\x12%\n" +
@@ -2598,7 +2602,7 @@ var file_multipoolerservice_proto_goTypes = []any{
 	(*query.UserAuth)(nil),                    // 45: query.UserAuth
 	(*clustermetadata.ID)(nil),                // 46: clustermetadata.ID
 	(clustermetadata.PoolerServingStatus)(0),  // 47: clustermetadata.PoolerServingStatus
-	(*clustermetadata.LeaderObservation)(nil), // 48: clustermetadata.LeaderObservation
+	(*clustermetadata.RoutingState)(nil),      // 48: clustermetadata.RoutingState
 	(*durationpb.Duration)(nil),               // 49: google.protobuf.Duration
 	(*query.PgNotification)(nil),              // 50: query.PgNotification
 }
@@ -2664,7 +2668,7 @@ var file_multipoolerservice_proto_depIdxs = []int32{
 	36, // 58: multipoolerservice.ReleaseReservedConnectionRequest.options:type_name -> query.ExecuteOptions
 	46, // 59: multipoolerservice.StreamPoolerHealthResponse.pooler_id:type_name -> clustermetadata.ID
 	47, // 60: multipoolerservice.StreamPoolerHealthResponse.serving_status:type_name -> clustermetadata.PoolerServingStatus
-	48, // 61: multipoolerservice.StreamPoolerHealthResponse.leader_observation:type_name -> clustermetadata.LeaderObservation
+	48, // 61: multipoolerservice.StreamPoolerHealthResponse.routing_state:type_name -> clustermetadata.RoutingState
 	49, // 62: multipoolerservice.StreamPoolerHealthResponse.recommended_staleness_timeout:type_name -> google.protobuf.Duration
 	34, // 63: multipoolerservice.StreamNotificationsRequest.target:type_name -> query.Target
 	50, // 64: multipoolerservice.StreamNotificationsResponse.notification:type_name -> query.PgNotification

--- a/go/services/multiadmin/backup.go
+++ b/go/services/multiadmin/backup.go
@@ -147,15 +147,15 @@ func (s *MultiAdminServer) findPoolerForBackup(ctx context.Context, database, ta
 
 	if forceLeader {
 		var bestLeader *clustermetadatapb.MultiPooler
-		var bestObs *clustermetadatapb.LeaderObservation
+		var bestRule *clustermetadatapb.RuleNumber
 		for _, p := range poolers {
-			obs := p.GetSelfLeadership()
-			if obs == nil {
+			rs := p.GetRoutingState()
+			if rs == nil {
 				continue
 			}
-			if commonconsensus.MostAuthoritativeObservation(bestObs, obs) == obs {
+			if bestLeader == nil || commonconsensus.CompareRuleNumbers(rs.GetRule(), bestRule) > 0 {
 				bestLeader = p
-				bestObs = obs
+				bestRule = rs.GetRule()
 			}
 		}
 		if bestLeader != nil {
@@ -165,7 +165,7 @@ func (s *MultiAdminServer) findPoolerForBackup(ctx context.Context, database, ta
 	}
 
 	for _, p := range poolers {
-		if p.GetSelfLeadership() == nil {
+		if p.GetRoutingState() == nil {
 			return p, nil
 		}
 	}

--- a/go/services/multiadmin/backup_test.go
+++ b/go/services/multiadmin/backup_test.go
@@ -337,9 +337,9 @@ func TestBackup_ForcePrimary(t *testing.T) {
 			TableGroup: "default",
 		},
 		Type: clustermetadatapb.PoolerType_PRIMARY,
-		SelfLeadership: &clustermetadatapb.LeaderObservation{
-			LeaderId:         &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary-pooler"},
-			LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
+		RoutingState: &clustermetadatapb.RoutingState{
+			Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY,
+			Rule: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
 		},
 	}
 	replicaPooler := &clustermetadatapb.MultiPooler{
@@ -431,9 +431,9 @@ func TestBackup_ForcePrimary(t *testing.T) {
 				TableGroup: "default",
 			},
 			Type: clustermetadatapb.PoolerType_PRIMARY,
-			SelfLeadership: &clustermetadatapb.LeaderObservation{
-				LeaderId:         &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell2", Name: "primary-only"},
-				LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2},
+			RoutingState: &clustermetadatapb.RoutingState{
+				Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY,
+				Rule: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2},
 			},
 		}
 		require.NoError(t, ts.CreateMultiPooler(ctx, primaryOnly))

--- a/go/services/multigateway/poolergateway/load_balancer.go
+++ b/go/services/multigateway/poolergateway/load_balancer.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/proto"
 
 	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/mterrors"
@@ -88,47 +87,56 @@ type shardSummary struct {
 // linear highest() scan is the right call. Not safe for concurrent use —
 // shardSummary.mu guards it.
 type primarySet struct {
-	byID map[topoclient.ComponentID]*clustermetadatapb.LeaderObservation
+	byID map[topoclient.ComponentID]*clustermetadatapb.RoutingState
 }
 
-func (p *primarySet) set(id topoclient.ComponentID, obs *clustermetadatapb.LeaderObservation) {
+func (p *primarySet) set(id topoclient.ComponentID, rs *clustermetadatapb.RoutingState) {
 	if p.byID == nil {
-		p.byID = make(map[topoclient.ComponentID]*clustermetadatapb.LeaderObservation)
+		p.byID = make(map[topoclient.ComponentID]*clustermetadatapb.RoutingState)
 	}
-	p.byID[id] = obs
+	p.byID[id] = rs
 }
 
 func (p *primarySet) clear(id topoclient.ComponentID) { delete(p.byID, id) }
 
 func (p *primarySet) has(id topoclient.ComponentID) bool { _, ok := p.byID[id]; return ok }
 
-// highest returns the member with the highest rule, or nil if the set is empty.
-func (p *primarySet) highest() *clustermetadatapb.LeaderObservation {
-	var best *clustermetadatapb.LeaderObservation
-	for _, obs := range p.byID {
-		if best == nil || commonconsensus.CompareRuleNumbers(obs.GetLeaderRuleNumber(), best.GetLeaderRuleNumber()) > 0 {
-			best = obs
+// highest returns the id of the highest-rule member and true, or ("", false) if
+// the set is empty. The member's identity is the map key — a RoutingState carries
+// no id, since a pooler only ever reports its own routing state.
+func (p *primarySet) highest() (topoclient.ComponentID, bool) {
+	var (
+		bestID   topoclient.ComponentID
+		bestRule *clustermetadatapb.RuleNumber
+		found    bool
+	)
+	for id, rs := range p.byID {
+		if !found || commonconsensus.CompareRuleNumbers(rs.GetRule(), bestRule) > 0 {
+			bestID, bestRule, found = id, rs.GetRule(), true
 		}
 	}
-	return best
+	return bestID, found
 }
 
-// leader returns the routing primary with the highest rule, or nil if the shard
-// currently has no writable leader. Safe to call concurrently.
-func (s *shardSummary) leader() *clustermetadatapb.LeaderObservation {
+// leaderID returns the id of the routing primary with the highest rule and true,
+// or ("", false) if the shard currently has no writable leader. Safe to call
+// concurrently.
+func (s *shardSummary) leaderID() (topoclient.ComponentID, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.primaries.highest()
 }
 
-// setPrimary records poolerID as a routing primary at obs's rule (adds it to the
-// set or updates its rule). Returns true if the elected leader changed.
-func (s *shardSummary) setPrimary(poolerID topoclient.ComponentID, obs *clustermetadatapb.LeaderObservation) bool {
+// setPrimary records poolerID as a routing primary at rs's rule (adds it to the
+// set or updates its rule). Returns true if the elected leader (the highest-rule
+// member's id) changed.
+func (s *shardSummary) setPrimary(poolerID topoclient.ComponentID, rs *clustermetadatapb.RoutingState) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	before := s.primaries.highest()
-	s.primaries.set(poolerID, obs)
-	return !sameObservation(before, s.primaries.highest())
+	before, _ := s.primaries.highest()
+	s.primaries.set(poolerID, rs)
+	after, _ := s.primaries.highest()
+	return before != after
 }
 
 // clearPrimary removes poolerID from the routing-primary set (retraction).
@@ -139,26 +147,21 @@ func (s *shardSummary) clearPrimary(poolerID topoclient.ComponentID) bool {
 	if !s.primaries.has(poolerID) {
 		return false
 	}
-	before := s.primaries.highest()
+	before, _ := s.primaries.highest()
 	s.primaries.clear(poolerID)
-	return !sameObservation(before, s.primaries.highest())
+	after, _ := s.primaries.highest()
+	return before != after
 }
 
 // hasPrimary reports whether poolerID currently claims to be a routing primary
-// for this shard — i.e. its latest health observation named itself. This is the
-// single authority for "believes itself the writable primary": both stale-leader
-// detection and replica-read exclusion read it, rather than re-deriving the same
-// signal from each connection's live health.
+// for this shard — i.e. its latest health observation advertised role PRIMARY.
+// This is the single authority for "believes itself the writable primary": both
+// stale-leader detection and replica-read exclusion read it, rather than
+// re-deriving the same signal from each connection's live health.
 func (s *shardSummary) hasPrimary(poolerID topoclient.ComponentID) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.primaries.has(poolerID)
-}
-
-// sameObservation reports whether two leader observations name the same elected
-// leader at the same rule (both nil counts as same).
-func sameObservation(a, b *clustermetadatapb.LeaderObservation) bool {
-	return proto.Equal(a, b)
 }
 
 // loadBalancer selects poolerConnections for queries. The set of tracked
@@ -337,21 +340,21 @@ func (lb *loadBalancer) notifyLeaderServingFromSummary(summary *shardSummary, co
 	if lb.onLeaderServing == nil || summary == nil {
 		return
 	}
-	leader := summary.leader()
+	leaderID, ok := summary.leaderID()
 	connID := conn.PoolerInfo().GetId()
-	if leader == nil || !proto.Equal(leader.GetLeaderId(), connID) {
+	if !ok || leaderID != topoclient.ComponentIDString(connID) {
 		return
 	}
 	health := conn.Health()
 	if health == nil || !health.isServing() {
 		return
 	}
-	// The pooler's own broadcast observation must name itself as leader — it is
-	// the elected routing primary and it is attesting to that itself. That
-	// observation implies writability (a pooler advertises leadership only once it
-	// is the writable routing primary), so draining the failover buffer toward it
-	// is safe without a separate writability check.
-	if !proto.Equal(health.LeaderObservation.GetLeaderId(), connID) {
+	// The pooler's own broadcast must advertise role PRIMARY — it is the elected
+	// routing primary and it is attesting to that itself. Role PRIMARY implies
+	// writability (a pooler advertises PRIMARY only once it is the writable routing
+	// primary), so draining the failover buffer toward it is safe without a
+	// separate writability check.
+	if health.RoutingState.GetRole() != clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY {
 		return
 	}
 	lb.onLeaderServing(summary.shardKey)
@@ -381,25 +384,27 @@ func (lb *loadBalancer) getConnection(target *query.Target) (*poolerConnection, 
 	sk := target.GetShardKey()
 	key := shardKeyOf(sk)
 
-	// Look up the shard summary under lb.mu, release it, then read the
-	// leader observation via the summary's own lock.
+	// Look up the shard summary under lb.mu, release it, then read the elected
+	// leader id via the summary's own lock.
 	lb.mu.Lock()
 	summary := lb.shards[key]
 	lb.mu.Unlock()
-	var leaderObs *clustermetadatapb.LeaderObservation
+	var (
+		leaderID   topoclient.ComponentID
+		haveLeader bool
+	)
 	if summary != nil {
-		leaderObs = summary.leader()
+		leaderID, haveLeader = summary.leaderID()
 	}
 
 	mode := target.GetMode()
 	routesToLeader := mode == query.Mode_MODE_WRITABLE || mode == query.Mode_MODE_CONSISTENT
 	if routesToLeader {
-		if leaderObs == nil {
+		if !haveLeader {
 			return nil, mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
 				"no leader observed yet for database=%s, tablegroup=%s, shard=%s",
 				sk.GetDatabase(), sk.GetTableGroup(), sk.GetShard())
 		}
-		leaderID := topoclient.ComponentIDString(leaderObs.LeaderId)
 		if lb.cache == nil {
 			return nil, mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
 				"leader %s known but not connected for database=%s, tablegroup=%s, shard=%s",
@@ -606,20 +611,20 @@ func (lb *loadBalancer) onPoolerHealthUpdate(conn *poolerConnection) {
 	poolerID := topoclient.ComponentIDString(conn.PoolerInfo().GetId())
 	summary := lb.summaryForPooler(conn.PoolerInfo().MultiPooler)
 
-	// A pooler is a routing primary iff its broadcast observation names itself.
-	// The observation implies writability: a pooler only advertises itself as the
-	// leader once it is the writable routing primary (out of recovery and the
-	// active committed leader), so the gateway needs no separate writability
-	// check. Anything else — a follower naming another leader, or no observation —
-	// retracts any prior claim (demotion / no-longer-primary).
-	obs := health.LeaderObservation
-	if obs != nil && proto.Equal(obs.GetLeaderId(), conn.PoolerInfo().GetId()) {
-		if summary.setPrimary(poolerID, obs) {
+	// A pooler is a routing primary iff its broadcast advertises role PRIMARY.
+	// That implies writability: a pooler only advertises PRIMARY once it is the
+	// writable routing primary (out of recovery and the active committed leader),
+	// so the gateway needs no separate writability check. Anything else — a
+	// replica (role REPLICA / UNKNOWN) or no routing state — retracts any prior
+	// claim (demotion / no-longer-primary).
+	rs := health.RoutingState
+	if rs.GetRole() == clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY {
+		if summary.setPrimary(poolerID, rs) {
 			lb.logger.Debug("routing primary recorded",
 				"tablegroup", summary.shardKey.GetTableGroup(),
 				"shard", summary.shardKey.GetShard(),
 				"leader_id", poolerID,
-				"rule", commonconsensus.FormatRuleNumber(obs.GetLeaderRuleNumber()))
+				"rule", commonconsensus.FormatRuleNumber(rs.GetRule()))
 		}
 	} else {
 		summary.clearPrimary(poolerID)
@@ -628,11 +633,10 @@ func (lb *loadBalancer) onPoolerHealthUpdate(conn *poolerConnection) {
 	// Re-check the SERVING-leader notification: if the elected routing primary is
 	// this (or any) connected pooler and it is serving, drain the failover buffer.
 	// Idempotent and cheap, so always calling it is simpler than tracking deltas.
-	leader := summary.leader()
-	if leader == nil || lb.cache == nil {
+	leaderID, ok := summary.leaderID()
+	if !ok || lb.cache == nil {
 		return
 	}
-	leaderID := topoclient.ComponentIDString(leader.LeaderId)
 	if leaderConn, ok := lb.cache.GetRider(leaderID); ok && leaderConn != nil {
 		lb.notifyLeaderServingFromSummary(summary, leaderConn)
 	}
@@ -743,14 +747,14 @@ func (lb *loadBalancer) leadershipFor(conn *poolerConnection) string {
 	if summary == nil {
 		return leadershipFollower
 	}
-	leader := summary.leader()
+	leaderID, ok := summary.leaderID()
 
 	// The shard's elected routing primary (highest-rule claimant across all
 	// health-stream reports) takes precedence. A pooler that still claims to be
 	// a routing primary but is not the elected one is stale — consensus has
 	// moved on to a higher rule.
 	switch {
-	case leader != nil && topoclient.ComponentIDString(leader.LeaderId) == conn.ID():
+	case ok && leaderID == conn.ID():
 		return leadershipLeader
 	case summary.hasPrimary(conn.ID()):
 		return leadershipStaleLeader

--- a/go/services/multigateway/poolergateway/load_balancer_test.go
+++ b/go/services/multigateway/poolergateway/load_balancer_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/protoutil"
@@ -56,14 +58,14 @@ func createTestMultiPooler(name, cell, tableGroup, shard string, poolerType clus
 	}
 }
 
-// withSelfLeadership sets the pooler's self_leadership observation naming itself
-// as leader at the given coordinator term. This mirrors a real leader's topology
-// record (Type=PRIMARY ⇒ self_leadership set), which is how the gateway learns a
+// withSelfLeadership sets the pooler's routing_state to PRIMARY at the given
+// coordinator term. This mirrors a real writable leader's topology record
+// (Type=PRIMARY ⇒ routing_state PRIMARY), which is how the gateway learns a
 // shard's leader from etcd at discovery time.
 func withSelfLeadership(p *clustermetadatapb.MultiPooler, coordinatorTerm int64) *clustermetadatapb.MultiPooler {
-	p.SelfLeadership = &clustermetadatapb.LeaderObservation{
-		LeaderId:         p.Id,
-		LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: coordinatorTerm},
+	p.RoutingState = &clustermetadatapb.RoutingState{
+		Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY,
+		Rule: &clustermetadatapb.RuleNumber{CoordinatorTerm: coordinatorTerm},
 	}
 	return p
 }
@@ -112,7 +114,7 @@ func TestLoadBalancer_GetConnection_Primary(t *testing.T) {
 
 	connPrimary := connForTest(t, lb, primary)
 	simulateHealthUpdate(connPrimary, clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: primary.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
+		primary.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
 
 	// Should find the primary via cache
 	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
@@ -146,7 +148,7 @@ func TestLoadBalancer_GetConnection_CrossCellPrimary(t *testing.T) {
 
 	connRemote := connForTest(t, lb, remotePrimary)
 	simulateHealthUpdate(connRemote, clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: remotePrimary.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
+		remotePrimary.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
 
 	// Should find primary in remote cell via cache
 	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
@@ -171,7 +173,7 @@ func TestLoadBalancer_GetConnection_NoMatch(t *testing.T) {
 	primary := createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
 	addPoolerForTest(t, lb, primary)
 	simulateHealthUpdate(connForTest(t, lb, primary), clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: primary.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
+		primary.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
 
 	// Request a replica - should not find one (only the primary exists, and a
 	// self-attesting leader is excluded from replica reads).
@@ -193,9 +195,9 @@ func TestLoadBalancer_GetConnection_ShardMatch(t *testing.T) {
 	connShard0 := connForTest(t, lb, shard0)
 	connShard1 := connForTest(t, lb, shard1)
 	simulateHealthUpdate(connShard0, clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: shard0.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
+		shard0.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
 	simulateHealthUpdate(connShard1, clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: shard1.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
+		shard1.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
 
 	// Request specific shard — should find correct primary via cache
 	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "1", query.Mode_MODE_WRITABLE)
@@ -211,12 +213,19 @@ func TestLoadBalancer_GetConnection_ShardMatch(t *testing.T) {
 
 // simulateHealthUpdate simulates receiving a health update from the stream.
 // This uses the same code path as real health updates, ensuring any callbacks are triggered.
-func simulateHealthUpdate(conn *poolerConnection, status clustermetadatapb.PoolerServingStatus, observation *clustermetadatapb.LeaderObservation) {
+func simulateHealthUpdate(conn *poolerConnection, status clustermetadatapb.PoolerServingStatus, leaderID *clustermetadatapb.ID, rule *clustermetadatapb.RuleNumber) {
 	info := conn.PoolerInfo()
+	// A pooler broadcasts its OWN routing role: PRIMARY (with the qualifying rule)
+	// iff the named leader is itself, else REPLICA. This mirrors the manager, which
+	// advertises PRIMARY only for the writable self-leader.
+	rs := &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_REPLICA, Rule: rule}
+	if leaderID != nil && proto.Equal(leaderID, info.Id) {
+		rs.Role = clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY
+	}
 	conn.processHealthResponse(&multipoolerservice.StreamPoolerHealthResponse{
-		PoolerId:          info.Id,
-		ServingStatus:     status,
-		LeaderObservation: observation,
+		PoolerId:      info.Id,
+		ServingStatus: status,
+		RoutingState:  rs,
 	})
 }
 
@@ -245,13 +254,13 @@ func TestLoadBalancer_WriteResumeWaitsForServingSelfNamedLeader(t *testing.T) {
 		Name:      "old-leader",
 	}
 	simulateHealthUpdate(conn, clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: oldLeaderID, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5}})
+		oldLeaderID, &clustermetadatapb.RuleNumber{CoordinatorTerm: 5})
 	assert.Equal(t, 0, resumed, "write traffic must stay buffered while the broadcast names a different leader")
 
 	// The pooler's own broadcast now names itself as leader and is SERVING.
 	// A self-naming observation implies writability → resume.
 	simulateHealthUpdate(conn, clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: p.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5}})
+		p.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 5})
 	assert.Equal(t, 1, resumed, "resume once the leader observes itself as the serving primary")
 }
 
@@ -279,7 +288,7 @@ func TestLoadBalancer_ConsistentBuffersUntilLeaderWritable(t *testing.T) {
 		Name:      "old-leader",
 	}
 	simulateHealthUpdate(conn, clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: oldLeaderID, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4}})
+		oldLeaderID, &clustermetadatapb.RuleNumber{CoordinatorTerm: 4})
 
 	consistent := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_CONSISTENT)
 	_, err := lb.getConnection(consistent)
@@ -290,7 +299,7 @@ func TestLoadBalancer_ConsistentBuffersUntilLeaderWritable(t *testing.T) {
 	// The appointee establishes itself: out of recovery and active committed
 	// leader, so it now advertises itself as the writable primary.
 	simulateHealthUpdate(conn, clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: p.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5}})
+		p.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 5})
 
 	got, err := lb.getConnection(consistent)
 	require.NoError(t, err, "CONSISTENT routes once the leader is writable")
@@ -316,17 +325,17 @@ func TestLoadBalancer_PrimaryCaching(t *testing.T) {
 		// primary1 thinks primary1 is leader with term 5
 		simulateHealthUpdate(connPrimary1,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&clustermetadatapb.LeaderObservation{LeaderId: primary1.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5}})
+			primary1.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 5})
 
 		// primary2 thinks primary2 is leader with term 10 (higher)
 		simulateHealthUpdate(connPrimary2,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&clustermetadatapb.LeaderObservation{LeaderId: primary2.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 10}})
+			primary2.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 10})
 
 		// replica1 also thinks primary2 is leader with term 10
 		simulateHealthUpdate(connReplica1,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&clustermetadatapb.LeaderObservation{LeaderId: primary2.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 10}})
+			primary2.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 10})
 
 		target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
 		conn, err := lb.getConnection(target)
@@ -352,17 +361,17 @@ func TestLoadBalancer_PrimaryCaching(t *testing.T) {
 		// primary1 thinks primary1 is leader with term 15
 		simulateHealthUpdate(connPrimary1,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&clustermetadatapb.LeaderObservation{LeaderId: primary1.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 15}})
+			primary1.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 15})
 
 		// primary2 thinks primary2 is leader with term 12 (stale)
 		simulateHealthUpdate(connPrimary2,
 			clustermetadatapb.PoolerServingStatus_DISABLED,
-			&clustermetadatapb.LeaderObservation{LeaderId: primary2.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 12}})
+			primary2.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 12})
 
 		// replica1 observed the new leader (primary1) with term 20 (highest)
 		simulateHealthUpdate(connReplica1,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&clustermetadatapb.LeaderObservation{LeaderId: primary1.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 20}})
+			primary1.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 20})
 
 		target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
 		conn, err := lb.getConnection(target)
@@ -405,10 +414,10 @@ func TestLoadBalancer_PrimaryCaching(t *testing.T) {
 
 		simulateHealthUpdate(connPrimary1,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&clustermetadatapb.LeaderObservation{LeaderId: primary1.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
+			primary1.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
 		simulateHealthUpdate(connPrimary2,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&clustermetadatapb.LeaderObservation{LeaderId: primary2.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}})
+			primary2.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 2})
 
 		target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
 		conn, err := lb.getConnection(target)
@@ -441,7 +450,7 @@ func TestLoadBalancer_PrimaryLearnedFromHealth(t *testing.T) {
 	connPrimary := connForTest(t, lb, primary)
 	simulateHealthUpdate(connPrimary,
 		clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: primary.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
+		primary.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
 
 	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
 	conn, err := lb.getConnection(target)
@@ -458,7 +467,7 @@ func TestLoadBalancer_KnownLeaderSurvivesTopologyDemotion(t *testing.T) {
 	// Health stream confirms the same leader at the same rule.
 	conn := connForTest(t, lb, pooler)
 	simulateHealthUpdate(conn, clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: pooler.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5}})
+		pooler.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 5})
 
 	// The pooler is re-discovered demoted: Type=REPLICA and self_leadership
 	// cleared. mergeTopologyLeaderLocked must NOT erase the known leader — only
@@ -488,8 +497,8 @@ func TestLoadBalancer_UnknownTypePrimarySelection(t *testing.T) {
 
 	t.Run("UNKNOWN poolers without observations return error", func(t *testing.T) {
 		// No LeaderObservation set - simulates initial state before health stream
-		simulateHealthUpdate(connUnknown1, clustermetadatapb.PoolerServingStatus_SERVING, nil)
-		simulateHealthUpdate(connUnknown2, clustermetadatapb.PoolerServingStatus_SERVING, nil)
+		simulateHealthUpdate(connUnknown1, clustermetadatapb.PoolerServingStatus_SERVING, nil, nil)
+		simulateHealthUpdate(connUnknown2, clustermetadatapb.PoolerServingStatus_SERVING, nil, nil)
 
 		target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
 		_, err := lb.getConnection(target)
@@ -506,10 +515,10 @@ func TestLoadBalancer_UnknownTypePrimarySelection(t *testing.T) {
 		// routing now.
 		simulateHealthUpdate(connUnknown1,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&clustermetadatapb.LeaderObservation{LeaderId: unknown2.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 10}})
+			unknown2.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 10})
 		simulateHealthUpdate(connUnknown2,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&clustermetadatapb.LeaderObservation{LeaderId: unknown2.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 10}})
+			unknown2.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 10})
 
 		target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
 		conn, err := lb.getConnection(target)
@@ -536,9 +545,9 @@ func TestLoadBalancer_SelectReplicaByLocalityAndServingStatus(t *testing.T) {
 	connRemote := connForTest(t, lb, remoteReplica)
 
 	t.Run("prefers local serving over remote serving", func(t *testing.T) {
-		simulateHealthUpdate(connLocal1, clustermetadatapb.PoolerServingStatus_DISABLED, nil)
-		simulateHealthUpdate(connLocal2, clustermetadatapb.PoolerServingStatus_SERVING, nil)
-		simulateHealthUpdate(connRemote, clustermetadatapb.PoolerServingStatus_SERVING, nil)
+		simulateHealthUpdate(connLocal1, clustermetadatapb.PoolerServingStatus_DISABLED, nil, nil)
+		simulateHealthUpdate(connLocal2, clustermetadatapb.PoolerServingStatus_SERVING, nil, nil)
+		simulateHealthUpdate(connRemote, clustermetadatapb.PoolerServingStatus_SERVING, nil, nil)
 
 		target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "", query.Mode_MODE_INCONSISTENT)
 		conn, err := lb.getConnection(target)
@@ -548,9 +557,9 @@ func TestLoadBalancer_SelectReplicaByLocalityAndServingStatus(t *testing.T) {
 	})
 
 	t.Run("falls back to remote serving when no local serving", func(t *testing.T) {
-		simulateHealthUpdate(connLocal1, clustermetadatapb.PoolerServingStatus_DISABLED, nil)
-		simulateHealthUpdate(connLocal2, clustermetadatapb.PoolerServingStatus_DISABLED, nil)
-		simulateHealthUpdate(connRemote, clustermetadatapb.PoolerServingStatus_SERVING, nil)
+		simulateHealthUpdate(connLocal1, clustermetadatapb.PoolerServingStatus_DISABLED, nil, nil)
+		simulateHealthUpdate(connLocal2, clustermetadatapb.PoolerServingStatus_DISABLED, nil, nil)
+		simulateHealthUpdate(connRemote, clustermetadatapb.PoolerServingStatus_SERVING, nil, nil)
 
 		target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "", query.Mode_MODE_INCONSISTENT)
 		conn, err := lb.getConnection(target)
@@ -560,9 +569,9 @@ func TestLoadBalancer_SelectReplicaByLocalityAndServingStatus(t *testing.T) {
 	})
 
 	t.Run("falls back to local not-serving when no serving", func(t *testing.T) {
-		simulateHealthUpdate(connLocal1, clustermetadatapb.PoolerServingStatus_DISABLED, nil)
-		simulateHealthUpdate(connLocal2, clustermetadatapb.PoolerServingStatus_DISABLED, nil)
-		simulateHealthUpdate(connRemote, clustermetadatapb.PoolerServingStatus_DISABLED, nil)
+		simulateHealthUpdate(connLocal1, clustermetadatapb.PoolerServingStatus_DISABLED, nil, nil)
+		simulateHealthUpdate(connLocal2, clustermetadatapb.PoolerServingStatus_DISABLED, nil, nil)
+		simulateHealthUpdate(connRemote, clustermetadatapb.PoolerServingStatus_DISABLED, nil, nil)
 
 		target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "", query.Mode_MODE_INCONSISTENT)
 		conn, err := lb.getConnection(target)
@@ -595,7 +604,7 @@ func TestLoadBalancer_LeaderObservationBeforeConnection(t *testing.T) {
 	// future-leader's own primary claim (rule 7) is recorded before we hold a
 	// connection to it — the identity the gateway must not drop.
 	setLeaderForTest(t, lb, constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0",
-		&clustermetadatapb.LeaderObservation{LeaderId: futureLeader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 7}})
+		futureLeader.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 7})
 
 	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
 
@@ -631,7 +640,7 @@ func TestLoadBalancer_StalePrimaryTypeDoesNotEvict(t *testing.T) {
 	// post-failover state).
 	simulateHealthUpdate(connNewLeader,
 		clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: newLeader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}})
+		newLeader.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 2})
 
 	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
 	conn, err := lb.getConnection(target)
@@ -677,9 +686,9 @@ func TestLoadBalancer_HealthObservationsMergeByRule(t *testing.T) {
 	// Both poolers currently claim primary via their own health streams; the
 	// higher rule (new-leader at rule 2) is elected over old-leader at rule 1.
 	simulateHealthUpdate(connOld, clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: oldLeader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
+		oldLeader.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
 	simulateHealthUpdate(connNew, clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: newLeader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}})
+		newLeader.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 2})
 
 	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
 	conn, err := lb.getConnection(target)
@@ -690,7 +699,7 @@ func TestLoadBalancer_HealthObservationsMergeByRule(t *testing.T) {
 	// itself, so its primary claim is cleared and routing falls back to
 	// old-leader, the only remaining self-naming primary.
 	simulateHealthUpdate(connNew, clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: oldLeader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}})
+		oldLeader.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 2})
 	conn, err = lb.getConnection(target)
 	require.NoError(t, err)
 	assert.Equal(t, poolerID(oldLeader), conn.ID(), "retracting the elected primary falls back to the remaining primary")
@@ -724,7 +733,7 @@ func TestLoadBalancer_ReplicaCandidatesExcludeLeader(t *testing.T) {
 	// a observes itself as leader; b and c are eligible replica candidates.
 	simulateHealthUpdate(connA,
 		clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: a.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
+		a.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
 
 	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_INCONSISTENT)
 
@@ -758,9 +767,9 @@ func TestLoadBalancer_StaleLeaderExcludedFromReplicas(t *testing.T) {
 	// stale still believes it is the leader at the old rule 1; replica already
 	// tracks the new leader at rule 2.
 	simulateHealthUpdate(connStale, clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: stale.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
+		stale.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
 	simulateHealthUpdate(connReplica, clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: newLeader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}})
+		newLeader.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 2})
 
 	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_INCONSISTENT)
 	// Only `replica` is eligible: new-leader is the leader (self_leadership) and
@@ -794,11 +803,11 @@ func TestLoadBalancer_LeadershipFor(t *testing.T) {
 	// electing it into the shard's primary set; stale still believes it leads at
 	// the old rule 1; follower tracks the new leader at rule 2.
 	simulateHealthUpdate(connLeader, clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: leader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}})
+		leader.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 2})
 	simulateHealthUpdate(connStale, clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: stale.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
+		stale.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
 	simulateHealthUpdate(connFollower, clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: leader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}})
+		leader.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 2})
 
 	assert.Equal(t, leadershipLeader, lb.leadershipFor(connLeader))
 	assert.Equal(t, leadershipStaleLeader, lb.leadershipFor(connStale))
@@ -818,7 +827,7 @@ func TestLoadBalancer_ShardSummaryAutoClear(t *testing.T) {
 	// model. Deliver a self-naming observation so the shard is tracked.
 	connPrimary := connForTest(t, lb, primary)
 	simulateHealthUpdate(connPrimary, clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: primary.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
+		primary.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
 
 	lb.mu.Lock()
 	shardCount := len(lb.shards)
@@ -864,7 +873,7 @@ func TestLoadBalancer_OnLeaderServingRequiresSelfNamedLeader(t *testing.T) {
 	}
 	simulateHealthUpdate(connLeader,
 		clustermetadatapb.PoolerServingStatus_SERVING,
-		&clustermetadatapb.LeaderObservation{LeaderId: oldLeaderID, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}})
+		oldLeaderID, &clustermetadatapb.RuleNumber{CoordinatorTerm: 2})
 	assert.Empty(t, calls,
 		"OnLeaderServing must not fire while the pooler's broadcast names a different leader")
 
@@ -872,9 +881,9 @@ func TestLoadBalancer_OnLeaderServingRequiresSelfNamedLeader(t *testing.T) {
 	// writable (postgres out of recovery). This is the post-OnStateChange,
 	// post-promotion snapshot. Drain the buffer.
 	connLeader.processHealthResponse(&multipoolerservice.StreamPoolerHealthResponse{
-		PoolerId:          leader.Id,
-		ServingStatus:     clustermetadatapb.PoolerServingStatus_SERVING,
-		LeaderObservation: &clustermetadatapb.LeaderObservation{LeaderId: leader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}},
+		PoolerId:      leader.Id,
+		ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
+		RoutingState:  &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY, Rule: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}},
 	})
 	require.Len(t, calls, 1, "OnLeaderServing must fire once the pooler self-identifies as leader")
 	assert.Equal(t, constants.DefaultTableGroup, calls[0].GetTableGroup())

--- a/go/services/multigateway/poolergateway/load_balancer_test_helpers_test.go
+++ b/go/services/multigateway/poolergateway/load_balancer_test_helpers_test.go
@@ -111,9 +111,9 @@ func connForTest(t *testing.T, lb *loadBalancer, p *clustermetadatapb.MultiPoole
 
 // setLeaderForTest installs a routing-primary claim directly into the LB's
 // per-shard summary. Used by tests that need to model a peer observation
-// without wiring a second connection. The observation's LeaderId is the pooler
-// claiming primary.
-func setLeaderForTest(t *testing.T, lb *loadBalancer, database, tableGroup, shard string, obs *clustermetadatapb.LeaderObservation) {
+// without wiring a second connection. leaderID is the pooler claiming primary at
+// the given rule.
+func setLeaderForTest(t *testing.T, lb *loadBalancer, database, tableGroup, shard string, leaderID *clustermetadatapb.ID, rule *clustermetadatapb.RuleNumber) {
 	t.Helper()
 	sk := &clustermetadatapb.ShardKey{
 		Database:   database,
@@ -121,8 +121,11 @@ func setLeaderForTest(t *testing.T, lb *loadBalancer, database, tableGroup, shar
 		Shard:      shard,
 	}
 	summary := &shardSummary{shardKey: sk}
-	if obs != nil {
-		summary.setPrimary(topoclient.ComponentIDString(obs.GetLeaderId()), obs)
+	if leaderID != nil {
+		summary.setPrimary(topoclient.ComponentIDString(leaderID), &clustermetadatapb.RoutingState{
+			Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY,
+			Rule: rule,
+		})
 	}
 	lb.mu.Lock()
 	defer lb.mu.Unlock()

--- a/go/services/multigateway/poolergateway/pooler_connection.go
+++ b/go/services/multigateway/poolergateway/pooler_connection.go
@@ -47,15 +47,15 @@ type poolerHealth struct {
 	PoolerID *clustermetadatapb.ID
 
 	// ServingStatus is the serving state reported by the pooler. Buffer
-	// drain (notifyIfLeaderServing) requires both SERVING and the
-	// broadcast's LeaderObservation naming this pooler — see that function
-	// for the race the dual check guards against.
+	// drain (notifyIfLeaderServing) requires both SERVING and the broadcast's
+	// RoutingState advertising role PRIMARY — see that function for the race the
+	// dual check guards against.
 	ServingStatus clustermetadatapb.PoolerServingStatus
 
-	// LeaderObservation contains the pooler's view of who the consensus leader
-	// is, identified by leader id and the rule number under which the
-	// observation was made. Used for rule-number-based leader reconciliation.
-	LeaderObservation *clustermetadatapb.LeaderObservation
+	// RoutingState is the pooler's self-reported routing/HA role plus the rule
+	// that qualifies it. role == PRIMARY marks the writable routing primary; the
+	// rule number is used as the failover-overlap tiebreaker among primaries.
+	RoutingState *clustermetadatapb.RoutingState
 
 	// ReplicationLagNs is the replication lag in nanoseconds reported by the pooler.
 	// Zero on the primary or when not yet measured.
@@ -86,12 +86,12 @@ func (h *poolerHealth) simpleCopy() *poolerHealth {
 		return nil
 	}
 	return &poolerHealth{
-		PoolerID:          h.PoolerID,
-		ServingStatus:     h.ServingStatus,
-		LeaderObservation: h.LeaderObservation,
-		ReplicationLagNs:  h.ReplicationLagNs,
-		LastError:         h.LastError,
-		LastResponse:      h.LastResponse,
+		PoolerID:         h.PoolerID,
+		ServingStatus:    h.ServingStatus,
+		RoutingState:     h.RoutingState,
+		ReplicationLagNs: h.ReplicationLagNs,
+		LastError:        h.LastError,
+		LastResponse:     h.LastResponse,
 	}
 }
 
@@ -174,7 +174,7 @@ func newPoolerConnection(
 	logger.DebugContext(ctx, "creating pooler connection",
 		"pooler_id", poolerID,
 		"addr", addr,
-		"is_leader", pooler.GetSelfLeadership() != nil)
+		"is_leader", pooler.GetRoutingState() != nil)
 
 	// Create gRPC connection with telemetry attributes
 	conn, err := grpccommon.NewClient(addr,
@@ -409,12 +409,12 @@ func (pc *poolerConnection) processHealthResponse(response *multipoolerservice.S
 
 	// Build new health snapshot from the response.
 	newHealth := &poolerHealth{
-		PoolerID:          response.PoolerId,
-		ServingStatus:     response.ServingStatus,
-		LeaderObservation: response.LeaderObservation,
-		ReplicationLagNs:  response.ReplicationLagNs,
-		LastError:         nil,
-		LastResponse:      time.Now(),
+		PoolerID:         response.PoolerId,
+		ServingStatus:    response.ServingStatus,
+		RoutingState:     response.RoutingState,
+		ReplicationLagNs: response.ReplicationLagNs,
+		LastError:        nil,
+		LastResponse:     time.Now(),
 	}
 
 	pc.healthMu.Lock()

--- a/go/services/multigateway/poolergateway/pooler_health_test.go
+++ b/go/services/multigateway/poolergateway/pooler_health_test.go
@@ -74,16 +74,16 @@ func TestPoolerHealthSimpleCopy(t *testing.T) {
 			Cell:      "zone1",
 			Name:      "pooler1",
 		}
-		primaryObs := &clustermetadatapb.LeaderObservation{LeaderId: poolerID, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 42}}
+		primaryRS := &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY, Rule: &clustermetadatapb.RuleNumber{CoordinatorTerm: 42}}
 		lastErr := errors.New("test error")
 		lastResp := time.Now()
 
 		original := &poolerHealth{
-			PoolerID:          poolerID,
-			ServingStatus:     clustermetadatapb.PoolerServingStatus_SERVING,
-			LeaderObservation: primaryObs,
-			LastError:         lastErr,
-			LastResponse:      lastResp,
+			PoolerID:      poolerID,
+			ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
+			RoutingState:  primaryRS,
+			LastError:     lastErr,
+			LastResponse:  lastResp,
 		}
 
 		copy := original.simpleCopy()
@@ -92,7 +92,7 @@ func TestPoolerHealthSimpleCopy(t *testing.T) {
 		require.NotNil(t, copy)
 		prototest.AssertEqual(t, original.PoolerID, copy.PoolerID)
 		assert.Equal(t, original.ServingStatus, copy.ServingStatus)
-		prototest.AssertEqual(t, original.LeaderObservation, copy.LeaderObservation)
+		prototest.AssertEqual(t, original.RoutingState, copy.RoutingState)
 		assert.Equal(t, original.LastError, copy.LastError)
 		assert.Equal(t, original.LastResponse, copy.LastResponse)
 
@@ -101,7 +101,7 @@ func TestPoolerHealthSimpleCopy(t *testing.T) {
 
 		// Verify pointer fields point to same underlying objects (shallow copy)
 		assert.Same(t, original.PoolerID, copy.PoolerID)
-		assert.Same(t, original.LeaderObservation, copy.LeaderObservation)
+		assert.Same(t, original.RoutingState, copy.RoutingState)
 	})
 
 	t.Run("modifying copy does not affect original", func(t *testing.T) {

--- a/go/services/multigateway/poolergateway/pooler_streaming_test.go
+++ b/go/services/multigateway/poolergateway/pooler_streaming_test.go
@@ -381,15 +381,11 @@ func TestPoolerConnection_StreamHealth_LeaderObservation(t *testing.T) {
 	setup := setupStreamingTest(t, t.Context())
 	waitForStreamOpened(t, setup.server)
 
-	// Send a response with LeaderObservation.
+	// Send a response with a PRIMARY routing_state.
 	resp := makeHealthResponse(clustermetadatapb.PoolerServingStatus_SERVING)
-	resp.LeaderObservation = &clustermetadatapb.LeaderObservation{
-		LeaderId: &clustermetadatapb.ID{
-			Component: clustermetadatapb.ID_MULTIPOOLER,
-			Cell:      "zone1",
-			Name:      "primary-pooler",
-		},
-		LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 42},
+	resp.RoutingState = &clustermetadatapb.RoutingState{
+		Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY,
+		Rule: &clustermetadatapb.RuleNumber{CoordinatorTerm: 42},
 	}
 	setup.server.responseCh <- resp
 
@@ -398,7 +394,7 @@ func TestPoolerConnection_StreamHealth_LeaderObservation(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond)
 
 	health := setup.conn.Health()
-	require.NotNil(t, health.LeaderObservation)
-	assert.Equal(t, int64(42), health.LeaderObservation.GetLeaderRuleNumber().GetCoordinatorTerm())
-	assert.Equal(t, "primary-pooler", health.LeaderObservation.LeaderId.GetName())
+	require.NotNil(t, health.RoutingState)
+	assert.Equal(t, clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY, health.RoutingState.GetRole())
+	assert.Equal(t, int64(42), health.RoutingState.GetRule().GetCoordinatorTerm())
 }

--- a/go/services/multigateway/status_test.go
+++ b/go/services/multigateway/status_test.go
@@ -56,9 +56,9 @@ func newTestPooler(cell, name, tableGroup, shard string, lifecycle clustermetada
 // record of a real PRIMARY pooler and is how the gateway learns of a leader
 // at discovery time.
 func withSelfLeader(p *clustermetadatapb.MultiPooler, coordinatorTerm int64) *clustermetadatapb.MultiPooler {
-	p.SelfLeadership = &clustermetadatapb.LeaderObservation{
-		LeaderId:         p.Id,
-		LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: coordinatorTerm},
+	p.RoutingState = &clustermetadatapb.RoutingState{
+		Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY,
+		Rule: &clustermetadatapb.RuleNumber{CoordinatorTerm: coordinatorTerm},
 	}
 	return p
 }

--- a/go/services/multiorch/recovery/pooler_watcher.go
+++ b/go/services/multiorch/recovery/pooler_watcher.go
@@ -95,7 +95,7 @@ func poolerCacheHooks(ctx context.Context, cache *store.PoolerCache, factory *st
 				"database", p.GetShardKey().GetDatabase(),
 				"tablegroup", p.GetShardKey().GetTableGroup(),
 				"shard", p.GetShardKey().GetShard(),
-				"leader", p.GetSelfLeadership().GetLeaderId() != nil,
+				"leader", p.GetRoutingState() != nil,
 			)
 			return store.NewPooler(
 				&multiorchdatapb.PoolerHealthState{

--- a/go/services/multipooler/grpcpoolerservice/service.go
+++ b/go/services/multipooler/grpcpoolerservice/service.go
@@ -31,7 +31,6 @@ import (
 	"github.com/multigres/multigres/go/common/queryservice"
 	"github.com/multigres/multigres/go/common/servenv"
 	"github.com/multigres/multigres/go/common/sqltypes"
-	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multipoolerpb "github.com/multigres/multigres/go/pb/multipoolerservice"
 	"github.com/multigres/multigres/go/pb/query"
 	"github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager"
@@ -864,17 +863,7 @@ func healthStateToProto(state *poolerserver.HealthState) *multipoolerpb.StreamPo
 	resp := &multipoolerpb.StreamPoolerHealthResponse{
 		PoolerId:      state.PoolerID,
 		ServingStatus: state.ServingStatus,
-	}
-
-	if state.LeaderObservation != nil {
-		// The pooler still tracks the observation by integer term internally;
-		// map it onto the rule-number-based wire type with leader_subterm 0.
-		// TODO: drive this from the (rule, primary) consensus state directly so
-		// the rule number (including subterm) is carried end to end.
-		resp.LeaderObservation = &clustermetadatapb.LeaderObservation{
-			LeaderId:         state.LeaderObservation.LeaderID,
-			LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: state.LeaderObservation.LeaderTerm},
-		}
+		RoutingState:  state.RoutingState,
 	}
 
 	if state.RecommendedStalenessTimeout > 0 {

--- a/go/services/multipooler/grpcpoolerservice/stream_replication_test.go
+++ b/go/services/multipooler/grpcpoolerservice/stream_replication_test.go
@@ -229,7 +229,7 @@ func servingPooler(t *testing.T, pm connpoolmanager.PoolManager) *poolerserver.Q
 	// nil Target, so admission skips the routing-role gate and keys only off the
 	// serving status; the routing role is therefore immaterial here.
 	require.NoError(t, p.OnStateChange(t.Context(),
-		servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+		servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRoleReplica}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	return p
 }
 

--- a/go/services/multipooler/internal/heartbeat/repltracker.go
+++ b/go/services/multipooler/internal/heartbeat/repltracker.go
@@ -88,7 +88,7 @@ func (rt *ReplTracker) makeNonPrimary() {
 // otherwise the reader runs. Writability already folds in the out-of-recovery
 // requirement, so heartbeats are never written to a standby.
 func (rt *ReplTracker) OnStateChange(_ context.Context, state servingstate.State) error {
-	if state.RoutingRole.Writable() && state.ServingStatus == clustermetadatapb.PoolerServingStatus_SERVING {
+	if state.Writable() && state.ServingStatus == clustermetadatapb.PoolerServingStatus_SERVING {
 		rt.makePrimary()
 	} else {
 		rt.makeNonPrimary()

--- a/go/services/multipooler/internal/heartbeat/repltracker_test.go
+++ b/go/services/multipooler/internal/heartbeat/repltracker_test.go
@@ -179,7 +179,7 @@ func TestReplTrackerOnStateChangeGating(t *testing.T) {
 			rt := NewReplTracker(queryService, slog.Default(), []byte("test-shard"), "test-pooler", 250)
 			defer rt.Close()
 
-			err := rt.OnStateChange(context.Background(), servingstate.State{RoutingRole: tt.routingRole, ServingStatus: tt.servingStatus})
+			err := rt.OnStateChange(context.Background(), servingstate.State{Routing: servingstate.RoutingState{Role: tt.routingRole}, ServingStatus: tt.servingStatus})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantPrimary, rt.IsPrimary())
 			assert.Equal(t, tt.wantPrimary, rt.hw.IsOpen(), "writer open state must match primary mode")

--- a/go/services/multipooler/internal/manager/consensus_manager_test.go
+++ b/go/services/multipooler/internal/manager/consensus_manager_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
@@ -208,13 +209,23 @@ func newTestManager(t *testing.T, opts ...testManagerOption) *MultiPoolerManager
 	if pm.record.Type() == clustermetadatapb.PoolerType_PRIMARY {
 		pm.stateManager.pgMode = pgmode.Primary
 	}
-	primaryBaseline := pm.stateManager.pgMode.OutOfRecovery()
-	baseline := servingstate.State{
-		Routing:       servingstate.RoutingState{Role: servingstate.RoutingRoleReplica},
-		ServingStatus: pm.record.ServingStatus(),
+	// Prime lastFannedOut to reflect what components last saw: the seeded record's
+	// LABEL (PRIMARY <-> primary) plus the rule that qualifies that role, chosen
+	// exactly as deriveRoutingState would (committed rule when PRIMARY, highest-
+	// known when REPLICA) so sameFanout — which now compares the rule — sees no
+	// drift at seed time. Drift is registered only when the observed
+	// postgresState / consensus later diverges from this seeded label.
+	cs := pm.consensusMgr.CachedConsensusStatus()
+	baselineRouting := servingstate.RoutingState{Role: servingstate.RoutingRoleReplica}
+	if pm.record.Type() == clustermetadatapb.PoolerType_PRIMARY {
+		baselineRouting.Role = servingstate.RoutingRolePrimary
+		baselineRouting.Rule = cs.GetCurrentPosition().GetRule().GetRuleNumber()
+	} else {
+		baselineRouting.Rule = commonconsensus.HighestKnownRule([]*clustermetadatapb.ConsensusStatus{cs}).GetRuleNumber()
 	}
-	if primaryBaseline {
-		baseline.Routing.Role = servingstate.RoutingRolePrimary
+	baseline := servingstate.State{
+		Routing:       baselineRouting,
+		ServingStatus: pm.record.ServingStatus(),
 	}
 	pm.stateManager.lastFannedOut = &baseline
 	return pm

--- a/go/services/multipooler/internal/manager/consensus_manager_test.go
+++ b/go/services/multipooler/internal/manager/consensus_manager_test.go
@@ -210,11 +210,11 @@ func newTestManager(t *testing.T, opts ...testManagerOption) *MultiPoolerManager
 	}
 	primaryBaseline := pm.stateManager.pgMode.OutOfRecovery()
 	baseline := servingstate.State{
-		RoutingRole:   servingstate.RoutingRoleReplica,
+		Routing:       servingstate.RoutingState{Role: servingstate.RoutingRoleReplica},
 		ServingStatus: pm.record.ServingStatus(),
 	}
 	if primaryBaseline {
-		baseline.RoutingRole = servingstate.RoutingRolePrimary
+		baseline.Routing.Role = servingstate.RoutingRolePrimary
 	}
 	pm.stateManager.lastFannedOut = &baseline
 	return pm

--- a/go/services/multipooler/internal/manager/health_provider.go
+++ b/go/services/multipooler/internal/manager/health_provider.go
@@ -56,9 +56,8 @@ type healthStreamer struct {
 	shard      string
 
 	// Mutable fields (updated via typed methods)
-	servingStatus     clustermetadatapb.PoolerServingStatus
-	poolerType        clustermetadatapb.PoolerType
-	leaderObservation *poolerserver.LeaderObservation
+	servingStatus clustermetadatapb.PoolerServingStatus
+	routingState  *clustermetadatapb.RoutingState
 
 	// Client management
 	clients map[chan *poolerserver.HealthState]struct{}
@@ -130,47 +129,24 @@ func (hs *healthStreamer) OnStateChange(ctx context.Context, state servingstate.
 	// not-serving: advertise-then-drain), so the phases would need to account for
 	// that. Low priority: the SERVING transition waited on here is fast.
 	if state.ServingStatus == clustermetadatapb.PoolerServingStatus_SERVING && hs.queryServer != nil {
-		hs.queryServer.AwaitStateChange(ctx, state.RoutingRole, state.ServingStatus)
+		hs.queryServer.AwaitStateChange(ctx, state.Routing.Role, state.ServingStatus)
 	}
 
 	hs.mu.Lock()
 	defer hs.mu.Unlock()
 
 	prev := hs.servingStatus
-	// PoolerType and the leader observation both derive from the routing role:
-	// PRIMARY / self-naming observation iff this pooler is the writable leader,
-	// REPLICA / nil otherwise. A leader mid-promotion is not yet routing PRIMARY,
-	// so it does not advertise itself until its rule commits.
-	hs.poolerType = poolerTypeForLeader(state.RoutingRole.Writable())
-	hs.leaderObservation = leaderObsFromState(state)
+	// The routing_state is published verbatim and is always set — role PRIMARY
+	// (with the committed rule) iff writable, else REPLICA (with the highest-known
+	// rule). A leader mid-promotion is not yet routing PRIMARY, so it advertises
+	// REPLICA until its rule commits.
+	hs.routingState = state.Routing.ToProto()
 	hs.servingStatus = state.ServingStatus
 	hs.broadcastLocked()
 	if prev != state.ServingStatus {
 		hs.metrics.recordTransition(ctx, prev, state.ServingStatus)
 	}
 	return nil
-}
-
-// leaderObsFromState converts the fanned self-leadership observation into the
-// health-stream form (self id + coordinator term), or nil when this pooler is
-// not the writable routing primary.
-func leaderObsFromState(state servingstate.State) *poolerserver.LeaderObservation {
-	if state.Leadership == nil {
-		return nil
-	}
-	return &poolerserver.LeaderObservation{
-		LeaderID:   state.Leadership.GetLeaderId(),
-		LeaderTerm: state.Leadership.GetLeaderRuleNumber().GetCoordinatorTerm(),
-	}
-}
-
-// poolerTypeForLeader maps a writable-leader boolean to the PoolerType label
-// (published on the health stream and persisted to the topology record).
-func poolerTypeForLeader(writableLeader bool) clustermetadatapb.PoolerType {
-	if writableLeader {
-		return clustermetadatapb.PoolerType_PRIMARY
-	}
-	return clustermetadatapb.PoolerType_REPLICA
 }
 
 // Broadcast sends the current state to all clients without changing any state.
@@ -194,7 +170,7 @@ func (hs *healthStreamer) buildStateLocked() *poolerserver.HealthState {
 	return &poolerserver.HealthState{
 		PoolerID:                    hs.poolerID,
 		ServingStatus:               hs.servingStatus,
-		LeaderObservation:           hs.leaderObservation,
+		RoutingState:                hs.routingState,
 		RecommendedStalenessTimeout: hs.recommendedStalenessTimeout,
 		ReplicationLagNs:            hs.replicationLagNs.Load(),
 	}

--- a/go/services/multipooler/internal/manager/health_provider_test.go
+++ b/go/services/multipooler/internal/manager/health_provider_test.go
@@ -45,7 +45,7 @@ func TestHealthStreamer_BroadcastToSubscribers(t *testing.T) {
 	assert.Equal(t, 2, hs.clientCount())
 
 	// Update state (triggers broadcast)
-	require.NoError(t, hs.OnStateChange(context.Background(), servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, hs.OnStateChange(context.Background(), servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRoleReplica}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// Both clients should receive the state
 	timeout1 := time.After(100 * time.Millisecond)
@@ -76,7 +76,7 @@ func TestHealthStreamer_SubscribeReceivesCurrentState(t *testing.T) {
 	hs := newHealthStreamer(logger, serviceID, "initial", "0")
 
 	// Set initial state via OnStateChange
-	require.NoError(t, hs.OnStateChange(context.Background(), servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, hs.OnStateChange(context.Background(), servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRoleReplica}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// Subscribe should return current state
 	state, _ := hs.subscribe()
@@ -102,7 +102,7 @@ func TestHealthStreamer_FullBufferClosesChannel(t *testing.T) {
 
 	// Send more than buffer size without draining
 	for range defaultHealthStreamBufferSize + 5 {
-		require.NoError(t, hs.OnStateChange(context.Background(), servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+		require.NoError(t, hs.OnStateChange(context.Background(), servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRoleReplica}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	}
 
 	// Channel should be closed due to buffer overflow
@@ -140,7 +140,7 @@ func TestHealthStreamer_GetState(t *testing.T) {
 	assert.Equal(t, clustermetadatapb.PoolerServingStatus_DISABLED, got.ServingStatus)
 
 	// Update and verify
-	require.NoError(t, hs.OnStateChange(context.Background(), servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, hs.OnStateChange(context.Background(), servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRoleReplica}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	got = hs.getState()
 	assert.Equal(t, clustermetadatapb.PoolerServingStatus_SERVING, got.ServingStatus)
 }
@@ -210,7 +210,7 @@ func TestHealthStreamer_OnStateChange(t *testing.T) {
 	_, ch := hs.subscribe()
 
 	// Call OnStateChange — updates both fields atomically with one broadcast
-	err := hs.OnStateChange(context.Background(), servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING})
+	err := hs.OnStateChange(context.Background(), servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING})
 	require.NoError(t, err)
 
 	// Verify subscriber receives a single broadcast with both fields updated
@@ -289,7 +289,7 @@ func TestHealthStreamer_WaitsForQueryServerOnServing(t *testing.T) {
 	// It should block because qps hasn't transitioned yet.
 	hsDone := make(chan struct{})
 	go func() {
-		_ = hs.OnStateChange(t.Context(), servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING})
+		_ = hs.OnStateChange(t.Context(), servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING})
 		close(hsDone)
 	}()
 
@@ -301,7 +301,7 @@ func TestHealthStreamer_WaitsForQueryServerOnServing(t *testing.T) {
 	}
 
 	// Now transition the query server.
-	require.NoError(t, qps.OnStateChange(t.Context(), servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, qps.OnStateChange(t.Context(), servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// Health streamer should unblock and broadcast.
 	select {
@@ -327,7 +327,7 @@ func TestHealthStreamer_DoesNotWaitOnNotServing(t *testing.T) {
 
 	// Create a query server that is PRIMARY/SERVING.
 	qps := poolerserver.NewQueryPoolerServer(logger, nil, nil, "", "", nil, 0, false)
-	require.NoError(t, qps.OnStateChange(t.Context(), servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, qps.OnStateChange(t.Context(), servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	hs.SetQueryServer(qps)
 
 	ch := make(chan *poolerserver.HealthState, 10)
@@ -336,7 +336,7 @@ func TestHealthStreamer_DoesNotWaitOnNotServing(t *testing.T) {
 	// DISABLED should broadcast immediately, even though qps is still PRIMARY/SERVING.
 	hsDone := make(chan struct{})
 	go func() {
-		_ = hs.OnStateChange(t.Context(), servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
+		_ = hs.OnStateChange(t.Context(), servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRoleReplica}, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
 		close(hsDone)
 	}()
 
@@ -366,25 +366,26 @@ func TestHealthStreamer_AdvertisesLeaderWhenWritable(t *testing.T) {
 	hs.clients[ch] = struct{}{}
 
 	// Leader, SERVING (can answer reads), but postgres still in recovery: routes
-	// REPLICA and carries no Leadership, so it advertises no leader.
+	// REPLICA, so the published routing_state is REPLICA — it advertises no leader.
 	require.NoError(t, hs.OnStateChange(t.Context(),
-		servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+		servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRoleReplica}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	st := <-ch
 	assert.Equal(t, clustermetadatapb.PoolerServingStatus_SERVING, st.ServingStatus)
-	assert.Nil(t, st.LeaderObservation, "leader still in recovery must not advertise itself")
+	assert.Equal(t, clustermetadatapb.RoutingRole_ROUTING_ROLE_REPLICA, st.RoutingState.GetRole(),
+		"leader still in recovery must not advertise itself as primary")
 
-	// Promotion completes (out of recovery): routes PRIMARY and carries a
-	// self-naming Leadership at the committed rule, so it advertises itself.
+	// Promotion completes (out of recovery): routes PRIMARY and carries the
+	// committed rule, so it advertises itself as the writable primary.
 	require.NoError(t, hs.OnStateChange(t.Context(),
 		servingstate.State{
-			RoutingRole:   servingstate.RoutingRolePrimary,
-			ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
-			Leadership: &clustermetadatapb.LeaderObservation{
-				LeaderId:         self,
-				LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 42},
+			Routing: servingstate.RoutingState{
+				Role: servingstate.RoutingRolePrimary,
+				Rule: &clustermetadatapb.RuleNumber{CoordinatorTerm: 42},
 			},
+			ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 		}))
 	st = <-ch
-	require.NotNil(t, st.LeaderObservation, "writable primary must advertise itself")
-	assert.Equal(t, int64(42), st.LeaderObservation.LeaderTerm)
+	assert.Equal(t, clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY, st.RoutingState.GetRole(),
+		"writable primary must advertise itself")
+	assert.Equal(t, int64(42), st.RoutingState.GetRule().GetCoordinatorTerm())
 }

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -1670,8 +1670,7 @@ func (pm *MultiPoolerManager) StartTopoRegistration(alarm func(string)) {
 // can publish over our shutdown state regardless of locking.
 func (pm *MultiPoolerManager) StopTopoRegistration(ctx context.Context) {
 	pm.record.Unregister(ctx, func(s *MutablePoolerRecordState) {
-		s.Type = clustermetadatapb.PoolerType_UNKNOWN
-		s.SelfLeadership = nil
+		s.RoutingState = nil
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_DISABLED
 		s.LifecycleStatus = &clustermetadatapb.PoolerLifecycle{
 			Status:  clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN,

--- a/go/services/multipooler/internal/manager/manager_test.go
+++ b/go/services/multipooler/internal/manager/manager_test.go
@@ -183,7 +183,7 @@ func TestManagerState_RetryUntilSuccess(t *testing.T) {
 		Type:          clustermetadatapb.PoolerType_PRIMARY,
 		ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 		// A PRIMARY record must name itself as leader (the record invariant).
-		SelfLeadership: &clustermetadatapb.LeaderObservation{LeaderId: serviceID},
+		RoutingState: &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY},
 		ShardKey: &clustermetadatapb.ShardKey{
 			Database:   database,
 			TableGroup: constants.DefaultTableGroup,
@@ -658,9 +658,8 @@ func TestPause_PreservesPublisher(t *testing.T) {
 	// Mutate to PRIMARY while paused. The publisher should still pick this
 	// up and reflect it in topology.
 	require.NoError(t, pm.record.Mutate(lockCtx, func(s *MutablePoolerRecordState) {
-		s.Type = clustermetadatapb.PoolerType_PRIMARY
 		// A PRIMARY must carry a self-leadership observation naming itself.
-		s.SelfLeadership = &clustermetadatapb.LeaderObservation{LeaderId: serviceID}
+		s.RoutingState = &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY}
 	}))
 
 	require.Eventually(t, func() bool {

--- a/go/services/multipooler/internal/manager/metrics_test.go
+++ b/go/services/multipooler/internal/manager/metrics_test.go
@@ -84,16 +84,16 @@ func TestServingTransitions(t *testing.T) {
 
 	// DISABLED (initial) → SERVING records one transition.
 	require.NoError(t, hs.OnStateChange(ctx,
-		servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+		servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// SERVING → SERVING is a no-op (role change only, primary → replica):
 	// no new transition.
 	require.NoError(t, hs.OnStateChange(ctx,
-		servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+		servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRoleReplica}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// SERVING → DISABLED records a second transition.
 	require.NoError(t, hs.OnStateChange(ctx,
-		servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
+		servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRoleReplica}, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
 
 	m := findMetric(t, reader, "mg.pooler.serving.transitions")
 	sum, ok := m.Data.(metricdata.Sum[int64])

--- a/go/services/multipooler/internal/manager/pooler_record.go
+++ b/go/services/multipooler/internal/manager/pooler_record.go
@@ -16,8 +16,6 @@ package manager
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -26,7 +24,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/multigres/multigres/go/common/servenv/toporeg"
-	"github.com/multigres/multigres/go/common/topoclient"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
 )
@@ -46,14 +43,13 @@ const (
 // immutable — exposing only this struct in the mutation API makes that
 // contract a property of the type system rather than a runtime check.
 type MutablePoolerRecordState struct {
-	Type            clustermetadatapb.PoolerType
 	ServingStatus   clustermetadatapb.PoolerServingStatus
 	LifecycleStatus *clustermetadatapb.PoolerLifecycle
-	// SelfLeadership is the pooler's most recent recorded consensus
-	// observation. Set ONLY when this pooler currently considers itself the
-	// leader of its shard; replicas leave it nil. Published into etcd so
-	// multigateway can bootstrap leader routing on discovery.
-	SelfLeadership *clustermetadatapb.LeaderObservation
+	// RoutingState is the pooler's self-reported routing/HA advertisement. Set
+	// ONLY when this pooler is the writable PRIMARY; replicas — and a consensus
+	// leader not yet writable — leave it nil. Published into etcd so multigateway
+	// can bootstrap write routing on discovery.
+	RoutingState *clustermetadatapb.RoutingState
 }
 
 // poolerTopoStore is the subset of topoclient.Store used by poolerRecord.
@@ -105,7 +101,7 @@ type poolerRecord struct {
 // state. The caller hands ownership of initial to the record; further access
 // must go through Snapshot, Mutate, or the typed accessors.
 //
-// Returns an error if the seed violates the Type ↔ SelfLeadership invariant
+// Returns an error if the seed violates the Type ↔ routing_state invariant
 // (see validateState). Every mutation is validated, so the seed must be too —
 // otherwise the record could hold a state Mutate would reject, surfacing only
 // at the first transition.
@@ -116,14 +112,6 @@ func newPoolerRecord(logger *slog.Logger, topoClient poolerTopoStore, initial *c
 		wakeup:     make(chan struct{}, 1),
 	}
 	r.desired.Store(proto.Clone(initial).(*clustermetadatapb.MultiPooler))
-	if err := r.validateState(&MutablePoolerRecordState{
-		Type:            initial.Type,
-		ServingStatus:   initial.ServingStatus,
-		LifecycleStatus: initial.LifecycleStatus,
-		SelfLeadership:  initial.SelfLeadership,
-	}); err != nil {
-		return nil, err
-	}
 	return r, nil
 }
 
@@ -156,10 +144,10 @@ func (r *poolerRecord) ServingStatus() clustermetadatapb.PoolerServingStatus {
 	return r.desired.Load().ServingStatus
 }
 
-// SelfLeadership returns the pooler's most recent recorded consensus
-// observation, or nil if this pooler is not currently the leader of its shard.
-func (r *poolerRecord) SelfLeadership() *clustermetadatapb.LeaderObservation {
-	return r.desired.Load().SelfLeadership
+// RoutingState returns the pooler's recorded routing/HA advertisement, or nil if
+// this pooler is not currently the writable PRIMARY of its shard.
+func (r *poolerRecord) RoutingState() *clustermetadatapb.RoutingState {
+	return r.desired.Load().RoutingState
 }
 
 // Snapshot returns a deep clone of the current desired state. Use this when
@@ -186,16 +174,14 @@ func (r *poolerRecord) Snapshot() *clustermetadatapb.MultiPooler {
 // simple field assignments only.
 //
 // Returns an error (without applying fn) if the resulting state violates the
-// consistency invariant between Type and SelfLeadership: a pooler is the
-// leader iff Type == PRIMARY iff SelfLeadership is set and names this
-// pooler. Callers must keep the two fields in sync.
+// consistency invariant between Type and routing_state: a persisted routing_state
+// must be PRIMARY and pairs with Type == PRIMARY (see validateState). Callers must
+// keep the two fields in sync.
 func (r *poolerRecord) Mutate(ctx context.Context, fn func(*MutablePoolerRecordState)) error {
 	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
 		return err
 	}
-	if err := r.applyMutation(fn); err != nil {
-		return err
-	}
+	r.applyMutation(fn)
 
 	// Non-blocking send: if the channel is already full, a publish is already
 	// pending and will pick up the latest desired state.
@@ -207,48 +193,55 @@ func (r *poolerRecord) Mutate(ctx context.Context, fn func(*MutablePoolerRecordS
 }
 
 // applyMutation clones the current desired proto, hands a
-// MutablePoolerRecordState view to fn, validates the Type ↔ SelfLeadership
-// invariant, then atomically stores the result. Caller is responsible for
-// sequencing (action lock, publisher state). Returns the validation error and
-// leaves the stored state unchanged on violation.
-func (r *poolerRecord) applyMutation(fn func(*MutablePoolerRecordState)) error {
+// MutablePoolerRecordState view to fn, then atomically stores the result with the
+// published PoolerType recomputed from the mutated lifecycle + routing state (see
+// typeForState). Caller is responsible for sequencing (action lock, publisher
+// state). It cannot fail: PoolerType is derived, so there is no cross-field
+// invariant to violate.
+func (r *poolerRecord) applyMutation(fn func(*MutablePoolerRecordState)) {
 	current := r.desired.Load()
 	state := MutablePoolerRecordState{
-		Type:            current.Type,
 		ServingStatus:   current.ServingStatus,
 		LifecycleStatus: current.LifecycleStatus,
-		SelfLeadership:  current.SelfLeadership,
+		RoutingState:    current.RoutingState,
 	}
 	fn(&state)
-	if err := r.validateState(&state); err != nil {
-		return err
-	}
 	next := proto.Clone(current).(*clustermetadatapb.MultiPooler)
-	next.Type = state.Type
+	next.Type = typeForState(state.LifecycleStatus, state.RoutingState)
 	next.ServingStatus = state.ServingStatus
 	next.LifecycleStatus = state.LifecycleStatus
-	next.SelfLeadership = state.SelfLeadership
+	next.RoutingState = state.RoutingState
 	r.desired.Store(next)
-	return nil
 }
 
-// validateState enforces the Type ↔ SelfLeadership consistency invariant: a
-// pooler is the leader iff Type == PRIMARY iff SelfLeadership is set and
-// names this pooler. Any deviation is a caller bug.
-func (r *poolerRecord) validateState(state *MutablePoolerRecordState) error {
-	isPrimary := state.Type == clustermetadatapb.PoolerType_PRIMARY
-	hasObs := state.SelfLeadership != nil
-	switch {
-	case isPrimary && !hasObs:
-		return errors.New("invariant violated: Type=PRIMARY but SelfLeadership is nil")
-	case !isPrimary && hasObs:
-		return fmt.Errorf("invariant violated: Type=%s but SelfLeadership is set", state.Type)
-	case hasObs && !proto.Equal(state.SelfLeadership.LeaderId, r.Id()):
-		return fmt.Errorf("invariant violated: SelfLeadership.LeaderId=%s does not match this pooler's Id=%s",
-			topoclient.ComponentIDString(state.SelfLeadership.LeaderId),
-			topoclient.ComponentIDString(r.Id()))
+// typeForState derives the published PoolerType — a pure projection, never stored
+// independently, so it can never drift from the routing state. A shutting-down
+// pooler is UNKNOWN; otherwise PRIMARY iff the routing role is PRIMARY (the
+// writable leader), else REPLICA.
+func typeForState(lifecycle *clustermetadatapb.PoolerLifecycle, routing *clustermetadatapb.RoutingState) clustermetadatapb.PoolerType {
+	if lifecycle.GetStatus() == clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN {
+		return clustermetadatapb.PoolerType_UNKNOWN
 	}
-	return nil
+	if routing.GetRole() == clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY {
+		return clustermetadatapb.PoolerType_PRIMARY
+	}
+	return clustermetadatapb.PoolerType_REPLICA
+}
+
+// routingStateForPublish reduces a to-be-published record to the etcd form: the
+// full routing state lives in the in-memory record (so internal readers and the
+// derived Type see role + rule for replicas too), but only the writable PRIMARY's
+// routing_state is persisted to etcd. Replicas — whose highest-known rule bumps
+// frequently — publish nil, so those bumps never churn etcd (successive replica
+// states reduce to an identical published form and dedup away). Returns a clone;
+// the input is not mutated.
+func routingStateForPublish(m *clustermetadatapb.MultiPooler) *clustermetadatapb.MultiPooler {
+	if m.GetRoutingState().GetRole() == clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY {
+		return m
+	}
+	out := proto.Clone(m).(*clustermetadatapb.MultiPooler)
+	out.RoutingState = nil
+	return out
 }
 
 // Register starts the publisher goroutine and kicks off initial registration
@@ -275,7 +268,7 @@ func (r *poolerRecord) Register(parent context.Context, alarm func(string)) {
 		// (via Mutate + final publish) so toporeg only needs to manage the
 		// retry goroutine's lifetime.
 		registerFunc := func(ctx context.Context) error {
-			return r.topoClient.RegisterMultiPooler(ctx, r.Snapshot(), true /* allowUpdate */)
+			return r.topoClient.RegisterMultiPooler(ctx, routingStateForPublish(r.Snapshot()), true /* allowUpdate */)
 		}
 		r.tr = toporeg.Register(registerFunc, func(context.Context) error { return nil }, alarm)
 	})
@@ -315,24 +308,21 @@ func (r *poolerRecord) Unregister(ctx context.Context, finalize func(*MutablePoo
 	r.publisherWG.Wait()
 
 	if finalize != nil {
-		if err := r.applyMutation(finalize); err != nil {
-			// Finalize must not put the record in an inconsistent state. Log
-			// and continue: a final publish still helps surface whatever the
-			// record currently holds, even if finalize was effectively a no-op.
-			r.logger.WarnContext(ctx, "Final mutation during Unregister rejected by invariant; publishing prior desired state",
-				"error", err)
-		}
+		r.applyMutation(finalize)
 	}
 
 	desired := r.desired.Load()
-	if desired != nil && !proto.Equal(desired, r.lastPublished.Load()) {
-		if err := r.topoClient.RegisterMultiPooler(ctx, desired, true); err != nil {
-			r.logger.WarnContext(ctx, "Final publish during Unregister failed; topology may be stale",
-				"error", err,
-				"type", desired.Type,
-				"serving_status", desired.ServingStatus)
-		} else {
-			r.lastPublished.Store(proto.Clone(desired).(*clustermetadatapb.MultiPooler))
+	if desired != nil {
+		pub := routingStateForPublish(desired)
+		if !proto.Equal(pub, r.lastPublished.Load()) {
+			if err := r.topoClient.RegisterMultiPooler(ctx, pub, true); err != nil {
+				r.logger.WarnContext(ctx, "Final publish during Unregister failed; topology may be stale",
+					"error", err,
+					"type", pub.Type,
+					"serving_status", pub.ServingStatus)
+			} else {
+				r.lastPublished.Store(proto.Clone(pub).(*clustermetadatapb.MultiPooler))
+			}
 		}
 	}
 
@@ -365,32 +355,33 @@ func (r *poolerRecord) publisherLoop(ctx context.Context, tickC <-chan time.Time
 // last successfully published state. A no-op when state is already current.
 func (r *poolerRecord) publishIfNeeded(ctx context.Context) {
 	desired := r.desired.Load()
-	lastPublished := r.lastPublished.Load()
-
 	if desired == nil {
 		return
 	}
-
-	if proto.Equal(desired, lastPublished) {
+	// Reduce to the etcd form (routing_state kept only for the writable PRIMARY),
+	// then dedup against the last published form: a replica's frequent
+	// highest-known-rule bumps reduce to an identical form and never churn etcd.
+	pub := routingStateForPublish(desired)
+	if proto.Equal(pub, r.lastPublished.Load()) {
 		return
 	}
 
 	r.logger.InfoContext(ctx, "Publishing multipooler state to topology",
-		"type", desired.Type,
-		"serving_status", desired.ServingStatus)
+		"type", pub.Type,
+		"serving_status", pub.ServingStatus)
 
 	publishCtx, cancel := context.WithTimeout(ctx, topoPublisherWriteTimeout)
 	defer cancel()
 
-	if err := r.topoClient.RegisterMultiPooler(publishCtx, desired, true); err != nil {
+	if err := r.topoClient.RegisterMultiPooler(publishCtx, pub, true); err != nil {
 		r.logger.ErrorContext(ctx, "Failed to publish multipooler state to topology; will retry",
 			"error", err,
-			"type", desired.Type,
-			"serving_status", desired.ServingStatus)
+			"type", pub.Type,
+			"serving_status", pub.ServingStatus)
 		return
 	}
 
-	r.lastPublished.Store(proto.Clone(desired).(*clustermetadatapb.MultiPooler))
+	r.lastPublished.Store(proto.Clone(pub).(*clustermetadatapb.MultiPooler))
 
 	r.logger.InfoContext(ctx, "Published multipooler state to topology",
 		"type", desired.Type,

--- a/go/services/multipooler/internal/manager/pooler_record_test.go
+++ b/go/services/multipooler/internal/manager/pooler_record_test.go
@@ -82,7 +82,7 @@ func newTestPoolerProto(poolerType clustermetadatapb.PoolerType, status clusterm
 	// Keep the Type ⇔ SelfLeadership invariant so the record validates: a
 	// PRIMARY names itself; any other type carries no self-leadership.
 	if poolerType == clustermetadatapb.PoolerType_PRIMARY {
-		mp.SelfLeadership = &clustermetadatapb.LeaderObservation{LeaderId: id}
+		mp.RoutingState = &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY}
 	}
 	return mp
 }
@@ -133,8 +133,7 @@ func TestPoolerRecord_PublishIfNeeded_WritesOnStateChange(t *testing.T) {
 	require.Equal(t, int32(1), ts.calls.Load())
 
 	require.NoError(t, r.Mutate(newActionLockedCtx(t), func(s *MutablePoolerRecordState) {
-		s.Type = clustermetadatapb.PoolerType_PRIMARY
-		s.SelfLeadership = primaryObs()
+		s.RoutingState = primaryObs()
 	}))
 	r.publishIfNeeded(t.Context())
 	assert.Equal(t, int32(2), ts.calls.Load())
@@ -166,8 +165,7 @@ func TestPoolerRecord_Mutate_UpdatesDesiredAndSchedulesPublish(t *testing.T) {
 	r := mustNewPoolerRecord(t, ts, newTestPoolerProto(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED))
 
 	require.NoError(t, r.Mutate(newActionLockedCtx(t), func(s *MutablePoolerRecordState) {
-		s.Type = clustermetadatapb.PoolerType_PRIMARY
-		s.SelfLeadership = primaryObs()
+		s.RoutingState = primaryObs()
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	}))
 
@@ -187,8 +185,7 @@ func TestPoolerRecord_Mutate_RequiresActionLock(t *testing.T) {
 	r := mustNewPoolerRecord(t, ts, newTestPoolerProto(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED))
 
 	err := r.Mutate(t.Context(), func(s *MutablePoolerRecordState) {
-		s.Type = clustermetadatapb.PoolerType_PRIMARY
-		s.SelfLeadership = primaryObs()
+		s.RoutingState = primaryObs()
 	})
 	require.Error(t, err)
 
@@ -207,8 +204,7 @@ func TestPoolerRecord_Mutate_CoalescesPendingWakeups(t *testing.T) {
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	}))
 	require.NoError(t, r.Mutate(ctx, func(s *MutablePoolerRecordState) {
-		s.Type = clustermetadatapb.PoolerType_PRIMARY
-		s.SelfLeadership = primaryObs()
+		s.RoutingState = primaryObs()
 	}))
 	require.NoError(t, r.Mutate(ctx, func(s *MutablePoolerRecordState) {
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_DISABLED
@@ -283,8 +279,7 @@ func TestPoolerRecord_WakeupTriggersImmediatePublish(t *testing.T) {
 	go r.publisherLoop(ctx, tickC)
 
 	require.NoError(t, r.Mutate(newActionLockedCtx(t), func(s *MutablePoolerRecordState) {
-		s.Type = clustermetadatapb.PoolerType_PRIMARY
-		s.SelfLeadership = primaryObs()
+		s.RoutingState = primaryObs()
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	}))
 
@@ -367,10 +362,11 @@ func TestPoolerRecord_RegisterAndUnregister(t *testing.T) {
 	}, time.Second, time.Millisecond)
 
 	// Mirror the production shutdown finalize (StopTopoRegistration): a leader
-	// stepping down clears its self-leadership to keep the record invariant.
+	// stepping down clears its routing_state and marks the lifecycle SHUTDOWN, so
+	// the published Type derives to UNKNOWN.
 	r.Unregister(t.Context(), func(s *MutablePoolerRecordState) {
-		s.Type = clustermetadatapb.PoolerType_UNKNOWN
-		s.SelfLeadership = nil
+		s.RoutingState = nil
+		s.LifecycleStatus = &clustermetadatapb.PoolerLifecycle{Status: clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN}
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_DISABLED
 	})
 
@@ -391,8 +387,7 @@ func TestPoolerRecord_Unregister_NoFinalize(t *testing.T) {
 
 	// Mutate to PRIMARY before Unregister.
 	require.NoError(t, r.Mutate(newActionLockedCtx(t), func(s *MutablePoolerRecordState) {
-		s.Type = clustermetadatapb.PoolerType_PRIMARY
-		s.SelfLeadership = primaryObs()
+		s.RoutingState = primaryObs()
 	}))
 
 	r.Unregister(t.Context(), nil)
@@ -402,70 +397,35 @@ func TestPoolerRecord_Unregister_NoFinalize(t *testing.T) {
 	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, seen.Type)
 }
 
-// TestPoolerRecord_Mutate_SelfLeadershipInvariant verifies Mutate rejects any
-// state that breaks the Type ⇔ SelfLeadership invariant (a pooler is the leader
-// iff Type==PRIMARY iff SelfLeadership is set and names this pooler) and leaves
-// the stored state unchanged on rejection.
-func TestPoolerRecord_Mutate_SelfLeadershipInvariant(t *testing.T) {
-	otherID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "other-pooler"}
-
-	t.Run("PRIMARY without observation is rejected", func(t *testing.T) {
+// TestPoolerRecord_DerivesTypeFromRoutingState verifies the published PoolerType
+// is a pure projection of routing_state + lifecycle (see typeForState): callers
+// set routing_state, never Type. A PRIMARY routing_state publishes Type PRIMARY;
+// clearing it publishes REPLICA; a SHUTDOWN lifecycle publishes UNKNOWN.
+func TestPoolerRecord_DerivesTypeFromRoutingState(t *testing.T) {
+	t.Run("routing_state PRIMARY publishes Type PRIMARY", func(t *testing.T) {
 		r := mustNewPoolerRecord(t, &fakeTopoStore{}, newTestPoolerProto(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_SERVING))
-		err := r.Mutate(newActionLockedCtx(t), func(s *MutablePoolerRecordState) {
-			s.Type = clustermetadatapb.PoolerType_PRIMARY
-		})
-		require.EqualError(t, err, "invariant violated: Type=PRIMARY but SelfLeadership is nil")
-		assert.Equal(t, clustermetadatapb.PoolerType_REPLICA, r.Type(), "rejected mutation must not apply")
-	})
-
-	t.Run("non-PRIMARY with observation is rejected", func(t *testing.T) {
-		r := mustNewPoolerRecord(t, &fakeTopoStore{}, newTestPoolerProto(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_SERVING))
-		err := r.Mutate(newActionLockedCtx(t), func(s *MutablePoolerRecordState) {
-			s.SelfLeadership = primaryObs()
-		})
-		require.EqualError(t, err, "invariant violated: Type=REPLICA but SelfLeadership is set")
-		assert.Nil(t, r.SelfLeadership(), "rejected mutation must not apply")
-	})
-
-	t.Run("observation naming another pooler is rejected", func(t *testing.T) {
-		r := mustNewPoolerRecord(t, &fakeTopoStore{}, newTestPoolerProto(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_SERVING))
-		err := r.Mutate(newActionLockedCtx(t), func(s *MutablePoolerRecordState) {
-			s.Type = clustermetadatapb.PoolerType_PRIMARY
-			s.SelfLeadership = &clustermetadatapb.LeaderObservation{LeaderId: otherID}
-		})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "does not match this pooler's Id")
-	})
-
-	t.Run("PRIMARY naming self is accepted", func(t *testing.T) {
-		r := mustNewPoolerRecord(t, &fakeTopoStore{}, newTestPoolerProto(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_SERVING))
-		err := r.Mutate(newActionLockedCtx(t), func(s *MutablePoolerRecordState) {
-			s.Type = clustermetadatapb.PoolerType_PRIMARY
-			s.SelfLeadership = primaryObs()
-		})
-		require.NoError(t, err)
+		require.NoError(t, r.Mutate(newActionLockedCtx(t), func(s *MutablePoolerRecordState) {
+			s.RoutingState = primaryObs()
+		}))
 		assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, r.Type())
-		require.NotNil(t, r.SelfLeadership())
-		assert.Equal(t, testPoolerID, r.SelfLeadership().GetLeaderId())
-	})
-}
-
-// TestNewPoolerRecord_ValidatesSeed verifies the constructor rejects a seed
-// that violates the Type ⇔ SelfLeadership invariant, so the record can never
-// hold a state that Mutate would reject.
-func TestNewPoolerRecord_ValidatesSeed(t *testing.T) {
-	t.Run("PRIMARY without observation is rejected", func(t *testing.T) {
-		seed := newTestPoolerProto(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
-		seed.SelfLeadership = nil
-		r, err := newPoolerRecord(newTestLogger(), &fakeTopoStore{}, seed)
-		require.EqualError(t, err, "invariant violated: Type=PRIMARY but SelfLeadership is nil")
-		assert.Nil(t, r)
+		require.NotNil(t, r.RoutingState())
+		assert.Equal(t, clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY, r.RoutingState().GetRole())
 	})
 
-	t.Run("valid REPLICA seed is accepted", func(t *testing.T) {
-		r, err := newPoolerRecord(newTestLogger(), &fakeTopoStore{},
-			newTestPoolerProto(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_DISABLED))
-		require.NoError(t, err)
-		require.NotNil(t, r)
+	t.Run("no routing_state publishes Type REPLICA", func(t *testing.T) {
+		r := mustNewPoolerRecord(t, &fakeTopoStore{}, newTestPoolerProto(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
+		require.NoError(t, r.Mutate(newActionLockedCtx(t), func(s *MutablePoolerRecordState) {
+			s.RoutingState = nil
+		}))
+		assert.Equal(t, clustermetadatapb.PoolerType_REPLICA, r.Type())
+		assert.Nil(t, r.RoutingState())
+	})
+
+	t.Run("SHUTDOWN lifecycle publishes Type UNKNOWN", func(t *testing.T) {
+		r := mustNewPoolerRecord(t, &fakeTopoStore{}, newTestPoolerProto(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_SERVING))
+		require.NoError(t, r.Mutate(newActionLockedCtx(t), func(s *MutablePoolerRecordState) {
+			s.LifecycleStatus = &clustermetadatapb.PoolerLifecycle{Status: clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN}
+		}))
+		assert.Equal(t, clustermetadatapb.PoolerType_UNKNOWN, r.Type())
 	})
 }

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -501,7 +501,7 @@ func TestDetermineRemedialAction(t *testing.T) {
 			if tt.poolerType == clustermetadatapb.PoolerType_PRIMARY {
 				// Record invariant: a PRIMARY record must carry a self-leadership
 				// observation that names itself.
-				seed.SelfLeadership = &clustermetadatapb.LeaderObservation{LeaderId: selfID}
+				seed.RoutingState = &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY}
 			}
 			pm := newTestManager(t,
 				withServiceID(selfID),
@@ -607,9 +607,9 @@ func TestDetermineRemedialAction_StalePrimaryDemote(t *testing.T) {
 			pm := newTestManager(t,
 				withServiceID(selfID),
 				withRecord(newRecordFromProto(&clustermetadatapb.MultiPooler{
-					Id:             selfID,
-					Type:           clustermetadatapb.PoolerType_PRIMARY,
-					SelfLeadership: &clustermetadatapb.LeaderObservation{LeaderId: selfID},
+					Id:           selfID,
+					Type:         clustermetadatapb.PoolerType_PRIMARY,
+					RoutingState: &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY},
 				})),
 				withReplicationPrimary(tt.seedPrimary),
 				withRuleStore(&fakeRuleStore{pos: tt.cachedPos}),
@@ -969,7 +969,7 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 			}
 			if tc.poolerType == clustermetadatapb.PoolerType_PRIMARY {
 				// Record invariant: a PRIMARY record must carry a self-leadership obs.
-				multipooler.SelfLeadership = &clustermetadatapb.LeaderObservation{LeaderId: multipooler.Id}
+				multipooler.RoutingState = &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY}
 			}
 			dir := t.TempDir()
 			// Seed a revocation of everything below term 1 so the manager has a term.
@@ -1007,7 +1007,7 @@ func TestTakeRemedialAction_ReconcileGUC(t *testing.T) {
 		Id:   selfID,
 		Type: clustermetadatapb.PoolerType_PRIMARY,
 		// A PRIMARY record must name itself as leader (the record invariant).
-		SelfLeadership: &clustermetadatapb.LeaderObservation{LeaderId: selfID},
+		RoutingState: &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY},
 	}, withRuleStore(frs))
 
 	lockCtx, err := pm.actionLock.Acquire(ctx, "test")
@@ -1045,10 +1045,10 @@ func TestTakeRemedialAction_ReconcileRole_AppliesRuleDerivedRole(t *testing.T) {
 		postgresState{pgctldAvailable: true, postgresRunning: true, pgMode: pgmode.Primary})
 
 	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, pm.record.Type())
-	obs := pm.record.SelfLeadership()
-	require.NotNil(t, obs, "ReconcileRole must apply the rule-derived role with its self-leadership observation when the rule names this pooler leader")
-	assert.Equal(t, multipooler.Id, obs.GetLeaderId())
-	assert.Equal(t, committed, obs.GetLeaderRuleNumber())
+	obs := pm.record.RoutingState()
+	require.NotNil(t, obs, "ReconcileRole must persist a PRIMARY routing_state when the rule names this pooler leader")
+	assert.Equal(t, clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY, obs.GetRole())
+	assert.Equal(t, committed, obs.GetRule())
 }
 
 func TestHasCompleteBackups_WithCompleteBackup(t *testing.T) {

--- a/go/services/multipooler/internal/manager/rpc_backup_test.go
+++ b/go/services/multipooler/internal/manager/rpc_backup_test.go
@@ -78,7 +78,7 @@ func createTestManagerWithBackupLocation(t *testing.T, poolerDir, tableGroup, sh
 	// Keep the Type ⇔ SelfLeadership invariant so the record validates: a
 	// PRIMARY names itself; any other type carries no self-leadership.
 	if poolerType == clustermetadatapb.PoolerType_PRIMARY {
-		multipoolerProto.SelfLeadership = &clustermetadatapb.LeaderObservation{LeaderId: multipoolerID}
+		multipoolerProto.RoutingState = &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY}
 	}
 
 	// Create a topology store with backup location if provided
@@ -812,7 +812,7 @@ exit 0
 						Database:   "test-database",
 					},
 					// A PRIMARY record must name itself as leader (the record invariant).
-					SelfLeadership: &clustermetadatapb.LeaderObservation{LeaderId: multipoolerID},
+					RoutingState: &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY},
 				}),
 				state:      ManagerStateReady,
 				actionLock: actionlock.NewActionLock(),

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -75,7 +75,7 @@ func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService, r
 		Type:          clustermetadatapb.PoolerType_PRIMARY,
 		ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 		// A PRIMARY record must name itself as leader (the record invariant).
-		SelfLeadership: &clustermetadatapb.LeaderObservation{LeaderId: serviceID},
+		RoutingState: &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY},
 		ShardKey: &clustermetadatapb.ShardKey{
 			Database:   database,
 			TableGroup: constants.DefaultTableGroup,
@@ -758,9 +758,9 @@ func TestPromote(t *testing.T) {
 				assert.Empty(t, update.GetAcceptedMembers())
 
 				state := pm.healthStreamer.getState()
-				require.NotNil(t, state.LeaderObservation)
-				assert.True(t, proto.Equal(selfID, state.LeaderObservation.LeaderID))
-				assert.Equal(t, int64(7), state.LeaderObservation.LeaderTerm)
+				require.NotNil(t, state.RoutingState)
+				assert.Equal(t, clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY, state.RoutingState.GetRole())
+				assert.Equal(t, int64(7), state.RoutingState.GetRule().GetCoordinatorTerm())
 
 				assert.Equal(t, int64(0), pm.consensusMgr.ResignedLeaderAtTerm(), "clearResignedLeaderAtTerm should have cleared the term")
 

--- a/go/services/multipooler/internal/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/internal/manager/rpc_initialization_test.go
@@ -323,10 +323,10 @@ func TestPromotion_PublishesSelfLeadership(t *testing.T) {
 
 	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, pm.record.Type())
 	assert.Equal(t, clustermetadatapb.PoolerServingStatus_SERVING, pm.record.ServingStatus())
-	obs := pm.record.SelfLeadership()
-	require.NotNil(t, obs, "promotion must publish a self-leadership observation")
-	assert.Equal(t, multipooler.Id, obs.GetLeaderId())
-	assert.Equal(t, rule.GetRuleNumber(), obs.GetLeaderRuleNumber())
+	obs := pm.record.RoutingState()
+	require.NotNil(t, obs, "promotion must publish a PRIMARY routing_state")
+	assert.Equal(t, clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY, obs.GetRole())
+	assert.Equal(t, rule.GetRuleNumber(), obs.GetRule())
 }
 
 // Integration Tests for MonitorPostgres

--- a/go/services/multipooler/internal/manager/rpc_manager_test.go
+++ b/go/services/multipooler/internal/manager/rpc_manager_test.go
@@ -113,7 +113,7 @@ func TestPrimaryPosition(t *testing.T) {
 			}
 			// A PRIMARY record must name itself as leader (the record invariant).
 			if tt.poolerType == clustermetadatapb.PoolerType_PRIMARY {
-				multipooler.SelfLeadership = &clustermetadatapb.LeaderObservation{LeaderId: serviceID}
+				multipooler.RoutingState = &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY}
 			}
 			require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 
@@ -188,7 +188,7 @@ func TestActionLock_MutationMethodsTimeout(t *testing.T) {
 		Type:          clustermetadatapb.PoolerType_PRIMARY,
 		ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 		// A PRIMARY record must name itself as leader (the record invariant).
-		SelfLeadership: &clustermetadatapb.LeaderObservation{LeaderId: serviceID},
+		RoutingState: &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY},
 		ShardKey: &clustermetadatapb.ShardKey{
 			Database:   database,
 			TableGroup: constants.DefaultTableGroup,
@@ -347,7 +347,7 @@ func TestReplicationStatus(t *testing.T) {
 			Type:          clustermetadatapb.PoolerType_PRIMARY,
 			ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 			// A PRIMARY record must name itself as leader (the record invariant).
-			SelfLeadership: &clustermetadatapb.LeaderObservation{LeaderId: serviceID},
+			RoutingState: &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY},
 			ShardKey: &clustermetadatapb.ShardKey{
 				Database:   database,
 				TableGroup: constants.DefaultTableGroup,
@@ -528,7 +528,7 @@ func TestReplicationStatus(t *testing.T) {
 			Type:          clustermetadatapb.PoolerType_PRIMARY,
 			ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 			// A PRIMARY record must name itself as leader (the record invariant).
-			SelfLeadership: &clustermetadatapb.LeaderObservation{LeaderId: serviceID},
+			RoutingState: &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY},
 			ShardKey: &clustermetadatapb.ShardKey{
 				Database:   database,
 				TableGroup: constants.DefaultTableGroup,
@@ -613,7 +613,7 @@ func TestReplicationStatus(t *testing.T) {
 			Type:          clustermetadatapb.PoolerType_PRIMARY,
 			ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 			// A PRIMARY record must name itself as leader (the record invariant).
-			SelfLeadership: &clustermetadatapb.LeaderObservation{LeaderId: serviceID},
+			RoutingState: &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY},
 			ShardKey: &clustermetadatapb.ShardKey{
 				Database:   database,
 				TableGroup: constants.DefaultTableGroup,
@@ -778,7 +778,7 @@ func TestUpdateConsensusRule_HistoryFailurePreventsGUCUpdate(t *testing.T) {
 		Type:          clustermetadatapb.PoolerType_PRIMARY,
 		ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 		// A PRIMARY record must name itself as leader (the record invariant).
-		SelfLeadership: &clustermetadatapb.LeaderObservation{LeaderId: serviceID},
+		RoutingState: &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY},
 		ShardKey: &clustermetadatapb.ShardKey{
 			Database:   database,
 			TableGroup: constants.DefaultTableGroup,

--- a/go/services/multipooler/internal/manager/rpc_set_primary_test.go
+++ b/go/services/multipooler/internal/manager/rpc_set_primary_test.go
@@ -367,8 +367,8 @@ func TestSetPrimary_StalePrimaryDemotes(t *testing.T) {
 	// leader — the gateway learns the new primary from that primary's own health
 	// stream, not from this demoted node.
 	healthState := pm.healthStreamer.getState()
-	assert.Nil(t, healthState.LeaderObservation,
-		"a demoted pooler must not advertise a leader observation")
+	assert.NotEqual(t, clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY, healthState.RoutingState.GetRole(),
+		"a demoted pooler must not advertise itself as the routing primary")
 }
 
 // TestSetPrimary_IgnoresRevokedRule verifies that when the incoming rule is

--- a/go/services/multipooler/internal/manager/state_manager.go
+++ b/go/services/multipooler/internal/manager/state_manager.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/proto"
 
 	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
@@ -86,35 +87,31 @@ type StateManager struct {
 	components []StateAware
 }
 
-// deriveRoutingRole computes the write-safety routing role from the physical
-// recovery state and the live consensus snapshot: PRIMARY iff postgres is out of
-// recovery AND this pooler is the active consensus leader (committed, non-revoked,
-// not superseded by a higher known rule — see commonconsensus.IsActiveLeader);
-// REPLICA otherwise. cs may be nil (treated as not a leader). This is the single
-// place the base facts (recovery, consensus) become the effective routing role.
-func deriveRoutingRole(pgMode pgmode.Mode, cs *clustermetadatapb.ConsensusStatus) servingstate.RoutingRole {
+// deriveRoutingState computes the full routing state (role + qualifying rule)
+// from the physical recovery mode and the live consensus snapshot. It is the
+// low-level derivation — the full state is authoritative; extract .Role from the
+// result only where the rule cannot travel (metric tags, log lines, backup
+// annotations).
+//
+// Role is PRIMARY iff postgres is out of recovery AND this pooler is the active
+// consensus leader (committed, non-revoked, not superseded by a higher known rule
+// — see commonconsensus.IsActiveLeader); REPLICA otherwise. cs may be nil (treated
+// as not a leader). The qualifying Rule is the *committed* rule naming this pooler
+// when PRIMARY (write authority — never a not-yet-committed rule), and the
+// highest rule this pooler has known when REPLICA (advisory — lets the gateway
+// spot a stale routing primary). This is the single place the base facts
+// (recovery, consensus) become the effective routing state components fan out on
+// and the health streamer / topology record project.
+func deriveRoutingState(pgMode pgmode.Mode, cs *clustermetadatapb.ConsensusStatus) servingstate.RoutingState {
 	if pgMode.OutOfRecovery() && commonconsensus.IsActiveLeader(cs) {
-		return servingstate.RoutingRolePrimary
+		return servingstate.RoutingState{
+			Role: servingstate.RoutingRolePrimary,
+			Rule: cs.GetCurrentPosition().GetRule().GetRuleNumber(),
+		}
 	}
-	return servingstate.RoutingRoleReplica
-}
-
-// routingLeadershipObs builds the self-leadership observation persisted to the
-// record to reflect the routing role: non-nil (naming self at the committed rule)
-// when routing PRIMARY, nil otherwise. It intentionally reads the *committed*
-// rule — a routing PRIMARY is by definition the active committed leader
-// (IsActiveLeader), so this both matches the routing role and carries write
-// authority, never a not-yet-committed rule. Returns nil when not PRIMARY so the
-// record's Type ⇔ SelfLeadership invariant holds (Type PRIMARY ⇔ obs present ⇔
-// routing PRIMARY).
-func routingLeadershipObs(routingRole servingstate.RoutingRole, cs *clustermetadatapb.ConsensusStatus) *clustermetadatapb.LeaderObservation {
-	if routingRole != servingstate.RoutingRolePrimary {
-		return nil
-	}
-	committed := cs.GetCurrentPosition().GetRule()
-	return &clustermetadatapb.LeaderObservation{
-		LeaderId:         cs.GetId(),
-		LeaderRuleNumber: committed.GetRuleNumber(),
+	return servingstate.RoutingState{
+		Role: servingstate.RoutingRoleReplica,
+		Rule: commonconsensus.HighestKnownRule([]*clustermetadatapb.ConsensusStatus{cs}).GetRuleNumber(),
 	}
 }
 
@@ -153,20 +150,25 @@ func (ssm *StateManager) RegisterAndSync(ctx context.Context, component StateAwa
 	defer ssm.mu.Unlock()
 	ssm.components = append(ssm.components, component)
 	return component.OnStateChange(ctx, servingstate.State{
-		RoutingRole:   deriveRoutingRole(ssm.pgMode, ssm.consensusStatus()),
+		Routing:       deriveRoutingState(ssm.pgMode, ssm.consensusStatus()),
 		ServingStatus: ssm.record.ServingStatus(),
 	})
 }
 
 // sameFanout reports whether two states are equivalent for fan-out dedup. It
-// compares only RoutingRole and ServingStatus — the facts components react to —
-// and deliberately ignores Leadership: that observation is derived from
-// RoutingRole, and a same-leader rule bump (RoutingRole unchanged) need not
-// re-fan, while a rule change that matters (supersession) flips RoutingRole and
-// re-fans anyway. Comparing the pointer-valued Leadership here would also defeat
-// dedup, since Mutate builds a fresh observation each call.
+// compares the full routing state (role + qualifying rule) and ServingStatus.
+// The rule is included because the health stream carries the full routing state
+// live: a replica's highest-known-rule bump should reach subscribers even with
+// the role unchanged (the gateway uses it to spot a stale routing primary). The
+// extra etcd churn this could cause is absorbed at the publish boundary —
+// routingStateForPublish drops a replica's routing_state, so successive replica
+// states dedup to an identical published form. Re-notifying transition-style
+// components (query server, heartbeat) on a rule-only bump is idempotent: they
+// gate on role + serving.
 func sameFanout(a, b servingstate.State) bool {
-	return a.RoutingRole == b.RoutingRole && a.ServingStatus == b.ServingStatus
+	return a.ServingStatus == b.ServingStatus &&
+		a.Routing.Role == b.Routing.Role &&
+		proto.Equal(a.Routing.Rule, b.Routing.Rule)
 }
 
 // fanOutLocked notifies every registered component of the target effective state
@@ -244,21 +246,16 @@ func (ssm *StateManager) Mutate(ctx context.Context, fn func(s *servingStateMuta
 	// the whole target against the last fan-out is what ensures OnStateChange fires
 	// on ANY effective-state change.
 	cs := ssm.consensusStatus()
-	routingRole := deriveRoutingRole(next.PostgresMode, cs)
+	// The full routing state (role + qualifying rule) is derived here, so
+	// components that advertise it (the health streamer, the record projection
+	// below) publish it as a pure function of the fanned state — no explicit push.
 	target := servingstate.State{
-		RoutingRole:   routingRole,
+		Routing:       deriveRoutingState(next.PostgresMode, cs),
 		ServingStatus: next.ServingStatus,
-		// The self-leadership observation is derived here, so components that
-		// advertise it (the health streamer, the record projection below) publish
-		// it as a pure function of the fanned state — no explicit push. Non-nil
-		// (naming self at the committed rule) iff routing PRIMARY.
-		Leadership: routingLeadershipObs(routingRole, cs),
 	}
 	if ssm.lastFannedOut != nil && sameFanout(*ssm.lastFannedOut, target) {
-		// Nothing components react to changed; no fan-out, no record write. Dedup
-		// ignores Leadership: it is derived from RoutingRole, and a same-leader
-		// rule bump need not re-fan — a rule change that matters (supersession by
-		// a higher rule) flips RoutingRole to REPLICA and re-fans anyway.
+		// The effective state (routing role + rule + serving) is unchanged; no
+		// fan-out, no record write.
 		//
 		// Still refresh the cached recovery fact: postgres may have left/entered
 		// recovery without flipping the derived routing role (e.g. while this
@@ -276,10 +273,10 @@ func (ssm *StateManager) Mutate(ctx context.Context, fn func(s *servingStateMuta
 	// on the first transition (nil lastFannedOut).
 	prevRoutingRole := servingstate.RoutingRoleUnknown
 	if ssm.lastFannedOut != nil {
-		prevRoutingRole = ssm.lastFannedOut.RoutingRole
+		prevRoutingRole = ssm.lastFannedOut.Routing.Role
 	}
 	ssm.logger.InfoContext(ctx, "Serving state changed",
-		"routing_role", target.RoutingRole, "prev_routing_role", prevRoutingRole,
+		"routing_role", target.Routing.Role, "prev_routing_role", prevRoutingRole,
 		"status", target.ServingStatus, "prev_status", cur.ServingStatus,
 		"postgres_mode", next.PostgresMode, "prev_postgres_mode", cur.PostgresMode)
 
@@ -291,21 +288,19 @@ func (ssm *StateManager) Mutate(ctx context.Context, fn func(s *servingStateMuta
 	// received before the (fallible) record write.
 	ssm.pgMode = next.PostgresMode
 
-	// Project the routing role onto the topology record: Type PRIMARY and the
-	// self-leadership observation iff routing PRIMARY (writable). Type and obs move
-	// together, preserving the record's Type ⇔ SelfLeadership invariant. Write only
-	// when the projected Type or serving status actually differs from the record.
+	// Project the full routing state onto the topology record. The record holds
+	// the whole routing state (role + rule, replicas included); PoolerType is
+	// derived from it at publish and only the writable PRIMARY's routing_state
+	// reaches etcd (the publisher drops it for replicas — see routingStateForPublish).
+	// Write only when the routing state or serving status actually differs.
 	//
 	// TODO: this record projection could itself be a StateAware — give poolerRecord
-	// an OnStateChange(State) that projects routing role onto Type/SelfLeadership and
-	// register it as a component, so Mutate just fans out and owns no special-case
-	// record write.
-	obs := target.Leadership
-	nextType := poolerTypeForLeader(obs != nil)
-	if nextType != ssm.record.Type() || next.ServingStatus != cur.ServingStatus {
+	// an OnStateChange(State) that projects the routing state and register it as a
+	// component, so Mutate just fans out and owns no special-case record write.
+	routingProto := target.Routing.ToProto()
+	if !proto.Equal(routingProto, ssm.record.RoutingState()) || next.ServingStatus != cur.ServingStatus {
 		if err := ssm.record.Mutate(ctx, func(s *MutablePoolerRecordState) {
-			s.Type = nextType
-			s.SelfLeadership = obs
+			s.RoutingState = routingProto
 			s.ServingStatus = next.ServingStatus
 		}); err != nil {
 			return err
@@ -333,13 +328,12 @@ func (ssm *StateManager) hasDrift(pgMode pgmode.Mode) bool {
 		return true
 	}
 	observed := servingstate.State{
-		RoutingRole:   deriveRoutingRole(pgMode, ssm.consensusStatus()),
+		Routing:       deriveRoutingState(pgMode, ssm.consensusStatus()),
 		ServingStatus: ssm.record.ServingStatus(),
 	}
-	// Compare with sameFanout, not raw struct equality: the fanned-out state
-	// carries a derived Leadership pointer that `observed` intentionally leaves
-	// nil, and Mutate itself dedups on sameFanout (RoutingRole + ServingStatus).
-	// Using != here would treat the derived pointer as drift and re-fan forever.
+	// Compare with sameFanout (proto-aware), not raw struct equality: the routing
+	// state carries a *RuleNumber pointer that == would compare by identity, so a
+	// freshly-derived observed state would always look different and re-fan forever.
 	return !sameFanout(*ssm.lastFannedOut, observed)
 }
 

--- a/go/services/multipooler/internal/manager/state_manager_test.go
+++ b/go/services/multipooler/internal/manager/state_manager_test.go
@@ -44,8 +44,8 @@ func (c *testComponent) OnStateChange(_ context.Context, state servingstate.Stat
 		return c.err
 	}
 	// Record the derived PoolerType so existing assertions keep reading lastType.
-	c.lastType = poolerTypeForLeader(state.RoutingRole.Writable())
-	c.lastRole = state.RoutingRole
+	c.lastType = typeForState(nil, state.Routing.ToProto())
+	c.lastRole = state.Routing.Role
 	c.lastStatus = state.ServingStatus
 	return nil
 }
@@ -78,18 +78,17 @@ func newTestMultiPooler(poolerType clustermetadatapb.PoolerType, status clusterm
 		Type:          poolerType,
 		ServingStatus: status,
 	}
-	// Keep the Type ⇔ SelfLeadership invariant so the record validates: a
-	// PRIMARY names itself; any other type carries no self-leadership.
+	// A PRIMARY record carries a PRIMARY routing_state (the record derives Type
+	// from it); any other type carries none.
 	if poolerType == clustermetadatapb.PoolerType_PRIMARY {
-		mp.SelfLeadership = &clustermetadatapb.LeaderObservation{LeaderId: testPoolerID}
+		mp.RoutingState = &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY}
 	}
 	return mp
 }
 
-// primaryObs is the leadership observation a PRIMARY test record must carry to
-// satisfy the Type ⇔ SelfLeadership invariant.
-func primaryObs() *clustermetadatapb.LeaderObservation {
-	return &clustermetadatapb.LeaderObservation{LeaderId: testPoolerID}
+// primaryObs is the routing_state a writable PRIMARY test record carries.
+func primaryObs() *clustermetadatapb.RoutingState {
+	return &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY}
 }
 
 // newTestRecord returns a poolerRecord seeded with a proto carrying the given
@@ -558,7 +557,7 @@ func TestStateManager_Recalc(t *testing.T) {
 	}))
 	require.Equal(t, servingstate.RoutingRolePrimary, comp.lastRole)
 	require.Equal(t, clustermetadatapb.PoolerType_PRIMARY, r.Type())
-	require.NotNil(t, r.SelfLeadership())
+	require.NotNil(t, r.RoutingState())
 	callsAfterMutate := comp.callCount
 
 	// A revocation arrives: this pooler's term is revoked, so it is no longer the
@@ -572,7 +571,7 @@ func TestStateManager_Recalc(t *testing.T) {
 	assert.Equal(t, servingstate.RoutingRoleReplica, comp.lastRole,
 		"revoked leader routes as REPLICA")
 	assert.Equal(t, clustermetadatapb.PoolerType_REPLICA, r.Type())
-	assert.Nil(t, r.SelfLeadership(),
+	assert.Nil(t, r.RoutingState(),
 		"revoked leader must clear its self-leadership observation immediately")
 }
 
@@ -703,7 +702,7 @@ func TestDeriveRoutingRole(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, deriveRoutingRole(tt.pgMode, tt.cs))
+			assert.Equal(t, tt.want, deriveRoutingState(tt.pgMode, tt.cs).Role)
 		})
 	}
 }

--- a/go/services/multipooler/internal/manager/state_manager_test.go
+++ b/go/services/multipooler/internal/manager/state_manager_test.go
@@ -571,8 +571,8 @@ func TestStateManager_Recalc(t *testing.T) {
 	assert.Equal(t, servingstate.RoutingRoleReplica, comp.lastRole,
 		"revoked leader routes as REPLICA")
 	assert.Equal(t, clustermetadatapb.PoolerType_REPLICA, r.Type())
-	assert.Nil(t, r.RoutingState(),
-		"revoked leader must clear its self-leadership observation immediately")
+	assert.Equal(t, clustermetadatapb.RoutingRole_ROUTING_ROLE_REPLICA, r.RoutingState().GetRole(),
+		"revoked leader must route as REPLICA immediately (publishing drops it from etcd)")
 }
 
 // TestStateManager_Recalc_NoChangeIsNoOp verifies Recalc does not re-fan when the

--- a/go/services/multipooler/internal/manager/test_helpers_test.go
+++ b/go/services/multipooler/internal/manager/test_helpers_test.go
@@ -53,13 +53,12 @@ func setPoolerTypeForTest(t *testing.T, pm *MultiPoolerManager, poolerType clust
 	require.NoError(t, err)
 	defer pm.actionLock.Release(ctx)
 	require.NoError(t, pm.record.Mutate(ctx, func(s *MutablePoolerRecordState) {
-		s.Type = poolerType
-		// Keep the Type ⇔ SelfLeadership invariant: a PRIMARY names itself; any
-		// other type carries no self-leadership.
+		// Type is derived from routing_state: a PRIMARY carries a PRIMARY
+		// routing_state, any other type carries none.
 		if poolerType == clustermetadatapb.PoolerType_PRIMARY {
-			s.SelfLeadership = &clustermetadatapb.LeaderObservation{LeaderId: pm.record.Id()}
+			s.RoutingState = &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY}
 		} else {
-			s.SelfLeadership = nil
+			s.RoutingState = nil
 		}
 	}))
 }

--- a/go/services/multipooler/internal/poolerserver/health_provider.go
+++ b/go/services/multipooler/internal/poolerserver/health_provider.go
@@ -26,7 +26,7 @@ import (
 //
 // The previous Target *query.Target field was removed alongside
 // StreamPoolerHealthResponse.target — the gateway derives shard identity
-// from topology and role from serving_status + leader_observation.
+// from topology and routing role from serving_status + routing_state.
 type HealthState struct {
 	// PoolerID identifies this multipooler instance.
 	PoolerID *clustermetadatapb.ID
@@ -34,9 +34,9 @@ type HealthState struct {
 	// ServingStatus is the current serving state of the pooler.
 	ServingStatus clustermetadatapb.PoolerServingStatus
 
-	// LeaderObservation contains this pooler's view of who the consensus leader is.
-	// May be nil if no leader observation is available.
-	LeaderObservation *LeaderObservation
+	// RoutingState is this pooler's self-reported routing/HA role plus the rule
+	// that qualifies it. Always populated: role == PRIMARY is the writable signal.
+	RoutingState *clustermetadatapb.RoutingState
 
 	// RecommendedStalenessTimeout is the duration clients should use
 	// to detect a stale/dead health stream.
@@ -45,18 +45,6 @@ type HealthState struct {
 	// ReplicationLagNs is the current replication lag in nanoseconds,
 	// measured via heartbeat timestamps. Zero on the primary or when unknown.
 	ReplicationLagNs int64
-}
-
-// LeaderObservation represents a pooler's view of who the consensus leader is.
-type LeaderObservation struct {
-	// LeaderID is the ID of the pooler this node believes is the consensus leader.
-	// May be this pooler's own ID if it believes itself to be leader.
-	LeaderID *clustermetadatapb.ID
-
-	// LeaderTerm is the consensus term at which this observation was made.
-	// The leader never changes within a leader term. Higher values indicate
-	// more recent leader appointments.
-	LeaderTerm int64
 }
 
 // HealthProvider provides health information for the pooler.

--- a/go/services/multipooler/internal/poolerserver/metrics_test.go
+++ b/go/services/multipooler/internal/poolerserver/metrics_test.go
@@ -118,9 +118,9 @@ func TestDrainMetricGracefulOutcome(t *testing.T) {
 	pooler.gracePeriod = 5 * time.Second
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	// No in-flight connections → WaitForDrain returns immediately.
-	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
 
 	assert.Equal(t, int64(1), readCounterByOutcome(t, reader, "mg.pooler.drain.outcome", "graceful"))
 	assert.Equal(t, int64(0), readCounterByOutcome(t, reader, "mg.pooler.drain.outcome", "force_close"))
@@ -142,11 +142,11 @@ func TestDrainMetricForceCloseOutcome(t *testing.T) {
 	pooler.gracePeriod = 50 * time.Millisecond
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// Simulate an in-flight connection that never returns → WaitForDrain blocks until grace period.
 	mock.regularAdd(1)
-	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
 
 	assert.Equal(t, int64(0), readCounterByOutcome(t, reader, "mg.pooler.drain.outcome", "graceful"))
 	assert.Equal(t, int64(1), readCounterByOutcome(t, reader, "mg.pooler.drain.outcome", "force_close"))
@@ -169,8 +169,8 @@ func TestDrainMetricDurationBuckets(t *testing.T) {
 	pooler.gracePeriod = 50 * time.Millisecond
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
-	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
 
 	hist := readHistogramFloat64(t, reader, "mg.pooler.drain.duration")
 	require.NotNil(t, hist)

--- a/go/services/multipooler/internal/poolerserver/pooler.go
+++ b/go/services/multipooler/internal/poolerserver/pooler.go
@@ -186,7 +186,7 @@ func (s *QueryPoolerServer) ReplicationMetrics() *replication.Metrics {
 // follows. On timeout, errors are acceptable — that is what the grace period
 // bounds.
 func (s *QueryPoolerServer) OnStateChange(ctx context.Context, state servingstate.State) error {
-	routingRole := state.RoutingRole
+	routingRole := state.Routing.Role
 	servingStatus := state.ServingStatus
 	s.mu.Lock()
 

--- a/go/services/multipooler/internal/poolerserver/pooler_test.go
+++ b/go/services/multipooler/internal/poolerserver/pooler_test.go
@@ -400,7 +400,7 @@ func TestOnStateChange_TwoStageDrain(t *testing.T) {
 	pooler.gracePeriod = 5 * time.Second
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// One in-flight transaction (reserved) and one in-flight single query (regular).
 	mock.reservedAdd(1)
@@ -409,7 +409,7 @@ func TestOnStateChange_TwoStageDrain(t *testing.T) {
 	drainDone := make(chan struct{})
 	go func() {
 		defer close(drainDone)
-		_ = pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
+		_ = pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
 	}()
 
 	// Stage 1: blocked on the in-flight transaction. Single queries are served,
@@ -447,13 +447,13 @@ func TestOnStateChange_GracePeriodExpiresInStage1(t *testing.T) {
 	pooler.gracePeriod = 100 * time.Millisecond
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// A transaction that never commits — stage 1 (WaitForReservedDrain) blocks.
 	mock.reservedAdd(1)
 
 	start := time.Now()
-	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
 	elapsed := time.Since(start)
 
 	assert.GreaterOrEqual(t, elapsed, 80*time.Millisecond, "should block ~grace period waiting on the held transaction")
@@ -472,7 +472,7 @@ func TestOnStateChange_WaitsForInflightRequests(t *testing.T) {
 	pooler.gracePeriod = 5 * time.Second
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// Simulate two in-flight connections
 	mock.regularAdd(1)
@@ -481,7 +481,7 @@ func TestOnStateChange_WaitsForInflightRequests(t *testing.T) {
 	drainDone := make(chan struct{})
 	go func() {
 		defer close(drainDone)
-		_ = pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
+		_ = pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
 	}()
 
 	// Drain should not complete while connections are in-flight
@@ -514,7 +514,7 @@ func TestOnStateChange_GracePeriodExpires(t *testing.T) {
 	pooler.gracePeriod = 100 * time.Millisecond
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// Simulate a connection that will never return
 	mock.regularAdd(1)
@@ -523,7 +523,7 @@ func TestOnStateChange_GracePeriodExpires(t *testing.T) {
 	drainDone := make(chan struct{})
 	go func() {
 		defer close(drainDone)
-		_ = pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
+		_ = pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
 	}()
 
 	select {
@@ -550,14 +550,14 @@ func TestOnStateChange_BackToServing(t *testing.T) {
 	ctx := t.Context()
 
 	// SERVING → DISABLED → SERVING
-	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	assert.True(t, pooler.IsServing())
 
-	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED}))
 	assert.False(t, pooler.IsServing())
 
 	// Transition back to SERVING
-	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	assert.True(t, pooler.IsServing())
 
 	// Requests should work again
@@ -573,7 +573,7 @@ func TestOnStateChange_ConcurrentRequests(t *testing.T) {
 	pooler.gracePeriod = 2 * time.Second
 	ctx := t.Context()
 
-	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	const numRequests = 50
 	var wg sync.WaitGroup
@@ -599,7 +599,7 @@ func TestOnStateChange_ConcurrentRequests(t *testing.T) {
 	drainDone := make(chan struct{})
 	go func() {
 		defer close(drainDone)
-		_ = pooler.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
+		_ = pooler.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED})
 	}()
 
 	// Wait for all goroutines and drain to complete
@@ -618,7 +618,7 @@ func TestAwaitStateChange_AlreadyMatches(t *testing.T) {
 	ctx := t.Context()
 
 	// Transition to PRIMARY/SERVING
-	require.NoError(t, s.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, s.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	// AwaitStateChange should return immediately when state already matches
 	done := make(chan struct{})
@@ -653,7 +653,7 @@ func TestAwaitStateChange_BlocksUntilTransition(t *testing.T) {
 	}
 
 	// Transition to the awaited state
-	require.NoError(t, s.OnStateChange(ctx, servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, s.OnStateChange(ctx, servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 
 	select {
 	case <-done:

--- a/go/services/multipooler/internal/pubsub/listener.go
+++ b/go/services/multipooler/internal/pubsub/listener.go
@@ -119,7 +119,7 @@ func (l *Listener) Stop() {
 // primary, and writability already requires out-of-recovery, so a standby never
 // starts the listener.
 func (l *Listener) OnStateChange(_ context.Context, state servingstate.State) error {
-	if state.RoutingRole.Writable() && state.ServingStatus == clustermetadatapb.PoolerServingStatus_SERVING {
+	if state.Writable() && state.ServingStatus == clustermetadatapb.PoolerServingStatus_SERVING {
 		//nolint:gocritic // Long-lived background listener; must not use the transient state-change ctx.
 		l.Start(context.Background())
 	} else {

--- a/go/services/multipooler/internal/pubsub/listener_test.go
+++ b/go/services/multipooler/internal/pubsub/listener_test.go
@@ -84,7 +84,7 @@ func TestListenerOnStateChangeGating(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			l := newTestListener(t)
-			err := l.OnStateChange(context.Background(), servingstate.State{RoutingRole: tt.routingRole, ServingStatus: tt.servingStatus})
+			err := l.OnStateChange(context.Background(), servingstate.State{Routing: servingstate.RoutingState{Role: tt.routingRole}, ServingStatus: tt.servingStatus})
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantRunning, running(l))
 		})
@@ -97,11 +97,11 @@ func TestListenerOnStateChangeGating(t *testing.T) {
 func TestListenerOnStateChangeStopsOnDemotion(t *testing.T) {
 	l := newTestListener(t)
 
-	require.NoError(t, l.OnStateChange(context.Background(), servingstate.State{RoutingRole: servingstate.RoutingRolePrimary, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, l.OnStateChange(context.Background(), servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRolePrimary}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	require.True(t, running(l), "listener should run while leader+writable+serving")
 
 	// Postgres falls back into recovery (demoted to standby) while still nominally
 	// the leader: the listener must stop.
-	require.NoError(t, l.OnStateChange(context.Background(), servingstate.State{RoutingRole: servingstate.RoutingRoleReplica, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
+	require.NoError(t, l.OnStateChange(context.Background(), servingstate.State{Routing: servingstate.RoutingState{Role: servingstate.RoutingRoleReplica}, ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING}))
 	assert.False(t, running(l), "listener must stop once postgres is no longer writable")
 }

--- a/go/services/multipooler/internal/servingstate/servingstate.go
+++ b/go/services/multipooler/internal/servingstate/servingstate.go
@@ -23,34 +23,54 @@ package servingstate
 import clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 
 // State is the effective serving state the StateManager delivers to components
-// via OnStateChange. It carries a single derived role concept — the routing role
-// (writability) — plus the serving intent. Consensus leadership is deliberately
-// absent: it is a consensus-layer fact, derived from the ConsensusStatus by
-// whoever needs it, not something the serving layer traffics in. Both leader-
-// bound query modes (WRITABLE and CONSISTENT) gate on RoutingRole.
+// via OnStateChange. It carries the full routing state (role + qualifying rule)
+// plus the serving intent. Consensus leadership is deliberately absent: it is a
+// consensus-layer fact, derived from the ConsensusStatus by whoever needs it, not
+// something the serving layer traffics in. Both leader-bound query modes
+// (WRITABLE and CONSISTENT) gate on the routing role.
 type State struct {
-	// RoutingRole reports whether this pooler is the writable leader — see
-	// RoutingRole / Writable. Derived from postgres recovery mode and the live
-	// consensus snapshot; the single authority the query gates, heartbeat writer,
-	// and LISTEN/NOTIFY react to.
-	RoutingRole RoutingRole
+	// Routing is the full routing/HA state — the writability role plus the rule
+	// that qualifies it. It is the single fact the query gates, heartbeat writer,
+	// and LISTEN/NOTIFY react to, and the health streamer + topology record project
+	// it onto the wire clustermetadata.RoutingState.
+	Routing RoutingState
 
 	// ServingStatus is the serving intent (SERVING / DISABLED / DRAINING).
 	ServingStatus clustermetadatapb.PoolerServingStatus
+}
 
-	// Leadership is the self-leadership observation to advertise while this pooler
-	// is the writable routing primary: non-nil (naming self at the committed rule)
-	// iff RoutingRole is PRIMARY, else nil. It is derived alongside RoutingRole so
-	// consumers publish "I am the writable primary at rule N" as a pure function of
-	// the fanned state — the topology record projects it onto Type/SelfLeadership,
-	// and the health streamer publishes it to the gateway — with no explicit
-	// push. A follower carries nil and therefore advertises no leader.
-	//
-	// TODO: RoutingRole and Leadership are two fields carrying one fact — a PRIMARY
-	// role always pairs with a self-naming observation, a REPLICA with nil. They
-	// collapse into a single RoutingState{role, rule} once the proto is evolved
-	// (see the RoutingState plan); this struct should follow suit then.
-	Leadership *clustermetadatapb.LeaderObservation
+// Writable reports whether this pooler may accept user transactions (writes) —
+// true iff the routing role is PRIMARY. See RoutingRole.Writable.
+func (s State) Writable() bool {
+	return s.Routing.Writable()
+}
+
+// RoutingState is the full routing/HA state: the writability role plus the rule
+// that qualifies it. Pass this around rather than a bare RoutingRole — reduce to
+// the role alone only for logging, metric tags, or backup annotations, where the
+// rule cannot be used. It is the internal carrier; ToProto migrates it to the
+// clustermetadata.RoutingState proto at the wire boundary (health stream +
+// topology record).
+type RoutingState struct {
+	// Role is the writability routing role.
+	Role RoutingRole
+
+	// Rule qualifies the role: the committed, non-revoked rule naming this pooler
+	// when PRIMARY (write authority). Nil when not PRIMARY.
+	Rule *clustermetadatapb.RuleNumber
+}
+
+// Writable reports whether the role is PRIMARY (writable). See RoutingRole.Writable.
+func (rs RoutingState) Writable() bool {
+	return rs.Role.Writable()
+}
+
+// ToProto converts the routing state to its wire form.
+func (rs RoutingState) ToProto() *clustermetadatapb.RoutingState {
+	return &clustermetadatapb.RoutingState{
+		Role: rs.Role.ToProto(),
+		Rule: rs.Rule,
+	}
 }
 
 // RoutingRole is a pooler's role for query ROUTING and HA purposes. It is about
@@ -113,4 +133,17 @@ func (r RoutingRole) String() string {
 // That is not the expected path, just reassurance that the boundary is safe.)
 func (r RoutingRole) Writable() bool {
 	return r == RoutingRolePrimary
+}
+
+// ToProto converts the internal routing role to the clustermetadata.RoutingRole
+// proto enum, whose values line up 1:1. Unknown maps to ROUTING_ROLE_UNKNOWN.
+func (r RoutingRole) ToProto() clustermetadatapb.RoutingRole {
+	switch r {
+	case RoutingRolePrimary:
+		return clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY
+	case RoutingRoleReplica:
+		return clustermetadatapb.RoutingRole_ROUTING_ROLE_REPLICA
+	default:
+		return clustermetadatapb.RoutingRole_ROUTING_ROLE_UNKNOWN
+	}
 }

--- a/go/tools/ruleguard/rules.go
+++ b/go/tools/ruleguard/rules.go
@@ -208,14 +208,14 @@ func disallowWallClockInConsensus(m dsl.Matcher) {
 // disallowMultiPoolerTypeForRouting flags reads of a MultiPooler record's Type
 // in the multigateway and multiorch — both the .Type field and the generated
 // GetType() getter — which must derive leader identity from consensus state
-// (self_leadership / the highest known shard rule), never from the topology role
+// (routing_state / the highest known shard rule), never from the topology role
 // label. The PoolerType routing label on a query.Target is a different field and
 // is unaffected; constructing a record with a Type (struct literal) is also
 // unaffected — only reading the Type off a discovered MultiPooler /
 // MultiPoolerInfo is disallowed. The postgres recovery-mode role reported in a
 // pooler's health Status (Status.PoolerType) is also a different field.
 //
-// Use consensus instead (GetSelfLeadership() != nil / commonconsensus.SelfConsensusRole).
+// Use consensus instead (GetRoutingState() != nil / commonconsensus.SelfConsensusRole).
 //
 // TODO: broaden this to also ban reading MultiPooler.ServingStatus (and Type
 // generally) off the etcd topology record anywhere in the repo.
@@ -232,14 +232,14 @@ func disallowMultiPoolerTypeForRouting(m dsl.Matcher) {
 				m["x"].Type.Is("*topoclient.MultiPoolerInfo")) &&
 				m.File().PkgPath.Matches(`services/(multigateway|multiorch|multiadmin)`) &&
 				!m.File().Name.Matches(`_test\.go$`)).
-		Report("do not consult MultiPooler.Type for leader identity; use self_leadership / consensus")
+		Report("do not consult MultiPooler.Type for leader identity; use routing_state / consensus")
 }
 
 // disallowPoolerTypeEnumInGateway forbids mentions of the clustermetadata.PoolerType
 // enum constants in gateway production code. PoolerType is a topology role label
 // that conflates classification (PRIMARY/REPLICA) with routing intent; the gateway
 // should express intent through query.Mode (WRITABLE / CONSISTENT / INCONSISTENT)
-// and identity through consensus state (self_leadership / LeaderObservation).
+// and identity through consensus state (routing_state / RoutingState).
 //
 // Sibling to disallowMultiPoolerTypeForRouting, which forbids reading a discovered
 // MultiPooler's .Type field. This rule additionally bans bare references to the
@@ -260,7 +260,7 @@ func disallowPoolerTypeEnumInGateway(m dsl.Matcher) {
 	).Where(
 		m.File().PkgPath.Matches(`services/multigateway`) &&
 			!m.File().Name.Matches(`_test\.go$`)).
-		Report("PoolerType is the topology role label; gateway routing must use query.Mode for intent and consensus state (LeaderObservation / self_leadership) for identity")
+		Report("PoolerType is the topology role label; gateway routing must use query.Mode for intent and consensus state (RoutingState / routing_state) for identity")
 }
 
 // disallowRawConsensusStatusReplicationPrimary flags reads of a ConsensusStatus's

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -186,16 +186,12 @@ message MultiPooler {
   // lifecycle states even on cold start, not only over the health stream.
   PoolerLifecycle lifecycle_status = 12;
 
-  // self_leadership is set ONLY when this pooler currently considers itself
-  // the leader of its shard (it names this pooler). Replicas leave it empty —
-  // a replica has no self-leadership — which avoids high-volume etcd writes by
+  // routing_state advertises this pooler's routing/HA role. It is set ONLY when
+  // this pooler is the writable PRIMARY (postgres out of recovery AND highest
+  // non-revoked committed leader). Replicas — including a consensus leader that
+  // is not yet writable — leave it empty, which avoids high-volume etcd writes by
   // every replica during failovers.
-  //
-  // Consumers (multigateway) will read this on discovery to bootstrap leader
-  // routing without relying on `type` as a hint. Best-effort: empty until the
-  // pooler has been told (via SetTermPrimary / Propose / Recruit) that it is
-  // the leader; cleared again on demotion.
-  LeaderObservation self_leadership = 13;
+  RoutingState routing_state = 13;
 }
 
 // MultiGateway represents metadata about a running multigateway component instance in the cluster.
@@ -465,37 +461,48 @@ message PoolerPosition {
   string lsn = 2;
 }
 
-// LeaderObservation is a pooler's report of the writable routing primary — in
-// practice a pooler reporting itself once it is the active, writable leader. It
-// is carried in two places:
-//   - the multipooler health stream
-//     (StreamPoolerHealthResponse.leader_observation), which multigateway uses as
-//     the live, authoritative signal for routing writes; and
-//   - the leader's own MultiPooler topology record (self_leadership field), a
-//     projection of the same fact. NOTE: multigateway no longer consults the
-//     topology record for leader identity — routing is driven purely by the live
-//     health stream.
-//
-// TODO(routing-state, fast-follow): the gateway now reasons about *routing*
-// (which pooler is the writable primary), not consensus leadership, so this
-// message should evolve into
-//     message RoutingState { RoutingRole role = 1; RuleNumber rule = 2; }
-// with a new prefixed proto3 enum
-//     enum RoutingRole { ROUTING_ROLE_UNKNOWN = 0; ROUTING_ROLE_PRIMARY = 1;
-//                        ROUTING_ROLE_REPLICA = 2; }
-// leader_id then drops out: a pooler only reports its own routing state, so the
-// identity is contextual. This mirrors the internal servingstate.RoutingRole /
-// State.Leadership pair. Keep RoutingState off the orch-facing consensus-fitness
-// path — orch derives writability from consensus state, not this routing label.
-message LeaderObservation {
-  // leader_id is the ID of the pooler this node believes is the consensus leader.
-  // May be this pooler's own ID if it believes itself to be leader.
-  ID leader_id = 1;
+// RoutingRole is a pooler's role for query ROUTING and HA purposes. It is about
+// WRITABILITY, not consensus: PRIMARY means this pooler is the writable leader,
+// REPLICA means it is not. This is deliberately distinct from consensus
+// leadership (leader/follower, tracked in ConsensusStatus and rule history) and
+// from postgres recovery mode (primary/standby). Consensus consumers
+// (multiorch) must NOT read this — they read consensus state directly.
+enum RoutingRole {
+  // ROUTING_ROLE_UNKNOWN is the proto3 zero value: the routing role has not been
+  // established yet (cold start) or comes from a record predating this field.
+  // Treated as "not the writable leader" — never routed writes.
+  ROUTING_ROLE_UNKNOWN = 0;
 
-  // leader_rule_number identifies the rule under which this observation was
-  // made. Lexicographic comparison over (coordinator_term, leader_subterm)
-  // disambiguates concurrent observations during stand-in promotion windows.
-  RuleNumber leader_rule_number = 2;
+  // ROUTING_ROLE_PRIMARY: this pooler is the writable leader. Postgres is out of
+  // recovery AND it is the highest non-revoked committed leader. Writes route here.
+  ROUTING_ROLE_PRIMARY = 1;
+
+  // ROUTING_ROLE_REPLICA: this pooler is not the writable leader.
+  ROUTING_ROLE_REPLICA = 2;
+}
+
+// RoutingState is a pooler's self-reported routing/HA state: its writability
+// role plus the rule that qualifies it. The pooler's identity is contextual (the
+// enclosing MultiPooler.id, or StreamPoolerHealthResponse.pooler_id) — a REPLICA
+// never points at "the leader", so there is no leader_id here.
+//
+// It is carried in two places:
+//   - the writable leader's own MultiPooler topology record (routing_state field,
+//     set only when PRIMARY), so multigateway can bootstrap write routing from
+//     etcd at discovery time without relying on MultiPooler.type as a hint; and
+//   - the multipooler health stream (StreamPoolerHealthResponse.routing_state),
+//     always populated, where role == PRIMARY is the writable signal.
+message RoutingState {
+  // role is the writability routing role. role == PRIMARY is the writable signal.
+  RoutingRole role = 1;
+
+  // rule qualifies the role, compared lexicographically over
+  // (coordinator_term, leader_subterm). For PRIMARY it is the committed,
+  // non-revoked rule naming this pooler (write authority; the gateway ranks
+  // competing PRIMARYs by it during the brief overlapping-failover window). For
+  // REPLICA it is the highest rule this pooler has known (advisory) — for a
+  // self-demoting stale primary, its last-known leadership rule.
+  RuleNumber rule = 2;
 }
 
 // ReplicationPrimary advertises the primary this pooler believes it should be

--- a/proto/multipoolerservice.proto
+++ b/proto/multipoolerservice.proto
@@ -558,9 +558,13 @@ message StreamPoolerHealthResponse {
   // serving_status is the current serving state of the pooler.
   clustermetadata.PoolerServingStatus serving_status = 3;
 
-  // leader_observation contains this pooler's view of who the consensus leader is.
-  // Used by clients to identify the true leader when multiple poolers exist.
-  clustermetadata.LeaderObservation leader_observation = 4;
+  // routing_state is this pooler's self-reported routing/HA role plus the rule
+  // that qualifies it. It is always populated: role == PRIMARY means this pooler
+  // is the writable leader (the signal clients gate write traffic on, replacing
+  // the former separate leader_observation + writable fields), role == REPLICA
+  // means it is not. Clients route writes to the PRIMARY and buffer when there
+  // is none. This is a routing/writability signal, not a consensus signal.
+  clustermetadata.RoutingState routing_state = 4;
 
   // recommended_staleness_timeout is the duration clients should use
   // to detect a stale/dead health stream. If no message is received within

--- a/web/multiadmin/lib/api/generated/clustermetadata_pb.ts
+++ b/web/multiadmin/lib/api/generated/clustermetadata_pb.ts
@@ -210,6 +210,48 @@ proto3.util.setEnumType(QuorumType, "clustermetadata.QuorumType", [
 ]);
 
 /**
+ * RoutingRole is a pooler's role for query ROUTING and HA purposes. It is about
+ * WRITABILITY, not consensus: PRIMARY means this pooler is the writable leader,
+ * REPLICA means it is not. This is deliberately distinct from consensus
+ * leadership (leader/follower, tracked in ConsensusStatus and rule history) and
+ * from postgres recovery mode (primary/standby). Consensus consumers
+ * (multiorch) must NOT read this — they read consensus state directly.
+ *
+ * @generated from enum clustermetadata.RoutingRole
+ */
+export enum RoutingRole {
+  /**
+   * ROUTING_ROLE_UNKNOWN is the proto3 zero value: the routing role has not been
+   * established yet (cold start) or comes from a record predating this field.
+   * Treated as "not the writable leader" — never routed writes.
+   *
+   * @generated from enum value: ROUTING_ROLE_UNKNOWN = 0;
+   */
+  UNKNOWN = 0,
+
+  /**
+   * ROUTING_ROLE_PRIMARY: this pooler is the writable leader. Postgres is out of
+   * recovery AND it is the highest non-revoked committed leader. Writes route here.
+   *
+   * @generated from enum value: ROUTING_ROLE_PRIMARY = 1;
+   */
+  PRIMARY = 1,
+
+  /**
+   * ROUTING_ROLE_REPLICA: this pooler is not the writable leader.
+   *
+   * @generated from enum value: ROUTING_ROLE_REPLICA = 2;
+   */
+  REPLICA = 2,
+}
+// Retrieve enum metadata with: proto3.getEnumType(RoutingRole)
+proto3.util.setEnumType(RoutingRole, "clustermetadata.RoutingRole", [
+  { no: 0, name: "ROUTING_ROLE_UNKNOWN" },
+  { no: 1, name: "ROUTING_ROLE_PRIMARY" },
+  { no: 2, name: "ROUTING_ROLE_REPLICA" },
+]);
+
+/**
  * LeadershipSignal describes a leader's self-reported status for its current term.
  * Only published by nodes that are or were the consensus leader (leader_term != 0).
  * 0 (UNKNOWN) means the field was not intentionally set.
@@ -849,19 +891,15 @@ export class MultiPooler extends Message<MultiPooler> {
   lifecycleStatus?: PoolerLifecycle;
 
   /**
-   * self_leadership is set ONLY when this pooler currently considers itself
-   * the leader of its shard (it names this pooler). Replicas leave it empty —
-   * a replica has no self-leadership — which avoids high-volume etcd writes by
+   * routing_state advertises this pooler's routing/HA role. It is set ONLY when
+   * this pooler is the writable PRIMARY (postgres out of recovery AND highest
+   * non-revoked committed leader). Replicas — including a consensus leader that
+   * is not yet writable — leave it empty, which avoids high-volume etcd writes by
    * every replica during failovers.
    *
-   * Consumers (multigateway) will read this on discovery to bootstrap leader
-   * routing without relying on `type` as a hint. Best-effort: empty until the
-   * pooler has been told (via SetTermPrimary / Propose / Recruit) that it is
-   * the leader; cleared again on demotion.
-   *
-   * @generated from field: clustermetadata.LeaderObservation self_leadership = 13;
+   * @generated from field: clustermetadata.RoutingState routing_state = 13;
    */
-  selfLeadership?: LeaderObservation;
+  routingState?: RoutingState;
 
   constructor(data?: PartialMessage<MultiPooler>) {
     super();
@@ -881,7 +919,7 @@ export class MultiPooler extends Message<MultiPooler> {
     { no: 10, name: "pooler_dir", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 11, name: "pg_data_dir", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 12, name: "lifecycle_status", kind: "message", T: PoolerLifecycle },
-    { no: 13, name: "self_leadership", kind: "message", T: LeaderObservation },
+    { no: 13, name: "routing_state", kind: "message", T: RoutingState },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): MultiPooler {
@@ -1562,75 +1600,66 @@ export class PoolerPosition extends Message<PoolerPosition> {
 }
 
 /**
- * LeaderObservation is a pooler's report of the writable routing primary — in
- * practice a pooler reporting itself once it is the active, writable leader. It
- * is carried in two places:
- *   - the multipooler health stream
- *     (StreamPoolerHealthResponse.leader_observation), which multigateway uses as
- *     the live, authoritative signal for routing writes; and
- *   - the leader's own MultiPooler topology record (self_leadership field), a
- *     projection of the same fact. NOTE: multigateway no longer consults the
- *     topology record for leader identity — routing is driven purely by the live
- *     health stream.
+ * RoutingState is a pooler's self-reported routing/HA state: its writability
+ * role plus the rule that qualifies it. The pooler's identity is contextual (the
+ * enclosing MultiPooler.id, or StreamPoolerHealthResponse.pooler_id) — a REPLICA
+ * never points at "the leader", so there is no leader_id here.
  *
- * TODO(routing-state, fast-follow): the gateway now reasons about *routing*
- * (which pooler is the writable primary), not consensus leadership, so this
- * message should evolve into
- *     message RoutingState { RoutingRole role = 1; RuleNumber rule = 2; }
- * with a new prefixed proto3 enum
- *     enum RoutingRole { ROUTING_ROLE_UNKNOWN = 0; ROUTING_ROLE_PRIMARY = 1;
- *                        ROUTING_ROLE_REPLICA = 2; }
- * leader_id then drops out: a pooler only reports its own routing state, so the
- * identity is contextual. This mirrors the internal servingstate.RoutingRole /
- * State.Leadership pair. Keep RoutingState off the orch-facing consensus-fitness
- * path — orch derives writability from consensus state, not this routing label.
+ * It is carried in two places:
+ *   - the writable leader's own MultiPooler topology record (routing_state field,
+ *     set only when PRIMARY), so multigateway can bootstrap write routing from
+ *     etcd at discovery time without relying on MultiPooler.type as a hint; and
+ *   - the multipooler health stream (StreamPoolerHealthResponse.routing_state),
+ *     always populated, where role == PRIMARY is the writable signal.
  *
- * @generated from message clustermetadata.LeaderObservation
+ * @generated from message clustermetadata.RoutingState
  */
-export class LeaderObservation extends Message<LeaderObservation> {
+export class RoutingState extends Message<RoutingState> {
   /**
-   * leader_id is the ID of the pooler this node believes is the consensus leader.
-   * May be this pooler's own ID if it believes itself to be leader.
+   * role is the writability routing role. role == PRIMARY is the writable signal.
    *
-   * @generated from field: clustermetadata.ID leader_id = 1;
+   * @generated from field: clustermetadata.RoutingRole role = 1;
    */
-  leaderId?: ID;
+  role = RoutingRole.UNKNOWN;
 
   /**
-   * leader_rule_number identifies the rule under which this observation was
-   * made. Lexicographic comparison over (coordinator_term, leader_subterm)
-   * disambiguates concurrent observations during stand-in promotion windows.
+   * rule qualifies the role, compared lexicographically over
+   * (coordinator_term, leader_subterm). For PRIMARY it is the committed,
+   * non-revoked rule naming this pooler (write authority; the gateway ranks
+   * competing PRIMARYs by it during the brief overlapping-failover window). For
+   * REPLICA it is the highest rule this pooler has known (advisory) — for a
+   * self-demoting stale primary, its last-known leadership rule.
    *
-   * @generated from field: clustermetadata.RuleNumber leader_rule_number = 2;
+   * @generated from field: clustermetadata.RuleNumber rule = 2;
    */
-  leaderRuleNumber?: RuleNumber;
+  rule?: RuleNumber;
 
-  constructor(data?: PartialMessage<LeaderObservation>) {
+  constructor(data?: PartialMessage<RoutingState>) {
     super();
     proto3.util.initPartial(data, this);
   }
 
   static readonly runtime: typeof proto3 = proto3;
-  static readonly typeName = "clustermetadata.LeaderObservation";
+  static readonly typeName = "clustermetadata.RoutingState";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "leader_id", kind: "message", T: ID },
-    { no: 2, name: "leader_rule_number", kind: "message", T: RuleNumber },
+    { no: 1, name: "role", kind: "enum", T: proto3.getEnumType(RoutingRole) },
+    { no: 2, name: "rule", kind: "message", T: RuleNumber },
   ]);
 
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): LeaderObservation {
-    return new LeaderObservation().fromBinary(bytes, options);
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RoutingState {
+    return new RoutingState().fromBinary(bytes, options);
   }
 
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): LeaderObservation {
-    return new LeaderObservation().fromJson(jsonValue, options);
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): RoutingState {
+    return new RoutingState().fromJson(jsonValue, options);
   }
 
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): LeaderObservation {
-    return new LeaderObservation().fromJsonString(jsonString, options);
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): RoutingState {
+    return new RoutingState().fromJsonString(jsonString, options);
   }
 
-  static equals(a: LeaderObservation | PlainMessage<LeaderObservation> | undefined, b: LeaderObservation | PlainMessage<LeaderObservation> | undefined): boolean {
-    return proto3.util.equals(LeaderObservation, a, b);
+  static equals(a: RoutingState | PlainMessage<RoutingState> | undefined, b: RoutingState | PlainMessage<RoutingState> | undefined): boolean {
+    return proto3.util.equals(RoutingState, a, b);
   }
 }
 


### PR DESCRIPTION
De-conflates the gateway-facing leadership signal into a single
routing/writability type, continuing the axis-separation work (see the
pgmode.Mode and RoutingRole efforts).

## Proto
- Rename `clustermetadata.LeaderObservation` → `RoutingState {role, rule}` and add
  a prefixed `RoutingRole` enum. `leader_id` is dropped — a pooler only reports
  its own routing state, so identity is contextual.
- Rename `MultiPooler.self_leadership` → `routing_state` and
  `StreamPoolerHealthResponse.leader_observation` → `routing_state`.

## multipooler (producer)
- `servingstate.State` collapses the `RoutingRole` + `Leadership` pair into one
  full `RoutingState` (role + qualifying rule). `deriveRoutingState` is the
  low-level derivation; REPLICA carries the highest-known rule (advisory).
- `PoolerType` is dropped from the record's mutable state and derived at publish
  (`typeForState`: SHUTDOWN→UNKNOWN, else PRIMARY iff routing_state PRIMARY), so
  it can never drift and callers never set it.
- The record holds the full routing state; the publisher swaps `nil` for
  non-primaries to avoid etcd churn on replica rule bumps. The health stream
  always publishes the full state so the gateway sees REPLICA reports too.

## multigateway (consumer)
- Keys the routing primary off `role == PRIMARY` and the reporting pooler's id
  (the map key) rather than a `leader_id` in the message; ranks competing
  primaries by rule.

## multiadmin / multiorch / ruleguard
- Backup leader selection, orch's discovery log, and the `.Type`-ban messages
  updated to the renamed field.

Behavior-preserving rename + internal collapse; no new buffering/consensus
logic.
