### PR TITLE
feat(multipooler): current_rule schema + two-phase write for stuck-proposal recovery

### DIFF
--- a/go/services/multipooler/internal/manager/consensus/rule_store.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -366,23 +367,31 @@ func (rs *ruleStore) CreateRuleTables(ctx context.Context, policy *clustermetada
 	defer cancel()
 
 	if _, err := rs.queryService.Query(execCtx, `CREATE TABLE multigres.current_rule (
-		shard_id                  BYTEA PRIMARY KEY,
-		coordinator_term          BIGINT NOT NULL,
-		leader_subterm            BIGINT NOT NULL,
-		leader_id                 TEXT,
-		coordinator_id            TEXT NOT NULL,
-		cohort_members            TEXT[] NOT NULL,
-		durability_policy_name    TEXT NOT NULL,
-		durability_quorum_type    TEXT NOT NULL,
-		durability_required_count INT NOT NULL,
-		created_at                TIMESTAMPTZ NOT NULL
+		shard_id                           BYTEA PRIMARY KEY,
+		decision_coordinator_term          BIGINT NOT NULL,
+		decision_leader_subterm            BIGINT NOT NULL,
+		leader_id                          TEXT,
+		coordinator_id                     TEXT NOT NULL,
+		cohort_members                     TEXT[] NOT NULL,
+		durability_policy_name             TEXT NOT NULL,
+		durability_quorum_type             TEXT NOT NULL,
+		durability_required_count          INT NOT NULL,
+		created_at                         TIMESTAMPTZ NOT NULL,
+		proposal_coordinator_term          BIGINT,
+		proposal_leader_subterm            BIGINT,
+		proposal_leader_id                 TEXT,
+		proposal_cohort_members            TEXT[],
+		proposal_durability_policy_name    TEXT,
+		proposal_durability_quorum_type    TEXT,
+		proposal_durability_required_count INT,
+		proposal_created_at                TIMESTAMPTZ
 	)`); err != nil {
 		return mterrors.Wrap(err, "failed to create current_rule table")
 	}
 
 	if _, err := rs.queryService.QueryArgs(execCtx, `
 		INSERT INTO multigres.current_rule
-		  (shard_id, coordinator_term, leader_subterm, coordinator_id, cohort_members,
+		  (shard_id, decision_coordinator_term, decision_leader_subterm, coordinator_id, cohort_members,
 		   durability_policy_name, durability_quorum_type, durability_required_count, created_at)
 		VALUES ($1, 0, 1, $2, '{}', $3, $4, $5, now())`,
 		[]byte("0"), topoclient.ClusterIDString(bootstrapID), policy.PolicyName, policy.QuorumType.String(), int64(policy.RequiredCount)); err != nil {
@@ -392,6 +401,13 @@ func (rs *ruleStore) CreateRuleTables(ctx context.Context, policy *clustermetada
 	// Each row records a cluster state change (promotion, cohort membership, durability policy).
 	// The composite primary key (coordinator_term, leader_subterm) uniquely identifies each rule;
 	// leader_subterm is assigned by the application as MAX(leader_subterm)+1 within a coordinator_term.
+	//
+	// Unlike current_rule, rule_history has no proposal_* columns: a row never needs decision
+	// and proposal fields simultaneously, since it's one row per rule number whose lifecycle is
+	// tracked by decided instead of by which column group is populated. decided starts false
+	// when a proposal is first written and is later UPDATEd to true once confirmed, rather than
+	// getting a second row — that's Step 3's two-phase write; every write today still inserts
+	// decided=true directly, since there is no proposal phase yet.
 	if _, err := rs.queryService.Query(execCtx, `CREATE TABLE multigres.rule_history (
 		coordinator_term          BIGINT NOT NULL,
 		leader_subterm            BIGINT NOT NULL,
@@ -406,6 +422,7 @@ func (rs *ruleStore) CreateRuleTables(ctx context.Context, policy *clustermetada
 		durability_quorum_type    TEXT NOT NULL,
 		durability_required_count INT NOT NULL,
 		operation                 TEXT,
+		decided                   BOOLEAN NOT NULL,
 		created_at                TIMESTAMPTZ NOT NULL,
 		PRIMARY KEY (coordinator_term, leader_subterm)
 	)`); err != nil {
@@ -442,9 +459,13 @@ func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clus
 		suffix = " FOR UPDATE NOWAIT"
 	}
 	result, err := rs.queryService.QueryArgs(ctx, `
-		SELECT coordinator_term, leader_subterm, leader_id, coordinator_id, cohort_members,
+		SELECT decision_coordinator_term, decision_leader_subterm, leader_id, coordinator_id, cohort_members,
 		       durability_policy_name, durability_quorum_type, durability_required_count,
 		       created_at,
+		       proposal_coordinator_term, proposal_leader_subterm, proposal_leader_id,
+		       proposal_cohort_members, proposal_durability_policy_name,
+		       proposal_durability_quorum_type, proposal_durability_required_count,
+		       proposal_created_at,
 		       CASE
 		         WHEN pg_is_in_recovery()
 		           THEN COALESCE(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn(), '0/0'::pg_lsn)
@@ -459,23 +480,27 @@ func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clus
 		return nil, mterrors.Errorf(mtrpcpb.Code_INTERNAL, "current_rule initial row missing for shard 0: tables may not be initialized")
 	}
 
-	var coordinatorTerm, leaderSubterm int64
-	var leaderIDStr, coordinatorIDStr *string
-	var cohortNames []string
-	var durabilityPolicyName, durabilityQuorumType string
-	var durabilityRequiredCount int64
-	var createdAt time.Time
+	var decision, proposal unvalidatedRuleRow
+	var coordinatorIDStr *string
 	var lsn string
 	if err := executor.ScanRow(result.Rows[0],
-		&coordinatorTerm,
-		&leaderSubterm,
-		&leaderIDStr,
+		&decision.coordinatorTerm,
+		&decision.leaderSubterm,
+		&decision.leaderIDStr,
 		&coordinatorIDStr,
-		&cohortNames,
-		&durabilityPolicyName,
-		&durabilityQuorumType,
-		&durabilityRequiredCount,
-		&createdAt,
+		&decision.cohortNames,
+		&decision.durabilityPolicyName,
+		&decision.durabilityQuorumType,
+		&decision.durabilityRequiredCount,
+		&decision.createdAt,
+		&proposal.coordinatorTerm,
+		&proposal.leaderSubterm,
+		&proposal.leaderIDStr,
+		&proposal.cohortNames,
+		&proposal.durabilityPolicyName,
+		&proposal.durabilityQuorumType,
+		&proposal.durabilityRequiredCount,
+		&proposal.createdAt,
 		&lsn,
 	); err != nil {
 		return nil, mterrors.Wrap(err, "failed to scan current_rule")
@@ -485,13 +510,7 @@ func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clus
 	if coordinatorIDStr != nil {
 		coordinatorIDStrVal = *coordinatorIDStr
 	}
-	pos, err := buildPoolerPosition(
-		coordinatorTerm, leaderSubterm,
-		leaderIDStr, coordinatorIDStrVal, cohortNames,
-		durabilityPolicyName, durabilityQuorumType, durabilityRequiredCount,
-		createdAt,
-		lsn,
-	)
+	pos, err := buildPoolerPosition(decision, coordinatorIDStrVal, proposal, lsn)
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to parse current_rule")
 	}
@@ -608,8 +627,11 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 	if err != nil {
 		return nil, err
 	}
-	// TODO: Propagation is not yet supported — the current schema has no
-	// proposal_* columns, so this can never actually fire today.
+	// TODO: Propagation is not yet supported. Nothing in today's write path
+	// below populates proposal_*, so this can't fire from a normal
+	// UpdateRule sequence — but a proposal can now exist in the DB (e.g.
+	// seeded directly via SQL, simulating a crash), so this guard is
+	// reachable, not dead code.
 	if !consensus.IsRuleDecided(current.GetPosition()) {
 		return nil, mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
 			"current rule has an undecided proposal; propagation is not yet supported")
@@ -639,8 +661,20 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 	}
 
 	// Resolve values to write: caller-supplied values take priority; nil retains existing.
+	//
+	// Outside of a promotion, an existing leader can't be replaced: the current leader
+	// is the one issuing this write, and it has no way to instantaneously stop accepting
+	// transactions the moment the row changes — only a promotion (which goes through
+	// revocation/fencing on the outgoing leader first) can safely hand off leadership.
+	// Establishing the very first leader (currentRule has none yet) has no such risk and
+	// is allowed either way.
 	newLeader := currentRule.GetLeaderId()
 	if update.leaderID != nil {
+		if !isPromotion && currentRule.GetLeaderId() != nil && !proto.Equal(update.leaderID, currentRule.GetLeaderId()) {
+			return nil, mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
+				"UpdateRule cannot change leader outside of a promotion: current leader %v, requested %v",
+				currentRule.GetLeaderId(), update.leaderID)
+		}
 		newLeader = update.leaderID
 	}
 	newCohort := currentRule.GetCohortMembers()
@@ -751,6 +785,19 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 	// including optional pg_rewind). For primary-side cohort changes standbys are
 	// already streaming and the ack is nearly immediate. RuleWriteTimeout covers
 	// both cases.
+	//
+	// KNOWN GAP, NOT YET FIXED: this write goes straight to decision_* in one
+	// shot. It should instead be two-phase — write proposal_* (and a
+	// rule_history row with decided=false) first, and only promote that same
+	// row to decision_*/decided=true once we have positive confirmation the
+	// write is durable. Today, if this process crashes or the context expires
+	// between issuing this query and observing its result, the sync-standby
+	// ack (and the WAL write behind it) may already be durable on other
+	// cohort members even though this process never learns that — the rule
+	// is decided in reality but this pooler has no record of it, so a later
+	// coordinator has nothing to discover and recover from. Two-phase closes
+	// that gap by making the attempt itself durable and observable
+	// (Position.Proposal) independent of whether this call ever returns.
 	execCtx, cancel := context.WithTimeout(ctx, timeouts.RuleWriteTimeout)
 	defer cancel()
 
@@ -789,25 +836,35 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 		    -- CAS: only proceed if the rule hasn't changed since we read it above.
 		    SELECT current_rule.shard_id
 		    FROM multigres.current_rule, params
-		    WHERE current_rule.shard_id = params.shard_id
-		      AND coordinator_term      = params.cas_term
-		      AND leader_subterm        = params.cas_subterm
+		    WHERE current_rule.shard_id      = params.shard_id
+		      AND decision_coordinator_term  = params.cas_term
+		      AND decision_leader_subterm    = params.cas_subterm
 		    FOR UPDATE NOWAIT
 		  ),
 		  updated AS (
 		    UPDATE multigres.current_rule
-		    SET coordinator_term          = params.new_term,
-		        leader_subterm            = params.new_subterm,
-		        leader_id                 = params.new_leader_id,
-		        coordinator_id            = params.new_coordinator_id,
-		        cohort_members            = params.new_cohort,
-		        durability_policy_name    = params.dp_name,
-		        durability_quorum_type    = params.dp_quorum_type,
-		        durability_required_count = params.dp_required_count,
-		        created_at                = params.created_at
+		    SET decision_coordinator_term          = params.new_term,
+		        decision_leader_subterm            = params.new_subterm,
+		        leader_id                           = params.new_leader_id,
+		        coordinator_id                      = params.new_coordinator_id,
+		        cohort_members                      = params.new_cohort,
+		        durability_policy_name              = params.dp_name,
+		        durability_quorum_type              = params.dp_quorum_type,
+		        durability_required_count           = params.dp_required_count,
+		        created_at                          = params.created_at,
+		        -- A normal (non-propagation) decision write always supersedes any
+		        -- pending proposal: it is, by construction, ahead of it.
+		        proposal_coordinator_term           = NULL,
+		        proposal_leader_subterm             = NULL,
+		        proposal_leader_id                  = NULL,
+		        proposal_cohort_members             = NULL,
+		        proposal_durability_policy_name     = NULL,
+		        proposal_durability_quorum_type     = NULL,
+		        proposal_durability_required_count  = NULL,
+		        proposal_created_at                 = NULL
 		    FROM locked, params
 		    WHERE current_rule.shard_id = params.shard_id
-		    RETURNING coordinator_term, leader_subterm, leader_id, coordinator_id, cohort_members,
+		    RETURNING decision_coordinator_term, decision_leader_subterm, leader_id, coordinator_id, cohort_members,
 		              durability_policy_name, durability_quorum_type, durability_required_count,
 		              params.created_at
 		  ),
@@ -815,19 +872,19 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 		    INSERT INTO multigres.rule_history
 		      (coordinator_term, leader_subterm, event_type, leader_id, coordinator_id,
 		       wal_position, operation, reason, cohort_members, accepted_members,
-		       durability_policy_name, durability_quorum_type, durability_required_count, created_at)
-		    SELECT updated.coordinator_term, updated.leader_subterm,
+		       durability_policy_name, durability_quorum_type, durability_required_count, decided, created_at)
+		    SELECT updated.decision_coordinator_term, updated.decision_leader_subterm,
 		           params.event_type, updated.leader_id, updated.coordinator_id,
 		           params.wal_position, params.operation, params.reason,
 		           updated.cohort_members, params.accepted_members,
 		           updated.durability_policy_name, updated.durability_quorum_type,
-		           updated.durability_required_count, params.created_at
+		           updated.durability_required_count, true, params.created_at
 		    FROM updated, params
 		    RETURNING coordinator_term
 		  )
 		-- Cross-joining inserted ensures a zero-row history insert (a bug) also returns zero
 		-- rows here, causing the caller to surface an error rather than silently succeeding.
-		SELECT updated.coordinator_term, updated.leader_subterm,
+		SELECT updated.decision_coordinator_term, updated.decision_leader_subterm,
 		       updated.leader_id, updated.coordinator_id, updated.cohort_members,
 		       updated.durability_policy_name, updated.durability_quorum_type,
 		       updated.durability_required_count,
@@ -866,36 +923,26 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 		return nil, errRuleConflict
 	}
 
-	var coordinatorTerm, leaderSubterm int64
-	var leaderIDStr *string
+	var decision unvalidatedRuleRow
 	var coordinatorIDStrResult string
-	var cohortNames []string
-	var durabilityPolicyName, durabilityQuorumType string
-	var durabilityRequiredCount int64
-	var createdAt time.Time
 	var lsn string
 	if err := executor.ScanSingleRow(result,
-		&coordinatorTerm,
-		&leaderSubterm,
-		&leaderIDStr,
+		&decision.coordinatorTerm,
+		&decision.leaderSubterm,
+		&decision.leaderIDStr,
 		&coordinatorIDStrResult,
-		&cohortNames,
-		&durabilityPolicyName,
-		&durabilityQuorumType,
-		&durabilityRequiredCount,
-		&createdAt,
+		&decision.cohortNames,
+		&decision.durabilityPolicyName,
+		&decision.durabilityQuorumType,
+		&decision.durabilityRequiredCount,
+		&decision.createdAt,
 		&lsn,
 	); err != nil {
 		return nil, mterrors.Wrap(err, "failed to scan written rule position")
 	}
 
-	pos, err := buildPoolerPosition(
-		coordinatorTerm, leaderSubterm,
-		leaderIDStr, coordinatorIDStrResult, cohortNames,
-		durabilityPolicyName, durabilityQuorumType, durabilityRequiredCount,
-		createdAt,
-		lsn,
-	)
+	// A normal decision write always clears any pending proposal.
+	pos, err := buildPoolerPosition(decision, coordinatorIDStrResult, unvalidatedRuleRow{}, lsn)
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to parse written rule position")
 	}
@@ -919,7 +966,7 @@ func (rs *ruleStore) queryRuleHistory(ctx context.Context, limit int) ([]ruleHis
 		SELECT coordinator_term, leader_subterm, event_type, leader_id, coordinator_id,
 		       wal_position, operation, reason, cohort_members, accepted_members,
 		       durability_policy_name, durability_quorum_type, durability_required_count,
-		       created_at
+		       decided, created_at
 		FROM multigres.rule_history
 		ORDER BY coordinator_term DESC, leader_subterm DESC
 		LIMIT $1`, limit)
@@ -947,6 +994,7 @@ func (rs *ruleStore) queryRuleHistory(ctx context.Context, limit int) ([]ruleHis
 			&rec.DurabilityPolicyName,
 			&rec.DurabilityQuorumType,
 			&durabilityRequiredCount,
+			&rec.Decided,
 			&rec.CreatedAt,
 		); err != nil {
 			return nil, mterrors.Wrap(err, "failed to parse rule_history row")
@@ -964,20 +1012,78 @@ func (rs *ruleStore) queryRuleHistory(ctx context.Context, limit int) ([]ruleHis
 // Helpers
 // ----------------------------------------------------------------------------
 
-// buildPoolerPosition constructs a *clustermetadatapb.PoolerPosition from raw DB column values.
-// leaderIDStr and coordinatorIDStr are app-name formatted strings (e.g. "zone1_pooler-name").
-// Durability fields are NOT NULL in the DB and are always populated in the returned position.
-// createdAt is the coordinator-supplied CreationTime persisted with the rule.
-func buildPoolerPosition(
+// unvalidatedRuleRow holds the raw, nullable column values for one rule
+// (decision or proposal) as scanned directly from SQL. Nullability here
+// tracks the Go scan target, not whether the value is logically optional —
+// see validate, the only way to turn this into a usable rule.
+type unvalidatedRuleRow struct {
+	coordinatorTerm         *int64
+	leaderSubterm           *int64
+	leaderIDStr             *string
+	cohortNames             []string
+	durabilityPolicyName    *string
+	durabilityQuorumType    *string
+	durabilityRequiredCount *int64
+	createdAt               *time.Time
+}
+
+// validate resolves r into a *clustermetadatapb.ShardRule — the only type
+// that can hold a parsed rule past this point, so once validate succeeds,
+// callers work with real, non-optional fields (RuleNumber, DurabilityPolicy)
+// instead of re-deriving presence from raw nullable columns at each use.
+//
+// Returns (nil, nil) if r is entirely unpopulated: for a proposal this means
+// no pending proposal, since current_rule's proposal_* columns are always
+// NULL together (see CreateRuleTables). A row that's only partially
+// populated is never treated as absent — that violates the "NULL together"
+// invariant and means corrupted state, so it's reported as an error instead
+// of silently defaulting the missing columns away.
+//
+// leader_id is nil-able regardless of decision vs. proposal: the initial
+// {0,1} bootstrap decision has no leader yet, and it's not part of the
+// "populated together" core — see the set/total check below.
+func (r unvalidatedRuleRow) validate() (*clustermetadatapb.ShardRule, error) {
+	set := 0
+	const total = 5
+	for _, isSet := range []bool{
+		r.coordinatorTerm != nil,
+		r.leaderSubterm != nil,
+		r.durabilityPolicyName != nil,
+		r.durabilityQuorumType != nil,
+		r.durabilityRequiredCount != nil,
+	} {
+		if isSet {
+			set++
+		}
+	}
+	if set == 0 {
+		return nil, nil
+	}
+	if set != total {
+		return nil, fmt.Errorf("partially populated rule row (%d/%d core columns set): expected all NULL together or all set together", set, total)
+	}
+
+	rule, err := buildShardRule(*r.coordinatorTerm, *r.leaderSubterm, r.leaderIDStr, r.cohortNames,
+		*r.durabilityPolicyName, *r.durabilityQuorumType, *r.durabilityRequiredCount)
+	if err != nil {
+		return nil, err
+	}
+	if r.createdAt != nil && !r.createdAt.IsZero() {
+		rule.CreationTime = timestamppb.New(*r.createdAt)
+	}
+	return rule, nil
+}
+
+// buildShardRule constructs a *clustermetadatapb.ShardRule from raw DB column
+// values shared by both the decision and proposal column groups. leaderIDStr is
+// an app-name formatted string (e.g. "zone1_pooler-name").
+func buildShardRule(
 	coordinatorTerm, leaderSubterm int64,
 	leaderIDStr *string,
-	coordinatorIDStr string,
 	cohortNames []string,
 	durabilityPolicyName, durabilityQuorumType string,
 	durabilityRequiredCount int64,
-	createdAt time.Time,
-	lsn string,
-) (*clustermetadatapb.PoolerPosition, error) {
+) (*clustermetadatapb.ShardRule, error) {
 	rule := &clustermetadatapb.ShardRule{
 		RuleNumber: &clustermetadatapb.RuleNumber{
 			CoordinatorTerm: coordinatorTerm,
@@ -991,20 +1097,6 @@ func buildPoolerPosition(
 			return nil, mterrors.Wrapf(err, "failed to parse leader_id %q", *leaderIDStr)
 		}
 		rule.LeaderId = id
-	}
-
-	if coordinatorIDStr != "" {
-		// Coordinator IDs are multiorch, not multipooler — ParseApplicationName
-		// is pooler-specific, so decode the cell_name encoding directly.
-		cell, name, err := topoclient.SplitClusterID(coordinatorIDStr)
-		if err != nil {
-			return nil, mterrors.Wrapf(err, "failed to parse coordinator_id %q", coordinatorIDStr)
-		}
-		rule.CoordinatorId = &clustermetadatapb.ID{
-			Component: clustermetadatapb.ID_MULTIORCH,
-			Cell:      cell,
-			Name:      name,
-		}
 	}
 
 	cohortIDs, err := appNamesToIDs(cohortNames)
@@ -1022,17 +1114,48 @@ func buildPoolerPosition(
 		QuorumType:    clustermetadatapb.QuorumType(v),
 		RequiredCount: int32(durabilityRequiredCount),
 	}
-	if !createdAt.IsZero() {
-		rule.CreationTime = timestamppb.New(createdAt)
+	return rule, nil
+}
+
+// buildPoolerPosition constructs a *clustermetadatapb.PoolerPosition from raw DB column values.
+// coordinatorIDStr is an app-name formatted string, decision-only — a proposal never carries a
+// coordinator_id, since it's verified purely by rule number, cohort, and durability policy, not
+// coordinator identity.
+func buildPoolerPosition(
+	decision unvalidatedRuleRow,
+	coordinatorIDStr string,
+	proposal unvalidatedRuleRow,
+	lsn string,
+) (*clustermetadatapb.PoolerPosition, error) {
+	decisionRule, err := decision.validate()
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to parse decision")
+	}
+	if decisionRule == nil {
+		return nil, mterrors.Errorf(mtrpcpb.Code_INTERNAL, "current_rule row has no decision")
 	}
 
-	// TODO: once the current_rule schema gains proposal_* columns,
-	// this read may need to surface an undecided proposal instead of always
-	// treating the row as a decision. Today's schema has no proposal
-	// concept yet, so everything read here is provisionally treated as
-	// decided even if it never actually reached quorum.
+	if coordinatorIDStr != "" {
+		// Coordinator IDs are multiorch, not multipooler — ParseApplicationName
+		// is pooler-specific, so decode the cell_name encoding directly.
+		cell, name, err := topoclient.SplitClusterID(coordinatorIDStr)
+		if err != nil {
+			return nil, mterrors.Wrapf(err, "failed to parse coordinator_id %q", coordinatorIDStr)
+		}
+		decisionRule.CoordinatorId = &clustermetadatapb.ID{
+			Component: clustermetadatapb.ID_MULTIORCH,
+			Cell:      cell,
+			Name:      name,
+		}
+	}
+
+	proposalRule, err := proposal.validate()
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to parse proposal")
+	}
+
 	return &clustermetadatapb.PoolerPosition{
-		Position: &clustermetadatapb.RulePosition{Decision: rule},
+		Position: &clustermetadatapb.RulePosition{Decision: decisionRule, Proposal: proposalRule},
 		Lsn:      lsn,
 	}, nil
 }
@@ -1065,6 +1188,7 @@ type ruleHistoryRecord struct {
 	DurabilityPolicyName    string
 	DurabilityQuorumType    string
 	DurabilityRequiredCount int32
+	Decided                 bool
 	CreatedAt               time.Time
 }
 

--- a/go/services/multipooler/internal/manager/consensus/rule_store.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store.go
@@ -627,17 +627,25 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 	if err != nil {
 		return nil, err
 	}
-	// TODO: Propagation is not yet supported — a coordinator that finds an
-	// existing undecided proposal here (left behind by a previous writer
-	// that crashed between phase 1 and phase 2 below) has no way to safely
-	// finish deciding it or supersede it; it can only fail closed until a
-	// future step teaches this path (or a dedicated recovery path) to do so.
-	if !consensus.IsRuleDecided(current.GetPosition()) {
+
+	// TODO: Implement propagation. For propagation:
+	// - This pooler should be in the incoming cohort
+	// - The rule request should be for a coordinator-led change that's identical to the
+	//   undecided proposal except that this pooler is the leader
+	// - Propagation will ensure that the "stuck" rule reaches quorum under its policy
+	//   by committing anything after the proposed rule. At that point we know the rule
+	//   is decided and we can atomically mark it as decided while also writing a new proposal
+	//   to make this pooler the leader.
+	if !update.skipOutgoingQuorum && !consensus.IsRuleDecided(current.GetPosition()) {
 		return nil, mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
 			"current rule has an undecided proposal; propagation is not yet supported")
 	}
+	// casOnProposal is true only when skipOutgoingQuorum let us past the guard
+	// above with an undecided proposal still present — i.e. the position we
+	// read (and must CAS against below) is the proposal, not the decision.
+	casOnProposal := !consensus.IsRuleDecided(current.GetPosition())
+	currentRule := consensus.PossiblyUndecidedRule(current.GetPosition())
 
-	currentRule := current.GetPosition().GetDecision()
 	currentTerm := currentRule.GetRuleNumber().GetCoordinatorTerm()
 	currentSubterm := currentRule.GetRuleNumber().GetLeaderSubterm()
 
@@ -806,32 +814,41 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 		  params AS (
 		    -- Name all query parameters once so the rest of the CTE references them by name.
 		    SELECT $1::bytea        AS shard_id,
-		           $2::bigint       AS cas_decision_term,
-		           $3::bigint       AS cas_decision_subterm,
-		           $4::bigint       AS new_term,
-		           $5::bigint       AS new_subterm,
-		           NULLIF($6, '')   AS new_leader_id,
-		           $7::text[]       AS new_cohort,
-		           $8::text         AS dp_name,
-		           $9::text         AS dp_quorum_type,
-		           $10::bigint      AS dp_required_count,
-		           $11::timestamptz AS created_at,
-		           $12::text        AS event_type,
-		           NULLIF($13, '')  AS wal_position,
-		           NULLIF($14, '')  AS operation,
-		           $15::text        AS reason,
-		           $16::text[]      AS accepted_members,
-		           $17::text        AS new_coordinator_id
+		           $2::bigint       AS cas_term,
+		           $3::bigint       AS cas_subterm,
+		           $4::boolean      AS cas_on_proposal,
+		           $5::bigint       AS new_term,
+		           $6::bigint       AS new_subterm,
+		           NULLIF($7, '')   AS new_leader_id,
+		           $8::text[]       AS new_cohort,
+		           $9::text         AS dp_name,
+		           $10::text        AS dp_quorum_type,
+		           $11::bigint      AS dp_required_count,
+		           $12::timestamptz AS created_at,
+		           $13::text        AS event_type,
+		           NULLIF($14, '')  AS wal_position,
+		           NULLIF($15, '')  AS operation,
+		           $16::text        AS reason,
+		           $17::text[]      AS accepted_members,
+		           $18::text        AS new_coordinator_id
 		  ),
 		  locked AS (
 		    -- NOWAIT returns an error immediately if another transaction holds the row lock
 		    -- rather than blocking; callers that see an error should retry.
-		    -- CAS: only proceed if the decision hasn't changed since we read it above.
+		    -- CAS: only proceed if the position we read (decision, or the
+		    -- proposal when skipOutgoingQuorum let us past an undecided one
+		    -- above) hasn't changed since we read it.
 		    SELECT current_rule.shard_id
 		    FROM multigres.current_rule, params
-		    WHERE current_rule.shard_id      = params.shard_id
-		      AND decision_coordinator_term  = params.cas_decision_term
-		      AND decision_leader_subterm    = params.cas_decision_subterm
+		    WHERE current_rule.shard_id = params.shard_id
+		      AND (
+		            (NOT params.cas_on_proposal
+		              AND decision_coordinator_term = params.cas_term
+		              AND decision_leader_subterm   = params.cas_subterm)
+		         OR (params.cas_on_proposal
+		              AND proposal_coordinator_term = params.cas_term
+		              AND proposal_leader_subterm   = params.cas_subterm)
+		          )
 		    FOR UPDATE NOWAIT
 		  ),
 		  updated AS (
@@ -894,8 +911,9 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 		       END::text AS current_lsn
 		FROM updated, inserted`,
 		[]byte("0"),        // shard_id
-		currentTerm,        // cas_decision_term
-		currentSubterm,     // cas_decision_subterm
+		currentTerm,        // cas_term
+		currentSubterm,     // cas_subterm
+		casOnProposal,      // cas_on_proposal
 		update.termNumber,  // new_term
 		nextSubterm,        // new_subterm
 		newLeaderStr,       // new_leader_id (NULLIF: leader absent on sentinel row)

--- a/go/services/multipooler/internal/manager/consensus/rule_store.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store.go
@@ -627,11 +627,11 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 	if err != nil {
 		return nil, err
 	}
-	// TODO: Propagation is not yet supported. Nothing in today's write path
-	// below populates proposal_*, so this can't fire from a normal
-	// UpdateRule sequence — but a proposal can now exist in the DB (e.g.
-	// seeded directly via SQL, simulating a crash), so this guard is
-	// reachable, not dead code.
+	// TODO: Propagation is not yet supported — a coordinator that finds an
+	// existing undecided proposal here (left behind by a previous writer
+	// that crashed between phase 1 and phase 2 below) has no way to safely
+	// finish deciding it or supersede it; it can only fail closed until a
+	// future step teaches this path (or a dedicated recovery path) to do so.
 	if !consensus.IsRuleDecided(current.GetPosition()) {
 		return nil, mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
 			"current rule has an undecided proposal; propagation is not yet supported")
@@ -786,18 +786,11 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 	// already streaming and the ack is nearly immediate. RuleWriteTimeout covers
 	// both cases.
 	//
-	// KNOWN GAP, NOT YET FIXED: this write goes straight to decision_* in one
-	// shot. It should instead be two-phase — write proposal_* (and a
-	// rule_history row with decided=false) first, and only promote that same
-	// row to decision_*/decided=true once we have positive confirmation the
-	// write is durable. Today, if this process crashes or the context expires
-	// between issuing this query and observing its result, the sync-standby
-	// ack (and the WAL write behind it) may already be durable on other
-	// cohort members even though this process never learns that — the rule
-	// is decided in reality but this pooler has no record of it, so a later
-	// coordinator has nothing to discover and recover from. Two-phase closes
-	// that gap by making the attempt itself durable and observable
-	// (Position.Proposal) independent of whether this call ever returns.
+	// Phase 1: write the proposal, not the decision. Writing the proposal first
+	// means a crash or a context timeout between this commit and phase 2 below
+	// leaves a durably observable trace (Position.Proposal, and a decided=false
+	// rule_history row) instead of the change being silently lost or a fresh
+	// coordinator having no record of it to discover and recover from.
 	execCtx, cancel := context.WithTimeout(ctx, timeouts.RuleWriteTimeout)
 	defer cancel()
 
@@ -813,72 +806,74 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 		  params AS (
 		    -- Name all query parameters once so the rest of the CTE references them by name.
 		    SELECT $1::bytea        AS shard_id,
-		           $2::bigint       AS cas_term,
-		           $3::bigint       AS cas_subterm,
+		           $2::bigint       AS cas_decision_term,
+		           $3::bigint       AS cas_decision_subterm,
 		           $4::bigint       AS new_term,
 		           $5::bigint       AS new_subterm,
 		           NULLIF($6, '')   AS new_leader_id,
-		           $7::text         AS new_coordinator_id,
-		           $8::text[]       AS new_cohort,
-		           $9::text         AS dp_name,
-		           $10::text        AS dp_quorum_type,
-		           $11::bigint      AS dp_required_count,
-		           $12::timestamptz AS created_at,
-		           $13::text        AS event_type,
-		           NULLIF($14, '')  AS wal_position,
-		           NULLIF($15, '')  AS operation,
-		           $16::text        AS reason,
-		           $17::text[]      AS accepted_members
+		           $7::text[]       AS new_cohort,
+		           $8::text         AS dp_name,
+		           $9::text         AS dp_quorum_type,
+		           $10::bigint      AS dp_required_count,
+		           $11::timestamptz AS created_at,
+		           $12::text        AS event_type,
+		           NULLIF($13, '')  AS wal_position,
+		           NULLIF($14, '')  AS operation,
+		           $15::text        AS reason,
+		           $16::text[]      AS accepted_members,
+		           $17::text        AS new_coordinator_id
 		  ),
 		  locked AS (
 		    -- NOWAIT returns an error immediately if another transaction holds the row lock
 		    -- rather than blocking; callers that see an error should retry.
-		    -- CAS: only proceed if the rule hasn't changed since we read it above.
+		    -- CAS: only proceed if the decision hasn't changed since we read it above.
 		    SELECT current_rule.shard_id
 		    FROM multigres.current_rule, params
 		    WHERE current_rule.shard_id      = params.shard_id
-		      AND decision_coordinator_term  = params.cas_term
-		      AND decision_leader_subterm    = params.cas_subterm
+		      AND decision_coordinator_term  = params.cas_decision_term
+		      AND decision_leader_subterm    = params.cas_decision_subterm
 		    FOR UPDATE NOWAIT
 		  ),
 		  updated AS (
 		    UPDATE multigres.current_rule
-		    SET decision_coordinator_term          = params.new_term,
-		        decision_leader_subterm            = params.new_subterm,
-		        leader_id                           = params.new_leader_id,
-		        coordinator_id                      = params.new_coordinator_id,
-		        cohort_members                      = params.new_cohort,
-		        durability_policy_name              = params.dp_name,
-		        durability_quorum_type              = params.dp_quorum_type,
-		        durability_required_count           = params.dp_required_count,
-		        created_at                          = params.created_at,
-		        -- A normal (non-propagation) decision write always supersedes any
-		        -- pending proposal: it is, by construction, ahead of it.
-		        proposal_coordinator_term           = NULL,
-		        proposal_leader_subterm             = NULL,
-		        proposal_leader_id                  = NULL,
-		        proposal_cohort_members             = NULL,
-		        proposal_durability_policy_name     = NULL,
-		        proposal_durability_quorum_type     = NULL,
-		        proposal_durability_required_count  = NULL,
-		        proposal_created_at                 = NULL
+		    SET proposal_coordinator_term          = params.new_term,
+		        proposal_leader_subterm            = params.new_subterm,
+		        proposal_leader_id                 = params.new_leader_id,
+		        proposal_cohort_members            = params.new_cohort,
+		        proposal_durability_policy_name    = params.dp_name,
+		        proposal_durability_quorum_type    = params.dp_quorum_type,
+		        proposal_durability_required_count = params.dp_required_count,
+		        proposal_created_at                = params.created_at
 		    FROM locked, params
 		    WHERE current_rule.shard_id = params.shard_id
-		    RETURNING decision_coordinator_term, decision_leader_subterm, leader_id, coordinator_id, cohort_members,
-		              durability_policy_name, durability_quorum_type, durability_required_count,
-		              params.created_at
+		    -- The decision_*/leader_id/coordinator_id/etc. columns below are
+		    -- unchanged by this UPDATE (only proposal_* is SET above) — returned
+		    -- anyway so the caller can build the full resulting PoolerPosition
+		    -- (decision + proposal + a fresh current_lsn) from one round trip,
+		    -- rather than reusing a pre-write LSN that's already stale by the
+		    -- time this write commits.
+		    RETURNING decision_coordinator_term, decision_leader_subterm, leader_id, coordinator_id,
+		              cohort_members, durability_policy_name, durability_quorum_type,
+		              durability_required_count, current_rule.created_at,
+		              proposal_coordinator_term, proposal_leader_subterm, proposal_leader_id,
+		              proposal_cohort_members, proposal_durability_policy_name,
+		              proposal_durability_quorum_type, proposal_durability_required_count,
+		              proposal_created_at
 		  ),
 		  inserted AS (
+		    -- decided starts false: this proposal isn't the decision yet. Phase 2
+		    -- (markProposalAsDecision) UPDATEs this exact row to decided=true rather
+		    -- than inserting a second one — one row per rule number, always.
 		    INSERT INTO multigres.rule_history
 		      (coordinator_term, leader_subterm, event_type, leader_id, coordinator_id,
 		       wal_position, operation, reason, cohort_members, accepted_members,
-		       durability_policy_name, durability_quorum_type, durability_required_count, decided, created_at)
-		    SELECT updated.decision_coordinator_term, updated.decision_leader_subterm,
-		           params.event_type, updated.leader_id, updated.coordinator_id,
-		           params.wal_position, params.operation, params.reason,
-		           updated.cohort_members, params.accepted_members,
-		           updated.durability_policy_name, updated.durability_quorum_type,
-		           updated.durability_required_count, true, params.created_at
+		       durability_policy_name, durability_quorum_type, durability_required_count,
+		       decided, created_at)
+		    SELECT params.new_term, params.new_subterm, params.event_type, params.new_leader_id,
+		           params.new_coordinator_id, params.wal_position, params.operation, params.reason,
+		           params.new_cohort, params.accepted_members,
+		           params.dp_name, params.dp_quorum_type, params.dp_required_count,
+		           false, params.created_at
 		    FROM updated, params
 		    RETURNING coordinator_term
 		  )
@@ -887,8 +882,11 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 		SELECT updated.decision_coordinator_term, updated.decision_leader_subterm,
 		       updated.leader_id, updated.coordinator_id, updated.cohort_members,
 		       updated.durability_policy_name, updated.durability_quorum_type,
-		       updated.durability_required_count,
-		       updated.created_at,
+		       updated.durability_required_count, updated.created_at,
+		       updated.proposal_coordinator_term, updated.proposal_leader_subterm,
+		       updated.proposal_leader_id, updated.proposal_cohort_members,
+		       updated.proposal_durability_policy_name, updated.proposal_durability_quorum_type,
+		       updated.proposal_durability_required_count, updated.proposal_created_at,
 		       CASE
 		         WHEN pg_is_in_recovery()
 		           THEN COALESCE(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn(), '0/0'::pg_lsn)
@@ -896,12 +894,11 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 		       END::text AS current_lsn
 		FROM updated, inserted`,
 		[]byte("0"),        // shard_id
-		currentTerm,        // cas_term
-		currentSubterm,     // cas_subterm
+		currentTerm,        // cas_decision_term
+		currentSubterm,     // cas_decision_subterm
 		update.termNumber,  // new_term
 		nextSubterm,        // new_subterm
 		newLeaderStr,       // new_leader_id (NULLIF: leader absent on sentinel row)
-		coordinatorIDStr,   // new_coordinator_id
 		newCohortParam,     // new_cohort
 		dpName,             // dp_name
 		dpQuorumType,       // dp_quorum_type
@@ -912,13 +909,172 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 		update.operation,   // operation    (NULLIF: optional)
 		update.reason,      // reason
 		acceptedParam,      // accepted_members
+		coordinatorIDStr,   // new_coordinator_id
 	)
 	if err != nil {
-		return nil, mterrors.Wrap(err, "failed to write rule history record")
+		return nil, mterrors.Wrap(err, "failed to write rule proposal")
 	}
 
 	// Zero rows means either the CAS check failed (concurrent write between our read
 	// and write) or the shard row is missing (should never happen after initialisation).
+	if len(result.Rows) == 0 {
+		return nil, errRuleConflict
+	}
+
+	var proposalWriteDecision, proposalWriteProposal unvalidatedRuleRow
+	var proposalWriteCoordinatorIDStr, proposalWriteLSN string
+	if err := executor.ScanSingleRow(result,
+		&proposalWriteDecision.coordinatorTerm,
+		&proposalWriteDecision.leaderSubterm,
+		&proposalWriteDecision.leaderIDStr,
+		&proposalWriteCoordinatorIDStr,
+		&proposalWriteDecision.cohortNames,
+		&proposalWriteDecision.durabilityPolicyName,
+		&proposalWriteDecision.durabilityQuorumType,
+		&proposalWriteDecision.durabilityRequiredCount,
+		&proposalWriteDecision.createdAt,
+		&proposalWriteProposal.coordinatorTerm,
+		&proposalWriteProposal.leaderSubterm,
+		&proposalWriteProposal.leaderIDStr,
+		&proposalWriteProposal.cohortNames,
+		&proposalWriteProposal.durabilityPolicyName,
+		&proposalWriteProposal.durabilityQuorumType,
+		&proposalWriteProposal.durabilityRequiredCount,
+		&proposalWriteProposal.createdAt,
+		&proposalWriteLSN,
+	); err != nil {
+		return nil, mterrors.Wrap(err, "failed to scan written rule proposal")
+	}
+
+	// Cache the proposal immediately: it's now durable (phase 1 blocked on the
+	// sync-standby ack), so a reader must be able to observe it even if this
+	// process dies before phase 2 below runs.
+	if proposalPos, err := buildPoolerPosition(
+		proposalWriteDecision, proposalWriteCoordinatorIDStr, proposalWriteProposal, proposalWriteLSN,
+	); err != nil {
+		return nil, mterrors.Wrap(err, "failed to parse proposal row into memory")
+	} else {
+		rs.cacheRuleObservation(proposalPos)
+	}
+
+	// Phase 2: promote the just-written proposal to decision.
+	pos, err := rs.markProposalAsDecision(ctx, update.termNumber, nextSubterm, coordinatorIDStr, update.createdAt)
+	if err != nil {
+		return nil, err
+	}
+
+	rs.cacheRuleObservation(pos)
+
+	// Apply the incoming (new) GUC after the write commits.
+	if err := rs.syncStandby.SetPolicy(lockedCtx, transition.Incoming); err != nil {
+		return nil, fmt.Errorf("post-write GUC: %w", err)
+	}
+
+	return pos, nil
+}
+
+// markProposalAsDecision promotes the current_rule row's proposal_* columns to
+// decision_*, clears proposal_*, and flips the matching rule_history row (keyed
+// by expectedTerm/expectedSubterm) from decided=false to decided=true. It is
+// phase 2 of every rule write: UpdateRule calls it immediately after writing
+// the matching proposal in phase 1. A future finalization path (recovering a
+// quorum-verified proposal left behind by a dead leader) would call it too,
+// with its own coordinatorID/createdAt describing who is deciding and when —
+// which may differ from whoever originally proposed.
+//
+// The CAS key is the proposal itself (expectedTerm/expectedSubterm), not the
+// prior decision: by the time this is called the proposal is the source of
+// truth for what's being decided, and matching it also guards against a
+// concurrent writer having raced in since the proposal was written.
+func (rs *ruleStore) markProposalAsDecision(
+	ctx context.Context,
+	expectedTerm, expectedSubterm int64,
+	coordinatorIDStr string,
+	createdAt time.Time,
+) (*clustermetadatapb.PoolerPosition, error) {
+	execCtx, cancel := context.WithTimeout(ctx, timeouts.RuleWriteTimeout)
+	defer cancel()
+
+	result, err := rs.queryService.QueryArgs(execCtx, `
+		WITH
+		  params AS (
+		    SELECT $1::bytea       AS shard_id,
+		           $2::bigint      AS expected_term,
+		           $3::bigint      AS expected_subterm,
+		           $4::text        AS new_coordinator_id,
+		           $5::timestamptz AS created_at
+		  ),
+		  locked AS (
+		    -- NOWAIT returns an error immediately if another transaction holds the row lock
+		    -- rather than blocking; callers that see an error should retry.
+		    -- CAS: only proceed if the pending proposal is exactly the one we expect.
+		    SELECT current_rule.shard_id
+		    FROM multigres.current_rule, params
+		    WHERE current_rule.shard_id     = params.shard_id
+		      AND proposal_coordinator_term = params.expected_term
+		      AND proposal_leader_subterm   = params.expected_subterm
+		    FOR UPDATE NOWAIT
+		  ),
+		  updated AS (
+		    UPDATE multigres.current_rule
+		    SET decision_coordinator_term        = proposal_coordinator_term,
+		        decision_leader_subterm          = proposal_leader_subterm,
+		        leader_id                        = proposal_leader_id,
+		        coordinator_id                   = params.new_coordinator_id,
+		        cohort_members                   = proposal_cohort_members,
+		        durability_policy_name           = proposal_durability_policy_name,
+		        durability_quorum_type           = proposal_durability_quorum_type,
+		        durability_required_count        = proposal_durability_required_count,
+		        created_at                       = params.created_at,
+		        proposal_coordinator_term          = NULL,
+		        proposal_leader_subterm            = NULL,
+		        proposal_leader_id                 = NULL,
+		        proposal_cohort_members            = NULL,
+		        proposal_durability_policy_name    = NULL,
+		        proposal_durability_quorum_type    = NULL,
+		        proposal_durability_required_count = NULL,
+		        proposal_created_at                = NULL
+		    FROM locked, params
+		    WHERE current_rule.shard_id = params.shard_id
+		    RETURNING decision_coordinator_term, decision_leader_subterm, leader_id, coordinator_id, cohort_members,
+		              durability_policy_name, durability_quorum_type, durability_required_count,
+		              params.created_at
+		  ),
+		  history_updated AS (
+		    UPDATE multigres.rule_history
+		    SET decided = true
+		    FROM params
+		    WHERE rule_history.coordinator_term = params.expected_term
+		      AND rule_history.leader_subterm   = params.expected_subterm
+		    RETURNING coordinator_term
+		  )
+		-- Cross-joining history_updated ensures a missing history row (a bug) also
+		-- returns zero rows here, causing the caller to surface an error rather than
+		-- silently succeeding.
+		SELECT updated.decision_coordinator_term, updated.decision_leader_subterm,
+		       updated.leader_id, updated.coordinator_id, updated.cohort_members,
+		       updated.durability_policy_name, updated.durability_quorum_type,
+		       updated.durability_required_count,
+		       updated.created_at,
+		       CASE
+		         WHEN pg_is_in_recovery()
+		           THEN COALESCE(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn(), '0/0'::pg_lsn)
+		         ELSE pg_current_wal_lsn()
+		       END::text AS current_lsn
+		FROM updated, history_updated`,
+		[]byte("0"), // shard_id
+		expectedTerm,
+		expectedSubterm,
+		coordinatorIDStr,
+		createdAt,
+	)
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to promote rule proposal to decision")
+	}
+
+	// Zero rows means either the CAS check failed (the expected proposal is no
+	// longer there — a concurrent writer raced in) or the shard row is missing
+	// (should never happen after initialisation).
 	if len(result.Rows) == 0 {
 		return nil, errRuleConflict
 	}
@@ -941,18 +1097,11 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 		return nil, mterrors.Wrap(err, "failed to scan written rule position")
 	}
 
-	// A normal decision write always clears any pending proposal.
+	// Marking a decision always clears the proposal it came from.
 	pos, err := buildPoolerPosition(decision, coordinatorIDStrResult, unvalidatedRuleRow{}, lsn)
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to parse written rule position")
 	}
-
-	// Apply the incoming (new) GUC after the write commits.
-	if err := rs.syncStandby.SetPolicy(lockedCtx, transition.Incoming); err != nil {
-		return nil, fmt.Errorf("post-write GUC: %w", err)
-	}
-
-	rs.cacheRuleObservation(pos)
 	return pos, nil
 }
 

--- a/go/services/multipooler/internal/manager/consensus/rule_store_pg_test.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store_pg_test.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -491,6 +492,122 @@ func TestRuleStorePG_ObservePosition_SurfacesStuckProposal(t *testing.T) {
 	require.NotNil(t, proposal.GetCreationTime())
 	assert.WithinDuration(t, proposalCreatedAt, proposal.GetCreationTime().AsTime(), time.Second,
 		"a proposal's own creation_time is observable independent of the decision it's transitioning from")
+}
+
+// seedStuckProposal writes a proposal directly via raw SQL, bypassing
+// UpdateRule entirely — there is no write path that leaves one behind on
+// demand, so this simulates a coordinator that crashed between UpdateRule's
+// two write phases (see rule_store.go). Returns the seeded rule number.
+func seedStuckProposal(ctx context.Context, t *testing.T, conn *client.Conn, term int64, leaderID *clustermetadatapb.ID, cohort []*clustermetadatapb.ID, policy *clustermetadatapb.DurabilityPolicy) *clustermetadatapb.RuleNumber {
+	t.Helper()
+	cohortNames := make([]string, len(cohort))
+	for i, id := range cohort {
+		cohortNames[i] = id.GetCell() + "_" + id.GetName()
+	}
+	_, err := conn.Query(ctx, fmt.Sprintf(`
+		UPDATE multigres.current_rule
+		SET proposal_coordinator_term = %d,
+		    proposal_leader_subterm = 0,
+		    proposal_leader_id = '%s_%s',
+		    proposal_cohort_members = '{%s}',
+		    proposal_durability_policy_name = '%s',
+		    proposal_durability_quorum_type = '%s',
+		    proposal_durability_required_count = %d,
+		    proposal_created_at = now()
+		WHERE shard_id = '0'::bytea`,
+		term,
+		leaderID.GetCell(), leaderID.GetName(),
+		strings.Join(cohortNames, ","),
+		policy.GetPolicyName(),
+		policy.GetQuorumType().String(),
+		policy.GetRequiredCount()))
+	require.NoError(t, err)
+	return &clustermetadatapb.RuleNumber{CoordinatorTerm: term, LeaderSubterm: 0}
+}
+
+// TestRuleStorePG_UpdateRule_RejectsWhenProposalStuck verifies that an
+// ordinary (non-skipOutgoingQuorum) write refuses to proceed while a stuck
+// proposal is present: it has no independent safety backing (no cert, no
+// verified quorum) to know whether overwriting it would discard durable work.
+func TestRuleStorePG_UpdateRule_RejectsWhenProposalStuck(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := withTestActionLock(t)
+	resetRuleStoreTables(ctx, t)
+
+	rs, conn := newTestRuleStore(ctx, t)
+	defer conn.Close()
+
+	coordinatorID := testPoolerID(t, "zone1", "coordinator-1")
+	leaderID := testPoolerID(t, "zone1", "leader-1")
+	cohort := []*clustermetadatapb.ID{
+		testPoolerID(t, "zone1", "member-1"),
+		testPoolerID(t, "zone1", "member-2"),
+	}
+	_, err := rs.UpdateRule(ctx,
+		NewRuleUpdate(3, coordinatorID, "promotion", "bootstrap", time.Now()).
+			WithLeader(leaderID).
+			WithCohort(cohort),
+	)
+	require.NoError(t, err)
+
+	seedStuckProposal(ctx, t, conn, 4, leaderID, cohort, testBootstrapPolicy())
+
+	_, err = rs.UpdateRule(ctx, NewRuleUpdate(3, coordinatorID, "config_change", "test", time.Now()))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "undecided proposal")
+	assert.Contains(t, err.Error(), "propagation is not yet supported")
+
+	// The rejected write must not have partially applied — decision and
+	// proposal are exactly as seeded.
+	pos, err := rs.ObservePosition(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), pos.GetPosition().GetDecision().GetRuleNumber().GetCoordinatorTerm())
+	require.NotNil(t, pos.GetPosition().GetProposal())
+	assert.Equal(t, int64(4), pos.GetPosition().GetProposal().GetRuleNumber().GetCoordinatorTerm())
+}
+
+// TestRuleStorePG_UpdateRule_SkipOutgoingQuorumSupersedesStuckProposal
+// verifies that skipOutgoingQuorum — the caller having already established
+// safety via an externally-certified cert — lets a write proceed even though
+// the current row carries a stuck proposal, CASing against that proposal
+// (not the stale decision) since that's the position actually being
+// superseded.
+func TestRuleStorePG_UpdateRule_SkipOutgoingQuorumSupersedesStuckProposal(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := withTestActionLock(t)
+	resetRuleStoreTables(ctx, t)
+
+	rs, conn := newTestRuleStore(ctx, t)
+	defer conn.Close()
+
+	coordinatorID := testPoolerID(t, "zone1", "coordinator-1")
+	leaderID := testPoolerID(t, "zone1", "leader-1")
+	cohort := []*clustermetadatapb.ID{
+		testPoolerID(t, "zone1", "member-1"),
+		testPoolerID(t, "zone1", "member-2"),
+	}
+	_, err := rs.UpdateRule(ctx,
+		NewRuleUpdate(3, coordinatorID, "promotion", "bootstrap", time.Now()).
+			WithLeader(leaderID).
+			WithCohort(cohort),
+	)
+	require.NoError(t, err)
+
+	stuckRuleNumber := seedStuckProposal(ctx, t, conn, 4, leaderID, cohort, testBootstrapPolicy())
+
+	newLeaderID := testPoolerID(t, "zone1", "leader-2")
+	pos, err := rs.UpdateRule(ctx,
+		NewRuleUpdate(5, coordinatorID, "promotion", "recover stuck proposal", time.Now()).
+			WithLeader(newLeaderID).
+			WithCohort(cohort).
+			WithPreviousRule(stuckRuleNumber.CoordinatorTerm, stuckRuleNumber.LeaderSubterm).
+			WithSkipOutgoingQuorum().
+			WithPromotionHook(func(context.Context) error { return nil }),
+	)
+	require.NoError(t, err, "skipOutgoingQuorum should supersede the stuck proposal")
+	assert.Equal(t, int64(5), pos.GetPosition().GetDecision().GetRuleNumber().GetCoordinatorTerm())
+	assert.Equal(t, "leader-2", pos.GetPosition().GetDecision().GetLeaderId().GetName())
+	assert.Nil(t, pos.GetPosition().GetProposal(), "the fresh write is fully decided, not stuck")
 }
 
 func TestRuleStorePG_UpdateRule_FirstWrite(t *testing.T) {

--- a/go/services/multipooler/internal/manager/consensus/rule_store_pg_test.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store_pg_test.go
@@ -1352,6 +1352,14 @@ func TestRuleStorePG_UpdateRule_PostWriteGUCFails(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "post-write GUC")
 	assert.Contains(t, err.Error(), "post-write alter failed")
+
+	// Both writes (phase 1's proposal, phase 2's decision) already committed to
+	// postgres before the post-write GUC apply ran — the cache must reflect that
+	// even though UpdateRule itself returns an error.
+	cached := rs.CachedPosition()
+	require.NotNil(t, cached, "the decided write must be cached despite the later GUC failure")
+	assert.Equal(t, int64(1), cached.GetPosition().GetDecision().GetRuleNumber().GetCoordinatorTerm())
+	assert.Nil(t, cached.GetPosition().GetProposal(), "phase 2 clears the proposal it decided")
 }
 
 func TestRuleStorePG_UpdateRule_InvalidLeaderID(t *testing.T) {

--- a/go/services/multipooler/internal/manager/consensus/rule_store_pg_test.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store_pg_test.go
@@ -416,6 +416,83 @@ func TestRuleStorePG_ObservePosition_InitialPolicyCarriedThroughUpdate(t *testin
 	assert.Equal(t, testBootstrapPolicy().RequiredCount, dp.RequiredCount)
 }
 
+// TestRuleStorePG_ObservePosition_SurfacesStuckProposal seeds a proposal
+// directly via raw SQL against current_rule, bypassing UpdateRule entirely —
+// there is no write path that produces one yet (see the two-phase-write gap
+// noted in UpdateRule). This is the concrete verification that the schema
+// migration actually closes the observability gap: once a proposal exists in
+// the DB, however it got there, ObservePosition must surface it.
+func TestRuleStorePG_ObservePosition_SurfacesStuckProposal(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := withTestActionLock(t)
+	resetRuleStoreTables(ctx, t)
+
+	rs, conn := newTestRuleStore(ctx, t)
+	defer conn.Close()
+
+	coordinatorID := testPoolerID(t, "zone1", "coordinator-1")
+	leaderID := testPoolerID(t, "zone1", "leader-1")
+	cohort := []*clustermetadatapb.ID{
+		testPoolerID(t, "zone1", "member-1"),
+		testPoolerID(t, "zone1", "member-2"),
+	}
+	now := time.Now()
+
+	_, err := rs.UpdateRule(ctx,
+		NewRuleUpdate(3, coordinatorID, "promotion", "bootstrap", now).
+			WithLeader(leaderID).
+			WithCohort(cohort),
+	)
+	require.NoError(t, err)
+
+	// Seed a pending proposal directly, simulating a crash between a WAL
+	// write reaching quorum and the coordinator marking it decided.
+	proposalCreatedAt := now.Add(time.Minute)
+	_, err = conn.Query(ctx, fmt.Sprintf(`
+		UPDATE multigres.current_rule
+		SET proposal_coordinator_term = 4,
+		    proposal_leader_subterm = 0,
+		    proposal_leader_id = '%s',
+		    proposal_cohort_members = '{%s}',
+		    proposal_durability_policy_name = '%s',
+		    proposal_durability_quorum_type = '%s',
+		    proposal_durability_required_count = %d,
+		    proposal_created_at = '%s'
+		WHERE shard_id = '0'::bytea`,
+		"zone1_leader-2",
+		"zone1_member-1,zone1_member-2",
+		testBootstrapPolicy().PolicyName,
+		testBootstrapPolicy().QuorumType.String(),
+		testBootstrapPolicy().RequiredCount,
+		proposalCreatedAt.UTC().Format("2006-01-02 15:04:05.999999-07")))
+	require.NoError(t, err)
+
+	pos, err := rs.ObservePosition(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, pos)
+
+	// The decision is unchanged.
+	assert.Equal(t, int64(3), pos.GetPosition().GetDecision().GetRuleNumber().GetCoordinatorTerm())
+	assert.Equal(t, "leader-1", pos.GetPosition().GetDecision().GetLeaderId().GetName())
+
+	// The stuck proposal is now observable.
+	proposal := pos.GetPosition().GetProposal()
+	require.NotNil(t, proposal, "a seeded proposal must be surfaced")
+	assert.Equal(t, int64(4), proposal.GetRuleNumber().GetCoordinatorTerm())
+	assert.Equal(t, int64(0), proposal.GetRuleNumber().GetLeaderSubterm())
+	require.NotNil(t, proposal.GetLeaderId())
+	assert.Equal(t, "leader-2", proposal.GetLeaderId().GetName(), "proposal names its own candidate leader")
+	require.Len(t, proposal.GetCohortMembers(), 2)
+	assert.Equal(t, "member-1", proposal.GetCohortMembers()[0].GetName())
+	assert.Equal(t, "member-2", proposal.GetCohortMembers()[1].GetName())
+	assert.Equal(t, testBootstrapPolicy().PolicyName, proposal.GetDurabilityPolicy().GetPolicyName())
+	assert.Equal(t, testBootstrapPolicy().QuorumType, proposal.GetDurabilityPolicy().GetQuorumType())
+	assert.Equal(t, testBootstrapPolicy().RequiredCount, proposal.GetDurabilityPolicy().GetRequiredCount())
+	require.NotNil(t, proposal.GetCreationTime())
+	assert.WithinDuration(t, proposalCreatedAt, proposal.GetCreationTime().AsTime(), time.Second,
+		"a proposal's own creation_time is observable independent of the decision it's transitioning from")
+}
+
 func TestRuleStorePG_UpdateRule_FirstWrite(t *testing.T) {
 	skipIfNoPG(t)
 	ctx := withTestActionLock(t)

--- a/go/services/multipooler/internal/manager/consensus/rule_store_pg_test.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store_pg_test.go
@@ -1479,6 +1479,38 @@ func TestRuleStorePG_UpdateRule_PostWriteGUCFails(t *testing.T) {
 	assert.Nil(t, cached.GetPosition().GetProposal(), "phase 2 clears the proposal it decided")
 }
 
+// TestRuleStorePG_UpdateRule_RejectsLeaderChangeOutsidePromotion verifies
+// that a non-promotion write can't replace an existing leader: only a
+// promotion (which fences the outgoing leader via revocation first) can
+// safely hand off leadership.
+func TestRuleStorePG_UpdateRule_RejectsLeaderChangeOutsidePromotion(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := withTestActionLock(t)
+	resetRuleStoreTables(ctx, t)
+
+	rs, conn := newTestRuleStore(ctx, t)
+	defer conn.Close()
+
+	coordinatorID := testPoolerID(t, "zone1", "coordinator-1")
+	leaderID := testPoolerID(t, "zone1", "leader-1")
+	_, err := rs.UpdateRule(ctx,
+		NewRuleUpdate(1, coordinatorID, "promotion", "bootstrap", time.Now()).WithLeader(leaderID),
+	)
+	require.NoError(t, err)
+
+	otherLeaderID := testPoolerID(t, "zone1", "leader-2")
+	_, err = rs.UpdateRule(ctx,
+		NewRuleUpdate(1, coordinatorID, "config_change", "test", time.Now()).WithLeader(otherLeaderID),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "UpdateRule cannot change leader outside of a promotion")
+
+	// The decision must be untouched.
+	pos, err := rs.ObservePosition(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "leader-1", pos.GetPosition().GetDecision().GetLeaderId().GetName())
+}
+
 func TestRuleStorePG_UpdateRule_InvalidLeaderID(t *testing.T) {
 	skipIfNoPG(t)
 	ctx := withTestActionLock(t)

--- a/go/services/multipooler/internal/manager/consensus/rule_store_test.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store_test.go
@@ -78,18 +78,18 @@ func TestQueryRuleHistory(t *testing.T) {
 					"coordinator_term", "leader_subterm", "event_type", "leader_id", "coordinator_id",
 					"wal_position", "operation", "reason", "cohort_members", "accepted_members",
 					"durability_policy_name", "durability_quorum_type", "durability_required_count",
-					"created_at",
+					"decided", "created_at",
 				},
 				[][]any{
 					{
 						int64(2), int64(1), "promotion", leaderAppName, coordID, walPos, operation,
 						"manual failover", "{zone1_pooler-2,zone1_pooler-3}", "{zone1_pooler-2}",
-						nil, nil, nil, createdAt,
+						nil, nil, nil, true, createdAt,
 					},
 					{
 						int64(1), int64(0), "replication_config", leaderAppName, coordID, nil, nil,
 						"initial bootstrap", "{zone1_pooler-1,zone1_pooler-2}", nil,
-						nil, nil, nil, createdAt,
+						nil, nil, nil, true, createdAt,
 					},
 				},
 			),
@@ -136,7 +136,7 @@ func TestQueryRuleHistory(t *testing.T) {
 					"coordinator_term", "leader_subterm", "event_type", "leader_id", "coordinator_id",
 					"wal_position", "operation", "reason", "cohort_members", "accepted_members",
 					"durability_policy_name", "durability_quorum_type", "durability_required_count",
-					"created_at",
+					"decided", "created_at",
 				},
 				[][]any{},
 			),
@@ -384,27 +384,41 @@ func TestScanRuleHistoryRow_AcceptedInvalid(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to parse accepted_members")
 }
 
+// mkDecisionRow builds an unvalidatedRuleRow with all core columns set, as a
+// real decision row always has.
+func mkDecisionRow(coordinatorTerm, leaderSubterm int64, leaderIDStr *string, cohortNames []string, durabilityPolicyName, durabilityQuorumType string, durabilityRequiredCount int64) unvalidatedRuleRow {
+	return unvalidatedRuleRow{
+		coordinatorTerm:         &coordinatorTerm,
+		leaderSubterm:           &leaderSubterm,
+		leaderIDStr:             leaderIDStr,
+		cohortNames:             cohortNames,
+		durabilityPolicyName:    &durabilityPolicyName,
+		durabilityQuorumType:    &durabilityQuorumType,
+		durabilityRequiredCount: &durabilityRequiredCount,
+	}
+}
+
 func TestBuildPoolerPosition_LeaderInvalid(t *testing.T) {
 	bad := "noseparator"
-	_, err := buildPoolerPosition(1, 0, &bad, "", nil, "AT_LEAST_2", "QUORUM_TYPE_AT_LEAST_N", 2, time.Time{}, "0/0")
+	_, err := buildPoolerPosition(mkDecisionRow(1, 0, &bad, nil, "AT_LEAST_2", "QUORUM_TYPE_AT_LEAST_N", 2), "", unvalidatedRuleRow{}, "0/0")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse leader_id")
 }
 
 func TestBuildPoolerPosition_CoordinatorInvalid(t *testing.T) {
-	_, err := buildPoolerPosition(1, 0, nil, "noseparator", nil, "AT_LEAST_2", "QUORUM_TYPE_AT_LEAST_N", 2, time.Time{}, "0/0")
+	_, err := buildPoolerPosition(mkDecisionRow(1, 0, nil, nil, "AT_LEAST_2", "QUORUM_TYPE_AT_LEAST_N", 2), "noseparator", unvalidatedRuleRow{}, "0/0")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse coordinator_id")
 }
 
 func TestBuildPoolerPosition_CohortInvalid(t *testing.T) {
-	_, err := buildPoolerPosition(1, 0, nil, "", []string{"noseparator"}, "AT_LEAST_2", "QUORUM_TYPE_AT_LEAST_N", 2, time.Time{}, "0/0")
+	_, err := buildPoolerPosition(mkDecisionRow(1, 0, nil, []string{"noseparator"}, "AT_LEAST_2", "QUORUM_TYPE_AT_LEAST_N", 2), "", unvalidatedRuleRow{}, "0/0")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse cohort_members")
 }
 
 func TestBuildPoolerPosition_UnknownQuorumType(t *testing.T) {
-	_, err := buildPoolerPosition(1, 0, nil, "", nil, "AT_LEAST_2", "QUORUM_TYPE_BOGUS", 2, time.Time{}, "0/0")
+	_, err := buildPoolerPosition(mkDecisionRow(1, 0, nil, nil, "AT_LEAST_2", "QUORUM_TYPE_BOGUS", 2), "", unvalidatedRuleRow{}, "0/0")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown quorum_type")
 }

--- a/go/services/multipooler/internal/manager/consensus/rule_store_test.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	commonconsensus "github.com/multigres/multigres/go/common/consensus"
+	"github.com/multigres/multigres/go/common/sqltypes"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor/mock"
 
@@ -452,4 +453,137 @@ func TestUpdateRule_RequiresCreatedAt(t *testing.T) {
 	_, err := rs.UpdateRule(withTestActionLock(t), update)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "UpdateRule requires a non-zero created_at")
+}
+
+// mockDecidedReadResult returns a mock result matching readCurrentRule's
+// column list: a decided rule at term 1, subterm 0, with a leader, a
+// two-member cohort, and an AT_LEAST_2 policy, and no pending proposal.
+// Used to get UpdateRule past its initial read so tests can target a
+// specific failure in the write path that follows.
+func mockDecidedReadResult() *sqltypes.Result {
+	return mock.MakeQueryResult(
+		[]string{
+			"decision_coordinator_term", "decision_leader_subterm", "leader_id", "coordinator_id", "cohort_members",
+			"durability_policy_name", "durability_quorum_type", "durability_required_count", "created_at",
+			"proposal_coordinator_term", "proposal_leader_subterm", "proposal_leader_id", "proposal_cohort_members",
+			"proposal_durability_policy_name", "proposal_durability_quorum_type", "proposal_durability_required_count",
+			"proposal_created_at", "current_lsn",
+		},
+		[][]any{
+			{
+				int64(1), int64(0), "zone1_leader-1", "zone1_coordinator-1", "{zone1_member-1,zone1_member-2}",
+				"AT_LEAST_2", "QUORUM_TYPE_AT_LEAST_N", int64(2), "2026-01-01 00:00:00+00",
+				nil, nil, nil, nil, nil, nil, nil, nil,
+				"0/100",
+			},
+		},
+	)
+}
+
+// readPattern matches readCurrentRule's SELECT; casOnProposalPattern and
+// expectedTermPattern match phase 1's and phase 2's queries respectively —
+// each names a params column unique to that query, so tests can target one
+// write phase without accidentally matching another.
+const (
+	readPattern          = "SELECT decision_coordinator_term, decision_leader_subterm, leader_id, coordinator_id, cohort_members"
+	casOnProposalPattern = "cas_on_proposal"
+	expectedTermPattern  = "AS expected_term"
+)
+
+func TestUpdateRule_Phase1WriteErrorPropagated(t *testing.T) {
+	mockQueryService := mock.NewQueryService()
+	rs := newMockRuleStore(mockQueryService)
+
+	mockQueryService.AddQueryPatternOnce(readPattern, mockDecidedReadResult())
+	mockQueryService.AddQueryPatternOnceWithError(casOnProposalPattern, errors.New("connection reset"))
+
+	coordinatorID := &clustermetadatapb.ID{Cell: "zone1", Name: "coordinator-1"}
+	_, err := rs.UpdateRule(withTestActionLock(t), NewRuleUpdate(1, coordinatorID, "config_change", "test", time.Now()))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write rule proposal")
+	assert.Contains(t, err.Error(), "connection reset")
+	assert.NoError(t, mockQueryService.ExpectationsWereMet())
+}
+
+func TestUpdateRule_Phase1ScanErrorPropagated(t *testing.T) {
+	mockQueryService := mock.NewQueryService()
+	rs := newMockRuleStore(mockQueryService)
+
+	mockQueryService.AddQueryPatternOnce(readPattern, mockDecidedReadResult())
+	// Phase 1's query succeeds but returns far fewer columns than UpdateRule
+	// scans for — a malformed response, not a query error.
+	mockQueryService.AddQueryPatternOnce(casOnProposalPattern,
+		mock.MakeQueryResult([]string{"decision_coordinator_term"}, [][]any{{int64(1)}}))
+
+	coordinatorID := &clustermetadatapb.ID{Cell: "zone1", Name: "coordinator-1"}
+	_, err := rs.UpdateRule(withTestActionLock(t), NewRuleUpdate(1, coordinatorID, "config_change", "test", time.Now()))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to scan written rule proposal")
+	assert.NoError(t, mockQueryService.ExpectationsWereMet())
+}
+
+func TestUpdateRule_Phase1ParseErrorPropagated(t *testing.T) {
+	mockQueryService := mock.NewQueryService()
+	rs := newMockRuleStore(mockQueryService)
+
+	mockQueryService.AddQueryPatternOnce(readPattern, mockDecidedReadResult())
+	// Phase 1's query succeeds and scans cleanly, but the decision it
+	// returns carries a durability_quorum_type buildShardRule can't parse —
+	// malformed content, not a malformed row shape.
+	mockQueryService.AddQueryPatternOnce(casOnProposalPattern, mock.MakeQueryResult(
+		[]string{
+			"decision_coordinator_term", "decision_leader_subterm", "leader_id", "coordinator_id", "cohort_members",
+			"durability_policy_name", "durability_quorum_type", "durability_required_count", "created_at",
+			"proposal_coordinator_term", "proposal_leader_subterm", "proposal_leader_id", "proposal_cohort_members",
+			"proposal_durability_policy_name", "proposal_durability_quorum_type", "proposal_durability_required_count",
+			"proposal_created_at", "current_lsn",
+		},
+		[][]any{
+			{
+				int64(1), int64(1), "zone1_leader-1", "zone1_coordinator-1", "{zone1_member-1,zone1_member-2}",
+				"AT_LEAST_2", "QUORUM_TYPE_BOGUS", int64(2), "2026-01-01 00:00:00+00",
+				nil, nil, nil, nil, nil, nil, nil, nil,
+				"0/100",
+			},
+		},
+	))
+
+	coordinatorID := &clustermetadatapb.ID{Cell: "zone1", Name: "coordinator-1"}
+	_, err := rs.UpdateRule(withTestActionLock(t), NewRuleUpdate(1, coordinatorID, "config_change", "test", time.Now()))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse proposal row into memory")
+	assert.NoError(t, mockQueryService.ExpectationsWereMet())
+}
+
+func TestUpdateRule_Phase2ErrorPropagated(t *testing.T) {
+	mockQueryService := mock.NewQueryService()
+	rs := newMockRuleStore(mockQueryService)
+
+	mockQueryService.AddQueryPatternOnce(readPattern, mockDecidedReadResult())
+	mockQueryService.AddQueryPatternOnce(casOnProposalPattern, mock.MakeQueryResult(
+		[]string{
+			"decision_coordinator_term", "decision_leader_subterm", "leader_id", "coordinator_id", "cohort_members",
+			"durability_policy_name", "durability_quorum_type", "durability_required_count", "created_at",
+			"proposal_coordinator_term", "proposal_leader_subterm", "proposal_leader_id", "proposal_cohort_members",
+			"proposal_durability_policy_name", "proposal_durability_quorum_type", "proposal_durability_required_count",
+			"proposal_created_at", "current_lsn",
+		},
+		[][]any{
+			{
+				int64(1), int64(0), "zone1_leader-1", "zone1_coordinator-1", "{zone1_member-1,zone1_member-2}",
+				"AT_LEAST_2", "QUORUM_TYPE_AT_LEAST_N", int64(2), "2026-01-01 00:00:00+00",
+				int64(1), int64(1), "zone1_leader-1", "{zone1_member-1,zone1_member-2}",
+				"AT_LEAST_2", "QUORUM_TYPE_AT_LEAST_N", int64(2), "2026-01-01 00:01:00+00",
+				"0/100",
+			},
+		},
+	))
+	mockQueryService.AddQueryPatternOnceWithError(expectedTermPattern, errors.New("connection reset"))
+
+	coordinatorID := &clustermetadatapb.ID{Cell: "zone1", Name: "coordinator-1"}
+	_, err := rs.UpdateRule(withTestActionLock(t), NewRuleUpdate(1, coordinatorID, "config_change", "test", time.Now()))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to promote rule proposal to decision")
+	assert.Contains(t, err.Error(), "connection reset")
+	assert.NoError(t, mockQueryService.ExpectationsWereMet())
 }

--- a/go/test/endtoend/multiorch/external_bootstrap_test.go
+++ b/go/test/endtoend/multiorch/external_bootstrap_test.go
@@ -237,8 +237,8 @@ func TestBootstrap_ViaExternalAPI(t *testing.T) {
 		// installed rule. After bootstrap it must reflect exactly what the
 		// caller proposed: leader, coordinator, cohort, and durability policy.
 		resp, err := primaryClient.Pooler.ExecuteQuery(t.Context(), `
-			SELECT coordinator_term,
-			       leader_subterm,
+			SELECT decision_coordinator_term,
+			       decision_leader_subterm,
 			       leader_id,
 			       coordinator_id,
 			       array_to_json(cohort_members)::text,
@@ -252,8 +252,8 @@ func TestBootstrap_ViaExternalAPI(t *testing.T) {
 		require.Len(t, resp.Rows, 1, "current_rule must have exactly one row per shard")
 
 		row := resp.Rows[0]
-		assert.Equal(t, "1", string(row.Values[0]), "coordinator_term should be 1")
-		assert.Equal(t, "0", string(row.Values[1]), "leader_subterm should be 0 for initial term")
+		assert.Equal(t, "1", string(row.Values[0]), "decision_coordinator_term should be 1")
+		assert.Equal(t, "0", string(row.Values[1]), "decision_leader_subterm should be 0 for initial term")
 		assert.Equal(t, setup.CellName+"_"+leaderID.Name, string(row.Values[2]), "leader_id should match")
 		assert.Equal(t, setup.CellName+"_multiorch", string(row.Values[3]), "coordinator_id should match orch")
 

--- a/go/test/endtoend/multiorch/stuck_proposal_test.go
+++ b/go/test/endtoend/multiorch/stuck_proposal_test.go
@@ -1,0 +1,348 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package multiorch contains end-to-end tests for multiorch behavior.
+//
+// These two tests exercise how a stuck (undecided) proposal — left behind by
+// a coordinator that crashed between UpdateRule's two write phases, see
+// rule_store.go's two-phase write — interacts with the two ways a rule can
+// change:
+//
+//   - TestCohortChangeRejectedWithStuckProposal: an ordinary (non-certified)
+//     rule change has no way to know whether the stuck proposal reflects
+//     durable, quorum-verified work, so it fails closed rather than risk
+//     silently discarding it.
+//   - TestApplyCertifiedRuleChange_FromStuckProposal: an externally-certified
+//     rule change (multiadmin.ApplyCertifiedRuleChange) can supersede it,
+//     because the caller's cert — not quorum verification of the stored
+//     decision — is what establishes safety here.
+package multiorch
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	adminserver "github.com/multigres/multigres/go/services/multiadmin"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multiadminpb "github.com/multigres/multigres/go/pb/multiadmin"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+)
+
+func TestCohortChangeRejectedWithStuckProposal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping TestCohortChangeRejectedWithStuckProposal test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("Skipping end-to-end stuck proposal test (short mode or no postgres binaries)")
+	}
+
+	// 3 nodes so there's a standby left after removing one from the cohort.
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultiorchCount(1),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+	)
+	defer cleanup()
+
+	t.Logf("Test cluster ready in directory: %s", setup.TempDir)
+	t.Logf("Identified primary: %s", setup.PrimaryName)
+
+	var replicaName string
+	for name := range setup.Multipoolers {
+		if name != setup.PrimaryName {
+			replicaName = name
+			break
+		}
+	}
+	require.NotEmpty(t, replicaName, "should have a replica")
+
+	primaryClient := setup.NewPrimaryClient(t)
+	defer primaryClient.Close()
+
+	ctx := context.Background()
+
+	statusResp, err := primaryClient.Manager.Status(ctx, &multipoolermanagerdatapb.StatusRequest{})
+	require.NoError(t, err, "Status should succeed")
+	decision := statusResp.GetConsensusStatus().GetCurrentPosition().GetPosition().GetDecision()
+	currentRule := decision.GetRuleNumber()
+	require.NotNil(t, currentRule, "primary must have a current rule number")
+	require.Nil(t, statusResp.GetConsensusStatus().GetCurrentPosition().GetPosition().GetProposal(),
+		"sanity check: no proposal exists yet")
+
+	// Seed a stuck proposal directly via raw SQL, bypassing UpdateRule entirely —
+	// there is no write path that leaves one behind on demand, so this simulates
+	// the crash-between-phases scenario the two-phase write is meant to survive.
+	// Reuses the current decision's own leader/cohort/policy content; only the
+	// rule number needs to be new to make it a distinct, observable proposal.
+	proposedTerm := currentRule.GetCoordinatorTerm() + 1
+	cohortNames := make([]string, len(decision.GetCohortMembers()))
+	for i, m := range decision.GetCohortMembers() {
+		cohortNames[i] = m.GetCell() + "_" + m.GetName()
+	}
+	cohortLiteral := "{" + strings.Join(cohortNames, ",") + "}"
+	_, err = primaryClient.Pooler.ExecuteQuery(ctx, fmt.Sprintf(`
+		UPDATE multigres.current_rule
+		SET proposal_coordinator_term = %d,
+		    proposal_leader_subterm = 0,
+		    proposal_leader_id = '%s_%s',
+		    proposal_cohort_members = '%s',
+		    proposal_durability_policy_name = '%s',
+		    proposal_durability_quorum_type = '%s',
+		    proposal_durability_required_count = %d,
+		    proposal_created_at = now()
+		WHERE shard_id = '0'::bytea`,
+		proposedTerm,
+		decision.GetLeaderId().GetCell(), decision.GetLeaderId().GetName(),
+		cohortLiteral,
+		decision.GetDurabilityPolicy().GetPolicyName(),
+		decision.GetDurabilityPolicy().GetQuorumType().String(),
+		decision.GetDurabilityPolicy().GetRequiredCount(),
+	), 0)
+	require.NoError(t, err, "seeding the stuck proposal should succeed")
+
+	// The stuck proposal must now be observable.
+	statusResp, err = primaryClient.Manager.Status(ctx, &multipoolermanagerdatapb.StatusRequest{})
+	require.NoError(t, err, "Status should succeed")
+	proposal := statusResp.GetConsensusStatus().GetCurrentPosition().GetPosition().GetProposal()
+	require.NotNil(t, proposal, "the seeded proposal must be observable")
+	assert.Equal(t, proposedTerm, proposal.GetRuleNumber().GetCoordinatorTerm())
+
+	// An ordinary cohort change must refuse to proceed while that proposal is
+	// undecided: it has no independent safety backing (no cert, no verified
+	// quorum) to know whether overwriting it would discard durable work.
+	_, err = primaryClient.Consensus.UpdateConsensusRule(ctx, &multipoolermanagerdatapb.UpdateConsensusRuleRequest{
+		Operation: multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_REMOVE,
+		StandbyIds: []*clustermetadatapb.ID{{
+			Component: clustermetadatapb.ID_MULTIPOOLER,
+			Cell:      "test-cell",
+			Name:      replicaName,
+		}},
+		ExpectedOutgoingRule: currentRule,
+	})
+	require.Error(t, err, "cohort change must be rejected while a proposal is stuck")
+	assert.ErrorContains(t, err, "undecided proposal")
+
+	// The decision must be untouched — the rejected write must not have
+	// partially applied.
+	statusResp, err = primaryClient.Manager.Status(ctx, &multipoolermanagerdatapb.StatusRequest{})
+	require.NoError(t, err, "Status should succeed")
+	assert.Equal(t, currentRule.GetCoordinatorTerm(),
+		statusResp.GetConsensusStatus().GetCurrentPosition().GetPosition().GetDecision().GetRuleNumber().GetCoordinatorTerm(),
+		"decision must be unchanged by the rejected cohort change")
+}
+
+func TestApplyCertifiedRuleChange_FromStuckProposal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping TestApplyCertifiedRuleChange_FromStuckProposal test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("Skipping end-to-end stuck proposal test (short mode or no postgres binaries)")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultiorchCount(1),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+	)
+	defer cleanup()
+
+	t.Logf("Test cluster ready in directory: %s", setup.TempDir)
+	t.Logf("Identified primary: %s", setup.PrimaryName)
+	oldPrimaryName := setup.PrimaryName
+
+	var newLeaderName string
+	for name := range setup.Multipoolers {
+		if name != oldPrimaryName {
+			newLeaderName = name
+			break
+		}
+	}
+	require.NotEmpty(t, newLeaderName, "should have a standby to promote")
+
+	primaryClient := setup.NewPrimaryClient(t)
+	defer primaryClient.Close()
+
+	ctx := t.Context()
+
+	statusResp, err := primaryClient.Manager.Status(ctx, &multipoolermanagerdatapb.StatusRequest{})
+	require.NoError(t, err, "Status should succeed")
+	decision := statusResp.GetConsensusStatus().GetCurrentPosition().GetPosition().GetDecision()
+	currentTerm := decision.GetRuleNumber().GetCoordinatorTerm()
+
+	var poolerIDs []*clustermetadatapb.ID
+	for _, name := range []string{"pooler-1", "pooler-2", "pooler-3"} {
+		poolerIDs = append(poolerIDs, &clustermetadatapb.ID{
+			Component: clustermetadatapb.ID_MULTIPOOLER,
+			Cell:      setup.CellName,
+			Name:      name,
+		})
+	}
+
+	// Restart multiorch (NewIsolated stops the bootstrap multiorch once the
+	// shard is up) and pause its automatic recovery: ApplyCertifiedRuleChange
+	// needs a live multiorch to dispatch to, and disabling recovery keeps this
+	// test deterministic (it's exercising the manual/CLI path specifically).
+	setup.StartMultiorchs(t.Context(), t)
+	defer setup.DisableRecovery(t, "multiorch")()
+
+	// Seed a stuck proposal directly via raw SQL on the current primary,
+	// bypassing UpdateRule entirely — there is no write path that leaves one
+	// behind on demand, so this simulates a coordinator that crashed between
+	// UpdateRule's two write phases (see rule_store.go). The seeded proposal
+	// keeps the same leader/cohort/policy as the current decision; only the
+	// rule number is new, since it's simulating an in-flight cohort or policy
+	// change, not a leader change.
+	stuckTerm := currentTerm + 1
+	_, err = primaryClient.Pooler.ExecuteQuery(ctx, fmt.Sprintf(`
+		UPDATE multigres.current_rule
+		SET proposal_coordinator_term = %d,
+		    proposal_leader_subterm = 0,
+		    proposal_leader_id = leader_id,
+		    proposal_cohort_members = cohort_members,
+		    proposal_durability_policy_name = durability_policy_name,
+		    proposal_durability_quorum_type = durability_quorum_type,
+		    proposal_durability_required_count = durability_required_count,
+		    proposal_created_at = now()
+		WHERE shard_id = '0'::bytea`, stuckTerm), 0)
+	require.NoError(t, err, "seeding the stuck proposal should succeed")
+
+	statusResp, err = primaryClient.Manager.Status(ctx, &multipoolermanagerdatapb.StatusRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, statusResp.GetConsensusStatus().GetCurrentPosition().GetPosition().GetProposal(),
+		"the seeded proposal must be observable before we try to recover from it")
+
+	// Kill the old primary now, matching the scenario this whole feature is
+	// about: a leader that crashed leaving a stuck proposal behind, not one
+	// that's still alive and needs a graceful demotion. This also sidesteps
+	// pg_rewind entirely — a live old primary that kept running would need it
+	// to rejoin (its WAL diverges from the new leader's timeline the moment
+	// a different node is promoted), which is an orthogonal concern to what
+	// this test is exercising.
+	oldPrimaryInst := setup.GetMultipoolerInstance(oldPrimaryName)
+	require.NotNil(t, oldPrimaryInst)
+	killMultipooler(t, oldPrimaryInst)
+
+	// Build an externally-certified rule change whose outgoing rule is the
+	// stuck proposal itself (not the last marked decision): the caller
+	// (a human/CLI operator, standing in for future automated propagation)
+	// has independently determined it's safe to treat the stuck proposal as
+	// the true baseline, and attests to that via the cert rather than
+	// relying on this multipooler ever having marked it decided.
+	orchProtoID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIORCH,
+		Cell:      setup.CellName,
+		Name:      "multiorch",
+	}
+	newLeaderID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      setup.CellName,
+		Name:      newLeaderName,
+	}
+	now := timestamppb.New(time.Now().UTC().Truncate(time.Microsecond))
+	newTerm := stuckTerm + 1
+
+	req := &multiadminpb.ApplyCertifiedRuleChangeRequest{
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   "postgres",
+			TableGroup: "default",
+			Shard:      "0-inf",
+		},
+		ProposedTransition: &clustermetadatapb.RulePosition{
+			Decision: &clustermetadatapb.ShardRule{
+				RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: stuckTerm},
+			},
+			Proposal: &clustermetadatapb.ShardRule{
+				RuleNumber:       &clustermetadatapb.RuleNumber{CoordinatorTerm: newTerm},
+				LeaderId:         newLeaderID,
+				CohortMembers:    poolerIDs,
+				DurabilityPolicy: decision.GetDurabilityPolicy(),
+				CoordinatorId:    orchProtoID,
+				CreationTime:     now,
+			},
+		},
+		CertSource: &multiadminpb.ApplyCertifiedRuleChangeRequest_Cert{
+			Cert: &clustermetadatapb.ExternallyCertifiedRevocation{
+				// Permissive: this test is exercising that the stuck proposal
+				// is accepted as the outgoing baseline, not re-deriving a real
+				// quorum-verified WAL floor.
+				FrozenLsn: "0/0",
+				TermRevocation: &clustermetadatapb.TermRevocation{
+					RevokedBelowTerm:       newTerm,
+					AcceptedCoordinatorId:  orchProtoID,
+					CoordinatorInitiatedAt: now,
+					OutgoingRule:           &clustermetadatapb.RuleNumber{CoordinatorTerm: stuckTerm, LeaderSubterm: 0},
+				},
+			},
+		},
+		Reason: "test-recover-stuck-proposal",
+	}
+
+	logger := slog.Default()
+	adminServer := adminserver.NewMultiadminServer(
+		setup.TopoServer, logger, grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	defer adminServer.Stop()
+
+	// The cohort still carries a recent term-acceptance record from the
+	// bootstrap multiorch's own recruitment a moment ago; recruiting again
+	// within that backoff window is deliberately rejected to avoid two
+	// coordinators racing (see checkRecentAcceptance). Retry past it.
+	var resp *multiadminpb.ApplyCertifiedRuleChangeResponse
+	require.Eventually(t, func() bool {
+		var applyErr error
+		applyCtx := utils.WithTimeout(t, 15*time.Second)
+		resp, applyErr = adminServer.ApplyCertifiedRuleChange(applyCtx, req)
+		if applyErr != nil {
+			t.Logf("ApplyCertifiedRuleChange not ready yet: %v", applyErr)
+			return false
+		}
+		return true
+	}, 10*time.Second, 500*time.Millisecond, "ApplyCertifiedRuleChange should succeed starting from a stuck proposal")
+	require.NotNil(t, resp.InstalledRule)
+	assert.Equal(t, newTerm, resp.InstalledRule.GetRuleNumber().GetCoordinatorTerm())
+	assert.Equal(t, newLeaderName, resp.InstalledRule.GetLeaderId().GetName())
+
+	// The new leader must be a decided (not stuck) rule at the new term.
+	// Only 1 standby is expected: the old primary is dead (killed above,
+	// simulating the crash this scenario is about) and stays out of the
+	// picture — recovering a live diverged node is a separate concern
+	// (pg_rewind), not what this test exercises.
+	setup.PrimaryName = newLeaderName
+	primaryName := waitForShardReady(t, setup, 1 /* expectedStandbyCount */, 15*time.Second)
+	require.Equal(t, newLeaderName, primaryName, "the promoted node should become primary")
+
+	newPrimaryClient := setup.NewPrimaryClient(t)
+	defer newPrimaryClient.Close()
+	statusResp, err = newPrimaryClient.Manager.Status(ctx, &multipoolermanagerdatapb.StatusRequest{})
+	require.NoError(t, err)
+	newPos := statusResp.GetConsensusStatus().GetCurrentPosition().GetPosition()
+	assert.Equal(t, newTerm, newPos.GetDecision().GetRuleNumber().GetCoordinatorTerm(),
+		"the stuck proposal is superseded by a fresh decided rule, exactly like any other promotion")
+	assert.Nil(t, newPos.GetProposal(), "the new leader's own write is fully decided, not stuck")
+}


### PR DESCRIPTION
- Splits `current_rule` into `decision_*`/`proposal_*` columns and adds `rule_history.decided`, so a rule change that reached WAL but was never confirmed decided is durably observable (`Position.Proposal`).
- Makes `UpdateRule` two-phase: write the proposal first (blocking on the sync-standby ack), then promote it to a decision — a crash between the two leaves a durable trace instead of silently losing the change.
- Lets an externally-certified write (`skipOutgoingQuorum`) supersede a stuck proposal instead of failing closed, CASing against the proposal it's replacing rather than the stale decision. An ordinary (non-certified) write still refuses to touch a stuck proposal.
