### PR TITLE
feat(multipooler): propagate a stuck proposal via ordinary automatic failover

### DIFF
--- a/go/common/consensus/durability.go
+++ b/go/common/consensus/durability.go
@@ -225,7 +225,7 @@ func BuildPolicyTransition(outgoing, incoming PolicyWithCohort) (*PolicyTransiti
 		return nil, fmt.Errorf("unsupported leader-led rule change: policy types must match (got %T and %T)", outgoing.Policy, incoming.Policy)
 	}
 
-	cohortSame := sameCohort(outgoing.Cohort, incoming.Cohort)
+	cohortSame := SameCohort(outgoing.Cohort, incoming.Cohort)
 	nSame := outN == inN
 
 	if cohortSame && nSame {
@@ -266,8 +266,8 @@ func policyFamily(p DurabilityPolicy) (n int, family string) {
 	}
 }
 
-// sameCohort reports whether a and b represent the same set of pooler IDs.
-func sameCohort(a, b []*clustermetadatapb.ID) bool {
+// SameCohort reports whether a and b represent the same set of pooler IDs.
+func SameCohort(a, b []*clustermetadatapb.ID) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/go/common/consensus/durability.go
+++ b/go/common/consensus/durability.go
@@ -225,7 +225,7 @@ func BuildPolicyTransition(outgoing, incoming PolicyWithCohort) (*PolicyTransiti
 		return nil, fmt.Errorf("unsupported leader-led rule change: policy types must match (got %T and %T)", outgoing.Policy, incoming.Policy)
 	}
 
-	cohortSame := SameCohort(outgoing.Cohort, incoming.Cohort)
+	cohortSame := sameCohort(outgoing.Cohort, incoming.Cohort)
 	nSame := outN == inN
 
 	if cohortSame && nSame {
@@ -266,8 +266,8 @@ func policyFamily(p DurabilityPolicy) (n int, family string) {
 	}
 }
 
-// SameCohort reports whether a and b represent the same set of pooler IDs.
-func SameCohort(a, b []*clustermetadatapb.ID) bool {
+// sameCohort reports whether a and b represent the same set of pooler IDs.
+func sameCohort(a, b []*clustermetadatapb.ID) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/go/common/consensus/proposals.go
+++ b/go/common/consensus/proposals.go
@@ -38,15 +38,25 @@ type RecruitmentResult struct {
 	// been filtered by whether they could accept it via ValidateRevocation.
 	TermRevocation *clustermetadatapb.TermRevocation
 
-	// OutgoingDecision is the decided ShardRule at the outgoing rule number
-	// (WAL-backed, authoritative), shared by every entry in EligibleLeaders.
-	// In practice this is never nil: every node always carries at least the
-	// initial {0,1} row written during initdb, so the public constructors
-	// (NewTermRevocation, cert authors) never produce the sentinel
-	// RuleNumber{0,0} that would leave it unset. skipOutgoingQuorum still
-	// knows this rule — it just chooses not to enforce a quorum check on
-	// its cohort, relying instead on a cert or the incoming-cohort check.
-	OutgoingDecision *clustermetadatapb.ShardRule
+	// OutgoingRule is the ShardRule at the outgoing rule number, shared by
+	// every entry in EligibleLeaders. It may be an undecided proposal rather
+	// than a decision — see OutgoingRuleDecided. In practice this is never
+	// nil: every node always carries at least the initial {0,1} row written
+	// during initdb, so the public constructors (NewTermRevocation, cert
+	// authors) never produce the sentinel RuleNumber{0,0} that would leave
+	// it unset. skipOutgoingQuorum still knows this rule — it just chooses
+	// not to enforce a quorum check on its cohort, relying instead on a cert
+	// or the incoming-cohort check.
+	OutgoingRule *clustermetadatapb.ShardRule
+
+	// OutgoingRuleDecided reports whether OutgoingRule came from a decision
+	// (WAL-backed, authoritative) rather than an undecided proposal. An
+	// undecided OutgoingRule is trusted without a separate quorum-proof step
+	// (see buildProposalCore) — that's safe because UpdateRule always
+	// finalizes it (deciding it exactly as it already stands, under its own
+	// Both policy) before applying anything new, regardless of whether the
+	// new proposal changes cohort or policy.
+	OutgoingRuleDecided bool
 
 	// EligibleLeaders are the recruited nodes with the best WAL position.
 	// For nodes with a recorded rule, this is those matching OutgoingRule's rule
@@ -96,11 +106,12 @@ const (
 // The INCOMING cohort (proposed in the returned proposal) is additionally
 // validated by validateProposal.
 //
-// TODO: This assumes OutgoingRule is already durably recorded. If a cohort change
-// was in progress when the leader failed, some nodes may hold OutgoingRule in WAL
-// while others do not, and the previous cohort's policy may apply instead. We
-// don't yet have enough information from the Recruit responses alone to detect
-// this safely, so for now we proceed optimistically.
+// The highest recorded rule may itself be an undecided proposal (a cohort or
+// leader change interrupted mid-write) rather than a decision — see
+// RecruitmentResult.OutgoingRuleDecided. buildProposalCore trusts it as the
+// outgoing baseline either way, but also requires sufficient recruitment
+// against the decision it's transitioning from: some recruited nodes may
+// still be caught up only to that decision, not yet to the proposal.
 func BuildSafeProposal(
 	revocation *clustermetadatapb.TermRevocation,
 	statuses []*clustermetadatapb.ConsensusStatus,
@@ -262,8 +273,8 @@ func buildProposalCore(
 	// recruit may be more advanced than it (whether by decision or by an
 	// undecided proposal), and any decided match must actually be decided
 	// (not itself undermined by a further undecided proposal).
-	expectedOutgoingDecision := revocation.GetOutgoingRule()
-	if expectedOutgoingDecision == nil {
+	expectedOutgoingRule := revocation.GetOutgoingRule()
+	if expectedOutgoingRule == nil {
 		return nil, errors.New("revocation.outgoing_rule is required (use NewTermRevocation to construct revocations)")
 	}
 
@@ -272,62 +283,71 @@ func buildProposalCore(
 		return nil, err
 	}
 
-	var outgoingDecision *clustermetadatapb.ShardRule
-	switch mode {
-	case requireOutgoingQuorum:
-		// Without a cert, an undecided most-advanced position can't be
-		// trusted: the proposal beyond it may already be decided elsewhere,
-		// via nodes we haven't recruited. Reject outright rather than risk
-		// promoting a leader on a rule that isn't actually the safe baseline.
-		if len(mostAdvanced) > 0 && !IsRuleDecided(highestPosition) {
+	// outgoingRule is decision-or-undecided-proposal alike: trusting an
+	// undecided position here needs no separate verification, under either
+	// mode. Whoever gets promoted still has to write a fresh proposal under
+	// the same durability policy and cohort, and that write can't get its
+	// synchronous ack unless the position it's superseding was actually
+	// durable — an unverified minority proposal just makes the promotion
+	// attempt fail to reach quorum, not succeed incorrectly. Under
+	// requireOutgoingQuorum, validateProposal enforces the "same policy and
+	// cohort" half of that argument by rejecting a proposal that changes
+	// either while outgoingRule is undecided.
+	outgoingRuleDecided := IsRuleDecided(highestPosition)
+	outgoingRule := PossiblyUndecidedRule(highestPosition)
+	if cmp := CompareRuleNumbers(outgoingRule.GetRuleNumber(), expectedOutgoingRule); cmp != 0 {
+		if mode == skipOutgoingQuorum {
+			// The externally-certified path has no coordinator "view" to
+			// re-discover — the caller's cert is simply stale relative to
+			// what's actually observed now.
 			return nil, fmt.Errorf(
-				"most advanced recruit %s has an undecided proposal %v beyond its decision %v; propagation is not yet supported",
-				topoclient.ClusterIDString(mostAdvanced[0].GetId()),
-				highestPosition.GetProposal().GetRuleNumber(), highestPosition.GetDecision().GetRuleNumber(),
+				"recruit %s reports rule %v, expected outgoing rule %v; cert no longer matches observed state",
+				topoclient.ClusterIDString(mostAdvanced[0].GetId()), outgoingRule.GetRuleNumber(), expectedOutgoingRule,
 			)
 		}
-		expected := RuleNumberPosition{Decision: expectedOutgoingDecision}
-		switch cmp := RuleNumberPositionOf(highestPosition).Compare(expected); {
-		case cmp > 0:
+		if cmp > 0 {
 			return nil, fmt.Errorf(
-				"recruit %s reports position %s ahead of expected outgoing position %v; coordinator view is stale, re-discover",
-				topoclient.ClusterIDString(mostAdvanced[0].GetId()), FormatRulePosition(highestPosition), expected.Decision,
-			)
-		case cmp < 0:
-			return nil, fmt.Errorf(
-				"no recruit reports the expected outgoing rule %v; cannot determine cohort for quorum check",
-				expected.Decision,
+				"recruit %s reports position %s ahead of expected outgoing rule %v; coordinator view is stale, re-discover",
+				topoclient.ClusterIDString(mostAdvanced[0].GetId()), FormatRulePosition(highestPosition), expectedOutgoingRule,
 			)
 		}
-		// cmp == 0: highestPosition matches expected exactly — decided, since
-		// the check above already ruled out an undecided highestPosition.
-		outgoingDecision = highestPosition.GetDecision()
+		return nil, fmt.Errorf(
+			"no recruit reports the expected outgoing rule %v; cannot determine cohort for quorum check",
+			expectedOutgoingRule,
+		)
+	}
 
-		// Validate revocation of the outgoing cohort: no parallel quorum can still
-		// form among the non-recruited nodes.
-		outgoingPolicy, err := NewPolicyFromProto(outgoingDecision.GetDurabilityPolicy())
+	if mode == requireOutgoingQuorum {
+		// Validate revocation of the outgoing cohort: no parallel quorum can
+		// still form among the non-recruited nodes. Skipped under
+		// skipOutgoingQuorum — the external certification already takes
+		// responsibility for that.
+		outgoingPolicy, err := NewPolicyFromProto(outgoingRule.GetDurabilityPolicy())
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse durability policy from rule: %w", err)
 		}
-		cohort := outgoingDecision.GetCohortMembers()
+		cohort := outgoingRule.GetCohortMembers()
 		if err := outgoingPolicy.CheckSufficientRecruitment(cohort, statusesToIDs(filterCohortStatuses(cohort, recruitedStatuses))); err != nil {
 			return nil, fmt.Errorf("insufficient outgoing cohort recruitment: %w", err)
 		}
 
-	case skipOutgoingQuorum:
-		// Outgoing-cohort quorum is not required. The outgoing rule can be non-durable, since
-		// the external certification is taking responsibility for making sure everything up to
-		// and including the proposal is revoked and no split brain using a different incoming cohort
-		// is possible.
-		possiblyUndecided := PossiblyUndecidedRule(highestPosition)
-		if cmp := CompareRuleNumbers(possiblyUndecided.GetRuleNumber(), expectedOutgoingDecision); cmp != 0 {
-			return nil, fmt.Errorf(
-				"recruit %s reports rule %v, expected outgoing rule %v; cert no longer matches observed state",
-				topoclient.ClusterIDString(mostAdvanced[0].GetId()), possiblyUndecided.GetRuleNumber(), expectedOutgoingDecision,
-			)
+		// outgoingRule being undecided means propagation (see rule_store.go's
+		// finalize step) will need a synchronous ack under the "Both" policy
+		// of the decision AND the proposal simultaneously, not just the
+		// proposal's own policy — so the decision's cohort must also have
+		// sufficient recruitment, or that write can never succeed regardless
+		// of how the new proposal is built.
+		if !outgoingRuleDecided {
+			decisionRule := highestPosition.GetDecision()
+			decisionPolicy, err := NewPolicyFromProto(decisionRule.GetDurabilityPolicy())
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse durability policy from decision: %w", err)
+			}
+			decisionCohort := decisionRule.GetCohortMembers()
+			if err := decisionPolicy.CheckSufficientRecruitment(decisionCohort, statusesToIDs(filterCohortStatuses(decisionCohort, recruitedStatuses))); err != nil {
+				return nil, fmt.Errorf("insufficient outgoing decision cohort recruitment: %w", err)
+			}
 		}
-		outgoingDecision = possiblyUndecided
-		// The incoming cohort is checked below after the proposal is built.
 	}
 
 	eligibleLeaders, err := narrowByLSN(mostAdvanced, minLSN)
@@ -336,9 +356,10 @@ func buildProposalCore(
 	}
 
 	result := RecruitmentResult{
-		TermRevocation:   revocation,
-		OutgoingDecision: outgoingDecision,
-		EligibleLeaders:  eligibleLeaders,
+		TermRevocation:      revocation,
+		OutgoingRule:        outgoingRule,
+		OutgoingRuleDecided: outgoingRuleDecided,
+		EligibleLeaders:     eligibleLeaders,
 	}
 
 	proposal, err := buildProposal(result)

--- a/go/common/consensus/proposals.go
+++ b/go/common/consensus/proposals.go
@@ -285,14 +285,14 @@ func buildProposalCore(
 
 	// outgoingRule is decision-or-undecided-proposal alike: trusting an
 	// undecided position here needs no separate verification, under either
-	// mode. Whoever gets promoted still has to write a fresh proposal under
-	// the same durability policy and cohort, and that write can't get its
-	// synchronous ack unless the position it's superseding was actually
-	// durable — an unverified minority proposal just makes the promotion
-	// attempt fail to reach quorum, not succeed incorrectly. Under
-	// requireOutgoingQuorum, validateProposal enforces the "same policy and
-	// cohort" half of that argument by rejecting a proposal that changes
-	// either while outgoingRule is undecided.
+	// mode. UpdateRule (see rule_store.go's maybeFinalizeStuckProposal) always
+	// finalizes an undecided outgoing rule first — deciding it exactly as it
+	// already stands, under its own synchronous-ack quorum proof — before
+	// applying anything new. That finalize commit is independent of whatever
+	// the caller's actual proposal changes, so a proposal built here is free
+	// to change cohort or durability policy even when outgoingRule is
+	// undecided; the resulting write is an entirely ordinary rule change from
+	// a clean decided baseline, with its own independent safety.
 	outgoingRuleDecided := IsRuleDecided(highestPosition)
 	outgoingRule := PossiblyUndecidedRule(highestPosition)
 	if cmp := CompareRuleNumbers(outgoingRule.GetRuleNumber(), expectedOutgoingRule); cmp != 0 {

--- a/go/common/consensus/proposals_test.go
+++ b/go/common/consensus/proposals_test.go
@@ -1804,10 +1804,10 @@ func TestSameCohort(t *testing.T) {
 	b := makeID("zone1", "b")
 	c := makeID("zone1", "c")
 
-	assert.True(t, SameCohort([]*clustermetadatapb.ID{a, b}, []*clustermetadatapb.ID{b, a}), "order should not matter")
-	assert.False(t, SameCohort([]*clustermetadatapb.ID{a, b}, []*clustermetadatapb.ID{a, c}))
-	assert.False(t, SameCohort([]*clustermetadatapb.ID{a, b}, []*clustermetadatapb.ID{a, b, c}))
-	assert.True(t, SameCohort(nil, nil))
+	assert.True(t, sameCohort([]*clustermetadatapb.ID{a, b}, []*clustermetadatapb.ID{b, a}), "order should not matter")
+	assert.False(t, sameCohort([]*clustermetadatapb.ID{a, b}, []*clustermetadatapb.ID{a, c}))
+	assert.False(t, sameCohort([]*clustermetadatapb.ID{a, b}, []*clustermetadatapb.ID{a, b, c}))
+	assert.True(t, sameCohort(nil, nil))
 }
 
 func TestCheckProposalPossible(t *testing.T) {

--- a/go/common/consensus/proposals_test.go
+++ b/go/common/consensus/proposals_test.go
@@ -267,6 +267,69 @@ func TestBuildProposalCore(t *testing.T) {
 		func() tc {
 			zone1 := poolerIDs.zone1
 			cohort := zone1.all[:3]
+			decidedRule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
+			undecidedProposal := makeRule(ruleNum(4, 0), atLeast(2), cohort...)
+			return tc{
+				name:       "undecided most-advanced position: insufficient outgoing cohort still rejected",
+				mode:       requireOutgoingQuorum,
+				revocation: revocation(5, ruleNum(4, 0)),
+				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
+					makeStatusWithProposal(zone1.a, &clustermetadatapb.RulePosition{Decision: decidedRule, Proposal: undecidedProposal}, revocation(5, ruleNum(4, 0)), "0/1000000"),
+				},
+				buildProposal: proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), cohort...)),
+				wantErr:       "insufficient outgoing cohort recruitment: majority not satisfied: recruited 1 of 3 cohort poolers, need at least 2",
+			}
+		}(),
+		func() tc {
+			zone1 := poolerIDs.zone1
+			cohort := zone1.all[:3]
+			decidedRule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
+			undecidedProposal := makeRule(ruleNum(4, 0), atLeast(2), cohort...)
+			return tc{
+				name:       "undecided most-advanced position: sufficient recruitment and unchanged cohort/policy succeeds",
+				mode:       requireOutgoingQuorum,
+				revocation: revocation(5, ruleNum(4, 0)),
+				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
+					makeStatusWithProposal(zone1.a, &clustermetadatapb.RulePosition{Decision: decidedRule, Proposal: undecidedProposal}, revocation(5, ruleNum(4, 0)), "0/1000000"),
+					makeStatusWithProposal(zone1.b, &clustermetadatapb.RulePosition{Decision: decidedRule, Proposal: undecidedProposal}, revocation(5, ruleNum(4, 0)), "0/1000000"),
+				},
+				// Same cohort and policy as the undecided proposal being superseded —
+				// only the leader identity is up to buildProposal/EligibleLeaders.
+				buildProposal: proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), cohort...)),
+				wantLeader:    "pooler-a",
+				checkResult: func(t *testing.T, r RecruitmentResult) {
+					assert.Equal(t, int64(4), r.OutgoingRule.GetRuleNumber().GetCoordinatorTerm(),
+						"the undecided proposal is trusted as OutgoingRule without a separate verification step")
+					assert.False(t, r.OutgoingRuleDecided)
+				},
+			}
+		}(),
+		func() tc {
+			zone1 := poolerIDs.zone1
+			// The decision's cohort (a, e, f) is different from the undecided
+			// proposal's cohort (a, b) — simulating a cohort change that was
+			// in flight when the leader crashed. Only a and b are recruited,
+			// which satisfies the proposal's own AT_LEAST_2 cohort but leaves
+			// the decision's cohort with only 1 of 3 recruited.
+			decisionCohort := []*clustermetadatapb.ID{zone1.a, zone1.e, zone1.f}
+			proposalCohort := []*clustermetadatapb.ID{zone1.a, zone1.b}
+			decidedRule := makeRule(ruleNum(3, 0), atLeast(2), decisionCohort...)
+			undecidedProposal := makeRule(ruleNum(4, 0), atLeast(2), proposalCohort...)
+			return tc{
+				name:       "undecided most-advanced position: proposal cohort sufficient but decision cohort insufficient still rejected",
+				mode:       requireOutgoingQuorum,
+				revocation: revocation(5, ruleNum(4, 0)),
+				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
+					makeStatusWithProposal(zone1.a, &clustermetadatapb.RulePosition{Decision: decidedRule, Proposal: undecidedProposal}, revocation(5, ruleNum(4, 0)), "0/1000000"),
+					makeStatusWithProposal(zone1.b, &clustermetadatapb.RulePosition{Decision: decidedRule, Proposal: undecidedProposal}, revocation(5, ruleNum(4, 0)), "0/1000000"),
+				},
+				buildProposal: proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), proposalCohort...)),
+				wantErr:       "insufficient outgoing decision cohort recruitment: majority not satisfied: recruited 1 of 3 cohort poolers, need at least 2",
+			}
+		}(),
+		func() tc {
+			zone1 := poolerIDs.zone1
+			cohort := zone1.all[:3]
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "callback proposes outsider: not among eligible leaders",
@@ -421,7 +484,7 @@ func TestBuildProposalCore(t *testing.T) {
 				},
 				wantLeader: "pooler-a",
 				checkResult: func(t *testing.T, r RecruitmentResult) {
-					assert.Equal(t, int64(3), r.OutgoingDecision.GetRuleNumber().GetCoordinatorTerm())
+					assert.Equal(t, int64(3), r.OutgoingRule.GetRuleNumber().GetCoordinatorTerm())
 					assert.Len(t, r.EligibleLeaders, 2, "only nodes at outgoingRule are eligible")
 					assert.NotEqual(t, "pooler-c", r.EligibleLeaders[0].GetId().GetName())
 				},
@@ -768,7 +831,7 @@ func TestBuildProposalCore(t *testing.T) {
 					makeStatus(zone1.a, higherRule, revocation(5, ruleNum(3, 0))),
 				},
 				buildProposal: proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), cohort...)),
-				wantErr:       "recruit zone1_pooler-a reports position 4.0 ahead of expected outgoing position coordinator_term:3; coordinator view is stale, re-discover",
+				wantErr:       "recruit zone1_pooler-a reports position 4.0 ahead of expected outgoing rule coordinator_term:3; coordinator view is stale, re-discover",
 			}
 		}(),
 		func() tc {
@@ -1107,7 +1170,7 @@ func TestBuildProposalCore(t *testing.T) {
 					return &consensusdatapb.CoordinatorProposal{
 						TermRevocation:     r.TermRevocation,
 						ProposalLeader:     &clustermetadatapb.PoolerAddress{Id: r.EligibleLeaders[0].GetId()},
-						ProposedTransition: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: r.TermRevocation.GetOutgoingRule()}, Proposal: r.OutgoingDecision}, // re-propose term-6 rule to propagate it
+						ProposedTransition: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: r.TermRevocation.GetOutgoingRule()}, Proposal: r.OutgoingRule}, // re-propose term-6 rule to propagate it
 					}, nil
 				},
 				wantErr: "proposal validation: proposed rule term 6 is below the recruitment revocation term 7",
@@ -1487,7 +1550,7 @@ func TestBuildSafeProposal_OutgoingRuleSelected(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, proposal)
-	assert.Equal(t, int64(3), gotResult.OutgoingDecision.GetRuleNumber().GetCoordinatorTerm())
+	assert.Equal(t, int64(3), gotResult.OutgoingRule.GetRuleNumber().GetCoordinatorTerm())
 	assert.Len(t, gotResult.EligibleLeaders, 2, "only nodes at outgoingRule are eligible")
 	// Leader must be a or b (both at newRule), not c.
 	leaderName := proposal.GetProposalLeader().GetId().GetName()
@@ -1642,7 +1705,7 @@ func TestBuildProposalCore_EligibleLeadersOrderDeterministic(t *testing.T) {
 	assert.Equal(t, collect(forward), collect(reversed), "eligible leader order must not depend on input order")
 }
 
-func TestBuildSafeProposal_CohortReplacementRequiresPropagation(t *testing.T) {
+func TestBuildSafeProposal_CohortReplacementRejectedWithUndecidedOutgoingRule(t *testing.T) {
 	// A is the leader for cohort [A, B, C] (AT_LEAST_2). A coordinator sends a
 	// Propose to replace the cohort with [D, E, F]. A writes the new rule to its
 	// rule_history; D and E stream that WAL from A and apply it. But B and C never
@@ -1661,13 +1724,16 @@ func TestBuildSafeProposal_CohortReplacementRequiresPropagation(t *testing.T) {
 	//     - promotes B with cohort [B,C]
 	//
 	//   Coordinator 2 sees D and E (both with an undecided proposal beyond
-	//   their decision): buildProposalCore's stopgap guard refuses to build a
-	//   proposal at all — "propagation is not yet supported" — rather than
-	//   trusting the phantom rule as if it were a marked decision. No second
+	//   their decision): the undecided proposal is trusted as outgoingRule
+	//   without a separate verification step (see buildProposalCore) — but
+	//   only once BOTH the decision's cohort AND the proposal's cohort have
+	//   sufficient recruitment, since finalizing it needs a synchronous ack
+	//   under their combined "Both" policy. Coordinator 2 recruited none of
+	//   the decision's cohort [A,B,C] (it only sees D and E), so it fails
+	//   there — before validateProposal's cohort-change check (which would
+	//   also refuse coordinator 2's [D,E,F] -> [D,E] cohort change while the
+	//   base being superseded is undecided) is ever reached. No second
 	//   leader is ever promoted, so there is no split brain.
-	//
-	// TODO: when propagation is implemented, this situation should trigger
-	// propagation rather than an error.
 	zone1 := poolerIDs.zone1
 	// zone1.a: old leader, crashed — not recruited.
 	// zone1.b, zone1.c: old cohort, respond to coord 1.
@@ -1729,7 +1795,7 @@ func TestBuildSafeProposal_CohortReplacementRequiresPropagation(t *testing.T) {
 
 	require.NoError(t, err1)
 	assert.NotNil(t, proposal1)
-	require.ErrorContains(t, err2, "propagation is not yet supported")
+	require.ErrorContains(t, err2, "insufficient outgoing decision cohort recruitment: majority not satisfied: recruited 0 of 3 cohort poolers, need at least 2")
 	assert.Nil(t, proposal2)
 }
 
@@ -1738,10 +1804,10 @@ func TestSameCohort(t *testing.T) {
 	b := makeID("zone1", "b")
 	c := makeID("zone1", "c")
 
-	assert.True(t, sameCohort([]*clustermetadatapb.ID{a, b}, []*clustermetadatapb.ID{b, a}), "order should not matter")
-	assert.False(t, sameCohort([]*clustermetadatapb.ID{a, b}, []*clustermetadatapb.ID{a, c}))
-	assert.False(t, sameCohort([]*clustermetadatapb.ID{a, b}, []*clustermetadatapb.ID{a, b, c}))
-	assert.True(t, sameCohort(nil, nil))
+	assert.True(t, SameCohort([]*clustermetadatapb.ID{a, b}, []*clustermetadatapb.ID{b, a}), "order should not matter")
+	assert.False(t, SameCohort([]*clustermetadatapb.ID{a, b}, []*clustermetadatapb.ID{a, c}))
+	assert.False(t, SameCohort([]*clustermetadatapb.ID{a, b}, []*clustermetadatapb.ID{a, b, c}))
+	assert.True(t, SameCohort(nil, nil))
 }
 
 func TestCheckProposalPossible(t *testing.T) {

--- a/go/common/consensus/revocation.go
+++ b/go/common/consensus/revocation.go
@@ -54,12 +54,7 @@ func NewTermRevocation(
 		return nil, errors.New("NewTermRevocation: initiatedAt must be non-nil")
 	}
 	// Discovery: the cohort's most advanced position anchors this
-	// revocation's outgoing_rule. Propagation (deriving it from a
-	// quorum-verified but undecided proposal) is not yet supported — the
-	// most advanced position must already be decided.
-	// TODO: Once propagation is implemented, revocations will be relative
-	// to an outgoing decision and we can also calculate the max revocation
-	// in this loop.
+	// revocation's outgoing_rule — decision or undecided proposal alike.
 	var maxPosition *clustermetadatapb.RulePosition
 	for _, cs := range statuses {
 		// Capture the first position we see (even an explicit zero-valued
@@ -73,16 +68,10 @@ func NewTermRevocation(
 	if maxPosition == nil {
 		return nil, errors.New("NewTermRevocation: no cohort member reports a recorded rule; agent should construct revocation directly with explicit outgoing_rule")
 	}
-	if !IsRuleDecided(maxPosition) {
-		return nil, fmt.Errorf("cohort's most advanced position is an undecided proposal at rule %s; propagation is not yet supported",
-			FormatRuleNumber(maxPosition.GetProposal().GetRuleNumber()))
-	}
-	outgoingRule := maxPosition.GetDecision().GetRuleNumber()
+	outgoingRule := PossiblyUndecidedRule(maxPosition).GetRuleNumber()
 
 	// The new revocation term must exceed every term any cohort member has
 	// already accepted or decided.
-	// TODO: once propagation is implemented, we only need to consider statuses where the
-	// outgoing decision matches the match decision we've found.
 	maxTerm := outgoingRule.GetCoordinatorTerm()
 	for _, cs := range statuses {
 		if t := cs.GetTermRevocation().GetRevokedBelowTerm(); t > maxTerm {
@@ -233,9 +222,8 @@ func ValidateRevocation(status *clustermetadatapb.ConsensusStatus, revocation *c
 			FormatRulePosition(pos.GetPosition()), FormatRuleNumber(outgoingRule), revokedBelowTerm,
 		)
 	}
-	// TODO: reject revocations whose outgoing_rule is known to be obsolete.
-	// This may require us to first have more clarity about what's a proposal vs
-	// what's a decision.
+	// TODO: reject revocations whose outgoing_rule is known to be obsolete
+	// because a higher rule number is already decided.
 
 	// Conditions 2 and 3: stored-revocation consistency.
 	stored := status.GetTermRevocation()

--- a/go/common/consensus/revocation_test.go
+++ b/go/common/consensus/revocation_test.go
@@ -335,18 +335,23 @@ func TestNewTermRevocation(t *testing.T) {
 		require.Nil(t, rev)
 	})
 
-	t.Run("cohort's most advanced position is an undecided proposal returns error", func(t *testing.T) {
-		// Propagation isn't supported yet: the most-advanced position across
-		// the cohort must already be decided. A node reporting only an
-		// undecided proposal beyond its decision must not be silently
-		// trusted as the outgoing rule.
+	t.Run("cohort's most advanced position is an undecided proposal: trusted as outgoing_rule", func(t *testing.T) {
+		// An undecided proposal beyond the decision is trusted as the
+		// outgoing rule without a separate verification step: whoever gets
+		// promoted still has to write a fresh proposal under the same
+		// durability policy and cohort, and that write can't get its
+		// synchronous ack unless the position it's superseding was
+		// actually durable — an unverified minority proposal just makes
+		// the promotion attempt fail to reach quorum, not succeed
+		// incorrectly.
 		statuses := []*clustermetadatapb.ConsensusStatus{
 			{CurrentPosition: positionWithUndecidedProposal(4, 6)},
 		}
 		rev, err := NewTermRevocation(statuses, coord, ts1)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "cohort's most advanced position is an undecided proposal at rule 6.0; propagation is not yet supported")
-		require.Nil(t, rev)
+		require.NoError(t, err)
+		require.NotNil(t, rev)
+		assert.Equal(t, int64(6), rev.GetOutgoingRule().GetCoordinatorTerm())
+		assert.Equal(t, int64(7), rev.GetRevokedBelowTerm())
 	})
 
 	t.Run("revocation-term-only statuses with no recorded rule return error", func(t *testing.T) {

--- a/go/pb/consensusdata/consensusdata.pb.go
+++ b/go/pb/consensusdata/consensusdata.pb.go
@@ -51,6 +51,15 @@ type CoordinatorProposal struct {
 	// this proposal supersedes. proposal is the full new rule being proposed: an
 	// entirely new rule or an existing one that hasn't yet finished propagating to
 	// durability.
+	//
+	// TODO: decision here doesn't always mean a confirmed decision — propagation
+	// (see go/common/consensus/proposals.go's buildProposalCore) can legitimately
+	// set it to a rule that was only ever an undecided proposal on the outgoing
+	// side, trusted as the baseline being superseded. RulePosition{Decision,
+	// Proposal} is otherwise used to mean "a pooler's own confirmed decision plus
+	// any outstanding proposal beyond it" (PoolerPosition.position), a different
+	// meaning that happens to share this shape. Introduce a dedicated message for
+	// a coordinator's proposed transition instead of reusing RulePosition here.
 	ProposedTransition *clustermetadata.RulePosition `protobuf:"bytes,3,opt,name=proposed_transition,json=proposedTransition,proto3" json:"proposed_transition,omitempty"`
 	// When true, the leader must apply the incoming cohort GUC directly without
 	// first satisfying the outgoing cohort quorum. Only valid for externally-

--- a/go/services/multiorch/consensus/leader_appointment_test.go
+++ b/go/services/multiorch/consensus/leader_appointment_test.go
@@ -175,10 +175,16 @@ func TestAppointLeader(t *testing.T) {
 	}
 }
 
-// TestAppointLeader_RejectsUndecidedMostAdvancedPosition confirms that
-// normal failover (requireOutgoingQuorum) refuses to proceed when the
-// cohort's most-advanced position is an undecided proposal.
-func TestAppointLeader_RejectsUndecidedMostAdvancedPosition(t *testing.T) {
+// TestAppointLeader_PropagatesUndecidedMostAdvancedPosition confirms that
+// normal failover (requireOutgoingQuorum) trusts the cohort's most-advanced
+// position as the outgoing baseline even when it's an undecided proposal —
+// no separate quorum-verification step is needed, since the fresh write
+// this promotion performs can't get its own synchronous ack unless the
+// position it supersedes was already durable. mp1 is both the only cohort
+// member and the only node reporting the undecided proposal, so recruitment
+// trivially succeeds; the resulting rule keeps mp1 as leader (propagation
+// never changes cohort or durability policy — see validateProposal).
+func TestAppointLeader_PropagatesUndecidedMostAdvancedPosition(t *testing.T) {
 	ctx := context.Background()
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	coordID := &clustermetadatapb.ID{
@@ -215,14 +221,31 @@ func TestAppointLeader_RejectsUndecidedMostAdvancedPosition(t *testing.T) {
 	}
 	require.NoError(t, ts.CreateMultipooler(ctx, mp.Multipooler))
 
-	shardKey := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: "default", Shard: "shard0"}
-	err := c.AppointLeader(ctx, shardKey, []*multiorchdatapb.PoolerHealthState{mp}, "test_failover")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "propagation is not yet supported")
+	fakeClient.RecruitResponses[topoclient.ComponentIDString(mpID)] = &consensusdatapb.RecruitResponse{
+		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+			Id: mpID,
+			CurrentPosition: &clustermetadatapb.PoolerPosition{
+				Lsn:      "0/1000000",
+				Position: &clustermetadatapb.RulePosition{Decision: oldRule, Proposal: undecidedProposal},
+			},
+		},
+	}
 
-	// No RPCs should have gone out — the rejection happens before recruitment.
-	require.Empty(t, fakeClient.PromoteRequests)
-	require.Empty(t, fakeClient.SetPrimaryRequests)
+	shardKey := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: "default", Shard: "shard0"}
+	require.NoError(t, c.AppointLeader(ctx, shardKey, []*multiorchdatapb.PoolerHealthState{mp}, "test_failover"))
+
+	leaderKey := topoclient.ComponentIDString(mpID)
+	propReq, ok := fakeClient.PromoteRequests[leaderKey]
+	require.True(t, ok, "Promote should be sent to mp1")
+	require.NotNil(t, propReq.GetProposal())
+	require.Equal(t, "mp1", propReq.GetProposal().GetProposalLeader().GetId().GetName())
+	require.Equal(t, int64(5), propReq.GetProposal().GetTermRevocation().GetRevokedBelowTerm(),
+		"revocation term should exceed the undecided proposal's term (4) by one")
+	proposedTransition := propReq.GetProposal().GetProposedTransition()
+	require.Equal(t, int64(4), proposedTransition.GetDecision().GetRuleNumber().GetCoordinatorTerm(),
+		"the undecided proposal is trusted as the outgoing decision")
+	require.ElementsMatch(t, []*clustermetadatapb.ID{mpID}, proposedTransition.GetProposal().GetCohortMembers(),
+		"propagation preserves the outgoing cohort — only the leader is re-proposed")
 }
 
 func TestAppointInitialLeader(t *testing.T) {

--- a/go/services/multiorch/consensus/rule_change.go
+++ b/go/services/multiorch/consensus/rule_change.go
@@ -382,7 +382,7 @@ func buildFailoverProposal(
 	result commonconsensus.RecruitmentResult,
 	addressByID map[string]*clustermetadatapb.PoolerAddress,
 ) (*consensusdatapb.CoordinatorProposal, error) {
-	if result.OutgoingDecision == nil {
+	if result.OutgoingRule == nil {
 		return nil, errors.New("no committed rule found; use bootstrap path for fresh clusters")
 	}
 	if len(result.EligibleLeaders) == 0 {
@@ -399,11 +399,11 @@ func buildFailoverProposal(
 		TermRevocation: result.TermRevocation,
 		ProposalLeader: addr,
 		ProposedTransition: &clustermetadatapb.RulePosition{
-			Decision: result.OutgoingDecision,
+			Decision: result.OutgoingRule,
 			Proposal: &clustermetadatapb.ShardRule{
 				RuleNumber:       &clustermetadatapb.RuleNumber{CoordinatorTerm: result.TermRevocation.GetRevokedBelowTerm()},
-				CohortMembers:    result.OutgoingDecision.GetCohortMembers(),
-				DurabilityPolicy: result.OutgoingDecision.GetDurabilityPolicy(),
+				CohortMembers:    result.OutgoingRule.GetCohortMembers(),
+				DurabilityPolicy: result.OutgoingRule.GetDurabilityPolicy(),
 				LeaderId:         leader.GetId(),
 				// The coordinator that ran the recruit round (carried in the
 				// revocation's accepted_coordinator_id) is also the
@@ -438,7 +438,7 @@ func buildBootstrapProposal(
 		TermRevocation: result.TermRevocation,
 		ProposalLeader: addr,
 		ProposedTransition: &clustermetadatapb.RulePosition{
-			Decision: result.OutgoingDecision,
+			Decision: result.OutgoingRule,
 			Proposal: &clustermetadatapb.ShardRule{
 				RuleNumber:       &clustermetadatapb.RuleNumber{CoordinatorTerm: result.TermRevocation.GetRevokedBelowTerm()},
 				CohortMembers:    cohortIDs,

--- a/go/services/multiorch/consensus/rule_change_test.go
+++ b/go/services/multiorch/consensus/rule_change_test.go
@@ -167,9 +167,9 @@ func TestBuildFailoverProposal(t *testing.T) {
 
 	t.Run("picks first eligible leader", func(t *testing.T) {
 		result := commonconsensus.RecruitmentResult{
-			TermRevocation:   rev,
-			OutgoingDecision: outgoingRule,
-			EligibleLeaders:  []*clustermetadatapb.ConsensusStatus{makeCS("mp1"), makeCS("mp2")},
+			TermRevocation:  rev,
+			OutgoingRule:    outgoingRule,
+			EligibleLeaders: []*clustermetadatapb.ConsensusStatus{makeCS("mp1"), makeCS("mp2")},
 		}
 
 		proposal, err := buildFailoverProposal(result, addressByID)
@@ -182,9 +182,9 @@ func TestBuildFailoverProposal(t *testing.T) {
 
 	t.Run("no OutgoingRule returns error", func(t *testing.T) {
 		result := commonconsensus.RecruitmentResult{
-			TermRevocation:   rev,
-			OutgoingDecision: nil,
-			EligibleLeaders:  []*clustermetadatapb.ConsensusStatus{makeCS("mp1")},
+			TermRevocation:  rev,
+			OutgoingRule:    nil,
+			EligibleLeaders: []*clustermetadatapb.ConsensusStatus{makeCS("mp1")},
 		}
 
 		_, err := buildFailoverProposal(result, addressByID)
@@ -194,9 +194,9 @@ func TestBuildFailoverProposal(t *testing.T) {
 
 	t.Run("no EligibleLeaders returns error", func(t *testing.T) {
 		result := commonconsensus.RecruitmentResult{
-			TermRevocation:   rev,
-			OutgoingDecision: outgoingRule,
-			EligibleLeaders:  nil,
+			TermRevocation:  rev,
+			OutgoingRule:    outgoingRule,
+			EligibleLeaders: nil,
 		}
 
 		_, err := buildFailoverProposal(result, addressByID)

--- a/go/services/multiorch/recovery/actions/reconcile_cohort.go
+++ b/go/services/multiorch/recovery/actions/reconcile_cohort.go
@@ -113,10 +113,7 @@ func (a *ReconcileCohortAction) Execute(ctx context.Context, problem types.Probl
 		return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
 			"no consensus leader known for shard %s", problem.ShardKey)
 	}
-	// Propagation is not yet supported — wait rather than dispatch a cohort
-	// change against an outgoing rule that isn't decided yet.
-	// TODO: once propagation lands, this should be able to proceed using a
-	// quorum-verified proposal as the outgoing rule.
+	// TODO: allow non-promotion rule changes to do propagation.
 	if !commonconsensus.IsRuleDecided(members.HighestKnownPosition) {
 		return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
 			"shard %s cannot update its cohort while it has an undecided proposal", problem.ShardKey)

--- a/go/services/multipooler/internal/manager/consensus/rule_store.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store.go
@@ -566,6 +566,154 @@ func (rs *ruleStore) readCurrentRuleLocked(ctx context.Context, inRecovery bool)
 	return pos, lockedCtx, nil
 }
 
+// resolveNewRuleValues resolves the leader/cohort/durability-policy values
+// UpdateRule should write: caller-supplied values (via the builder) take
+// priority, nil retains the existing value from currentRule. Also validates
+// the resolved cohort can satisfy the resolved policy, and computes the
+// incoming PolicyWithCohort used both by propagation's finalize step (see
+// finalizeStuckProposal) and the GUC transition.
+func resolveNewRuleValues(
+	currentRule *clustermetadatapb.ShardRule,
+	update *RuleUpdateBuilder,
+	isPromotion bool,
+) (newLeader *clustermetadatapb.ID, newCohort []*clustermetadatapb.ID, newDP *clustermetadatapb.DurabilityPolicy, incomingPWC consensus.PolicyWithCohort, err error) {
+	// Outside of a promotion, an existing leader can't be replaced: the current leader
+	// is the one issuing this write, and it has no way to instantaneously stop accepting
+	// transactions the moment the row changes — only a promotion (which goes through
+	// revocation/fencing on the outgoing leader first) can safely hand off leadership.
+	// Establishing the very first leader (currentRule has none yet) has no such risk and
+	// is allowed either way.
+	newLeader = currentRule.GetLeaderId()
+	if update.leaderID != nil {
+		if !isPromotion && currentRule.GetLeaderId() != nil && !proto.Equal(update.leaderID, currentRule.GetLeaderId()) {
+			return nil, nil, nil, consensus.PolicyWithCohort{}, mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
+				"UpdateRule cannot change leader outside of a promotion: current leader %v, requested %v",
+				currentRule.GetLeaderId(), update.leaderID)
+		}
+		newLeader = update.leaderID
+	}
+	newCohort = currentRule.GetCohortMembers()
+	if update.cohortMembers != nil {
+		newCohort = update.cohortMembers
+	}
+	newDP = currentRule.GetDurabilityPolicy()
+	if update.durabilityPolicy != nil {
+		dp := update.durabilityPolicy
+		if dp.QuorumType == clustermetadatapb.QuorumType_QUORUM_TYPE_UNKNOWN || dp.RequiredCount <= 0 {
+			return nil, nil, nil, consensus.PolicyWithCohort{}, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
+				"durability policy has missing or invalid fields: quorum_type=%v required_count=%d",
+				dp.QuorumType, dp.RequiredCount)
+		}
+		newDP = dp
+	}
+
+	// Validate that the new cohort can satisfy the new durability policy.
+	if len(newCohort) > 0 {
+		policy, policyErr := consensus.NewPolicyFromProto(newDP)
+		if policyErr != nil {
+			return nil, nil, nil, consensus.PolicyWithCohort{}, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT, "invalid durability policy: %v", policyErr)
+		}
+		if achievableErr := policy.CheckAchievable(newCohort); achievableErr != nil {
+			return nil, nil, nil, consensus.PolicyWithCohort{}, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT, "cohort cannot achieve durability policy: %v", achievableErr)
+		}
+	}
+
+	incomingPWC, err = consensus.NewPolicyWithCohort(newCohort, newDP)
+	if err != nil {
+		return nil, nil, nil, consensus.PolicyWithCohort{}, err
+	}
+	return newLeader, newCohort, newDP, incomingPWC, nil
+}
+
+// maybeFinalizeStuckProposal implements propagation: when current carries an
+// undecided proposal, finish deciding it exactly as it already stands — same
+// leader, cohort, and policy the proposal names — before doing anything else
+// with it. Returns current unchanged (and promoted=false) if current is
+// already decided.
+//
+// Both quorum modes propagate here, differing only in which policy backs the
+// finalize commit:
+//
+//   - requireOutgoingQuorum: the "Both" policy of the previous decision and
+//     the stuck proposal. That commit's synchronous ack is the quorum
+//     proof — it can't succeed unless the position it finalizes was already
+//     durable.
+//   - skipOutgoingQuorum: the incoming (new) policy directly, the same one
+//     the ordinary (non-propagated) skipOutgoingQuorum write also uses.
+//     There's no quorum to prove here — the cert is a separate, independent
+//     safety mechanism that already covers an arbitrary transition — so
+//     there's no reason to require an ack from the old (possibly
+//     unreachable) cohort.
+//
+// Either way this keeps two concerns cleanly separated instead of conflating
+// them into one write: "finish what the stuck write already committed to"
+// (an honest historical record — decision.leader_id stays whoever the
+// proposal named, even though that leader may now be unreachable) from
+// "apply the caller's requested change" (an entirely ordinary write from a
+// clean decided baseline, handled by the rest of UpdateRule, free to change
+// leader/cohort/policy like any other rule change). Neither write ever
+// claims a different leader wrote something it didn't — the exact bug this
+// design avoids.
+func (rs *ruleStore) maybeFinalizeStuckProposal(
+	ctx, lockedCtx context.Context,
+	current *clustermetadatapb.PoolerPosition,
+	update *RuleUpdateBuilder,
+	isPromotion bool,
+	incomingPWC consensus.PolicyWithCohort,
+) (*clustermetadatapb.PoolerPosition, bool, error) {
+	if consensus.IsRuleDecided(current.GetPosition()) {
+		return current, false, nil
+	}
+
+	stuckProposal := current.GetPosition().GetProposal()
+	stuckRuleNumber := stuckProposal.GetRuleNumber()
+
+	var finalizePolicy consensus.PolicyWithCohort
+	if update.skipOutgoingQuorum {
+		finalizePolicy = incomingPWC
+	} else {
+		var err error
+		finalizePolicy, err = expectedSyncStandbyPolicy(current.GetPosition())
+		if err != nil {
+			return nil, false, fmt.Errorf("propagation: computing decision->proposal transition: %w", err)
+		}
+	}
+	if err := rs.syncStandby.SetPolicy(lockedCtx, finalizePolicy); err != nil {
+		return nil, false, fmt.Errorf("propagation: pre-promote GUC: %w", err)
+	}
+
+	promoted := false
+	if isPromotion {
+		if err := update.promotionHook(lockedCtx); err != nil {
+			return nil, false, fmt.Errorf("propagation: promotion hook: %w", err)
+		}
+		promoted = true
+	}
+
+	// Confirm the stuck proposal's own quorum before trusting it: a no-op
+	// write under the policy above only succeeds if that proposal's WAL is
+	// already durable across the required standbys. Under skipOutgoingQuorum
+	// this isn't proving anything about the old proposal specifically — the
+	// cert already establishes safety — it's just an ordinary commit needed
+	// to make progress.
+	if err := rs.confirmProposalQuorum(lockedCtx, stuckRuleNumber.GetCoordinatorTerm(), stuckRuleNumber.GetLeaderSubterm()); err != nil {
+		return nil, false, fmt.Errorf("propagation: failed to confirm stuck proposal quorum: %w", err)
+	}
+
+	// coordinatorID and createdAt are finalized exactly as the proposal
+	// already stands too, same as leader/cohort/policy: this call decides
+	// what was already proposed, it doesn't write anything new, so every
+	// field of the resulting decision comes from the proposal itself.
+	decidedPos, err := rs.markProposalAsDecision(ctx,
+		stuckRuleNumber.GetCoordinatorTerm(), stuckRuleNumber.GetLeaderSubterm(),
+		topoclient.ClusterIDString(stuckProposal.GetCoordinatorId()), stuckProposal.GetCreationTime().AsTime())
+	if err != nil {
+		return nil, false, fmt.Errorf("propagation: failed to finish deciding stuck proposal: %w", err)
+	}
+
+	return decidedPos, promoted, nil
+}
+
 // UpdateRule writes a new rule to current_rule and rule_history.
 //
 // The leader_subterm is assigned as:
@@ -587,6 +735,16 @@ func (rs *ruleStore) readCurrentRuleLocked(ctx context.Context, inRecovery bool)
 // This operation uses the remote-operation-timeout and will fail if it cannot
 // complete within that time. A timeout typically indicates that synchronous
 // replication is not functioning.
+//
+// TODO: a promotion (propagated or not) that fails partway through — e.g. the
+// caller retries after a timeout — cannot currently be retried safely if
+// postgres already left recovery: isPromotion is derived from
+// update.promotionHook != nil, so a retry would call promotionHook (pg_promote)
+// again on a node that's no longer a standby. Making this idempotent would
+// mean only invoking promotionHook when postgres is actually still in
+// recovery (checked directly here, not inferred from the caller's builder),
+// so a retry that finds itself already promoted but not yet at a decided
+// leader can safely skip straight to finishing the write.
 func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) (*clustermetadatapb.PoolerPosition, error) {
 	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
 		return nil, fmt.Errorf("UpdateRule: %w", err)
@@ -628,24 +786,24 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 		return nil, err
 	}
 
-	// TODO: Implement propagation. For propagation:
-	// - This pooler should be in the incoming cohort
-	// - The rule request should be for a coordinator-led change that's identical to the
-	//   undecided proposal except that this pooler is the leader
-	// - Propagation will ensure that the "stuck" rule reaches quorum under its policy
-	//   by committing anything after the proposed rule. At that point we know the rule
-	//   is decided and we can atomically mark it as decided while also writing a new proposal
-	//   to make this pooler the leader.
-	if !update.skipOutgoingQuorum && !consensus.IsRuleDecided(current.GetPosition()) {
+	// A write with no independent safety backing (no cert, not a promotion)
+	// has no way to know whether an existing undecided proposal reflects
+	// durable, quorum-verified work — silently overwriting it could discard
+	// something a later coordinator needed to discover and recover from, so
+	// it fails closed here. Past this guard, at least one of skipOutgoingQuorum
+	// (externally-certified) or isPromotion (ordinary automatic failover) is
+	// always true — see finalizeStuckProposal below.
+	if !consensus.IsRuleDecided(current.GetPosition()) && !update.skipOutgoingQuorum && !isPromotion {
 		return nil, mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
 			"current rule has an undecided proposal; propagation is not yet supported")
 	}
-	// casOnProposal is true only when skipOutgoingQuorum let us past the guard
-	// above with an undecided proposal still present — i.e. the position we
-	// read (and must CAS against below) is the proposal, not the decision.
-	casOnProposal := !consensus.IsRuleDecided(current.GetPosition())
-	currentRule := consensus.PossiblyUndecidedRule(current.GetPosition())
 
+	// currentRule/currentTerm/currentSubterm reflect the position as read,
+	// undecided or not: propagation below never changes a proposal's own
+	// content (leader/cohort/policy/rule number), only whether it's marked
+	// decided — so resolving values against the pre-finalize read here gives
+	// the same answer as resolving them post-finalize would.
+	currentRule := consensus.PossiblyUndecidedRule(current.GetPosition())
 	currentTerm := currentRule.GetRuleNumber().GetCoordinatorTerm()
 	currentSubterm := currentRule.GetRuleNumber().GetLeaderSubterm()
 
@@ -668,56 +826,29 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 		nextSubterm = currentSubterm + 1
 	}
 
-	// Resolve values to write: caller-supplied values take priority; nil retains existing.
-	//
-	// Outside of a promotion, an existing leader can't be replaced: the current leader
-	// is the one issuing this write, and it has no way to instantaneously stop accepting
-	// transactions the moment the row changes — only a promotion (which goes through
-	// revocation/fencing on the outgoing leader first) can safely hand off leadership.
-	// Establishing the very first leader (currentRule has none yet) has no such risk and
-	// is allowed either way.
-	newLeader := currentRule.GetLeaderId()
-	if update.leaderID != nil {
-		if !isPromotion && currentRule.GetLeaderId() != nil && !proto.Equal(update.leaderID, currentRule.GetLeaderId()) {
-			return nil, mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
-				"UpdateRule cannot change leader outside of a promotion: current leader %v, requested %v",
-				currentRule.GetLeaderId(), update.leaderID)
-		}
-		newLeader = update.leaderID
-	}
-	newCohort := currentRule.GetCohortMembers()
-	if update.cohortMembers != nil {
-		newCohort = update.cohortMembers
-	}
-	newDP := currentRule.GetDurabilityPolicy()
-	if update.durabilityPolicy != nil {
-		dp := update.durabilityPolicy
-		if dp.QuorumType == clustermetadatapb.QuorumType_QUORUM_TYPE_UNKNOWN || dp.RequiredCount <= 0 {
-			return nil, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
-				"durability policy has missing or invalid fields: quorum_type=%v required_count=%d",
-				dp.QuorumType, dp.RequiredCount)
-		}
-		newDP = dp
+	newLeader, newCohort, newDP, incomingPWC, err := resolveNewRuleValues(currentRule, update, isPromotion)
+	if err != nil {
+		return nil, err
 	}
 
-	// Validate that the new cohort can satisfy the new durability policy.
-	if len(newCohort) > 0 {
-		policy, err := consensus.NewPolicyFromProto(newDP)
-		if err != nil {
-			return nil, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT, "invalid durability policy: %v", err)
-		}
-		if err := policy.CheckAchievable(newCohort); err != nil {
-			return nil, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT, "cohort cannot achieve durability policy: %v", err)
-		}
+	// Propagation: whenever the read position is undecided, finish deciding
+	// it exactly as it already stands — same leader, cohort, and policy the
+	// proposal names — before doing anything else with it. See
+	// maybeFinalizeStuckProposal's doc comment for the full design rationale.
+	// promoted tracks whether promotionHook already ran there, so the
+	// ordinary isPromotion branch further below doesn't call it a second
+	// time — pg_promote() only needs to happen once before either write.
+	// The returned position isn't needed here: currentRule/currentTerm/
+	// currentSubterm above already reflect it (finalize never changes a
+	// proposal's own content, only whether it's marked decided).
+	_, promoted, err := rs.maybeFinalizeStuckProposal(ctx, lockedCtx, current, update, isPromotion, incomingPWC)
+	if err != nil {
+		return nil, err
 	}
 
 	// Compute the GUC transition. The Both policy satisfies the old and new durability
 	// requirements simultaneously and is applied before the WAL write. The Incoming
 	// (new) policy is applied after the write commits.
-	incomingPWC, err := consensus.NewPolicyWithCohort(newCohort, newDP)
-	if err != nil {
-		return nil, err
-	}
 	var transition *consensus.PolicyTransition
 	if update.skipOutgoingQuorum {
 		// Skip BuildPolicyTransition and apply the incoming cohort directly.
@@ -778,8 +909,12 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 		if err := rs.syncStandby.SetPolicy(lockedCtx, transition.Both); err != nil {
 			return nil, fmt.Errorf("pre-promote GUC: %w", err)
 		}
-		if err := update.promotionHook(lockedCtx); err != nil {
-			return nil, fmt.Errorf("promotion hook: %w", err)
+		// promoted means propagation's finalize step above already ran
+		// promotionHook (pg_promote only needs to happen once).
+		if !promoted {
+			if err := update.promotionHook(lockedCtx); err != nil {
+				return nil, fmt.Errorf("promotion hook: %w", err)
+			}
 		}
 	} else {
 		if err := rs.syncStandby.SetPolicy(lockedCtx, transition.Both); err != nil {
@@ -794,194 +929,41 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 	// already streaming and the ack is nearly immediate. RuleWriteTimeout covers
 	// both cases.
 	//
-	// Phase 1: write the proposal, not the decision. Writing the proposal first
-	// means a crash or a context timeout between this commit and phase 2 below
-	// leaves a durably observable trace (Position.Proposal, and a decided=false
-	// rule_history row) instead of the change being silently lost or a fresh
-	// coordinator having no record of it to discover and recover from.
-	execCtx, cancel := context.WithTimeout(ctx, timeouts.RuleWriteTimeout)
-	defer cancel()
-
-	if isPromotion {
-		var ackSpan trace.Span
-		execCtx, ackSpan = telemetry.Tracer().Start(execCtx, "consensus/standby-ack",
-			trace.WithAttributes(attribute.Bool("is_promotion", true)))
-		defer ackSpan.End()
+	// Propose: write the proposal, not the decision. Writing the proposal first
+	// means a crash or a context timeout between this commit and the finalize
+	// step below leaves a durably observable trace (Position.Proposal, and a
+	// decided=false rule_history row) instead of the change being silently
+	// lost or a fresh coordinator having no record of it to discover and
+	// recover from.
+	// writeRuleProposal caches the resulting position itself, so its return
+	// value isn't needed here.
+	if _, err := rs.writeRuleProposal(ctx, ruleProposalWriteParams{
+		casTerm:          currentTerm,
+		casSubterm:       currentSubterm,
+		newTerm:          update.termNumber,
+		newSubterm:       nextSubterm,
+		newLeaderStr:     newLeaderStr,
+		newCohort:        newCohortParam,
+		dpName:           dpName,
+		dpQuorumType:     dpQuorumType,
+		dpRequiredCount:  dpRequiredCount,
+		createdAt:        update.createdAt,
+		eventType:        update.eventType,
+		walPosition:      update.walPosition,
+		operation:        update.operation,
+		reason:           update.reason,
+		acceptedMembers:  acceptedParam,
+		coordinatorIDStr: coordinatorIDStr,
+		isPromotion:      isPromotion,
+	}); err != nil {
+		return nil, err
 	}
 
-	result, err := rs.queryService.QueryArgs(execCtx, `
-		WITH
-		  params AS (
-		    -- Name all query parameters once so the rest of the CTE references them by name.
-		    SELECT $1::bytea        AS shard_id,
-		           $2::bigint       AS cas_term,
-		           $3::bigint       AS cas_subterm,
-		           $4::boolean      AS cas_on_proposal,
-		           $5::bigint       AS new_term,
-		           $6::bigint       AS new_subterm,
-		           NULLIF($7, '')   AS new_leader_id,
-		           $8::text[]       AS new_cohort,
-		           $9::text         AS dp_name,
-		           $10::text        AS dp_quorum_type,
-		           $11::bigint      AS dp_required_count,
-		           $12::timestamptz AS created_at,
-		           $13::text        AS event_type,
-		           NULLIF($14, '')  AS wal_position,
-		           NULLIF($15, '')  AS operation,
-		           $16::text        AS reason,
-		           $17::text[]      AS accepted_members,
-		           $18::text        AS new_coordinator_id
-		  ),
-		  locked AS (
-		    -- NOWAIT returns an error immediately if another transaction holds the row lock
-		    -- rather than blocking; callers that see an error should retry.
-		    -- CAS: only proceed if the position we read (decision, or the
-		    -- proposal when skipOutgoingQuorum let us past an undecided one
-		    -- above) hasn't changed since we read it.
-		    SELECT current_rule.shard_id
-		    FROM multigres.current_rule, params
-		    WHERE current_rule.shard_id = params.shard_id
-		      AND (
-		            (NOT params.cas_on_proposal
-		              AND decision_coordinator_term = params.cas_term
-		              AND decision_leader_subterm   = params.cas_subterm)
-		         OR (params.cas_on_proposal
-		              AND proposal_coordinator_term = params.cas_term
-		              AND proposal_leader_subterm   = params.cas_subterm)
-		          )
-		    FOR UPDATE NOWAIT
-		  ),
-		  updated AS (
-		    UPDATE multigres.current_rule
-		    SET proposal_coordinator_term          = params.new_term,
-		        proposal_leader_subterm            = params.new_subterm,
-		        proposal_leader_id                 = params.new_leader_id,
-		        proposal_cohort_members            = params.new_cohort,
-		        proposal_durability_policy_name    = params.dp_name,
-		        proposal_durability_quorum_type    = params.dp_quorum_type,
-		        proposal_durability_required_count = params.dp_required_count,
-		        proposal_created_at                = params.created_at
-		    FROM locked, params
-		    WHERE current_rule.shard_id = params.shard_id
-		    -- The decision_*/leader_id/coordinator_id/etc. columns below are
-		    -- unchanged by this UPDATE (only proposal_* is SET above) — returned
-		    -- anyway so the caller can build the full resulting PoolerPosition
-		    -- (decision + proposal + a fresh current_lsn) from one round trip,
-		    -- rather than reusing a pre-write LSN that's already stale by the
-		    -- time this write commits.
-		    RETURNING decision_coordinator_term, decision_leader_subterm, leader_id, coordinator_id,
-		              cohort_members, durability_policy_name, durability_quorum_type,
-		              durability_required_count, current_rule.created_at,
-		              proposal_coordinator_term, proposal_leader_subterm, proposal_leader_id,
-		              proposal_cohort_members, proposal_durability_policy_name,
-		              proposal_durability_quorum_type, proposal_durability_required_count,
-		              proposal_created_at
-		  ),
-		  inserted AS (
-		    -- decided starts false: this proposal isn't the decision yet. Phase 2
-		    -- (markProposalAsDecision) UPDATEs this exact row to decided=true rather
-		    -- than inserting a second one — one row per rule number, always.
-		    INSERT INTO multigres.rule_history
-		      (coordinator_term, leader_subterm, event_type, leader_id, coordinator_id,
-		       wal_position, operation, reason, cohort_members, accepted_members,
-		       durability_policy_name, durability_quorum_type, durability_required_count,
-		       decided, created_at)
-		    SELECT params.new_term, params.new_subterm, params.event_type, params.new_leader_id,
-		           params.new_coordinator_id, params.wal_position, params.operation, params.reason,
-		           params.new_cohort, params.accepted_members,
-		           params.dp_name, params.dp_quorum_type, params.dp_required_count,
-		           false, params.created_at
-		    FROM updated, params
-		    RETURNING coordinator_term
-		  )
-		-- Cross-joining inserted ensures a zero-row history insert (a bug) also returns zero
-		-- rows here, causing the caller to surface an error rather than silently succeeding.
-		SELECT updated.decision_coordinator_term, updated.decision_leader_subterm,
-		       updated.leader_id, updated.coordinator_id, updated.cohort_members,
-		       updated.durability_policy_name, updated.durability_quorum_type,
-		       updated.durability_required_count, updated.created_at,
-		       updated.proposal_coordinator_term, updated.proposal_leader_subterm,
-		       updated.proposal_leader_id, updated.proposal_cohort_members,
-		       updated.proposal_durability_policy_name, updated.proposal_durability_quorum_type,
-		       updated.proposal_durability_required_count, updated.proposal_created_at,
-		       CASE
-		         WHEN pg_is_in_recovery()
-		           THEN COALESCE(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn(), '0/0'::pg_lsn)
-		         ELSE pg_current_wal_lsn()
-		       END::text AS current_lsn
-		FROM updated, inserted`,
-		[]byte("0"),        // shard_id
-		currentTerm,        // cas_term
-		currentSubterm,     // cas_subterm
-		casOnProposal,      // cas_on_proposal
-		update.termNumber,  // new_term
-		nextSubterm,        // new_subterm
-		newLeaderStr,       // new_leader_id (NULLIF: leader absent on sentinel row)
-		newCohortParam,     // new_cohort
-		dpName,             // dp_name
-		dpQuorumType,       // dp_quorum_type
-		dpRequiredCount,    // dp_required_count
-		update.createdAt,   // created_at
-		update.eventType,   // event_type
-		update.walPosition, // wal_position (NULLIF: optional)
-		update.operation,   // operation    (NULLIF: optional)
-		update.reason,      // reason
-		acceptedParam,      // accepted_members
-		coordinatorIDStr,   // new_coordinator_id
-	)
-	if err != nil {
-		return nil, mterrors.Wrap(err, "failed to write rule proposal")
-	}
-
-	// Zero rows means either the CAS check failed (concurrent write between our read
-	// and write) or the shard row is missing (should never happen after initialisation).
-	if len(result.Rows) == 0 {
-		return nil, errRuleConflict
-	}
-
-	var proposalWriteDecision, proposalWriteProposal unvalidatedRuleRow
-	var proposalWriteCoordinatorIDStr, proposalWriteLSN string
-	if err := executor.ScanSingleRow(result,
-		&proposalWriteDecision.coordinatorTerm,
-		&proposalWriteDecision.leaderSubterm,
-		&proposalWriteDecision.leaderIDStr,
-		&proposalWriteCoordinatorIDStr,
-		&proposalWriteDecision.cohortNames,
-		&proposalWriteDecision.durabilityPolicyName,
-		&proposalWriteDecision.durabilityQuorumType,
-		&proposalWriteDecision.durabilityRequiredCount,
-		&proposalWriteDecision.createdAt,
-		&proposalWriteProposal.coordinatorTerm,
-		&proposalWriteProposal.leaderSubterm,
-		&proposalWriteProposal.leaderIDStr,
-		&proposalWriteProposal.cohortNames,
-		&proposalWriteProposal.durabilityPolicyName,
-		&proposalWriteProposal.durabilityQuorumType,
-		&proposalWriteProposal.durabilityRequiredCount,
-		&proposalWriteProposal.createdAt,
-		&proposalWriteLSN,
-	); err != nil {
-		return nil, mterrors.Wrap(err, "failed to scan written rule proposal")
-	}
-
-	// Cache the proposal immediately: it's now durable (phase 1 blocked on the
-	// sync-standby ack), so a reader must be able to observe it even if this
-	// process dies before phase 2 below runs.
-	if proposalPos, err := buildPoolerPosition(
-		proposalWriteDecision, proposalWriteCoordinatorIDStr, proposalWriteProposal, proposalWriteLSN,
-	); err != nil {
-		return nil, mterrors.Wrap(err, "failed to parse proposal row into memory")
-	} else {
-		rs.cacheRuleObservation(proposalPos)
-	}
-
-	// Phase 2: promote the just-written proposal to decision.
+	// Finalize: promote the just-written proposal to decision.
 	pos, err := rs.markProposalAsDecision(ctx, update.termNumber, nextSubterm, coordinatorIDStr, update.createdAt)
 	if err != nil {
 		return nil, err
 	}
-
-	rs.cacheRuleObservation(pos)
 
 	// Apply the incoming (new) GUC after the write commits.
 	if err := rs.syncStandby.SetPolicy(lockedCtx, transition.Incoming); err != nil {
@@ -994,11 +976,13 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 // markProposalAsDecision promotes the current_rule row's proposal_* columns to
 // decision_*, clears proposal_*, and flips the matching rule_history row (keyed
 // by expectedTerm/expectedSubterm) from decided=false to decided=true. It is
-// phase 2 of every rule write: UpdateRule calls it immediately after writing
-// the matching proposal in phase 1. A future finalization path (recovering a
-// quorum-verified proposal left behind by a dead leader) would call it too,
-// with its own coordinatorID/createdAt describing who is deciding and when —
-// which may differ from whoever originally proposed.
+// the finalize step of every rule write: UpdateRule calls it immediately
+// after writing the matching proposal in the propose step, passing
+// coordinatorIDStr/createdAt as that same propose write's own fields.
+// Propagation's finalize step also calls it, but to decide the stuck
+// proposal exactly as it already stands — there coordinatorIDStr/createdAt
+// (like leader/cohort/policy) come from the
+// proposal itself, not from whoever is now finalizing it.
 //
 // The CAS key is the proposal itself (expectedTerm/expectedSubterm), not the
 // prior decision: by the time this is called the proposal is the source of
@@ -1120,7 +1104,267 @@ func (rs *ruleStore) markProposalAsDecision(
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to parse written rule position")
 	}
+	rs.cacheRuleObservation(pos)
 	return pos, nil
+}
+
+// ruleProposalWriteParams holds the resolved values for writeRuleProposal's
+// propose write. All fields are pre-resolved by UpdateRule (defaults applied,
+// IDs converted to app names, etc.) — this struct is just a wide argument
+// list.
+type ruleProposalWriteParams struct {
+	casTerm, casSubterm int64
+	newTerm, newSubterm int64
+	newLeaderStr        string
+	newCohort           []string
+	dpName              string
+	dpQuorumType        string
+	dpRequiredCount     int64
+	createdAt           time.Time
+	eventType           string
+	walPosition         string
+	operation           string
+	reason              string
+	acceptedMembers     []string
+	coordinatorIDStr    string
+	isPromotion         bool
+}
+
+// writeRuleProposal performs the propose step of a rule write: it writes the
+// proposal (not the decision) to current_rule and inserts the matching
+// decided=false rule_history row. Writing the proposal first means a crash
+// or a context timeout between this commit and the finalize step
+// (markProposalAsDecision) leaves a durably observable trace
+// (Position.Proposal, and a decided=false rule_history row) instead of the
+// change being silently lost or a fresh coordinator having no record of it
+// to discover and recover from.
+//
+// This write blocks until a sync-standby WAL ack arrives. For promotions the
+// ack only arrives after the full SetPrimary round-trip (Recruit clears all
+// replication; standbys reconnect only after SetPrimary, including optional
+// pg_rewind). For primary-side cohort changes standbys are already streaming
+// and the ack is nearly immediate. RuleWriteTimeout covers both cases.
+func (rs *ruleStore) writeRuleProposal(ctx context.Context, p ruleProposalWriteParams) (*clustermetadatapb.PoolerPosition, error) {
+	execCtx, cancel := context.WithTimeout(ctx, timeouts.RuleWriteTimeout)
+	defer cancel()
+
+	if p.isPromotion {
+		var ackSpan trace.Span
+		execCtx, ackSpan = telemetry.Tracer().Start(execCtx, "consensus/standby-ack",
+			trace.WithAttributes(attribute.Bool("is_promotion", true)))
+		defer ackSpan.End()
+	}
+
+	result, err := rs.queryService.QueryArgs(execCtx, `
+		WITH
+		  params AS (
+		    -- Name all query parameters once so the rest of the CTE references them by name.
+		    SELECT $1::bytea        AS shard_id,
+		           $2::bigint       AS cas_term,
+		           $3::bigint       AS cas_subterm,
+		           $4::bigint       AS new_term,
+		           $5::bigint       AS new_subterm,
+		           NULLIF($6, '')   AS new_leader_id,
+		           $7::text[]       AS new_cohort,
+		           $8::text         AS dp_name,
+		           $9::text         AS dp_quorum_type,
+		           $10::bigint      AS dp_required_count,
+		           $11::timestamptz AS created_at,
+		           $12::text        AS event_type,
+		           NULLIF($13, '')  AS wal_position,
+		           NULLIF($14, '')  AS operation,
+		           $15::text        AS reason,
+		           $16::text[]      AS accepted_members,
+		           $17::text        AS new_coordinator_id
+		  ),
+		  locked AS (
+		    -- NOWAIT returns an error immediately if another transaction holds the row lock
+		    -- rather than blocking; callers that see an error should retry.
+		    -- CAS: only proceed if the decision we read hasn't changed since we
+		    -- read it. Always decision, never proposal: propagation above
+		    -- (unconditionally, in every mode) finalizes any undecided position
+		    -- before this write ever runs, so the row we're CASing against here
+		    -- is always already decided.
+		    SELECT current_rule.shard_id
+		    FROM multigres.current_rule, params
+		    WHERE current_rule.shard_id = params.shard_id
+		      AND decision_coordinator_term = params.cas_term
+		      AND decision_leader_subterm   = params.cas_subterm
+		    FOR UPDATE NOWAIT
+		  ),
+		  updated AS (
+		    UPDATE multigres.current_rule
+		    SET proposal_coordinator_term          = params.new_term,
+		        proposal_leader_subterm            = params.new_subterm,
+		        proposal_leader_id                 = params.new_leader_id,
+		        proposal_cohort_members            = params.new_cohort,
+		        proposal_durability_policy_name    = params.dp_name,
+		        proposal_durability_quorum_type    = params.dp_quorum_type,
+		        proposal_durability_required_count = params.dp_required_count,
+		        proposal_created_at                = params.created_at
+		    FROM locked, params
+		    WHERE current_rule.shard_id = params.shard_id
+		    -- The decision_*/leader_id/coordinator_id/etc. columns below are
+		    -- unchanged by this UPDATE (only proposal_* is SET above) — returned
+		    -- anyway so the caller can build the full resulting PoolerPosition
+		    -- (decision + proposal + a fresh current_lsn) from one round trip,
+		    -- rather than reusing a pre-write LSN that's already stale by the
+		    -- time this write commits.
+		    RETURNING decision_coordinator_term, decision_leader_subterm, leader_id, coordinator_id,
+		              cohort_members, durability_policy_name, durability_quorum_type,
+		              durability_required_count, current_rule.created_at,
+		              proposal_coordinator_term, proposal_leader_subterm, proposal_leader_id,
+		              proposal_cohort_members, proposal_durability_policy_name,
+		              proposal_durability_quorum_type, proposal_durability_required_count,
+		              proposal_created_at
+		  ),
+		  inserted AS (
+		    -- decided starts false: this proposal isn't the decision yet. The
+		    -- finalize step (markProposalAsDecision) UPDATEs this exact row to decided=true rather
+		    -- than inserting a second one — one row per rule number, always.
+		    INSERT INTO multigres.rule_history
+		      (coordinator_term, leader_subterm, event_type, leader_id, coordinator_id,
+		       wal_position, operation, reason, cohort_members, accepted_members,
+		       durability_policy_name, durability_quorum_type, durability_required_count,
+		       decided, created_at)
+		    SELECT params.new_term, params.new_subterm, params.event_type, params.new_leader_id,
+		           params.new_coordinator_id, params.wal_position, params.operation, params.reason,
+		           params.new_cohort, params.accepted_members,
+		           params.dp_name, params.dp_quorum_type, params.dp_required_count,
+		           false, params.created_at
+		    FROM updated, params
+		    RETURNING coordinator_term
+		  )
+		-- Cross-joining inserted ensures a zero-row history insert (a bug) also returns zero
+		-- rows here, causing the caller to surface an error rather than silently succeeding.
+		SELECT updated.decision_coordinator_term, updated.decision_leader_subterm,
+		       updated.leader_id, updated.coordinator_id, updated.cohort_members,
+		       updated.durability_policy_name, updated.durability_quorum_type,
+		       updated.durability_required_count, updated.created_at,
+		       updated.proposal_coordinator_term, updated.proposal_leader_subterm,
+		       updated.proposal_leader_id, updated.proposal_cohort_members,
+		       updated.proposal_durability_policy_name, updated.proposal_durability_quorum_type,
+		       updated.proposal_durability_required_count, updated.proposal_created_at,
+		       CASE
+		         WHEN pg_is_in_recovery()
+		           THEN COALESCE(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn(), '0/0'::pg_lsn)
+		         ELSE pg_current_wal_lsn()
+		       END::text AS current_lsn
+		FROM updated, inserted`,
+		[]byte("0"), // shard_id
+		p.casTerm,
+		p.casSubterm,
+		p.newTerm,
+		p.newSubterm,
+		p.newLeaderStr,
+		p.newCohort,
+		p.dpName,
+		p.dpQuorumType,
+		p.dpRequiredCount,
+		p.createdAt,
+		p.eventType,
+		p.walPosition,
+		p.operation,
+		p.reason,
+		p.acceptedMembers,
+		p.coordinatorIDStr,
+	)
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to write rule proposal")
+	}
+
+	// Zero rows means either the CAS check failed (concurrent write between our read
+	// and write) or the shard row is missing (should never happen after initialisation).
+	if len(result.Rows) == 0 {
+		return nil, errRuleConflict
+	}
+
+	var proposalWriteDecision, proposalWriteProposal unvalidatedRuleRow
+	var proposalWriteCoordinatorIDStr, proposalWriteLSN string
+	if err := executor.ScanSingleRow(result,
+		&proposalWriteDecision.coordinatorTerm,
+		&proposalWriteDecision.leaderSubterm,
+		&proposalWriteDecision.leaderIDStr,
+		&proposalWriteCoordinatorIDStr,
+		&proposalWriteDecision.cohortNames,
+		&proposalWriteDecision.durabilityPolicyName,
+		&proposalWriteDecision.durabilityQuorumType,
+		&proposalWriteDecision.durabilityRequiredCount,
+		&proposalWriteDecision.createdAt,
+		&proposalWriteProposal.coordinatorTerm,
+		&proposalWriteProposal.leaderSubterm,
+		&proposalWriteProposal.leaderIDStr,
+		&proposalWriteProposal.cohortNames,
+		&proposalWriteProposal.durabilityPolicyName,
+		&proposalWriteProposal.durabilityQuorumType,
+		&proposalWriteProposal.durabilityRequiredCount,
+		&proposalWriteProposal.createdAt,
+		&proposalWriteLSN,
+	); err != nil {
+		return nil, mterrors.Wrap(err, "failed to scan written rule proposal")
+	}
+
+	pos, err := buildPoolerPosition(
+		proposalWriteDecision, proposalWriteCoordinatorIDStr, proposalWriteProposal, proposalWriteLSN,
+	)
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to parse proposal row into memory")
+	}
+
+	// Cache immediately: it's now durable (this write blocked on the
+	// sync-standby ack), so a reader must be able to observe it even if this
+	// process dies before the finalize step runs.
+	rs.cacheRuleObservation(pos)
+	return pos, nil
+}
+
+// confirmProposalQuorum performs a no-op write to the stuck proposal's own
+// row, under whatever synchronous_standby_names policy the caller has
+// already applied. Its only purpose is the write itself: postgres has no
+// direct way to query whether an existing WAL entry already met its quorum
+// rules, but a fresh commit that requires a synchronous ack under those same
+// rules can't succeed unless it did. This is the quorum proof propagation
+// needs before it may trust and finalize the proposal via
+// markProposalAsDecision.
+func (rs *ruleStore) confirmProposalQuorum(ctx context.Context, expectedTerm, expectedSubterm int64) error {
+	execCtx, cancel := context.WithTimeout(ctx, timeouts.RuleWriteTimeout)
+	defer cancel()
+
+	result, err := rs.queryService.QueryArgs(execCtx, `
+		WITH
+		  params AS (
+		    SELECT $1::bytea  AS shard_id,
+		           $2::bigint AS expected_term,
+		           $3::bigint AS expected_subterm
+		  ),
+		  locked AS (
+		    -- NOWAIT returns an error immediately if another transaction holds the row lock
+		    -- rather than blocking; callers that see an error should retry.
+		    SELECT current_rule.shard_id
+		    FROM multigres.current_rule, params
+		    WHERE current_rule.shard_id      = params.shard_id
+		      AND proposal_coordinator_term = params.expected_term
+		      AND proposal_leader_subterm   = params.expected_subterm
+		    FOR UPDATE NOWAIT
+		  )
+		UPDATE multigres.current_rule
+		SET proposal_created_at = proposal_created_at
+		FROM locked
+		WHERE current_rule.shard_id = locked.shard_id
+		RETURNING proposal_coordinator_term`,
+		[]byte("0"), // shard_id
+		expectedTerm,
+		expectedSubterm)
+	if err != nil {
+		return mterrors.Wrap(err, "failed to confirm stuck proposal quorum")
+	}
+
+	// Zero rows means the expected proposal is no longer there — a concurrent
+	// writer raced in since it was read.
+	if len(result.Rows) == 0 {
+		return errRuleConflict
+	}
+	return nil
 }
 
 // queryRuleHistory returns the most recent rule history records in descending

--- a/go/services/multipooler/internal/manager/consensus/rule_store_pg_test.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store_pg_test.go
@@ -419,10 +419,12 @@ func TestRuleStorePG_ObservePosition_InitialPolicyCarriedThroughUpdate(t *testin
 
 // TestRuleStorePG_ObservePosition_SurfacesStuckProposal seeds a proposal
 // directly via raw SQL against current_rule, bypassing UpdateRule entirely —
-// there is no write path that produces one yet (see the two-phase-write gap
-// noted in UpdateRule). This is the concrete verification that the schema
-// migration actually closes the observability gap: once a proposal exists in
-// the DB, however it got there, ObservePosition must surface it.
+// UpdateRule's propose step can leave one behind (a crash or timeout before
+// the finalize step runs), but not deterministically on demand, which is why
+// this test seeds one directly instead. This is the concrete verification
+// that the schema migration actually closes the observability gap: once a
+// proposal exists in the DB, however it got there, ObservePosition must
+// surface it.
 func TestRuleStorePG_ObservePosition_SurfacesStuckProposal(t *testing.T) {
 	skipIfNoPG(t)
 	ctx := withTestActionLock(t)
@@ -504,11 +506,12 @@ func seedStuckProposal(ctx context.Context, t *testing.T, conn *client.Conn, ter
 	for i, id := range cohort {
 		cohortNames[i] = id.GetCell() + "_" + id.GetName()
 	}
+	leaderIDStr := leaderID.GetCell() + "_" + leaderID.GetName()
 	_, err := conn.Query(ctx, fmt.Sprintf(`
 		UPDATE multigres.current_rule
 		SET proposal_coordinator_term = %d,
 		    proposal_leader_subterm = 0,
-		    proposal_leader_id = '%s_%s',
+		    proposal_leader_id = '%s',
 		    proposal_cohort_members = '{%s}',
 		    proposal_durability_policy_name = '%s',
 		    proposal_durability_quorum_type = '%s',
@@ -516,12 +519,34 @@ func seedStuckProposal(ctx context.Context, t *testing.T, conn *client.Conn, ter
 		    proposal_created_at = now()
 		WHERE shard_id = '0'::bytea`,
 		term,
-		leaderID.GetCell(), leaderID.GetName(),
+		leaderIDStr,
 		strings.Join(cohortNames, ","),
 		policy.GetPolicyName(),
 		policy.GetQuorumType().String(),
 		policy.GetRequiredCount()))
 	require.NoError(t, err)
+
+	// markProposalAsDecision's CAS cross-joins with a matching rule_history row
+	// (decided=false), mirroring what the propose step of an ordinary write inserts. A
+	// real stuck proposal always has this row; seed it here too so the finalize
+	// step in propagation can find it.
+	_, err = conn.Query(ctx, fmt.Sprintf(`
+		INSERT INTO multigres.rule_history
+		  (coordinator_term, leader_subterm, event_type, leader_id, coordinator_id,
+		   wal_position, operation, reason, cohort_members, accepted_members,
+		   durability_policy_name, durability_quorum_type, durability_required_count,
+		   decided, created_at)
+		VALUES (%d, 0, 'promotion', '%s', 'zone1_coordinator-1', '0/0', 'promotion', 'seeded stuck proposal',
+		        '{%s}', '{%s}', '%s', '%s', %d, false, now())`,
+		term,
+		leaderIDStr,
+		strings.Join(cohortNames, ","),
+		strings.Join(cohortNames, ","),
+		policy.GetPolicyName(),
+		policy.GetQuorumType().String(),
+		policy.GetRequiredCount()))
+	require.NoError(t, err)
+
 	return &clustermetadatapb.RuleNumber{CoordinatorTerm: term, LeaderSubterm: 0}
 }
 
@@ -608,6 +633,75 @@ func TestRuleStorePG_UpdateRule_SkipOutgoingQuorumSupersedesStuckProposal(t *tes
 	assert.Equal(t, int64(5), pos.GetPosition().GetDecision().GetRuleNumber().GetCoordinatorTerm())
 	assert.Equal(t, "leader-2", pos.GetPosition().GetDecision().GetLeaderId().GetName())
 	assert.Nil(t, pos.GetPosition().GetProposal(), "the fresh write is fully decided, not stuck")
+}
+
+// TestRuleStorePG_UpdateRule_PropagatesViaFinalizeThenPromote verifies the
+// two-phase propagation design: an ordinary (non-certified) promotion that
+// finds an undecided proposal first finishes deciding it exactly as it
+// already stands — same leader, cohort, policy — before doing an entirely
+// separate, ordinary promotion to the new leader. Checks rule_history for
+// both decided rows to confirm the stuck proposal's own leader identity
+// (leader-1) is preserved honestly, rather than being overwritten with the
+// new leader's identity (leader-3) — the exact bug this design avoids.
+func TestRuleStorePG_UpdateRule_PropagatesViaFinalizeThenPromote(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := withTestActionLock(t)
+	resetRuleStoreTables(ctx, t)
+
+	rs, conn := newTestRuleStore(ctx, t)
+	defer conn.Close()
+
+	coordinatorID := testPoolerID(t, "zone1", "coordinator-1")
+	leaderID := testPoolerID(t, "zone1", "leader-1")
+	cohort := []*clustermetadatapb.ID{
+		testPoolerID(t, "zone1", "member-1"),
+		testPoolerID(t, "zone1", "member-2"),
+	}
+	_, err := rs.UpdateRule(ctx,
+		NewRuleUpdate(3, coordinatorID, "promotion", "bootstrap", time.Now()).
+			WithLeader(leaderID).
+			WithCohort(cohort),
+	)
+	require.NoError(t, err)
+
+	stuckRuleNumber := seedStuckProposal(ctx, t, conn, 4, leaderID, cohort, testBootstrapPolicy())
+
+	newLeaderID := testPoolerID(t, "zone1", "leader-3")
+	promotionHookCalls := 0
+	pos, err := rs.UpdateRule(ctx,
+		NewRuleUpdate(5, coordinatorID, "promotion", "auto-recover stuck proposal", time.Now()).
+			WithLeader(newLeaderID).
+			WithCohort(cohort).
+			WithPromotionHook(func(context.Context) error {
+				promotionHookCalls++
+				return nil
+			}),
+	)
+	require.NoError(t, err, "an ordinary promotion should propagate the stuck proposal without a cert")
+	assert.Equal(t, 1, promotionHookCalls, "pg_promote must run exactly once, not once per phase")
+	assert.Equal(t, int64(5), pos.GetPosition().GetDecision().GetRuleNumber().GetCoordinatorTerm())
+	assert.Equal(t, "leader-3", pos.GetPosition().GetDecision().GetLeaderId().GetName())
+	assert.Nil(t, pos.GetPosition().GetProposal(), "the fresh write is fully decided, not stuck")
+
+	records, err := rs.queryRuleHistory(ctx, 10)
+	require.NoError(t, err)
+	byTerm := make(map[int64]ruleHistoryRecord)
+	for _, rec := range records {
+		byTerm[rec.CoordinatorTerm] = rec
+	}
+
+	stuckRec, ok := byTerm[stuckRuleNumber.CoordinatorTerm]
+	require.True(t, ok, "the stuck proposal's own term must have a rule_history row")
+	assert.True(t, stuckRec.Decided, "the stuck proposal must be finalized as decided")
+	require.NotNil(t, stuckRec.LeaderID)
+	assert.Equal(t, "leader-1", stuckRec.LeaderID.appName[len("zone1_"):],
+		"the finalized stuck rule must keep its own original leader identity, not the new leader's")
+
+	newRec, ok := byTerm[5]
+	require.True(t, ok, "the new leader's promotion must have its own rule_history row")
+	assert.True(t, newRec.Decided)
+	require.NotNil(t, newRec.LeaderID)
+	assert.Equal(t, "leader-3", newRec.LeaderID.appName[len("zone1_"):])
 }
 
 func TestRuleStorePG_UpdateRule_FirstWrite(t *testing.T) {
@@ -1470,13 +1564,13 @@ func TestRuleStorePG_UpdateRule_PostWriteGUCFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "post-write GUC")
 	assert.Contains(t, err.Error(), "post-write alter failed")
 
-	// Both writes (phase 1's proposal, phase 2's decision) already committed to
+	// Both writes (the propose step's proposal, the finalize step's decision) already committed to
 	// postgres before the post-write GUC apply ran — the cache must reflect that
 	// even though UpdateRule itself returns an error.
 	cached := rs.CachedPosition()
 	require.NotNil(t, cached, "the decided write must be cached despite the later GUC failure")
 	assert.Equal(t, int64(1), cached.GetPosition().GetDecision().GetRuleNumber().GetCoordinatorTerm())
-	assert.Nil(t, cached.GetPosition().GetProposal(), "phase 2 clears the proposal it decided")
+	assert.Nil(t, cached.GetPosition().GetProposal(), "the finalize step clears the proposal it decided")
 }
 
 // TestRuleStorePG_UpdateRule_RejectsLeaderChangeOutsidePromotion verifies

--- a/go/services/multipooler/internal/manager/consensus/rule_store_test.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store_test.go
@@ -480,22 +480,22 @@ func mockDecidedReadResult() *sqltypes.Result {
 	)
 }
 
-// readPattern matches readCurrentRule's SELECT; casOnProposalPattern and
-// expectedTermPattern match phase 1's and phase 2's queries respectively —
+// readPattern matches readCurrentRule's SELECT; proposeWritePattern and
+// expectedTermPattern match the propose and finalize queries respectively —
 // each names a params column unique to that query, so tests can target one
 // write phase without accidentally matching another.
 const (
-	readPattern          = "SELECT decision_coordinator_term, decision_leader_subterm, leader_id, coordinator_id, cohort_members"
-	casOnProposalPattern = "cas_on_proposal"
-	expectedTermPattern  = "AS expected_term"
+	readPattern         = "SELECT decision_coordinator_term, decision_leader_subterm, leader_id, coordinator_id, cohort_members"
+	proposeWritePattern = "AS new_subterm"
+	expectedTermPattern = "AS expected_term"
 )
 
-func TestUpdateRule_Phase1WriteErrorPropagated(t *testing.T) {
+func TestUpdateRule_ProposeWriteErrorPropagated(t *testing.T) {
 	mockQueryService := mock.NewQueryService()
 	rs := newMockRuleStore(mockQueryService)
 
 	mockQueryService.AddQueryPatternOnce(readPattern, mockDecidedReadResult())
-	mockQueryService.AddQueryPatternOnceWithError(casOnProposalPattern, errors.New("connection reset"))
+	mockQueryService.AddQueryPatternOnceWithError(proposeWritePattern, errors.New("connection reset"))
 
 	coordinatorID := &clustermetadatapb.ID{Cell: "zone1", Name: "coordinator-1"}
 	_, err := rs.UpdateRule(withTestActionLock(t), NewRuleUpdate(1, coordinatorID, "config_change", "test", time.Now()))
@@ -505,14 +505,14 @@ func TestUpdateRule_Phase1WriteErrorPropagated(t *testing.T) {
 	assert.NoError(t, mockQueryService.ExpectationsWereMet())
 }
 
-func TestUpdateRule_Phase1ScanErrorPropagated(t *testing.T) {
+func TestUpdateRule_ProposeScanErrorPropagated(t *testing.T) {
 	mockQueryService := mock.NewQueryService()
 	rs := newMockRuleStore(mockQueryService)
 
 	mockQueryService.AddQueryPatternOnce(readPattern, mockDecidedReadResult())
-	// Phase 1's query succeeds but returns far fewer columns than UpdateRule
+	// The propose query succeeds but returns far fewer columns than UpdateRule
 	// scans for — a malformed response, not a query error.
-	mockQueryService.AddQueryPatternOnce(casOnProposalPattern,
+	mockQueryService.AddQueryPatternOnce(proposeWritePattern,
 		mock.MakeQueryResult([]string{"decision_coordinator_term"}, [][]any{{int64(1)}}))
 
 	coordinatorID := &clustermetadatapb.ID{Cell: "zone1", Name: "coordinator-1"}
@@ -522,15 +522,15 @@ func TestUpdateRule_Phase1ScanErrorPropagated(t *testing.T) {
 	assert.NoError(t, mockQueryService.ExpectationsWereMet())
 }
 
-func TestUpdateRule_Phase1ParseErrorPropagated(t *testing.T) {
+func TestUpdateRule_ProposeParseErrorPropagated(t *testing.T) {
 	mockQueryService := mock.NewQueryService()
 	rs := newMockRuleStore(mockQueryService)
 
 	mockQueryService.AddQueryPatternOnce(readPattern, mockDecidedReadResult())
-	// Phase 1's query succeeds and scans cleanly, but the decision it
+	// The propose query succeeds and scans cleanly, but the decision it
 	// returns carries a durability_quorum_type buildShardRule can't parse —
 	// malformed content, not a malformed row shape.
-	mockQueryService.AddQueryPatternOnce(casOnProposalPattern, mock.MakeQueryResult(
+	mockQueryService.AddQueryPatternOnce(proposeWritePattern, mock.MakeQueryResult(
 		[]string{
 			"decision_coordinator_term", "decision_leader_subterm", "leader_id", "coordinator_id", "cohort_members",
 			"durability_policy_name", "durability_quorum_type", "durability_required_count", "created_at",
@@ -555,12 +555,12 @@ func TestUpdateRule_Phase1ParseErrorPropagated(t *testing.T) {
 	assert.NoError(t, mockQueryService.ExpectationsWereMet())
 }
 
-func TestUpdateRule_Phase2ErrorPropagated(t *testing.T) {
+func TestUpdateRule_FinalizeErrorPropagated(t *testing.T) {
 	mockQueryService := mock.NewQueryService()
 	rs := newMockRuleStore(mockQueryService)
 
 	mockQueryService.AddQueryPatternOnce(readPattern, mockDecidedReadResult())
-	mockQueryService.AddQueryPatternOnce(casOnProposalPattern, mock.MakeQueryResult(
+	mockQueryService.AddQueryPatternOnce(proposeWritePattern, mock.MakeQueryResult(
 		[]string{
 			"decision_coordinator_term", "decision_leader_subterm", "leader_id", "coordinator_id", "cohort_members",
 			"durability_policy_name", "durability_quorum_type", "durability_required_count", "created_at",

--- a/go/test/endtoend/multiorch/stuck_proposal_test.go
+++ b/go/test/endtoend/multiorch/stuck_proposal_test.go
@@ -14,19 +14,25 @@
 
 // Package multiorch contains end-to-end tests for multiorch behavior.
 //
-// These two tests exercise how a stuck (undecided) proposal — left behind by
-// a coordinator that crashed between UpdateRule's two write phases, see
-// rule_store.go's two-phase write — interacts with the two ways a rule can
+// These tests exercise how a stuck (undecided) proposal — left behind by a
+// coordinator that crashed between UpdateRule's two write phases, see
+// rule_store.go's two-phase write — interacts with the ways a rule can
 // change:
 //
-//   - TestCohortChangeRejectedWithStuckProposal: an ordinary (non-certified)
-//     rule change has no way to know whether the stuck proposal reflects
-//     durable, quorum-verified work, so it fails closed rather than risk
-//     silently discarding it.
+//   - TestCohortChangeRejectedWithStuckProposal: an ordinary rule change
+//     that also changes cohort or durability policy has no way to know
+//     whether the stuck proposal reflects durable, quorum-verified work,
+//     so it fails closed rather than risk silently discarding it.
 //   - TestApplyCertifiedRuleChange_FromStuckProposal: an externally-certified
 //     rule change (multiadmin.ApplyCertifiedRuleChange) can supersede it,
 //     because the caller's cert — not quorum verification of the stored
 //     decision — is what establishes safety here.
+//   - TestStuckProposalAutoRecovers: ordinary automatic failover (no cert)
+//     also recovers it, as long as the failover doesn't also change cohort
+//     or durability policy — see buildProposalCore/validateProposal. The
+//     fresh write the new leader performs can't get its own synchronous ack
+//     unless the stuck proposal it supersedes was already durable, so no
+//     separate quorum-verification step is needed.
 package multiorch
 
 import (
@@ -344,5 +350,144 @@ func TestApplyCertifiedRuleChange_FromStuckProposal(t *testing.T) {
 	newPos := statusResp.GetConsensusStatus().GetCurrentPosition().GetPosition()
 	assert.Equal(t, newTerm, newPos.GetDecision().GetRuleNumber().GetCoordinatorTerm(),
 		"the stuck proposal is superseded by a fresh decided rule, exactly like any other promotion")
+	assert.Nil(t, newPos.GetProposal(), "the new leader's own write is fully decided, not stuck")
+}
+
+// TestStuckProposalAutoRecovers shows that ordinary automatic failover — no
+// cert, no manual CLI/admin intervention — also recovers a stuck proposal on
+// its own, as long as the failover doesn't also change cohort or durability
+// policy. Complements TestApplyCertifiedRuleChange_FromStuckProposal, which
+// needs a cert specifically because multiadmin's flow allows changing
+// cohort/policy in the same step; ordinary failover here keeps them
+// unchanged, so no cert is needed at all.
+func TestStuckProposalAutoRecovers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping TestStuckProposalAutoRecovers test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("Skipping end-to-end stuck proposal test (short mode or no postgres binaries)")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultiorchCount(1),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+	)
+	defer cleanup()
+
+	t.Logf("Test cluster ready in directory: %s", setup.TempDir)
+	t.Logf("Identified primary: %s", setup.PrimaryName)
+	oldPrimaryName := setup.PrimaryName
+
+	primaryClient := setup.NewPrimaryClient(t)
+	defer primaryClient.Close()
+
+	ctx := t.Context()
+
+	statusResp, err := primaryClient.Manager.Status(ctx, &multipoolermanagerdatapb.StatusRequest{})
+	require.NoError(t, err, "Status should succeed")
+	decision := statusResp.GetConsensusStatus().GetCurrentPosition().GetPosition().GetDecision()
+	currentTerm := decision.GetRuleNumber().GetCoordinatorTerm()
+
+	// Restart multiorch (NewIsolated stops the bootstrap multiorch once the
+	// shard is up) and pause its automatic recovery while we set up the
+	// stuck-proposal scenario, so it doesn't race the seeding below.
+	setup.StartMultiorchs(t.Context(), t)
+	resumeRecovery := setup.DisableRecovery(t, "multiorch")
+
+	// Seed a stuck proposal directly via raw SQL on the current primary,
+	// bypassing UpdateRule entirely — see the sibling tests in this file for
+	// why. Same leader/cohort/policy as the current decision: the whole
+	// point of this test is that ordinary failover can recover it without a
+	// cert precisely because nothing but the leader is changing.
+	stuckTerm := currentTerm + 1
+	_, err = primaryClient.Pooler.ExecuteQuery(ctx, fmt.Sprintf(`
+		UPDATE multigres.current_rule
+		SET proposal_coordinator_term = %d,
+		    proposal_leader_subterm = 0,
+		    proposal_leader_id = leader_id,
+		    proposal_cohort_members = cohort_members,
+		    proposal_durability_policy_name = durability_policy_name,
+		    proposal_durability_quorum_type = durability_quorum_type,
+		    proposal_durability_required_count = durability_required_count,
+		    proposal_created_at = now()
+		WHERE shard_id = '0'::bytea`, stuckTerm), 0)
+	require.NoError(t, err, "seeding the stuck proposal should succeed")
+
+	// A real stuck proposal always has a matching decided=false rule_history
+	// row, inserted by the propose step of the two-phase UpdateRule write it got stuck
+	// partway through. markProposalAsDecision's finalize step (propagation)
+	// depends on that row existing, so the raw-SQL seed above must mirror it
+	// too, copying the decision's own leader/cohort/policy since nothing else
+	// is changing here.
+	_, err = primaryClient.Pooler.ExecuteQuery(ctx, fmt.Sprintf(`
+		INSERT INTO multigres.rule_history
+		  (coordinator_term, leader_subterm, event_type, leader_id, coordinator_id,
+		   wal_position, operation, reason, cohort_members, accepted_members,
+		   durability_policy_name, durability_quorum_type, durability_required_count,
+		   decided, created_at)
+		SELECT %d, 0, 'promotion', leader_id, coordinator_id, '0/0', 'promotion',
+		       'seeded stuck proposal', cohort_members, cohort_members,
+		       durability_policy_name, durability_quorum_type, durability_required_count,
+		       false, now()
+		FROM multigres.current_rule
+		WHERE shard_id = '0'::bytea`, stuckTerm), 0)
+	require.NoError(t, err, "seeding the stuck proposal's rule_history row should succeed")
+
+	statusResp, err = primaryClient.Manager.Status(ctx, &multipoolermanagerdatapb.StatusRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, statusResp.GetConsensusStatus().GetCurrentPosition().GetPosition().GetProposal(),
+		"the seeded proposal must be observable before we try to recover from it")
+
+	// Kill postgres (not the multipooler process) on the old primary: the
+	// scenario this whole feature is about is a leader that crashed leaving
+	// a stuck proposal behind, not one that's still alive. Keeping
+	// multipooler running lets it report "postgres not running" to
+	// multiorch's health poller, which is what actually drives automatic
+	// failover here — a dead multipooler process would only be detected as
+	// unreachable, a slower and different signal. Disable restarts first so
+	// the monitor doesn't bring postgres back up before failover runs. The
+	// two surviving standbys already replicated the same stuck proposal
+	// (current_rule is an ordinary replicated table), so either is eligible
+	// to propagate it.
+	oldPrimaryInst := setup.GetMultipoolerInstance(oldPrimaryName)
+	require.NotNil(t, oldPrimaryInst)
+	oldPrimaryManagerClient, err := shardsetup.NewMultipoolerClient(oldPrimaryInst.Multipooler.GrpcPort)
+	require.NoError(t, err)
+	defer oldPrimaryManagerClient.Close()
+	_, err = oldPrimaryManagerClient.Manager.SetPostgresRestartsEnabled(utils.WithShortDeadline(t),
+		&multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest{Enabled: false})
+	require.NoError(t, err)
+
+	setup.KillPostgres(t, oldPrimaryName)
+
+	// Let multiorch auto-recover: no cert, no manual RPC, just ordinary
+	// automatic failover trusting the undecided proposal as its outgoing
+	// baseline (see NewTermRevocation/buildProposalCore).
+	resumeRecovery()
+	shardsetup.WaitForNewPrimary(t, setup, oldPrimaryName, 30*time.Second)
+
+	// Re-enable restarts on the old primary now that a new leader is in
+	// place: it comes back as a stale primary, and RequireRecovery's
+	// problem-free bar can't be met while it stays permanently down.
+	_, err = oldPrimaryManagerClient.Manager.SetPostgresRestartsEnabled(utils.WithShortDeadline(t),
+		&multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest{Enabled: true})
+	require.NoError(t, err)
+
+	setup.RequireRecovery(t, "multiorch", 20*time.Second)
+
+	newPrimary := setup.RefreshPrimary(t)
+	require.NotNil(t, newPrimary)
+	require.NotEqual(t, oldPrimaryName, newPrimary.Name, "a surviving standby should have been promoted")
+	setup.PrimaryName = newPrimary.Name
+
+	newPrimaryClient := setup.NewPrimaryClient(t)
+	defer newPrimaryClient.Close()
+	statusResp, err = newPrimaryClient.Manager.Status(ctx, &multipoolermanagerdatapb.StatusRequest{})
+	require.NoError(t, err)
+	newPos := statusResp.GetConsensusStatus().GetCurrentPosition().GetPosition()
+	assert.Greater(t, newPos.GetDecision().GetRuleNumber().GetCoordinatorTerm(), stuckTerm,
+		"the stuck proposal is superseded by a fresh decided rule at a higher term")
 	assert.Nil(t, newPos.GetProposal(), "the new leader's own write is fully decided, not stuck")
 }

--- a/proto/consensusdata.proto
+++ b/proto/consensusdata.proto
@@ -36,6 +36,15 @@ message CoordinatorProposal {
   // this proposal supersedes. proposal is the full new rule being proposed: an
   // entirely new rule or an existing one that hasn't yet finished propagating to
   // durability.
+  //
+  // TODO: decision here doesn't always mean a confirmed decision — propagation
+  // (see go/common/consensus/proposals.go's buildProposalCore) can legitimately
+  // set it to a rule that was only ever an undecided proposal on the outgoing
+  // side, trusted as the baseline being superseded. RulePosition{Decision,
+  // Proposal} is otherwise used to mean "a pooler's own confirmed decision plus
+  // any outstanding proposal beyond it" (PoolerPosition.position), a different
+  // meaning that happens to share this shape. Introduce a dedicated message for
+  // a coordinator's proposed transition instead of reusing RulePosition here.
   clustermetadata.RulePosition proposed_transition = 3;
 
   // When true, the leader must apply the incoming cohort GUC directly without


### PR DESCRIPTION
Ordinary automatic failover now trusts a cohort's most-advanced undecided proposal as its outgoing baseline instead of rejecting it outright. Both quorum modes (ordinary failover and externally-certified writes) finalize the stuck proposal first -- deciding it exactly as it already stands, under its own synchronous-ack quorum proof -- before applying the caller's actual change from a clean decided baseline. This removes the need for an external cert in the common case where only the leader is changing.

UpdateRule is decomposed into resolveNewRuleValues/maybeFinalizeStuckProposal/writeRuleProposal, each caching its own write's position rather than leaving that to callers.