### PR TITLE
ci(coverage): write timing summary for coverage jobs too

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -81,6 +81,9 @@ jobs:
 
       - name: Stop port pool server
         run: kill "$PORT_POOL_PID" || true
+      - name: Write timing summary
+        if: ${{ !cancelled() }}
+        run: go run ./go/tools/testtiming/summary coverage-direct-test-results.jsonl
       - name: Upload direct coverage artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
@@ -154,6 +157,9 @@ jobs:
 
       - name: Stop port pool server
         run: kill "$PORT_POOL_PID" || true
+      - name: Write timing summary
+        if: ${{ !cancelled() }}
+        run: go run ./go/tools/testtiming/summary coverage-subprocess-test-results.jsonl
       - name: Convert subprocess coverage to text format
         run: go tool covdata textfmt -i=coverage-subprocess-raw -o=coverage-subprocess.txt
       - name: Upload subprocess coverage artifact

--- a/go/tools/testtiming/summary/main.go
+++ b/go/tools/testtiming/summary/main.go
@@ -13,10 +13,15 @@
 // limitations under the License.
 
 // Command summary reads the integration test JSONL output (gotestsum
-// --jsonfile), extracts the timeout-bounded timing measurements that the
-// end-to-end tests record via testtiming.Record (startup, failover, etc.), and
-// writes a mean±99.9%CI / min / p50 / p95 / p99 / max markdown table to
-// $GITHUB_STEP_SUMMARY (or stdout when that variable is unset).
+// --jsonfile, or plain `go test -json`), extracts the timeout-bounded timing
+// measurements that the end-to-end tests record via testtiming.Record
+// (startup, failover, etc.), and writes a mean±99.9%CI / min / p50 / p95 /
+// p99 / max markdown table to $GITHUB_STEP_SUMMARY (or stdout when that
+// variable is unset).
+//
+// The JSONL path defaults to defaultJSONLPath but can be overridden via the
+// first command-line argument, e.g. `go run ./go/tools/testtiming/summary
+// coverage-direct-test-results.jsonl`.
 //
 // Measurements arrive as testtiming.Measurement payloads inside go test -json
 // "attr" events; see the testtiming package for the wire contract.
@@ -39,7 +44,7 @@ import (
 )
 
 const (
-	jsonlPath = "integration-test-results.jsonl"
+	defaultJSONLPath = "integration-test-results.jsonl"
 
 	// status thresholds, as a percentage of the timeout limit.
 	warnPct = 70.0
@@ -120,6 +125,13 @@ func main() {
 }
 
 func run() error {
+	jsonlPath := defaultJSONLPath
+	if len(os.Args) > 1 {
+		jsonlPath = os.Args[1]
+	}
+
+	// #nosec G703 -- jsonlPath is a CI-controlled argument (this file's own workflow
+	// invocations), not external/untrusted input.
 	f, err := os.Open(jsonlPath)
 	if err != nil {
 		if os.IsNotExist(err) {


### PR DESCRIPTION
## Summary
- The `Write timing summary` step (`go/tools/testtiming/summary`) only ever ran in `test-integration.yml`, reading a hardcoded `integration-test-results.jsonl`.
- `coverage.yml`'s two jobs (`coverage-direct`, `coverage-subprocess`) run the same e2e suite but never wrote a timing summary — despite coverage instrumentation adding ~30-50% overhead, which is exactly when a test's timeout margin is most likely to get tight.
- Parameterized the jsonl path as an optional CLI arg (default unchanged) and added a "Write timing summary" step to both coverage jobs, pointed at their own jsonl output.
