### PR TITLE
fix(servenv): reject empty mTLS allow-list in grpc auth

### DIFF
--- a/go/common/servenv/grpc_server_auth_mtls.go
+++ b/go/common/servenv/grpc_server_auth_mtls.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -68,8 +69,13 @@ func (ma *MtlsAuthPlugin) Authenticate(ctx context.Context, fullMethod string) (
 }
 
 func mtlsAuthPluginInitializer() (Authenticator, error) {
+	substrings := strings.Split(clientCertSubstrings, ":")
+	// An empty substring matches every certificate subject, authorizing all clients.
+	if slices.Contains(substrings, "") {
+		return nil, fmt.Errorf("--grpc-auth-mtls-allowed-substrings must be a non-empty colon-separated list without empty entries, got %q", clientCertSubstrings)
+	}
 	mtlsAuthPlugin := &MtlsAuthPlugin{
-		clientCertSubstrings: strings.Split(clientCertSubstrings, ":"),
+		clientCertSubstrings: substrings,
 	}
 	slog.Info("mtls auth plugin have initialized successfully with allowed client cert name substrings", "clientSubstrings", clientCertSubstrings)
 	return mtlsAuthPlugin, nil

--- a/go/common/servenv/grpc_server_auth_mtls.go
+++ b/go/common/servenv/grpc_server_auth_mtls.go
@@ -31,18 +31,19 @@ import (
 )
 
 var (
-	// clientCertSubstrings list of substrings of at least one of the client certificate names to use during authorization
+	// clientCertSubstrings list of substrings of at least one of the client certificate names to use during authorization.
+	// Must be non-empty when mtls auth is enabled; empty entries are rejected at startup.
 	clientCertSubstrings string
 	// MtlsAuthPlugin implements AuthPlugin interface
 	_ Authenticator = (*MtlsAuthPlugin)(nil)
 )
 
 func registerGRPCServerAuthMTLSFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&clientCertSubstrings, "grpc-auth-mtls-allowed-substrings", clientCertSubstrings, "List of substrings of at least one of the client certificate names (separated by colon).")
+	fs.StringVar(&clientCertSubstrings, "grpc-auth-mtls-allowed-substrings", clientCertSubstrings, "List of substrings of at least one of the client certificate names (separated by colon). Required when --grpc-auth-mode=mtls; must not contain empty entries.")
 }
 
-// MtlsAuthPlugin  implements static username/password authentication for grpc. It contains an array of username/passwords
-// that will be authorized to connect to the grpc server.
+// MtlsAuthPlugin implements mTLS authentication for grpc. A client is authorized if any of the
+// configured substrings occurs in the subject of any of its verified certificates.
 type MtlsAuthPlugin struct {
 	clientCertSubstrings []string
 }

--- a/go/common/servenv/grpc_server_auth_mtls_test.go
+++ b/go/common/servenv/grpc_server_auth_mtls_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package servenv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMtlsAuthPluginInitializer(t *testing.T) {
+	tests := []struct {
+		name       string
+		substrings string
+		wantErr    bool
+	}{
+		{name: "empty allow-list rejected", substrings: "", wantErr: true},
+		{name: "empty token rejected", substrings: "client-a::client-b", wantErr: true},
+		{name: "trailing empty token rejected", substrings: "client-a:", wantErr: true},
+		{name: "valid single entry", substrings: "client-a", wantErr: false},
+		{name: "valid multiple entries", substrings: "client-a:client-b", wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := clientCertSubstrings
+			t.Cleanup(func() { clientCertSubstrings = orig })
+			clientCertSubstrings = tt.substrings
+
+			auth, err := mtlsAuthPluginInitializer()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "grpc-auth-mtls-allowed-substrings")
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, auth)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Reject an empty `--grpc-auth-mtls-allowed-substrings` (and empty entries like `a::b` or a trailing `a:`) at server startup when `--grpc-auth-mode=mtls`, instead of silently authorizing every CA-valid client certificate.
- Align the flag help, variable comment, and `MtlsAuthPlugin` doc comment with the new validation.

## Problem

In mTLS mode the allow-list is parsed with `strings.Split(clientCertSubstrings, ":")`. An empty flag yields `[""]`, and `strings.Contains(subject, "")` is always true, so any certificate the configured CA ever issued is authorized. Empty entries in an otherwise-populated list (`a::b`, `a:`) silently turn a restrictive allow-list into allow-all. This behavior was inherited verbatim from Vitess.

## Solution

The plugin initializer now returns an error if the split list contains any empty entry (which also covers the fully-empty flag). The error propagates through the auth plugin initializer, so a misconfigured server fails fast at startup rather than accepting all clients. `MtlsAuthPlugin` is constructed in exactly one place and its field is unexported, so no other path can produce a permissive instance.

Added `grpc_server_auth_mtls_test.go` covering the empty flag, a mid-list empty token, a trailing empty token, and valid single/multiple entries.