### PR TITLE
refactor: enforce routing/consensus axis separation via ruleguard

### DIFF
--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -1093,7 +1093,16 @@ type MultiPooler struct {
 	ShardKey *ShardKey `protobuf:"bytes,2,opt,name=shard_key,json=shardKey,proto3" json:"shard_key,omitempty"` //
 	// If range based sharding is used, range for the pooler's shard.
 	KeyRange *KeyRange `protobuf:"bytes,5,opt,name=key_range,json=keyRange,proto3" json:"key_range,omitempty"`
-	// PoolerType is the kind of pooler: PRIMARY or REPLICA
+	// PoolerType is the kind of pooler: PRIMARY or REPLICA.
+	//
+	// TODO(pooler-type-removal): this label is now derived, not authoritative —
+	// the multipooler computes it at publish from routing_state + lifecycle
+	// (SHUTDOWN->UNKNOWN, else PRIMARY iff routing_state PRIMARY, else REPLICA;
+	// DRAINED is no longer produced) and nothing inside multigres reads it for
+	// identity. The remaining reader is the external multigres-operator
+	// (FindPrimaryPooler + drain + status role map). Once the operator switches
+	// those reads to routing_state.role == PRIMARY, this field can stop being
+	// published and then be removed.
 	Type PoolerType `protobuf:"varint,6,opt,name=type,proto3,enum=clustermetadata.PoolerType" json:"type,omitempty"`
 	// PoolerServingStatus is the current type of the pooler.
 	ServingStatus PoolerServingStatus `protobuf:"varint,7,opt,name=serving_status,json=servingStatus,proto3,enum=clustermetadata.PoolerServingStatus" json:"serving_status,omitempty"`

--- a/go/services/multiorch/recovery/pooler_watcher.go
+++ b/go/services/multiorch/recovery/pooler_watcher.go
@@ -95,7 +95,6 @@ func poolerCacheHooks(ctx context.Context, cache *store.PoolerCache, factory *st
 				"database", p.GetShardKey().GetDatabase(),
 				"tablegroup", p.GetShardKey().GetTableGroup(),
 				"shard", p.GetShardKey().GetShard(),
-				"leader", p.GetRoutingState() != nil,
 			)
 			return store.NewPooler(
 				&multiorchdatapb.PoolerHealthState{

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -202,9 +202,8 @@ type MultiPoolerManager struct {
 
 // promotionState tracks which parts of the promotion are complete
 type promotionState struct {
-	pgMode              pgmode.Mode
-	isPrimaryInTopology bool
-	currentLSN          string
+	pgMode     pgmode.Mode
+	currentLSN string
 }
 
 // demotionState tracks which parts of the demotion are complete
@@ -1318,16 +1317,8 @@ func (pm *MultiPoolerManager) checkPromotionState(ctx context.Context) (*promoti
 		}
 	}
 
-	// Check topology state
-	pm.mu.Lock()
-	poolerType := pm.record.Type()
-	pm.mu.Unlock()
-
-	state.isPrimaryInTopology = (poolerType == clustermetadatapb.PoolerType_PRIMARY)
-
 	pm.logger.InfoContext(ctx, "Checked promotion state",
-		"postgres_mode", state.pgMode,
-		"is_primary_in_topology", state.isPrimaryInTopology)
+		"postgres_mode", state.pgMode)
 
 	return state, nil
 }

--- a/go/tools/ruleguard/rules.go
+++ b/go/tools/ruleguard/rules.go
@@ -290,3 +290,41 @@ func disallowRawConsensusStatusReplicationPrimary(m dsl.Matcher) {
 				!m.File().Name.Matches(`_test\.go$`)).
 		Report("do not read ConsensusStatus.ReplicationPrimary directly; use commonconsensus.ReplicationPrimaryOrNil, which treats a phantom 0/0 entry as absent")
 }
+
+// disallowRoutingStateInOrch flags the multiorch reading a topology record's
+// routing_state. routing_state is a gateway-facing writability signal; orch must
+// derive leadership from consensus state (commonconsensus.SelfConsensusRole over
+// the ConsensusStatus), never from the routing label. This is the routing-axis
+// sibling of disallowMultiPoolerTypeForRouting (which bans the .Type label).
+// Test files are excluded.
+func disallowRoutingStateInOrch(m dsl.Matcher) {
+	m.Import("github.com/multigres/multigres/go/pb/clustermetadata")
+	m.Import("github.com/multigres/multigres/go/common/topoclient")
+
+	m.Match(`$x.RoutingState`, `$x.GetRoutingState()`).
+		Where(
+			(m["x"].Type.Is("*clustermetadata.MultiPooler") ||
+				m["x"].Type.Is("*topoclient.MultiPoolerInfo")) &&
+				m.File().PkgPath.Matches(`services/multiorch`) &&
+				!m.File().Name.Matches(`_test\.go$`)).
+		Report("do not consult routing_state in multiorch; derive leadership from consensus state (commonconsensus.SelfConsensusRole)")
+}
+
+// disallowConsensusStateInGateway flags the multigateway consulting consensus
+// leadership. The gateway routes on writability (RoutingState) alone; consensus
+// state (the SelfConsensusRole / IsActiveLeader / NamesSelfAsLeader accessors over
+// a ConsensusStatus) is orch's domain and must not leak into routing decisions.
+// Mirror of disallowRoutingStateInOrch for the consensus axis. Test files are
+// excluded.
+func disallowConsensusStateInGateway(m dsl.Matcher) {
+	m.Import("github.com/multigres/multigres/go/common/consensus")
+
+	m.Match(
+		`consensus.SelfConsensusRole($*_)`,
+		`consensus.IsActiveLeader($*_)`,
+		`consensus.NamesSelfAsLeader($*_)`,
+	).Where(
+		m.File().PkgPath.Matches(`services/multigateway`) &&
+			!m.File().Name.Matches(`_test\.go$`)).
+		Report("multigateway must not consult consensus state; route on RoutingState (writability) only")
+}

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -160,7 +160,16 @@ message MultiPooler {
   // If range based sharding is used, range for the pooler's shard.
   KeyRange key_range = 5;
 
-  // PoolerType is the kind of pooler: PRIMARY or REPLICA
+  // PoolerType is the kind of pooler: PRIMARY or REPLICA.
+  //
+  // TODO(pooler-type-removal): this label is now derived, not authoritative —
+  // the multipooler computes it at publish from routing_state + lifecycle
+  // (SHUTDOWN->UNKNOWN, else PRIMARY iff routing_state PRIMARY, else REPLICA;
+  // DRAINED is no longer produced) and nothing inside multigres reads it for
+  // identity. The remaining reader is the external multigres-operator
+  // (FindPrimaryPooler + drain + status role map). Once the operator switches
+  // those reads to routing_state.role == PRIMARY, this field can stop being
+  // published and then be removed.
   PoolerType type = 6;
 
   // PoolerServingStatus is the current type of the pooler.

--- a/web/multiadmin/lib/api/generated/clustermetadata_pb.ts
+++ b/web/multiadmin/lib/api/generated/clustermetadata_pb.ts
@@ -837,7 +837,16 @@ export class MultiPooler extends Message<MultiPooler> {
   keyRange?: KeyRange;
 
   /**
-   * PoolerType is the kind of pooler: PRIMARY or REPLICA
+   * PoolerType is the kind of pooler: PRIMARY or REPLICA.
+   *
+   * TODO(pooler-type-removal): this label is now derived, not authoritative —
+   * the multipooler computes it at publish from routing_state + lifecycle
+   * (SHUTDOWN->UNKNOWN, else PRIMARY iff routing_state PRIMARY, else REPLICA;
+   * DRAINED is no longer produced) and nothing inside multigres reads it for
+   * identity. The remaining reader is the external multigres-operator
+   * (FindPrimaryPooler + drain + status role map). Once the operator switches
+   * those reads to routing_state.role == PRIMARY, this field can stop being
+   * published and then be removed.
    *
    * @generated from field: clustermetadata.PoolerType type = 6;
    */


### PR DESCRIPTION
Enforces the routing/consensus axis separation: the gateway routes on
`RoutingState` (writability) and multiorch derives leadership from consensus, so
neither should read the other's signal.

## Fixes
- Drop the `routing_state` read from orch's pooler-discovery log line — orch
  derives leadership from consensus (`SelfConsensusRole`), never the topology
  routing label; at discovery time there's no consensus snapshot, so the log
  omits it.
- Drop `promotionState.isPrimaryInTopology`: it was write-only (set from the
  `PoolerType` label, only ever logged).

## ruleguards
- `disallowRoutingStateInOrch`: multiorch must not read `routing_state` /
  `GetRoutingState()` on a topology record — the routing-axis sibling of the
  existing `MultiPooler.Type` ban.
- `disallowConsensusStateInGateway`: multigateway must not consult consensus
  (`SelfConsensusRole` / `IsActiveLeader` / `NamesSelfAsLeader`) — it routes on
  `RoutingState` only.

## Proto
Add a TODO on `MultiPooler.type` noting it is now derived at publish and no
longer consulted for routing/leader identity, so it can be removed once external
consumers move to `routing_state.role`.
