### PR TITLE
fix(multipooler): reconcile drifted primary_conninfo on SetPrimary no-op

### DIFF
--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -430,6 +430,33 @@ func (pm *MultiPoolerManager) primaryConnInfoDiffersFromRecorded(ctx context.Con
 	return parsed.GetHost() != targetHost || parsed.GetPort() != targetPort
 }
 
+// reconcilePrimaryConnInfoToRecorded re-applies primary_conninfo so it points
+// at the currently-recorded ReplicationPrimary. Callers detect drift via
+// primaryConnInfoDiffersFromRecorded, which guarantees GetReplicationPrimary()
+// has a valid target by the time this runs. logPrefix distinguishes the two
+// call sites (the periodic monitor tick vs. an in-line SetPrimary reconcile)
+// in logs.
+//
+// TODO: when suspectedDivergence=true (an unexpected demotion happened
+// without a follow-up pg_rewind), just setting primary_conninfo is not
+// enough — the WAL receiver will fail to start due to timeline divergence.
+// Route through demoteStalePrimaryLocked instead, which runs pg_rewind
+// dry-run (cheap when there's no divergence) before re-establishing
+// replication. This would let both callers self-heal a stuck-replica
+// scenario without waiting for orch's FixReplicationAction to issue a
+// RewindToSource RPC.
+func (pm *MultiPoolerManager) reconcilePrimaryConnInfoToRecorded(ctx context.Context, logPrefix string) {
+	target := pm.consensusMgr.GetReplicationPrimary().GetPrimary()
+	pm.logger.InfoContext(ctx, logPrefix+": primary_conninfo drift detected; rewriting to recorded primary",
+		"target_primary", target.GetId().GetName(),
+		"target_host", target.GetHost(),
+		"target_port", target.GetPostgresPort())
+	if err := pm.setPrimaryConnInfoLocked(ctx, target.GetHost(), target.GetPostgresPort(),
+		true /* stopReplicationBefore */, true /* startReplicationAfter */); err != nil {
+		pm.logger.ErrorContext(ctx, logPrefix+": failed to reconcile primary_conninfo", "error", err)
+	}
+}
+
 // determineRoleAction returns the action needed to align this pooler's role with
 // the rule-derived intended role: demote a stale primary, resign when the rule
 // names us leader but postgres is a standby, etc.
@@ -681,26 +708,7 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 		}
 
 	case remedialActionFixPrimaryConnInfo:
-		rp := pm.consensusMgr.GetReplicationPrimary()
-		target := rp.GetPrimary()
-		targetHost := target.GetHost()
-		targetPort := target.GetPostgresPort()
-		pm.logger.InfoContext(ctx, "MonitorPostgres: primary_conninfo drift detected; rewriting to recorded primary",
-			"target_primary", target.GetId().GetName(),
-			"target_host", targetHost,
-			"target_port", targetPort)
-		// TODO: when suspectedDivergence=true (an unexpected demotion happened
-		// without a follow-up pg_rewind), just setting primary_conninfo is
-		// not enough — the WAL receiver will fail to start due to timeline
-		// divergence. Route through demoteStalePrimaryLocked instead, which
-		// runs pg_rewind dry-run (cheap when there's no divergence) before
-		// re-establishing replication. This would let the monitor self-heal
-		// a stuck-replica scenario without waiting for orch's
-		// FixReplicationAction to issue a RewindToSource RPC.
-		if err := pm.setPrimaryConnInfoLocked(ctx, targetHost, targetPort,
-			true /* stopReplicationBefore */, true /* startReplicationAfter */); err != nil {
-			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to reconcile primary_conninfo", "error", err)
-		}
+		pm.reconcilePrimaryConnInfoToRecorded(ctx, "MonitorPostgres")
 
 	case remedialActionStartPostgres:
 		// Honour the in-memory flag set by tests and demos to suppress auto-restart

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -604,6 +604,20 @@ func (pm *MultiPoolerManager) SetPrimary(ctx context.Context, req *consensusdata
 		pm.logger.InfoContext(ctx, "SetPrimary: incoming rule not higher, no-op",
 			"incoming_rule", rule.GetRuleNumber(),
 			"self_rule", selfPos.GetRule().GetRuleNumber())
+		// The rule itself is a no-op, but primary_conninfo may have drifted
+		// from what we're recorded as following (e.g. an operator or test
+		// manually cleared it without changing consensus state). We already
+		// hold the action lock and have everything needed to check — fix it
+		// now rather than leaving it to MonitorPostgres's next periodic tick,
+		// up to monitorRetryInterval away.
+		//
+		// Read the target back from the just-updated record rather than
+		// trusting this call's own leader/port: RecordTermPrimary has its own
+		// staleness comparison against whatever was already recorded, so this
+		// request may not be what actually got persisted.
+		if pm.primaryConnInfoDiffersFromRecorded(ctx) {
+			pm.reconcilePrimaryConnInfoToRecorded(ctx, "SetPrimary")
+		}
 		return &consensusdatapb.SetPrimaryResponse{ConsensusStatus: pm.consensusMgr.CachedConsensusStatus()}, nil
 	}
 

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -615,7 +615,9 @@ func (pm *MultiPoolerManager) SetPrimary(ctx context.Context, req *consensusdata
 		// trusting this call's own leader/port: RecordTermPrimary has its own
 		// staleness comparison against whatever was already recorded, so this
 		// request may not be what actually got persisted.
-		if pm.primaryConnInfoDiffersFromRecorded(ctx) {
+		if pgMode, err := pm.postgresMode(ctx); err != nil {
+			pm.logger.WarnContext(ctx, "SetPrimary: failed to check recovery status before drift check; skipping", "error", err)
+		} else if !pgMode.OutOfRecovery() && pm.primaryConnInfoDiffersFromRecorded(ctx) {
 			pm.reconcilePrimaryConnInfoToRecorded(ctx, "SetPrimary")
 		}
 		return &consensusdatapb.SetPrimaryResponse{ConsensusStatus: pm.consensusMgr.CachedConsensusStatus()}, nil

--- a/go/services/multipooler/internal/manager/rpc_set_primary_test.go
+++ b/go/services/multipooler/internal/manager/rpc_set_primary_test.go
@@ -223,6 +223,11 @@ func TestSetPrimary_NoOpWhenPositionNotHigher(t *testing.T) {
 func TestSetPrimary_NoOpReconcilesDriftedConnInfo(t *testing.T) {
 	mockQueryService := mock.NewQueryService()
 
+	// The postgres-mode guard before the drift check: this pooler must be a
+	// standby for the drift check to even run.
+	mockQueryService.AddQueryPatternOnce("SELECT pg_is_in_recovery",
+		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
+
 	// primaryConnInfoDiffersFromRecorded's drift check: live conninfo is
 	// empty (drifted/cleared), which always counts as drift.
 	mockQueryService.AddQueryPatternOnce("SELECT current_setting\\('primary_conninfo'",
@@ -267,6 +272,40 @@ func TestSetPrimary_NoOpReconcilesDriftedConnInfo(t *testing.T) {
 
 	assert.Contains(t, capturedConnInfoSQL, "host=primary-host",
 		"drifted primary_conninfo should be reconciled to the recorded primary's host")
+	assert.NoError(t, mockQueryService.ExpectationsWereMet())
+}
+
+// TestSetPrimary_NoOpSkipsDriftCheckWhenPrimary verifies that the no-op path's
+// drift check never runs when this pooler is itself out of recovery (a
+// primary). Without this guard, a stale SetPrimary arriving right after a
+// process restart (before any fresh Promote/SetPrimary this lifetime
+// repopulated the ReplicationPrimary cache with self as leader) could reach
+// primaryConnInfoDiffersFromRecorded and needlessly attempt a reconcile that
+// setPrimaryConnInfoLocked's own guardrail would then have to reject. Only
+// the single postgres-mode query should be issued — proven by there being no
+// mock for current_setting('primary_conninfo') or ALTER SYSTEM at all.
+func TestSetPrimary_NoOpSkipsDriftCheckWhenPrimary(t *testing.T) {
+	mockQueryService := mock.NewQueryService()
+
+	// The postgres-mode guard: this pooler is a primary (out of recovery),
+	// so nothing past this single query should run.
+	mockQueryService.AddQueryPatternOnce("SELECT pg_is_in_recovery",
+		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"f"}}))
+
+	pm, _ := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(7)})
+
+	leader := newLeaderAddress("other-leader", "other-host", 5432)
+	req := &consensusdatapb.SetPrimaryRequest{
+		ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
+			Rule:    ruleAtTermForLeader(leader, 3), // lower than self (7): no-op gate
+			Primary: leader,
+		},
+	}
+	resp, err := pm.SetPrimary(t.Context(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.ConsensusStatus)
+
 	assert.NoError(t, mockQueryService.ExpectationsWereMet())
 }
 

--- a/go/services/multipooler/internal/manager/rpc_set_primary_test.go
+++ b/go/services/multipooler/internal/manager/rpc_set_primary_test.go
@@ -214,6 +214,62 @@ func TestSetPrimary_NoOpWhenPositionNotHigher(t *testing.T) {
 	}
 }
 
+// TestSetPrimary_NoOpReconcilesDriftedConnInfo verifies that even when the
+// incoming rule is not higher (so the main apply branch is skipped),
+// SetPrimary still detects and fixes a live primary_conninfo that has
+// drifted from the recorded primary (e.g. cleared out-of-band by an operator
+// or test) — rather than silently no-op'ing and leaving the fix to
+// MonitorPostgres's next periodic tick.
+func TestSetPrimary_NoOpReconcilesDriftedConnInfo(t *testing.T) {
+	mockQueryService := mock.NewQueryService()
+
+	// primaryConnInfoDiffersFromRecorded's drift check: live conninfo is
+	// empty (drifted/cleared), which always counts as drift.
+	mockQueryService.AddQueryPatternOnce("SELECT current_setting\\('primary_conninfo'",
+		mock.MakeQueryResult([]string{"current_setting"}, [][]any{{nil}}))
+
+	// reconcilePrimaryConnInfoToRecorded -> setPrimaryConnInfoLocked's own
+	// guardrail + pause/apply/resume sequence.
+	mockQueryService.AddQueryPatternOnce("SELECT pg_is_in_recovery",
+		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
+	mockQueryService.AddQueryPatternOnce("SELECT pg_wal_replay_pause",
+		mock.MakeQueryResult(nil, nil))
+	replayStateCols := []string{"replay_lsn", "is_paused"}
+	mockQueryService.AddQueryPattern("^SELECT pg_last_wal_replay_lsn",
+		mock.MakeQueryResult(replayStateCols, [][]any{{"0/100", true}}))
+
+	var capturedConnInfoSQL string
+	mockQueryService.AddQueryPatternWithCallback(
+		"ALTER SYSTEM SET primary_conninfo",
+		mock.MakeQueryResult(nil, nil),
+		func(sql string) { capturedConnInfoSQL = sql },
+	)
+	expectReloadConfig(mockQueryService)
+	mockQueryService.AddQueryPattern("^SELECT 1$", mock.MakeQueryResult(nil, nil))
+	mockQueryService.AddQueryPatternOnce("SELECT pg_wal_replay_resume",
+		mock.MakeQueryResult(nil, nil))
+
+	pm, _ := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(7)})
+
+	leader := newLeaderAddress("current-primary", "primary-host", 5432)
+	req := &consensusdatapb.SetPrimaryRequest{
+		ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
+			// Same term as self: the rule-position gate treats this as a
+			// no-op, but the conninfo drift must still be reconciled.
+			Rule:    ruleAtTermForLeader(leader, 7),
+			Primary: leader,
+		},
+	}
+	resp, err := pm.SetPrimary(t.Context(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.ConsensusStatus)
+
+	assert.Contains(t, capturedConnInfoSQL, "host=primary-host",
+		"drifted primary_conninfo should be reconciled to the recorded primary's host")
+	assert.NoError(t, mockQueryService.ExpectationsWereMet())
+}
+
 // TestSetPrimary_StandbyAppliesNewPrimary verifies the standby branch: when the
 // receiver is in recovery and the incoming position is higher, SetPrimary issues
 // the same setPrimaryConnInfo work (stop replication -> ALTER SYSTEM SET

--- a/go/test/endtoend/multiorch/fix_replication_test.go
+++ b/go/test/endtoend/multiorch/fix_replication_test.go
@@ -16,11 +16,13 @@ package multiorch
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
@@ -134,7 +136,7 @@ func TestFixReplication(t *testing.T) {
 		}
 		count := string(result.Rows[0].Values[0])
 		if count != "1" {
-			t.Logf("Waiting for data to replicate... count=%s", count)
+			t.Logf("Waiting for data to replicate... count=%s %s", count, replicationDiagnostics(t, primaryClient, replicaClient))
 			return false
 		}
 		return true
@@ -183,7 +185,7 @@ func TestFixReplication(t *testing.T) {
 		}
 		count := string(result.Rows[0].Values[0])
 		if count != "1" {
-			t.Logf("Waiting for data to replicate... count=%s", count)
+			t.Logf("Waiting for data to replicate... count=%s %s", count, replicationDiagnostics(t, primaryClient, replicaClient))
 			return false
 		}
 		return true
@@ -237,6 +239,53 @@ func TestFixReplication(t *testing.T) {
 	verifyReplicationStreaming(t, replicaClient)
 
 	t.Log("TestFixReplication completed successfully")
+}
+
+// replicationDiagnostics renders enough state from both the replica and the
+// primary to tell whether a replica that's "not yet replicating" is: not
+// connected at all, connected to the wrong host, connected but not
+// streaming/paused, or streaming but simply behind — and whether the two
+// nodes even agree on who the current leader is. Used in "waiting for data
+// to replicate" polling loops to aid flake investigation without needing to
+// dig through preserved logs after the fact.
+func replicationDiagnostics(t *testing.T, primaryClient, replicaClient *shardsetup.MultipoolerClient) string {
+	t.Helper()
+
+	ctx := utils.WithTimeout(t, 5*time.Second)
+
+	replicaStatus, replicaErr := replicaClient.Manager.Status(ctx, &multipoolermanagerdatapb.StatusRequest{})
+	primaryStatus, primaryErr := primaryClient.Manager.Status(ctx, &multipoolermanagerdatapb.StatusRequest{})
+	if replicaErr != nil || primaryErr != nil {
+		return fmt.Sprintf("[replica status err=%v, primary status err=%v]", replicaErr, primaryErr)
+	}
+
+	repl := replicaStatus.GetStatus().GetReplicationStatus()
+	walReceiver := repl.GetWalReceiverStatus()
+	if walReceiver == "" {
+		walReceiver = "none"
+	}
+
+	// recorded_primary is what SetPrimary/Promote last told the replica to use
+	// (best-effort, not persisted) — distinct from primary_conninfo, which is
+	// the pooler's own reconciliation of that record onto postgres. A nil/empty
+	// recorded_primary means orch never informed this pooler at all.
+	rp := replicaStatus.GetConsensusStatus().GetReplicationPrimary()
+	recordedPrimary := "none"
+	if rp != nil {
+		recordedPrimary = fmt.Sprintf("host=%s rule=%s rewind_ready=%v",
+			rp.GetPrimary().GetHost(), commonconsensus.FormatRuleNumber(rp.GetRule().GetRuleNumber()), rp.GetRewindReady())
+	}
+
+	return fmt.Sprintf(
+		"[replica: wal_receiver=%s, connected_to=%s, last_receive_lsn=%s, last_replay_lsn=%s, rule=%s, recorded_primary=[%s] | primary: rule=%s]",
+		walReceiver,
+		repl.GetPrimaryConnInfo().GetHost(),
+		repl.GetLastReceiveLsn(),
+		repl.GetLastReplayLsn(),
+		commonconsensus.FormatRuleNumber(replicaStatus.GetConsensusStatus().GetCurrentPosition().GetRule().GetRuleNumber()),
+		recordedPrimary,
+		commonconsensus.FormatRuleNumber(primaryStatus.GetConsensusStatus().GetCurrentPosition().GetRule().GetRuleNumber()),
+	)
 }
 
 // verifyReplicationStreaming checks that the replica has replication configured and is receiving WAL


### PR DESCRIPTION
## Summary
- `SetPrimary`'s rule-position no-op gate treated "position unchanged" the same as "position went backward" — in both cases it returned early without checking whether `primary_conninfo` itself had drifted from the recorded primary.
- The only backstop for that drift was `MonitorPostgres`'s periodic tick, 5 seconds apart, which is why `TestFixReplication` flaked roughly one run in three (~3/10-13 in local repro): `RequireRecovery` reported success while the replica was still waiting on the next monitor tick to actually reconfigure.
- `SetPrimary` already holds the action lock and has everything needed to check for drift itself, so it now does that inline via the same `primaryConnInfoDiffersFromRecorded` check the monitor uses, closing the race instead of waiting up to 5s for it.
- Extracted the reconcile logic (previously inlined in `MonitorPostgres`'s `remedialActionFixPrimaryConnInfo`) into a shared `reconcilePrimaryConnInfoToRecorded` so both call sites can't drift apart.
- Added diagnostics to `TestFixReplication`'s polling loops (wal receiver state, recorded primary, rewind-readiness) so any future flake here is diagnosable from CI logs alone, without needing local repro.

## Test plan
- New unit test `TestSetPrimary_NoOpReconcilesDriftedConnInfo` exercises the fix directly (drifted conninfo + unchanged rule position → still reconciled).
- `TestFixReplication` run locally 15/15 times with the fix (previously observed ~70-80% pass rate before the fix, reproduced both locally and via linked CI failures).