### PR TITLE
refactor(consensus): drop per-policy CheckSufficientRecruitment, derive revocation from SatisfiedBy

### DIFF
--- a/docs/ha/rule-change.md
+++ b/docs/ha/rule-change.md
@@ -105,7 +105,7 @@ pooler that crashes and restarts still honors it.
 ### Why recruitment is enough: majority + revocation
 
 The coordinator only proceeds once the recruited set is large enough, checked by
-[`CheckSufficientRecruitment`](../../go/common/consensus/policy_at_least_n.go)
+[`CheckSufficientRecruitment`](../../go/common/consensus/durability.go)
 over the **outgoing** cohort. Two thresholds combine:
 
 ```text
@@ -252,7 +252,7 @@ from both succeeding.
 | Four-phase orchestration            | [`rule_change.go`](../../go/services/multiorch/consensus/rule_change.go) (`coordinatorLedRuleChange.Run`)                                             |
 | Proposal building + quorum proofs   | [`proposals.go`](../../go/common/consensus/proposals.go) (`BuildSafeProposal`, `buildProposalCore`, `discoverMostAdvancedTimeline`)                   |
 | Term derivation                     | [`revocation.go`](../../go/common/consensus/revocation.go) (`NewTermRevocation`)                                                                      |
-| Recruitment thresholds              | [`policy_at_least_n.go`](../../go/common/consensus/policy_at_least_n.go) (`CheckSufficientRecruitment`)                                               |
+| Recruitment thresholds              | [`durability.go`](../../go/common/consensus/durability.go) (`CheckSufficientRecruitment`)                                                             |
 | Pooler RPC handlers                 | [`rpc_consensus.go`](../../go/services/multipooler/internal/manager/rpc_consensus.go) (`Recruit`, `Promote`, `SetPrimary`)                            |
 | Rule write + GUC transition         | [`rule_store.go`](../../go/services/multipooler/internal/manager/consensus/rule_store.go), [`durability.go`](../../go/common/consensus/durability.go) |
 | RPC contracts                       | [`consensusdata.proto`](../../proto/consensusdata.proto)                                                                                              |

--- a/docs/ha/state-model.md
+++ b/docs/ha/state-model.md
@@ -93,7 +93,7 @@ A **quorum** is any subset of the cohort that satisfies the policy. The
 overview's example "AT_LEAST_2 of {N1, N2, N3, N4}" is a `DurabilityPolicy` with
 `quorum_type = AT_LEAST_N`, `required_count = 2`, over a four-member cohort.
 
-Whether a cohort can even satisfy a policy is checked by `CheckAchievable`
+Whether a cohort can even satisfy a policy is checked by `SatisfiedBy`
 ([policy_at_least_n.go](../../go/common/consensus/policy_at_least_n.go),
 [policy_multi_cell.go](../../go/common/consensus/policy_multi_cell.go)) before a
 rule is written — you cannot install `AT_LEAST_2` over a one-member cohort.

--- a/go/common/consensus/cohort_safety.go
+++ b/go/common/consensus/cohort_safety.go
@@ -71,5 +71,5 @@ func IsCohortMemberRemovalSafe(rule *clustermetadatapb.ShardRule, memberID *clus
 			recruited = append(recruited, id)
 		}
 	}
-	return policy.CheckSufficientRecruitment(newCohort, recruited) == nil
+	return CheckSufficientRecruitment(policy, newCohort, recruited) == nil
 }

--- a/go/common/consensus/durability.go
+++ b/go/common/consensus/durability.go
@@ -23,6 +23,7 @@ import (
 	"github.com/multigres/multigres/go/common/topoclient"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	"github.com/multigres/multigres/go/tools/sortedmaps"
 )
 
 // ParseUserSpecifiedDurabilityPolicy converts a policy name string into a DurabilityPolicy message.
@@ -283,12 +284,29 @@ func validateRecruitedSubset(cohort, recruited []*clustermetadatapb.ID) error {
 	return nil
 }
 
+// normalizeIDs returns a deduplicated, cell_name-sorted copy of ids, keeping
+// one representative entry per distinct pooler. Mirrors deduplicateStatuses'
+// role for ConsensusStatus: give downstream counting and set-difference
+// logic a canonical input so a duplicate entry can't be double-counted.
+func normalizeIDs(ids []*clustermetadatapb.ID) []*clustermetadatapb.ID {
+	byKey := make(map[string]*clustermetadatapb.ID, len(ids))
+	for _, id := range ids {
+		byKey[topoclient.ClusterIDString(id)] = id
+	}
+	return sortedmaps.Values(byKey)
+}
+
 // validateMajority returns nil if recruited forms a strict majority of cohort
 // (|recruited| >= cohort/2 + 1). This guarantees recruitment-set intersection:
 // any two recruitments that each clear a majority must share at least one
 // pooler, because if they were disjoint their union would exceed the cohort
 // size. Shared intersection + "one accept per term" at the pooler level is
 // what makes concurrent recruitments mutually exclusive.
+//
+// Assumes cohort and recruited are already normalizeIDs-deduplicated; a
+// duplicate entry would otherwise inflate the count past the true number of
+// distinct poolers backing it, passing with fewer poolers than the guarantee
+// above actually requires.
 func validateMajority(cohort, recruited []*clustermetadatapb.ID) error {
 	majority := len(cohort)/2 + 1
 	if len(recruited) < majority {
@@ -334,6 +352,12 @@ func unrecruitedOf(cohort, recruited []*clustermetadatapb.ID) []*clustermetadata
 // proposal-specific concern handled by the leader-appointment layer via
 // SatisfiedBy(recruited) or similar.
 func CheckSufficientRecruitment(policy DurabilityPolicy, cohort, recruited []*clustermetadatapb.ID) error {
+	// Normalize before any counting: a duplicate entry in either slice must
+	// not be double-counted by validateMajority or leak a repeated pooler
+	// into the revocation check below.
+	cohort = normalizeIDs(cohort)
+	recruited = normalizeIDs(recruited)
+
 	if err := validateRecruitedSubset(cohort, recruited); err != nil {
 		return err
 	}

--- a/go/common/consensus/durability.go
+++ b/go/common/consensus/durability.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/multigres/multigres/go/common/topoclient"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
@@ -40,29 +41,16 @@ func ParseUserSpecifiedDurabilityPolicy(name string) (*clustermetadatapb.Durabil
 
 // DurabilityPolicy captures the quorum semantics of a single durability rule.
 //
-// It exposes two checks a coordinator needs to safely appoint a new leader
-// under the generalized-consensus model:
-//
-//  1. Achievability: a pre-flight feasibility gate. Checks if the proposed cohort could
-//     satisfy this policy's durability conditions.
-//  2. Sufficient recruitment: the recruited subset of a recorded cohort can
-//     form a fresh quorum (candidacy) AND intersects every other quorum the
-//     cohort could form (revocation).
+// It exposes the feasibility check a coordinator needs to safely appoint a
+// new leader under the generalized-consensus model: whether a given set of
+// poolers could satisfy this policy's durability conditions.
 type DurabilityPolicy interface {
-	// CheckAchievable returns nil if the proposed cohort could satisfy
-	// this policy. Used as a pre-flight feasibility gate before attempting
-	// recruitment.
-	CheckAchievable(proposedCohort []*clustermetadatapb.ID) error
-
-	// CheckSufficientRecruitment returns nil if recruited is sufficient to
-	// safely establish a new leader. This has two obligations:
-	//
-	//   - Candidacy: recruited can form a fresh quorum under this policy, so
-	//     the new leader has forward progress.
-	//   - Revocation: recruited intersects every other quorum the cohort
-	//     could form under this policy, so no parallel quorum can still
-	//     commit outside our recruitment.
-	CheckSufficientRecruitment(cohort, recruited []*clustermetadatapb.ID) error
+	// SatisfiedBy returns nil if poolers, taken as a whole, could satisfy
+	// this policy — regardless of what poolers represents (a proposed
+	// cohort's feasibility, a recruited set's candidacy, an un-recruited
+	// leftover's rogue-quorum risk, etc.). Callers decide what to check by
+	// choosing which set to pass in.
+	SatisfiedBy(poolers []*clustermetadatapb.ID) error
 
 	// BuildSyncReplicationConfig returns the Postgres-level config the primary
 	// must apply to satisfy this policy's durability obligations.
@@ -310,25 +298,64 @@ func validateMajority(cohort, recruited []*clustermetadatapb.ID) error {
 	return nil
 }
 
-// unrecruitedKeyCount returns the number of distinct keyFn-keys of cohort
-// poolers that are not present in recruited. Membership is always determined
-// at the pooler level (ClusterIDString); keyFn controls the dimension of
-// aggregation for the counted set.
-//
-// If the count is N or more, those entries could form a rogue quorum on
-// their own.
-//
-//   - MultiCell passes GetCell as keyFn, so multiple un-recruited poolers in the
-//     same cell collapse into a single entry — the count is the number of
-//     cells with at least one un-recruited pooler.
-func unrecruitedKeyCount(cohort, recruited []*clustermetadatapb.ID, keyFn func(*clustermetadatapb.ID) string) int {
+// unrecruitedOf returns the cohort poolers not present in recruited.
+func unrecruitedOf(cohort, recruited []*clustermetadatapb.ID) []*clustermetadatapb.ID {
 	recruitedPoolers := poolerKeysOf(recruited)
-	uncovered := make(map[string]struct{})
+	unrecruited := make([]*clustermetadatapb.ID, 0, len(cohort))
 	for _, p := range cohort {
-		if _, ok := recruitedPoolers[topoclient.ClusterIDString(p)]; ok {
-			continue
+		if _, ok := recruitedPoolers[topoclient.ClusterIDString(p)]; !ok {
+			unrecruited = append(unrecruited, p)
 		}
-		uncovered[keyFn(p)] = struct{}{}
 	}
-	return len(uncovered)
+	return unrecruited
+}
+
+// CheckSufficientRecruitment returns nil if recruited is sufficient to
+// safely establish a new leader under policy. It enforces the two
+// proposal-agnostic invariants every policy needs:
+//
+//   - Majority: recruited is a strict majority of cohort. This is what
+//     makes proposal numbers unique — any two coordinators attempting a
+//     rule change at the same term must recruit overlapping majorities, so
+//     only one of them can win the term.
+//   - Revocation: the un-recruited leftover poolers cannot themselves
+//     achieve the policy — checked by asking the policy's own SatisfiedBy
+//     about the leftover set. If the leftovers *could* achieve it, they
+//     could work together to write a durable transaction under the
+//     outgoing rule, so the rule isn't actually frozen and revocation is
+//     violated. This is why every policy's bespoke revocation check turned
+//     out to be SatisfiedBy inverted and applied to the complementary set:
+//     achievability and revocation are the same question, just asked about
+//     the two sides of the recruited/un-recruited split — no
+//     policy-specific code is needed here at all.
+//
+// Candidacy (whether recruited itself satisfies the policy for the
+// *proposed* leadership change) is not checked here — that is a
+// proposal-specific concern handled by the leader-appointment layer via
+// SatisfiedBy(recruited) or similar.
+func CheckSufficientRecruitment(policy DurabilityPolicy, cohort, recruited []*clustermetadatapb.ID) error {
+	if err := validateRecruitedSubset(cohort, recruited); err != nil {
+		return err
+	}
+	if err := validateMajority(cohort, recruited); err != nil {
+		return err
+	}
+
+	unrecruited := unrecruitedOf(cohort, recruited)
+	if policy.SatisfiedBy(unrecruited) == nil {
+		return fmt.Errorf("revocation not satisfied: un-recruited cohort poolers %s could independently satisfy %s",
+			formatIDs(unrecruited), policy.Description())
+	}
+	return nil
+}
+
+// formatIDs renders IDs as a bracketed, comma-separated list of
+// cluster-unique pooler keys (e.g. "[cell1_pooler-1, cell1_pooler-2]"), for
+// use in error messages that need to name specific poolers.
+func formatIDs(ids []*clustermetadatapb.ID) string {
+	keys := make([]string, len(ids))
+	for i, id := range ids {
+		keys[i] = topoclient.ClusterIDString(id)
+	}
+	return "[" + strings.Join(keys, ", ") + "]"
 }

--- a/go/common/consensus/durability_test.go
+++ b/go/common/consensus/durability_test.go
@@ -95,11 +95,7 @@ func TestNewPolicyWithCohort(t *testing.T) {
 // family — its method bodies are deliberately minimal.
 type stubPolicy struct{}
 
-func (stubPolicy) CheckSufficientRecruitment([]*clustermetadatapb.ID, []*clustermetadatapb.ID) error {
-	return nil
-}
-
-func (stubPolicy) CheckAchievable([]*clustermetadatapb.ID) error { return nil }
+func (stubPolicy) SatisfiedBy([]*clustermetadatapb.ID) error { return nil }
 
 func (stubPolicy) BuildSyncReplicationConfig(*slog.Logger, []*clustermetadatapb.ID, *clustermetadatapb.ID) (*SyncReplicationConfig, error) {
 	return nil, nil

--- a/go/common/consensus/policy_at_least_n.go
+++ b/go/common/consensus/policy_at_least_n.go
@@ -29,8 +29,9 @@ type AtLeastNPolicy struct {
 	N int
 }
 
-// SatisfiedBy returns nil iff poolers has at least N members.
+// SatisfiedBy returns nil iff poolers has at least N distinct members.
 func (p AtLeastNPolicy) SatisfiedBy(poolers []*clustermetadatapb.ID) error {
+	poolers = normalizeIDs(poolers)
 	if len(poolers) < p.N {
 		return fmt.Errorf("durability not satisfied: %d poolers, required %d",
 			len(poolers), p.N)

--- a/go/common/consensus/policy_at_least_n.go
+++ b/go/common/consensus/policy_at_least_n.go
@@ -29,58 +29,11 @@ type AtLeastNPolicy struct {
 	N int
 }
 
-// CheckAchievable returns nil iff the proposed cohort has at least N poolers.
-func (p AtLeastNPolicy) CheckAchievable(proposedCohort []*clustermetadatapb.ID) error {
-	if len(proposedCohort) < p.N {
-		return fmt.Errorf("durability not achievable: proposed cohort has %d poolers, required %d",
-			len(proposedCohort), p.N)
-	}
-	return nil
-}
-
-// CheckSufficientRecruitment enforces two proposal-agnostic invariants:
-//   - Revocation: fewer than N cohort poolers are absent from recruited, so no
-//     N-subset of the cohort avoids our recruitment — no parallel quorum can
-//     still form outside our recruited set.
-//   - Majority: recruited is a strict majority of cohort, so any two
-//     concurrent recruitments must share at least one pooler and, via
-//     "one accept per term", cannot both complete.
-//
-// Candidacy (whether the recruited set satisfies the policy's quorum under
-// the *proposed* leadership change) is not checked here — that is a
-// proposal-specific concern handled by the leader-appointment layer via
-// CheckAchievable.
-func (p AtLeastNPolicy) CheckSufficientRecruitment(cohort, recruited []*clustermetadatapb.ID) error {
-	if err := validateRecruitedSubset(cohort, recruited); err != nil {
-		return err
-	}
-
-	// The two obligations below combine into a single binding threshold:
-	//
-	//   |recruited| >= max(
-	//     len(cohort)/2 + 1,   // majority — any two recruitments must share a pooler
-	//     len(cohort) - N + 1, // revocation — un-recruited cannot form an N-quorum
-	//   )
-	//
-	// We check each separately so failures report the specific reason.
-
-	// Majority: prevents two coordinators from recruiting disjoint sets at the same term.
-	if err := validateMajority(cohort, recruited); err != nil {
-		return err
-	}
-
-	// Revocation: if N or more cohort poolers are un-recruited, they could form a
-	// quorum on their own. Example: AT_LEAST_N with N=2 and a cohort of 5 poolers.
-	// After recruiting pooler-1, pooler-2, and pooler-3, we still need to recruit
-	// pooler-4 OR pooler-5 — otherwise the 2 unrecruited poolers could form their
-	// own 2-pooler quorum that still satisfies the durability policy.
-	//
-	// Relies on validateRecruitedSubset above: recruited ⊆ cohort, so the
-	// length difference equals the un-recruited count.
-	unrecruited := len(cohort) - len(recruited)
-	if unrecruited >= p.N {
-		return fmt.Errorf("revocation not satisfied: %d cohort poolers not recruited, another possible quorum could be formed of %d",
-			unrecruited, p.N)
+// SatisfiedBy returns nil iff poolers has at least N members.
+func (p AtLeastNPolicy) SatisfiedBy(poolers []*clustermetadatapb.ID) error {
+	if len(poolers) < p.N {
+		return fmt.Errorf("durability not satisfied: %d poolers, required %d",
+			len(poolers), p.N)
 	}
 	return nil
 }

--- a/go/common/consensus/policy_at_least_n_test.go
+++ b/go/common/consensus/policy_at_least_n_test.go
@@ -94,6 +94,18 @@ func TestAtLeastNPolicy_SatisfiedBy(t *testing.T) {
 			n:              1,
 			proposedCohort: []*clustermetadatapb.ID{id("pooler-1", "cell1")},
 		},
+		{
+			// Regression: a duplicated pooler entry must not be counted
+			// twice. Raw length here is 2 (matching N=2), but only 1
+			// distinct pooler backs it.
+			name: "AT_LEAST_2 with a duplicated pooler is not achievable",
+			n:    2,
+			proposedCohort: []*clustermetadatapb.ID{
+				id("pooler-1", "cell1"),
+				id("pooler-1", "cell1"),
+			},
+			wantErrMsg: "durability not satisfied: 1 poolers, required 2",
+		},
 	}
 
 	for _, tc := range tests {
@@ -171,6 +183,27 @@ func TestAtLeastNPolicy_CheckSufficientRecruitment(t *testing.T) {
 				id("pooler-5", "cell1"),
 			},
 			recruited: []*clustermetadatapb.ID{
+				id("pooler-1", "cell1"),
+				id("pooler-2", "cell1"),
+			},
+			wantErrMsg: "majority not satisfied: recruited 2 of 5 cohort poolers, need at least 3",
+		},
+		{
+			// Regression: a duplicate entry in recruited must not be
+			// double-counted toward majority. Raw len(recruited) here is 3
+			// (matching the majority of 3), but only 2 distinct poolers
+			// back it, so this must still fail majority.
+			name: "AT_LEAST_2 with a duplicated recruited pooler does not inflate the majority count",
+			n:    2,
+			cohort: []*clustermetadatapb.ID{
+				id("pooler-1", "cell1"),
+				id("pooler-2", "cell1"),
+				id("pooler-3", "cell1"),
+				id("pooler-4", "cell1"),
+				id("pooler-5", "cell1"),
+			},
+			recruited: []*clustermetadatapb.ID{
+				id("pooler-1", "cell1"),
 				id("pooler-1", "cell1"),
 				id("pooler-2", "cell1"),
 			},
@@ -261,7 +294,7 @@ func TestAtLeastNPolicy_CheckSufficientRecruitment(t *testing.T) {
 				id("pooler-3", "cell1"), id("pooler-4", "cell1"),
 				id("pooler-5", "cell1"), id("pooler-6", "cell1"),
 			},
-			wantErrMsg: "revocation not satisfied: un-recruited cohort poolers [cell1_pooler-7, cell1_pooler-8, cell1_pooler-9, cell1_pooler-10] could independently satisfy",
+			wantErrMsg: "revocation not satisfied: un-recruited cohort poolers [cell1_pooler-10, cell1_pooler-7, cell1_pooler-8, cell1_pooler-9] could independently satisfy",
 		},
 		{
 			name: "AT_LEAST_1 needs the whole cohort recruited because any single pooler can be an old quorum",

--- a/go/common/consensus/policy_at_least_n_test.go
+++ b/go/common/consensus/policy_at_least_n_test.go
@@ -50,7 +50,7 @@ func id(name, cell string) *clustermetadatapb.ID {
 	}
 }
 
-func TestAtLeastNPolicy_CheckAchievable(t *testing.T) {
+func TestAtLeastNPolicy_SatisfiedBy(t *testing.T) {
 	tests := []struct {
 		name           string
 		n              int
@@ -78,7 +78,7 @@ func TestAtLeastNPolicy_CheckAchievable(t *testing.T) {
 			name:           "AT_LEAST_2 with 1 pooler in proposed cohort is not achievable",
 			n:              2,
 			proposedCohort: []*clustermetadatapb.ID{id("pooler-1", "cell1")},
-			wantErrMsg:     "proposed cohort has 1 poolers, required 2",
+			wantErrMsg:     "durability not satisfied: 1 poolers, required 2",
 		},
 		{
 			name: "AT_LEAST_3 with 2 poolers in proposed cohort is not achievable",
@@ -87,7 +87,7 @@ func TestAtLeastNPolicy_CheckAchievable(t *testing.T) {
 				id("pooler-1", "cell1"),
 				id("pooler-2", "cell1"),
 			},
-			wantErrMsg: "proposed cohort has 2 poolers, required 3",
+			wantErrMsg: "durability not satisfied: 2 poolers, required 3",
 		},
 		{
 			name:           "AT_LEAST_1 with 1 pooler in proposed cohort is achievable",
@@ -99,7 +99,7 @@ func TestAtLeastNPolicy_CheckAchievable(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			p := AtLeastNPolicy{N: tc.n}
-			err := p.CheckAchievable(tc.proposedCohort)
+			err := p.SatisfiedBy(tc.proposedCohort)
 			if tc.wantErrMsg == "" {
 				require.NoError(t, err)
 			} else {
@@ -191,7 +191,7 @@ func TestAtLeastNPolicy_CheckSufficientRecruitment(t *testing.T) {
 				id("pooler-2", "cell1"),
 				id("pooler-3", "cell1"),
 			},
-			wantErrMsg: "revocation not satisfied: 2 cohort poolers not recruited",
+			wantErrMsg: "revocation not satisfied: un-recruited cohort poolers [cell1_pooler-4, cell1_pooler-5] could independently satisfy",
 		},
 		{
 			name: "AT_LEAST_2 with 4 of 5 cohort poolers is sufficient (1 missing < 2)",
@@ -261,7 +261,7 @@ func TestAtLeastNPolicy_CheckSufficientRecruitment(t *testing.T) {
 				id("pooler-3", "cell1"), id("pooler-4", "cell1"),
 				id("pooler-5", "cell1"), id("pooler-6", "cell1"),
 			},
-			wantErrMsg: "revocation not satisfied: 4 cohort poolers not recruited",
+			wantErrMsg: "revocation not satisfied: un-recruited cohort poolers [cell1_pooler-7, cell1_pooler-8, cell1_pooler-9, cell1_pooler-10] could independently satisfy",
 		},
 		{
 			name: "AT_LEAST_1 needs the whole cohort recruited because any single pooler can be an old quorum",
@@ -275,14 +275,14 @@ func TestAtLeastNPolicy_CheckSufficientRecruitment(t *testing.T) {
 				id("pooler-1", "cell1"),
 				id("pooler-2", "cell1"),
 			},
-			wantErrMsg: "revocation not satisfied: 1 cohort poolers not recruited",
+			wantErrMsg: "revocation not satisfied: un-recruited cohort poolers [cell1_pooler-3] could independently satisfy",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			p := AtLeastNPolicy{N: tc.n}
-			err := p.CheckSufficientRecruitment(tc.cohort, tc.recruited)
+			err := CheckSufficientRecruitment(p, tc.cohort, tc.recruited)
 			if tc.wantErrMsg == "" {
 				require.NoError(t, err)
 			} else {

--- a/go/common/consensus/policy_multi_cell.go
+++ b/go/common/consensus/policy_multi_cell.go
@@ -30,50 +30,12 @@ type MultiCellPolicy struct {
 	N int
 }
 
-// CheckAchievable returns nil iff the proposed cohort spans at least N
-// distinct cells.
-func (p MultiCellPolicy) CheckAchievable(proposedCohort []*clustermetadatapb.ID) error {
-	cells := cellsOf(proposedCohort)
+// SatisfiedBy returns nil iff poolers spans at least N distinct cells.
+func (p MultiCellPolicy) SatisfiedBy(poolers []*clustermetadatapb.ID) error {
+	cells := cellsOf(poolers)
 	if len(cells) < p.N {
-		return fmt.Errorf("durability not achievable: proposed cohort spans %d cells, required %d",
+		return fmt.Errorf("durability not satisfied: poolers span %d cells, required %d",
 			len(cells), p.N)
-	}
-	return nil
-}
-
-// CheckSufficientRecruitment enforces two proposal-agnostic invariants:
-//   - Revocation: the un-recruited cohort poolers span fewer than N distinct
-//     cells, so they cannot themselves form a commit quorum satisfying the
-//     policy. Cell coverage by recruited is not enough when a cell holds
-//     multiple poolers: a recruited pooler in a cell does not block an
-//     un-recruited pooler in the same cell from participating in a separate
-//     quorum elsewhere.
-//   - Majority: recruited is a pooler-majority of cohort, so any two
-//     concurrent recruitments must share at least one pooler. Cell-level
-//     intersection is not sufficient here because two pooler-disjoint
-//     recruitments can share cells when a cell has multiple poolers.
-//
-// Candidacy (whether recruited spans enough cells for the *proposed*
-// leadership change) is not checked here — that is a proposal-specific
-// concern handled by the leader-appointment layer via CheckAchievable.
-func (p MultiCellPolicy) CheckSufficientRecruitment(cohort, recruited []*clustermetadatapb.ID) error {
-	if err := validateRecruitedSubset(cohort, recruited); err != nil {
-		return err
-	}
-
-	if err := validateMajority(cohort, recruited); err != nil {
-		return err
-	}
-
-	// Revocation: if the un-recruited cohort poolers themselves span N or more cells, they could
-	// form a commit quorum on their own under this policy. We can't allow that.
-	// Example: MULTI_CELL_AT_LEAST_2 and a cohort of 6 poolers (2 per cell across 3 cells).
-	// Recruiting one pooler from each cell covers every cohort cell, but the 3 un-recruited
-	// poolers still span 3 cells — enough to form a separate 2-cell quorum on their own.
-	unrecruitedCells := unrecruitedKeyCount(cohort, recruited, func(id *clustermetadatapb.ID) string { return id.GetCell() })
-	if unrecruitedCells >= p.N {
-		return fmt.Errorf("revocation not satisfied: un-recruited cohort poolers span %d cells, another possible quorum could be formed spanning %d cells",
-			unrecruitedCells, p.N)
 	}
 	return nil
 }

--- a/go/common/consensus/policy_multi_cell.go
+++ b/go/common/consensus/policy_multi_cell.go
@@ -32,6 +32,11 @@ type MultiCellPolicy struct {
 
 // SatisfiedBy returns nil iff poolers spans at least N distinct cells.
 func (p MultiCellPolicy) SatisfiedBy(poolers []*clustermetadatapb.ID) error {
+	// cellsOf already dedupes by cell, so a duplicate pooler entry can't
+	// inflate the cell count the way it could a raw pooler count — this
+	// normalization is for consistency with AtLeastNPolicy.SatisfiedBy, not
+	// because it changes cellsOf's result here.
+	poolers = normalizeIDs(poolers)
 	cells := cellsOf(poolers)
 	if len(cells) < p.N {
 		return fmt.Errorf("durability not satisfied: poolers span %d cells, required %d",

--- a/go/common/consensus/policy_multi_cell_test.go
+++ b/go/common/consensus/policy_multi_cell_test.go
@@ -23,7 +23,7 @@ import (
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 )
 
-func TestMultiCellPolicy_CheckAchievable(t *testing.T) {
+func TestMultiCellPolicy_SatisfiedBy(t *testing.T) {
 	tests := []struct {
 		name           string
 		n              int
@@ -55,7 +55,7 @@ func TestMultiCellPolicy_CheckAchievable(t *testing.T) {
 				id("pooler-2", "cell1"),
 				id("pooler-3", "cell1"),
 			},
-			wantErrMsg: "proposed cohort spans 1 cells, required 2",
+			wantErrMsg: "durability not satisfied: poolers span 1 cells, required 2",
 		},
 		{
 			name: "MULTI_CELL_3 with poolers in 2 cells is not achievable",
@@ -64,14 +64,14 @@ func TestMultiCellPolicy_CheckAchievable(t *testing.T) {
 				id("pooler-1", "cell1"),
 				id("pooler-2", "cell2"),
 			},
-			wantErrMsg: "proposed cohort spans 2 cells, required 3",
+			wantErrMsg: "durability not satisfied: poolers span 2 cells, required 3",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			p := MultiCellPolicy{N: tc.n}
-			err := p.CheckAchievable(tc.proposedCohort)
+			err := p.SatisfiedBy(tc.proposedCohort)
 			if tc.wantErrMsg == "" {
 				require.NoError(t, err)
 			} else {
@@ -188,7 +188,7 @@ func TestMultiCellPolicy_CheckSufficientRecruitment(t *testing.T) {
 				id("pooler-1b", "cell1"),
 				id("pooler-1c", "cell1"),
 			},
-			wantErrMsg: "revocation not satisfied: un-recruited cohort poolers span 2 cells",
+			wantErrMsg: "revocation not satisfied: un-recruited cohort poolers [cell2_pooler-2, cell3_pooler-3] could independently satisfy",
 		},
 		{
 			name: "MULTI_CELL_2 with a recruited pooler outside the cohort is rejected",
@@ -209,7 +209,7 @@ func TestMultiCellPolicy_CheckSufficientRecruitment(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			p := MultiCellPolicy{N: tc.n}
-			err := p.CheckSufficientRecruitment(tc.cohort, tc.recruited)
+			err := CheckSufficientRecruitment(p, tc.cohort, tc.recruited)
 			if tc.wantErrMsg == "" {
 				require.NoError(t, err)
 			} else {

--- a/go/common/consensus/proposals.go
+++ b/go/common/consensus/proposals.go
@@ -310,7 +310,7 @@ func buildProposalCore(
 			return nil, fmt.Errorf("failed to parse durability policy from rule: %w", err)
 		}
 		cohort := outgoingDecision.GetCohortMembers()
-		if err := outgoingPolicy.CheckSufficientRecruitment(cohort, statusesToIDs(filterCohortStatuses(cohort, recruitedStatuses))); err != nil {
+		if err := CheckSufficientRecruitment(outgoingPolicy, cohort, statusesToIDs(filterCohortStatuses(cohort, recruitedStatuses))); err != nil {
 			return nil, fmt.Errorf("insufficient outgoing cohort recruitment: %w", err)
 		}
 
@@ -523,7 +523,7 @@ func validateProposal(
 		return fmt.Errorf("invalid durability policy in proposal: %w", err)
 	}
 
-	if err := p.CheckAchievable(recruitedInProposedCohort); err != nil {
+	if err := p.SatisfiedBy(recruitedInProposedCohort); err != nil {
 		return fmt.Errorf("recruited proposed cohort cannot achieve durability: %w", err)
 	}
 	if mode == skipOutgoingQuorum {
@@ -532,7 +532,7 @@ func validateProposal(
 		// leaders). Sufficient recruitment (majority overlap) ensures any two
 		// concurrent recruitments of the same cohort and durability policy must
 		// overlap and therefore cannot both independently succeed or cause split brain.
-		if err := p.CheckSufficientRecruitment(proposedRule.GetCohortMembers(), recruitedInProposedCohort); err != nil {
+		if err := CheckSufficientRecruitment(p, proposedRule.GetCohortMembers(), recruitedInProposedCohort); err != nil {
 			return fmt.Errorf("insufficient proposed cohort recruitment: %w", err)
 		}
 	}

--- a/go/common/consensus/proposals_test.go
+++ b/go/common/consensus/proposals_test.go
@@ -356,7 +356,7 @@ func TestBuildProposalCore(t *testing.T) {
 						ProposedTransition: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: r.TermRevocation.GetOutgoingRule()}, Proposal: makeRule(ruleNum(5, 0), atLeast(2), zone1.a, d, e)},
 					}, nil
 				},
-				wantErr: "proposal validation: recruited proposed cohort cannot achieve durability: durability not achievable: proposed cohort has 1 poolers, required 2",
+				wantErr: "proposal validation: recruited proposed cohort cannot achieve durability: durability not satisfied: 1 poolers, required 2",
 			}
 		}(),
 		func() tc {
@@ -447,7 +447,7 @@ func TestBuildProposalCore(t *testing.T) {
 						ProposedTransition: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: r.TermRevocation.GetOutgoingRule()}, Proposal: makeRule(ruleNum(5, 0), atLeast(2), zone1.a)},
 					}, nil
 				},
-				wantErr: "proposal validation: recruited proposed cohort cannot achieve durability: durability not achievable: proposed cohort has 1 poolers, required 2",
+				wantErr: "proposal validation: recruited proposed cohort cannot achieve durability: durability not satisfied: 1 poolers, required 2",
 			}
 		}(),
 		func() tc {
@@ -1022,7 +1022,7 @@ func TestBuildProposalCore(t *testing.T) {
 						ProposedTransition: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: r.TermRevocation.GetOutgoingRule()}, Proposal: makeRule(ruleNum(5, 0), atLeast(2), cohort...)},
 					}, nil
 				},
-				wantErr: "proposal validation: recruited proposed cohort cannot achieve durability: durability not achievable: proposed cohort has 1 poolers, required 2",
+				wantErr: "proposal validation: recruited proposed cohort cannot achieve durability: durability not satisfied: 1 poolers, required 2",
 			}
 		}(),
 		func() tc {
@@ -1433,7 +1433,7 @@ func TestBuildSafeProposal_InsufficientRecruitedFromProposedCohort(t *testing.T)
 
 	_, err := BuildSafeProposal(revocation(5, ruleNum(3, 0)), statuses, buildProposal)
 
-	require.EqualError(t, err, "proposal validation: recruited proposed cohort cannot achieve durability: durability not achievable: proposed cohort has 1 poolers, required 2")
+	require.EqualError(t, err, "proposal validation: recruited proposed cohort cannot achieve durability: durability not satisfied: 1 poolers, required 2")
 }
 
 func TestBuildSafeProposal_BuildProposalError(t *testing.T) {
@@ -1542,7 +1542,7 @@ func TestBuildSafeProposal_ProposedPolicyNotAchievable(t *testing.T) {
 
 	_, err := BuildSafeProposal(revocation(5, ruleNum(3, 0)), statuses, buildProposal)
 
-	require.EqualError(t, err, "proposal validation: recruited proposed cohort cannot achieve durability: durability not achievable: proposed cohort has 1 poolers, required 2")
+	require.EqualError(t, err, "proposal validation: recruited proposed cohort cannot achieve durability: durability not satisfied: 1 poolers, required 2")
 }
 
 func TestBuildSafeProposal_DuplicateStatusIgnoredForQuorum(t *testing.T) {

--- a/go/services/multiadmin/rule_change.go
+++ b/go/services/multiadmin/rule_change.go
@@ -292,7 +292,7 @@ func (s *MultiadminServer) probeCohort(
 // subset (by ComparePoolerPosition — decision, then proposal, then LSN).
 //
 // Insufficient responses is a hard failure: per
-// durabilityPolicy.CheckSufficientRecruitment, the reachable subset must be
+// commonconsensus.CheckSufficientRecruitment, the reachable subset must be
 // enough to satisfy the new rule's quorum. If not, the cert we'd derive
 // could be missing the most-advanced node in the proposed cohort.
 func (s *MultiadminServer) probeMostAdvanced(
@@ -320,7 +320,7 @@ func (s *MultiadminServer) probeMostAdvanced(
 
 	// Require a quorum of the proposed cohort to respond. Without that,
 	// the derived cert could understate the cohort's most-advanced position.
-	if err := policy.CheckSufficientRecruitment(cohortMembers, reachable); err != nil {
+	if err := commonconsensus.CheckSufficientRecruitment(policy, cohortMembers, reachable); err != nil {
 		return nil, status.Errorf(codes.Unavailable, "insufficient cohort responses to derive cert: %v", err)
 	}
 

--- a/go/services/multiorch/recovery/actions/shard_init_action.go
+++ b/go/services/multiorch/recovery/actions/shard_init_action.go
@@ -112,7 +112,7 @@ func (a *ShardInitAction) Execute(ctx context.Context, problem types.Problem) er
 	for i, p := range initializedPoolers {
 		initializedIDs[i] = p.Health().Multipooler.Id
 	}
-	if err := durabilityPolicy.CheckAchievable(initializedIDs); err != nil {
+	if err := durabilityPolicy.SatisfiedBy(initializedIDs); err != nil {
 		return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
 			"insufficient initialized poolers for initial cohort (have %d): %v", len(initializedPoolers), err)
 	}
@@ -144,7 +144,7 @@ func (a *ShardInitAction) Execute(ctx context.Context, problem types.Problem) er
 	for i, p := range committedCohort {
 		committedCohortIDs[i] = p.Multipooler.Id
 	}
-	if err := durabilityPolicy.CheckAchievable(committedCohortIDs); err != nil {
+	if err := durabilityPolicy.SatisfiedBy(committedCohortIDs); err != nil {
 		return mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
 			"insufficient committed cohort poolers reachable (have %d of %d): %v",
 			len(committedCohort), len(committedIDs), err)

--- a/go/services/multiorch/recovery/analysis/shard_needs_initialization_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/shard_needs_initialization_analyzer.go
@@ -74,7 +74,7 @@ func (a *ShardNeedsInitializationAnalyzer) Analyze(sa *ShardAnalysis) ([]types.P
 			initializedIDs = append(initializedIDs, poolerID(pa))
 		}
 	}
-	if err := durabilityPolicy.CheckAchievable(initializedIDs); err != nil {
+	if err := durabilityPolicy.SatisfiedBy(initializedIDs); err != nil {
 		// Not achievable yet — silently skip; the analyzer re-evaluates as poolers come online.
 		return nil, nil //nolint:nilerr
 	}

--- a/go/services/multipooler/internal/manager/consensus/rule_store.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store.go
@@ -706,7 +706,7 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 		if err != nil {
 			return nil, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT, "invalid durability policy: %v", err)
 		}
-		if err := policy.CheckAchievable(newCohort); err != nil {
+		if err := policy.SatisfiedBy(newCohort); err != nil {
 			return nil, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT, "cohort cannot achieve durability policy: %v", err)
 		}
 	}

--- a/go/services/multipooler/internal/manager/consensus/rule_store_pg_test.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store_pg_test.go
@@ -1083,7 +1083,7 @@ func TestRuleStorePG_UpdateRule_DurabilityPolicyAchievabilityRejected(t *testing
 			WithCohort(singleCellCohort),
 	)
 	require.Error(t, err, "UpdateRule must reject a cohort that cannot satisfy the durability policy")
-	assert.EqualError(t, err, "cohort cannot achieve durability policy: durability not achievable: proposed cohort spans 1 cells, required 2")
+	assert.EqualError(t, err, "cohort cannot achieve durability policy: durability not satisfied: poolers span 1 cells, required 2")
 }
 
 // ----------------------------------------------------------------------------

--- a/go/test/endtoend/multipooler/rpc_consensus_test.go
+++ b/go/test/endtoend/multipooler/rpc_consensus_test.go
@@ -365,7 +365,7 @@ func TestUpdateConsensusRule(t *testing.T) {
 				ExpectedOutgoingRule: currentRuleNumberFromClient(t, t.Context(), primaryManagerClient),
 			})
 		require.Error(t, err, "Removing all standbys should fail")
-		assert.Contains(t, err.Error(), "durability not achievable", "Error should indicate cohort cannot satisfy durability policy")
+		assert.Contains(t, err.Error(), "durability not satisfied", "Error should indicate cohort cannot satisfy durability policy")
 		t.Log("Confirmed: removing all standbys correctly rejected")
 	})
 


### PR DESCRIPTION
## Summary
- `AtLeastNPolicy` and `MultiCellPolicy` each had a bespoke `CheckSufficientRecruitment` implementing the same majority + revocation invariants. The revocation check was structurally identical to that same policy's own achievability check, just inverted and applied to the un-recruited leftover set — so both are replaced with a single free function (`CheckSufficientRecruitment`) that asks the policy itself, removing `CheckSufficientRecruitment` from the `DurabilityPolicy` interface entirely.
- Renamed `CheckAchievable` to `SatisfiedBy` (and its `proposedCohort` parameter to `poolers`), since it's now called with proposed cohorts, recruited sets, and un-recruited leftovers alike — the old name/param only fit the first case.
- Revocation-failure error messages now name the actual un-recruited poolers instead of just a count.