### PR TITLE
feat(docker): Supabase cluster image + forward MULTIGRES_PG_EXTRA_CONF

### DIFF
--- a/.github/workflows/docker-build-cluster.yml
+++ b/.github/workflows/docker-build-cluster.yml
@@ -26,8 +26,27 @@ permissions:
 
 jobs:
   docker-cluster:
-    name: Build and Push cluster Docker Image
+    name: Build and Push ${{ matrix.image }} Docker Image
     runs-on: ubuntu-24.04
+
+    strategy:
+      # Don't let one variant's failure cancel the other's build.
+      fail-fast: false
+      matrix:
+        include:
+          # Stock cluster image: official Debian PostgreSQL base. The Dockerfile
+          # default (PROVISION_PG_PACKAGES=true) installs pgBackRest, pgvector,
+          # and procps from the PGDG APT repo.
+          - image: multigres-cluster
+            extra_build_args: ""
+          # Supabase variant: built on the "-multigres" Supabase Postgres base,
+          # which already bundles pgBackRest, pgvector, and pgrep. That base is
+          # Alpine (no apt), so package provisioning must be skipped; the
+          # Dockerfile guardrail asserts the base actually ships those three.
+          - image: multigres-cluster-supabase
+            extra_build_args: |
+              POSTGRES_IMAGE=supabase/postgres:17.6.1.142-multigres
+              PROVISION_PG_PACKAGES=false
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -49,7 +68,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
-          images: ghcr.io/${{ github.repository_owner }}/multigres-cluster
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
           # latest tracks main (not the latest release tag), so disable the
           # action's automatic latest and tag it explicitly on the default
           # branch. Version tags (vX.Y.Z) produce the semver tags below.
@@ -75,9 +94,12 @@ jobs:
           file: ./Dockerfile.cluster
           build-args: |
             GO_VERSION=${{ steps.goversion.outputs.version }}
+            ${{ matrix.extra_build_args }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Scope the GHA cache per variant so the two images don't clobber each
+          # other's layer cache (different bases, different provisioning).
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -51,6 +51,16 @@ jobs:
           - image: multigres-cluster
             context: .
             file: ./Dockerfile.cluster
+          # Same Dockerfile.cluster as above, but built on the "-multigres"
+          # Supabase Postgres base (which already bundles pgBackRest, pgvector,
+          # and pgrep). That base is Alpine, so apt-based provisioning is
+          # skipped; the Dockerfile guardrail asserts the base ships them.
+          - image: multigres-cluster-supabase
+            context: .
+            file: ./Dockerfile.cluster
+            extra_build_args: |
+              POSTGRES_IMAGE=supabase/postgres:17.6.1.142-multigres
+              PROVISION_PG_PACKAGES=false
 
     steps:
       - name: Check out code
@@ -113,13 +123,17 @@ jobs:
           # harmless build-arg warning); the Go images pin their base to it.
           build-args: |
             GO_VERSION=${{ steps.goversion.outputs.version }}
+            ${{ matrix.extra_build_args }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           provenance: mode=max
           sbom: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Scope the GHA cache per image so parallel matrix builds don't
+          # clobber each other's cache manifest (the two cluster variants
+          # share a Dockerfile but differ in base and provisioning).
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
           platforms: linux/amd64,linux/arm64
 
       - name: Verify published image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,11 @@ services:
       # connection pooler to this value minus 10. Forwarded from the host env so
       # CI / callers can override it without editing this file; empty = default.
       MULTIGRES_PG_MAX_CONNECTIONS: "${MULTIGRES_PG_MAX_CONNECTIONS:-}"
+      # Extra raw postgresql.conf text (one setting per line), appended to every
+      # cell's config at first init. This is how you set startup-only GUCs like
+      # shared_preload_libraries (e.g. to load pg_cron/pg_net). Forwarded from
+      # the host env like the knob above; empty = none.
+      MULTIGRES_PG_EXTRA_CONF: "${MULTIGRES_PG_EXTRA_CONF:-}"
     ports:
       - "15432:15432" # zone1 multigateway — PostgreSQL wire protocol
       - "15100:15100" # multigateway HTTP (status/metrics)


### PR DESCRIPTION
## Summary

- Publish a `multigres-cluster-supabase` image alongside the stock `multigres-cluster`, built on the `supabase/postgres:17.6.1.142-multigres` base (Alpine, `PROVISION_PG_PACKAGES=false`), in both the push-to-main cluster build and the nightly build matrices. This lets consumer CI pull a prebuilt cluster image on the Supabase Postgres base instead of building it themselves.
- Forward `MULTIGRES_PG_EXTRA_CONF` from the host env in `docker-compose.yml`. The entrypoint already applied it, and `MULTIGRES_PG_MAX_CONNECTIONS` was already forwarded, but this knob was missed — so there was no way via compose to set startup-only GUCs like `shared_preload_libraries`, which pg_cron/pg_net need to load.

## Notes

- No `Dockerfile.cluster` change was needed: the `-multigres` base already bundles pgBackRest, pgvector, and pgrep, so its `PROVISION_PG_PACKAGES=false` guardrail passes. The base tag is pinned for reproducibility. Per-image GHA cache scope keeps the two cluster variants from clobbering each other's cache.
- Verified locally: the Supabase cluster image builds and serves queries through the gateway including `CREATE EXTENSION vector`; and with the compose fix, running compose with `MULTIGRES_PG_EXTRA_CONF=shared_preload_libraries='pg_cron,pg_net'` brings both extensions up (`SHOW shared_preload_libraries` → `pg_cron,pg_net`, `CREATE EXTENSION pg_cron`/`pg_net` succeed).