### PR TITLE
fix(multipooler): preserve real PG diagnostics for terminated reserved connections

### DIFF
--- a/go/common/mterrors/code.go
+++ b/go/common/mterrors/code.go
@@ -71,17 +71,38 @@ func NewIdleSessionTimeout() *PgDiagnostic {
 // NewReservedConnectionTerminated creates a PgDiagnostic for a reserved
 // connection that was terminated before its in-flight work could continue or
 // be concluded — e.g. force-closed when a planned failover drain exceeded its
-// grace period while the client sat idle. The message is deliberately not
-// transaction-specific: a reserved connection may hold a transaction or only
-// non-transactional session state (temp tables, portals, COPY, LISTEN), and
-// the same termination applies to all of them. SQLSTATE 40001
-// (serialization_failure) so clients and ORMs retry their in-flight work; the
-// connection's state was rolled back, so a retry is the correct recovery.
+// grace period while the client sat idle, or the backend socket died with no
+// diagnostic ever received (a hard crash, network partition, or SIGKILL). The
+// message is deliberately not transaction-specific: a reserved connection may
+// hold a transaction or only non-transactional session state (temp tables,
+// portals, COPY, LISTEN), and the same termination applies to all of them.
+//
+// SQLSTATE 08006 (connection_failure): the reserved backend behind the
+// client's session is genuinely gone, so whatever it held (transaction, temp
+// tables, portals) is lost and must be redone — the same class of signal
+// IsConnectionError itself checks for. This is deliberately NOT 40001
+// (serialization_failure): that code tells a client its connection is still
+// good and only the transaction needs retrying on it, which is false here.
+// Call this ONLY when no real diagnostic was received — prefer surfacing
+// Postgres's own FATAL (e.g. 57P01 admin_shutdown) verbatim when one exists;
+// see reservedConnTerminatedError in the multipooler executor.
+//
+// Severity is deliberately ERROR, not FATAL, even though 08006 usually
+// accompanies a FATAL in real PostgreSQL. Unlike NewAuthenticationTimeout or
+// NewIdleSessionTimeout (which fire on the client's own frontend connection
+// and correctly end it), this fires when a multipooler-side reserved *backend*
+// died — the client's frontend connection to multigateway is still alive and
+// is expected to keep serving statements on a freshly pooled backend. FATAL
+// severity with no following ReadyForQuery is exactly the wire signal real
+// PostgreSQL clients use to conclude a connection is now closed (see e.g.
+// pgx's pgconn pipeline, which calls asyncClose() on precisely this pattern):
+// marking this FATAL made standards-compliant clients tear down a frontend
+// connection multigateway had no intention of closing.
 //
 // This is deliberately NOT MTF01: the connection is gone, so there is nothing
 // to buffer or auto-retry inside the cluster — only the client can replay it.
 func NewReservedConnectionTerminated(reservedConnID uint64) *PgDiagnostic {
-	return NewPgError("ERROR", PgSSSerializationFailure,
+	return NewPgError("ERROR", PgSSConnectionFailure,
 		"reserved connection terminated during a planned failover; please retry",
 		fmt.Sprintf("reserved connection %d was terminated", reservedConnID))
 }

--- a/go/common/pgprotocol/client/copy_done_response_test.go
+++ b/go/common/pgprotocol/client/copy_done_response_test.go
@@ -62,9 +62,17 @@ func buildCommandComplete(tag string) []byte {
 // is a 1-byte type, a null-terminated value; the field list ends with a
 // single 0 byte.
 func buildErrorResponse(sqlstate, message string) []byte {
+	return buildErrorResponseWithSeverity("ERROR", sqlstate, message)
+}
+
+// buildErrorResponseWithSeverity is buildErrorResponse with an explicit
+// severity, so tests can construct FATAL/PANIC ErrorResponses (the ones
+// PostgreSQL sends immediately before closing the connection, with no
+// ReadyForQuery to follow).
+func buildErrorResponseWithSeverity(severity, sqlstate, message string) []byte {
 	var body bytes.Buffer
 	body.WriteByte('S') // severity
-	body.WriteString("ERROR")
+	body.WriteString(severity)
 	body.WriteByte(0)
 	body.WriteByte('C') // SQLSTATE
 	body.WriteString(sqlstate)

--- a/go/common/pgprotocol/client/extended.go
+++ b/go/common/pgprotocol/client/extended.go
@@ -464,6 +464,9 @@ func (c *Conn) processExecuteResponses(ctx context.Context, callback func(ctx co
 	for {
 		msgType, body, err := c.readMessage()
 		if err != nil {
+			if firstErr != nil {
+				return false, firstErr
+			}
 			return false, fmt.Errorf("failed to read message: %w", err)
 		}
 
@@ -533,8 +536,14 @@ func (c *Conn) processExecuteResponses(ctx context.Context, callback func(ctx co
 			return completed, firstErr
 
 		case protocol.MsgErrorResponse:
+			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
 			if firstErr == nil {
-				firstErr = c.parseError(body)
+				firstErr = diag
+			}
+			// FATAL/PANIC terminates the connection immediately; PostgreSQL
+			// never sends a following ReadyForQuery, so don't wait for one.
+			if diag.IsFatal() {
+				return false, firstErr
 			}
 
 		case protocol.MsgNoticeResponse:
@@ -660,6 +669,9 @@ func (c *Conn) waitForParseComplete(_ context.Context) error {
 	for {
 		msgType, body, err := c.readMessage()
 		if err != nil {
+			if firstErr != nil {
+				return firstErr
+			}
 			return fmt.Errorf("failed to read message: %w", err)
 		}
 
@@ -678,8 +690,14 @@ func (c *Conn) waitForParseComplete(_ context.Context) error {
 			return nil
 
 		case protocol.MsgErrorResponse:
+			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
 			if firstErr == nil {
-				firstErr = c.parseError(body)
+				firstErr = diag
+			}
+			// FATAL/PANIC terminates the connection immediately; PostgreSQL
+			// never sends a following ReadyForQuery, so don't wait for one.
+			if diag.IsFatal() {
+				return firstErr
 			}
 
 		case protocol.MsgNoticeResponse:
@@ -708,6 +726,9 @@ func (c *Conn) waitForCloseComplete(_ context.Context) error {
 	for {
 		msgType, body, err := c.readMessage()
 		if err != nil {
+			if firstErr != nil {
+				return firstErr
+			}
 			return fmt.Errorf("failed to read message: %w", err)
 		}
 
@@ -726,8 +747,14 @@ func (c *Conn) waitForCloseComplete(_ context.Context) error {
 			return nil
 
 		case protocol.MsgErrorResponse:
+			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
 			if firstErr == nil {
-				firstErr = c.parseError(body)
+				firstErr = diag
+			}
+			// FATAL/PANIC terminates the connection immediately; PostgreSQL
+			// never sends a following ReadyForQuery, so don't wait for one.
+			if diag.IsFatal() {
+				return firstErr
 			}
 
 		case protocol.MsgNoticeResponse:
@@ -755,6 +782,9 @@ func (c *Conn) waitForReadyForQuery(_ context.Context) error {
 	for {
 		msgType, body, err := c.readMessage()
 		if err != nil {
+			if firstErr != nil {
+				return firstErr
+			}
 			return fmt.Errorf("failed to read message: %w", err)
 		}
 
@@ -764,8 +794,14 @@ func (c *Conn) waitForReadyForQuery(_ context.Context) error {
 			return firstErr
 
 		case protocol.MsgErrorResponse:
+			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
 			if firstErr == nil {
-				firstErr = c.parseError(body)
+				firstErr = diag
+			}
+			// FATAL/PANIC terminates the connection immediately; PostgreSQL
+			// never sends a following ReadyForQuery, so don't wait for one.
+			if diag.IsFatal() {
+				return firstErr
 			}
 
 		case protocol.MsgNoticeResponse:
@@ -795,6 +831,9 @@ func (c *Conn) processDescribeResponses(_ context.Context) (*query.StatementDesc
 	for {
 		msgType, body, err := c.readMessage()
 		if err != nil {
+			if firstErr != nil {
+				return nil, firstErr
+			}
 			return nil, fmt.Errorf("failed to read message: %w", err)
 		}
 
@@ -830,8 +869,14 @@ func (c *Conn) processDescribeResponses(_ context.Context) (*query.StatementDesc
 			return desc, nil
 
 		case protocol.MsgErrorResponse:
+			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
 			if firstErr == nil {
-				firstErr = c.parseError(body)
+				firstErr = diag
+			}
+			// FATAL/PANIC terminates the connection immediately; PostgreSQL
+			// never sends a following ReadyForQuery, so don't wait for one.
+			if diag.IsFatal() {
+				return nil, firstErr
 			}
 
 		case protocol.MsgNoticeResponse:
@@ -886,6 +931,9 @@ func (c *Conn) processBindAndExecuteResponses(ctx context.Context, callback func
 	for {
 		msgType, body, err := c.readMessage()
 		if err != nil {
+			if firstErr != nil {
+				return false, firstErr
+			}
 			return false, fmt.Errorf("failed to read message: %w", err)
 		}
 
@@ -970,8 +1018,14 @@ func (c *Conn) processBindAndExecuteResponses(ctx context.Context, callback func
 			return completed, nil
 
 		case protocol.MsgErrorResponse:
+			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
 			if firstErr == nil {
-				firstErr = c.parseError(body)
+				firstErr = diag
+			}
+			// FATAL/PANIC terminates the connection immediately; PostgreSQL
+			// never sends a following ReadyForQuery, so don't wait for one.
+			if diag.IsFatal() {
+				return false, firstErr
 			}
 
 		case protocol.MsgNoticeResponse:
@@ -1010,6 +1064,9 @@ func (c *Conn) processBindAndDescribeResponses(_ context.Context) (*query.Statem
 	for {
 		msgType, body, err := c.readMessage()
 		if err != nil {
+			if firstErr != nil {
+				return nil, firstErr
+			}
 			return nil, fmt.Errorf("failed to read message: %w", err)
 		}
 
@@ -1041,8 +1098,14 @@ func (c *Conn) processBindAndDescribeResponses(_ context.Context) (*query.Statem
 			return desc, nil
 
 		case protocol.MsgErrorResponse:
+			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
 			if firstErr == nil {
-				firstErr = c.parseError(body)
+				firstErr = diag
+			}
+			// FATAL/PANIC terminates the connection immediately; PostgreSQL
+			// never sends a following ReadyForQuery, so don't wait for one.
+			if diag.IsFatal() {
+				return nil, firstErr
 			}
 
 		case protocol.MsgNoticeResponse:
@@ -1119,6 +1182,9 @@ func (c *Conn) processPrepareAndExecuteResponses(ctx context.Context, callback f
 	for {
 		msgType, body, err := c.readMessage()
 		if err != nil {
+			if firstErr != nil {
+				return firstErr
+			}
 			return fmt.Errorf("failed to read message: %w", err)
 		}
 
@@ -1200,8 +1266,14 @@ func (c *Conn) processPrepareAndExecuteResponses(ctx context.Context, callback f
 			return nil
 
 		case protocol.MsgErrorResponse:
+			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
 			if firstErr == nil {
-				firstErr = c.parseError(body)
+				firstErr = diag
+			}
+			// FATAL/PANIC terminates the connection immediately; PostgreSQL
+			// never sends a following ReadyForQuery, so don't wait for one.
+			if diag.IsFatal() {
+				return firstErr
 			}
 
 		case protocol.MsgNoticeResponse:
@@ -1264,6 +1336,9 @@ func (c *Conn) processBindDescribeAndExecuteResponses(ctx context.Context, callb
 	for {
 		msgType, body, err := c.readMessage()
 		if err != nil {
+			if firstErr != nil {
+				return false, firstErr
+			}
 			return false, fmt.Errorf("failed to read message: %w", err)
 		}
 
@@ -1339,8 +1414,14 @@ func (c *Conn) processBindDescribeAndExecuteResponses(ctx context.Context, callb
 			return completed, nil
 
 		case protocol.MsgErrorResponse:
+			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
 			if firstErr == nil {
-				firstErr = c.parseError(body)
+				firstErr = diag
+			}
+			// FATAL/PANIC terminates the connection immediately; PostgreSQL
+			// never sends a following ReadyForQuery, so don't wait for one.
+			if diag.IsFatal() {
+				return false, firstErr
 			}
 
 		case protocol.MsgNoticeResponse:

--- a/go/common/pgprotocol/client/extended.go
+++ b/go/common/pgprotocol/client/extended.go
@@ -464,10 +464,7 @@ func (c *Conn) processExecuteResponses(ctx context.Context, callback func(ctx co
 	for {
 		msgType, body, err := c.readMessage()
 		if err != nil {
-			if firstErr != nil {
-				return false, firstErr
-			}
-			return false, fmt.Errorf("failed to read message: %w", err)
+			return false, readLoopErr(firstErr, err)
 		}
 
 		switch msgType {
@@ -536,13 +533,7 @@ func (c *Conn) processExecuteResponses(ctx context.Context, callback func(ctx co
 			return completed, firstErr
 
 		case protocol.MsgErrorResponse:
-			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
-			if firstErr == nil {
-				firstErr = diag
-			}
-			// FATAL/PANIC terminates the connection immediately; PostgreSQL
-			// never sends a following ReadyForQuery, so don't wait for one.
-			if diag.IsFatal() {
+			if handleErrorResponse(body, &firstErr) {
 				return false, firstErr
 			}
 
@@ -659,6 +650,34 @@ func (c *Conn) writeFlush() error {
 }
 
 // Response processing methods.
+//
+// Every loop below shares the same FATAL/PANIC handling, factored into
+// readLoopErr and handleErrorResponse: a read failure after a diagnostic was
+// already captured just means the expected socket close following that
+// diagnostic, and PostgreSQL never sends ReadyForQuery after a FATAL/PANIC
+// severity error, so waiting for one would discard the diagnostic just
+// parsed in favor of that same read failure.
+
+// readLoopErr converts a readMessage failure into the error a response loop
+// should return, preferring an already-captured diagnostic (firstErr) over
+// the raw read failure that follows it.
+func readLoopErr(firstErr, err error) error {
+	if firstErr != nil {
+		return firstErr
+	}
+	return fmt.Errorf("failed to read message: %w", err)
+}
+
+// handleErrorResponse parses an ErrorResponse body, records it in firstErr if
+// no error has been captured yet, and reports whether the response loop must
+// stop immediately (FATAL/PANIC severity).
+func handleErrorResponse(body []byte, firstErr *error) (stop bool) {
+	diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
+	if *firstErr == nil {
+		*firstErr = diag
+	}
+	return diag.IsFatal()
+}
 
 // waitForParseComplete waits for ParseComplete and ReadyForQuery.
 // Always reads until ReadyForQuery to keep the connection in a clean state.
@@ -669,10 +688,7 @@ func (c *Conn) waitForParseComplete(_ context.Context) error {
 	for {
 		msgType, body, err := c.readMessage()
 		if err != nil {
-			if firstErr != nil {
-				return firstErr
-			}
-			return fmt.Errorf("failed to read message: %w", err)
+			return readLoopErr(firstErr, err)
 		}
 
 		switch msgType {
@@ -690,13 +706,7 @@ func (c *Conn) waitForParseComplete(_ context.Context) error {
 			return nil
 
 		case protocol.MsgErrorResponse:
-			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
-			if firstErr == nil {
-				firstErr = diag
-			}
-			// FATAL/PANIC terminates the connection immediately; PostgreSQL
-			// never sends a following ReadyForQuery, so don't wait for one.
-			if diag.IsFatal() {
+			if handleErrorResponse(body, &firstErr) {
 				return firstErr
 			}
 
@@ -726,10 +736,7 @@ func (c *Conn) waitForCloseComplete(_ context.Context) error {
 	for {
 		msgType, body, err := c.readMessage()
 		if err != nil {
-			if firstErr != nil {
-				return firstErr
-			}
-			return fmt.Errorf("failed to read message: %w", err)
+			return readLoopErr(firstErr, err)
 		}
 
 		switch msgType {
@@ -747,13 +754,7 @@ func (c *Conn) waitForCloseComplete(_ context.Context) error {
 			return nil
 
 		case protocol.MsgErrorResponse:
-			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
-			if firstErr == nil {
-				firstErr = diag
-			}
-			// FATAL/PANIC terminates the connection immediately; PostgreSQL
-			// never sends a following ReadyForQuery, so don't wait for one.
-			if diag.IsFatal() {
+			if handleErrorResponse(body, &firstErr) {
 				return firstErr
 			}
 
@@ -782,10 +783,7 @@ func (c *Conn) waitForReadyForQuery(_ context.Context) error {
 	for {
 		msgType, body, err := c.readMessage()
 		if err != nil {
-			if firstErr != nil {
-				return firstErr
-			}
-			return fmt.Errorf("failed to read message: %w", err)
+			return readLoopErr(firstErr, err)
 		}
 
 		switch msgType {
@@ -794,13 +792,7 @@ func (c *Conn) waitForReadyForQuery(_ context.Context) error {
 			return firstErr
 
 		case protocol.MsgErrorResponse:
-			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
-			if firstErr == nil {
-				firstErr = diag
-			}
-			// FATAL/PANIC terminates the connection immediately; PostgreSQL
-			// never sends a following ReadyForQuery, so don't wait for one.
-			if diag.IsFatal() {
+			if handleErrorResponse(body, &firstErr) {
 				return firstErr
 			}
 
@@ -831,10 +823,7 @@ func (c *Conn) processDescribeResponses(_ context.Context) (*query.StatementDesc
 	for {
 		msgType, body, err := c.readMessage()
 		if err != nil {
-			if firstErr != nil {
-				return nil, firstErr
-			}
-			return nil, fmt.Errorf("failed to read message: %w", err)
+			return nil, readLoopErr(firstErr, err)
 		}
 
 		switch msgType {
@@ -869,13 +858,7 @@ func (c *Conn) processDescribeResponses(_ context.Context) (*query.StatementDesc
 			return desc, nil
 
 		case protocol.MsgErrorResponse:
-			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
-			if firstErr == nil {
-				firstErr = diag
-			}
-			// FATAL/PANIC terminates the connection immediately; PostgreSQL
-			// never sends a following ReadyForQuery, so don't wait for one.
-			if diag.IsFatal() {
+			if handleErrorResponse(body, &firstErr) {
 				return nil, firstErr
 			}
 
@@ -931,10 +914,7 @@ func (c *Conn) processBindAndExecuteResponses(ctx context.Context, callback func
 	for {
 		msgType, body, err := c.readMessage()
 		if err != nil {
-			if firstErr != nil {
-				return false, firstErr
-			}
-			return false, fmt.Errorf("failed to read message: %w", err)
+			return false, readLoopErr(firstErr, err)
 		}
 
 		switch msgType {
@@ -1018,13 +998,7 @@ func (c *Conn) processBindAndExecuteResponses(ctx context.Context, callback func
 			return completed, nil
 
 		case protocol.MsgErrorResponse:
-			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
-			if firstErr == nil {
-				firstErr = diag
-			}
-			// FATAL/PANIC terminates the connection immediately; PostgreSQL
-			// never sends a following ReadyForQuery, so don't wait for one.
-			if diag.IsFatal() {
+			if handleErrorResponse(body, &firstErr) {
 				return false, firstErr
 			}
 
@@ -1064,10 +1038,7 @@ func (c *Conn) processBindAndDescribeResponses(_ context.Context) (*query.Statem
 	for {
 		msgType, body, err := c.readMessage()
 		if err != nil {
-			if firstErr != nil {
-				return nil, firstErr
-			}
-			return nil, fmt.Errorf("failed to read message: %w", err)
+			return nil, readLoopErr(firstErr, err)
 		}
 
 		switch msgType {
@@ -1098,13 +1069,7 @@ func (c *Conn) processBindAndDescribeResponses(_ context.Context) (*query.Statem
 			return desc, nil
 
 		case protocol.MsgErrorResponse:
-			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
-			if firstErr == nil {
-				firstErr = diag
-			}
-			// FATAL/PANIC terminates the connection immediately; PostgreSQL
-			// never sends a following ReadyForQuery, so don't wait for one.
-			if diag.IsFatal() {
+			if handleErrorResponse(body, &firstErr) {
 				return nil, firstErr
 			}
 
@@ -1182,10 +1147,7 @@ func (c *Conn) processPrepareAndExecuteResponses(ctx context.Context, callback f
 	for {
 		msgType, body, err := c.readMessage()
 		if err != nil {
-			if firstErr != nil {
-				return firstErr
-			}
-			return fmt.Errorf("failed to read message: %w", err)
+			return readLoopErr(firstErr, err)
 		}
 
 		switch msgType {
@@ -1266,13 +1228,7 @@ func (c *Conn) processPrepareAndExecuteResponses(ctx context.Context, callback f
 			return nil
 
 		case protocol.MsgErrorResponse:
-			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
-			if firstErr == nil {
-				firstErr = diag
-			}
-			// FATAL/PANIC terminates the connection immediately; PostgreSQL
-			// never sends a following ReadyForQuery, so don't wait for one.
-			if diag.IsFatal() {
+			if handleErrorResponse(body, &firstErr) {
 				return firstErr
 			}
 
@@ -1336,10 +1292,7 @@ func (c *Conn) processBindDescribeAndExecuteResponses(ctx context.Context, callb
 	for {
 		msgType, body, err := c.readMessage()
 		if err != nil {
-			if firstErr != nil {
-				return false, firstErr
-			}
-			return false, fmt.Errorf("failed to read message: %w", err)
+			return false, readLoopErr(firstErr, err)
 		}
 
 		switch msgType {
@@ -1414,13 +1367,7 @@ func (c *Conn) processBindDescribeAndExecuteResponses(ctx context.Context, callb
 			return completed, nil
 
 		case protocol.MsgErrorResponse:
-			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
-			if firstErr == nil {
-				firstErr = diag
-			}
-			// FATAL/PANIC terminates the connection immediately; PostgreSQL
-			// never sends a following ReadyForQuery, so don't wait for one.
-			if diag.IsFatal() {
+			if handleErrorResponse(body, &firstErr) {
 				return false, firstErr
 			}
 

--- a/go/common/pgprotocol/client/extended_test.go
+++ b/go/common/pgprotocol/client/extended_test.go
@@ -166,6 +166,77 @@ func TestProcessBindDescribeAndExecuteResponses_FatalErrorWithoutReadyForQuery_P
 	assert.Equal(t, "57P01", diag.Code)
 }
 
+// TestExtendedResponseLoops_ReadFailureWrapsErrorWhenNothingCaptured covers
+// readLoopErr's fallback branch at every one of the nine extended-protocol
+// response loops' call sites: when the socket fails before any diagnostic
+// was ever parsed, the loop must return a wrapped read error, not a nil or
+// swallowed failure.
+func TestExtendedResponseLoops_ReadFailureWrapsErrorWhenNothingCaptured(t *testing.T) {
+	cases := []struct {
+		name string
+		call func(c *Conn) error
+	}{
+		{"waitForParseComplete", func(c *Conn) error {
+			return c.waitForParseComplete(context.Background())
+		}},
+		{"waitForCloseComplete", func(c *Conn) error {
+			return c.waitForCloseComplete(context.Background())
+		}},
+		{"waitForReadyForQuery", func(c *Conn) error {
+			return c.waitForReadyForQuery(context.Background())
+		}},
+		{"processDescribeResponses", func(c *Conn) error {
+			_, err := c.processDescribeResponses(context.Background())
+			return err
+		}},
+		{"processExecuteResponses", func(c *Conn) error {
+			_, err := c.processExecuteResponses(context.Background(), nil)
+			return err
+		}},
+		{"processBindAndExecuteResponses", func(c *Conn) error {
+			_, err := c.processBindAndExecuteResponses(context.Background(), nil)
+			return err
+		}},
+		{"processBindAndDescribeResponses", func(c *Conn) error {
+			_, err := c.processBindAndDescribeResponses(context.Background())
+			return err
+		}},
+		{"processPrepareAndExecuteResponses", func(c *Conn) error {
+			return c.processPrepareAndExecuteResponses(context.Background(), nil)
+		}},
+		{"processBindDescribeAndExecuteResponses", func(c *Conn) error {
+			_, err := c.processBindDescribeAndExecuteResponses(context.Background(), nil)
+			return err
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestReadOnlyConn(nil) // empty input: the first read fails immediately
+			err := tc.call(c)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to read message")
+		})
+	}
+}
+
+// TestWaitForParseComplete_NonFatalErrorThenReadFailure_PreservesFirstError
+// covers readLoopErr's other branch: a non-fatal ErrorResponse leaves the
+// loop waiting for ReadyForQuery, and if the socket then fails (e.g. the
+// server crashed after sending the error but before the trailing RFQ), the
+// loop must still return the diagnostic already captured rather than
+// masking it with the read failure that follows.
+func TestWaitForParseComplete_NonFatalErrorThenReadFailure_PreservesFirstError(t *testing.T) {
+	input := buildErrorResponse("42601", "syntax error at or near \"nonsense\"")
+
+	c := newTestReadOnlyConn(input)
+	err := c.waitForParseComplete(context.Background())
+
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag), "expected a *mterrors.PgDiagnostic, got %T: %v", err, err)
+	assert.Equal(t, "42601", diag.Code)
+}
+
 func TestWriteParse(t *testing.T) {
 	var buf bytes.Buffer
 	conn := &Conn{

--- a/go/common/pgprotocol/client/extended_test.go
+++ b/go/common/pgprotocol/client/extended_test.go
@@ -17,13 +17,154 @@ package client
 import (
 	"bufio"
 	"bytes"
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 )
+
+// TestBindAndExecute_FatalErrorWithoutReadyForQuery_PreservesDiagnostic
+// exercises the extended query protocol equivalent of the simple-query fix
+// in query_test.go: Postgrex (and other clients using the extended
+// protocol) hits this exact path for a self pg_terminate_backend(pg_backend_pid()).
+// PostgreSQL sends BindComplete, then a FATAL ErrorResponse, then closes the
+// connection without ever sending ReadyForQuery. processBindAndExecuteResponses
+// must return that diagnostic instead of the read failure that follows it.
+func TestBindAndExecute_FatalErrorWithoutReadyForQuery_PreservesDiagnostic(t *testing.T) {
+	var input bytes.Buffer
+	writeRawMessage(&input, protocol.MsgBindComplete, nil)
+	input.Write(buildErrorResponseWithSeverity("FATAL", "57P01", "terminating connection due to administrator command"))
+	// No ReadyForQuery follows: the input ends here, exactly like PostgreSQL
+	// closing the socket right after a FATAL.
+
+	c := newTestReadOnlyConn(input.Bytes())
+	_, err := c.processBindAndExecuteResponses(context.Background(), nil)
+
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag), "expected a *mterrors.PgDiagnostic, got %T: %v", err, err)
+	assert.Equal(t, "FATAL", diag.Severity)
+	assert.Equal(t, "57P01", diag.Code)
+}
+
+// TestWaitForParseComplete_FatalErrorWithoutReadyForQuery_PreservesDiagnostic
+// covers waitForParseComplete's identical FATAL/PANIC handling to
+// processBindAndExecuteResponses above: PostgreSQL sends a FATAL
+// ErrorResponse in place of ParseComplete and closes the connection without
+// a trailing ReadyForQuery.
+func TestWaitForParseComplete_FatalErrorWithoutReadyForQuery_PreservesDiagnostic(t *testing.T) {
+	input := buildErrorResponseWithSeverity("FATAL", "57P01", "terminating connection due to administrator command")
+
+	c := newTestReadOnlyConn(input)
+	err := c.waitForParseComplete(context.Background())
+
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag), "expected a *mterrors.PgDiagnostic, got %T: %v", err, err)
+	assert.Equal(t, "FATAL", diag.Severity)
+	assert.Equal(t, "57P01", diag.Code)
+}
+
+// TestWaitForCloseComplete_FatalErrorWithoutReadyForQuery_PreservesDiagnostic
+// covers waitForCloseComplete's identical FATAL/PANIC handling.
+func TestWaitForCloseComplete_FatalErrorWithoutReadyForQuery_PreservesDiagnostic(t *testing.T) {
+	input := buildErrorResponseWithSeverity("FATAL", "57P01", "terminating connection due to administrator command")
+
+	c := newTestReadOnlyConn(input)
+	err := c.waitForCloseComplete(context.Background())
+
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag), "expected a *mterrors.PgDiagnostic, got %T: %v", err, err)
+	assert.Equal(t, "FATAL", diag.Severity)
+	assert.Equal(t, "57P01", diag.Code)
+}
+
+// TestWaitForReadyForQuery_FatalErrorWithoutReadyForQuery_PreservesDiagnostic
+// covers waitForReadyForQuery's identical FATAL/PANIC handling.
+func TestWaitForReadyForQuery_FatalErrorWithoutReadyForQuery_PreservesDiagnostic(t *testing.T) {
+	input := buildErrorResponseWithSeverity("FATAL", "57P01", "terminating connection due to administrator command")
+
+	c := newTestReadOnlyConn(input)
+	err := c.waitForReadyForQuery(context.Background())
+
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag), "expected a *mterrors.PgDiagnostic, got %T: %v", err, err)
+	assert.Equal(t, "FATAL", diag.Severity)
+	assert.Equal(t, "57P01", diag.Code)
+}
+
+// TestProcessExecuteResponses_FatalErrorWithoutReadyForQuery_PreservesDiagnostic
+// covers processExecuteResponses' identical FATAL/PANIC handling.
+func TestProcessExecuteResponses_FatalErrorWithoutReadyForQuery_PreservesDiagnostic(t *testing.T) {
+	input := buildErrorResponseWithSeverity("FATAL", "57P01", "terminating connection due to administrator command")
+
+	c := newTestReadOnlyConn(input)
+	_, err := c.processExecuteResponses(context.Background(), nil)
+
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag), "expected a *mterrors.PgDiagnostic, got %T: %v", err, err)
+	assert.Equal(t, "FATAL", diag.Severity)
+	assert.Equal(t, "57P01", diag.Code)
+}
+
+// TestProcessDescribeResponses_FatalErrorWithoutReadyForQuery_PreservesDiagnostic
+// covers processDescribeResponses' identical FATAL/PANIC handling.
+func TestProcessDescribeResponses_FatalErrorWithoutReadyForQuery_PreservesDiagnostic(t *testing.T) {
+	input := buildErrorResponseWithSeverity("FATAL", "57P01", "terminating connection due to administrator command")
+
+	c := newTestReadOnlyConn(input)
+	_, err := c.processDescribeResponses(context.Background())
+
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag), "expected a *mterrors.PgDiagnostic, got %T: %v", err, err)
+	assert.Equal(t, "FATAL", diag.Severity)
+	assert.Equal(t, "57P01", diag.Code)
+}
+
+// TestProcessBindAndDescribeResponses_FatalErrorWithoutReadyForQuery_PreservesDiagnostic
+// covers processBindAndDescribeResponses' identical FATAL/PANIC handling.
+func TestProcessBindAndDescribeResponses_FatalErrorWithoutReadyForQuery_PreservesDiagnostic(t *testing.T) {
+	input := buildErrorResponseWithSeverity("FATAL", "57P01", "terminating connection due to administrator command")
+
+	c := newTestReadOnlyConn(input)
+	_, err := c.processBindAndDescribeResponses(context.Background())
+
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag), "expected a *mterrors.PgDiagnostic, got %T: %v", err, err)
+	assert.Equal(t, "FATAL", diag.Severity)
+	assert.Equal(t, "57P01", diag.Code)
+}
+
+// TestProcessPrepareAndExecuteResponses_FatalErrorWithoutReadyForQuery_PreservesDiagnostic
+// covers processPrepareAndExecuteResponses' identical FATAL/PANIC handling.
+func TestProcessPrepareAndExecuteResponses_FatalErrorWithoutReadyForQuery_PreservesDiagnostic(t *testing.T) {
+	input := buildErrorResponseWithSeverity("FATAL", "57P01", "terminating connection due to administrator command")
+
+	c := newTestReadOnlyConn(input)
+	err := c.processPrepareAndExecuteResponses(context.Background(), nil)
+
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag), "expected a *mterrors.PgDiagnostic, got %T: %v", err, err)
+	assert.Equal(t, "FATAL", diag.Severity)
+	assert.Equal(t, "57P01", diag.Code)
+}
+
+// TestProcessBindDescribeAndExecuteResponses_FatalErrorWithoutReadyForQuery_PreservesDiagnostic
+// covers processBindDescribeAndExecuteResponses' identical FATAL/PANIC handling.
+func TestProcessBindDescribeAndExecuteResponses_FatalErrorWithoutReadyForQuery_PreservesDiagnostic(t *testing.T) {
+	input := buildErrorResponseWithSeverity("FATAL", "57P01", "terminating connection due to administrator command")
+
+	c := newTestReadOnlyConn(input)
+	_, err := c.processBindDescribeAndExecuteResponses(context.Background(), nil)
+
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag), "expected a *mterrors.PgDiagnostic, got %T: %v", err, err)
+	assert.Equal(t, "FATAL", diag.Severity)
+	assert.Equal(t, "57P01", diag.Code)
+}
 
 func TestWriteParse(t *testing.T) {
 	var buf bytes.Buffer

--- a/go/common/pgprotocol/client/query.go
+++ b/go/common/pgprotocol/client/query.go
@@ -241,6 +241,15 @@ func (c *Conn) processQueryResponses(ctx context.Context, callback func(ctx cont
 		// Read message.
 		msgType, body, err := c.readMessage()
 		if err != nil {
+			// A FATAL/PANIC ErrorResponse (e.g. pg_terminate_backend, admin
+			// shutdown) terminates the connection immediately and is never
+			// followed by ReadyForQuery. If we already parsed that diagnostic
+			// below, the read failure here is just the expected socket close —
+			// return the real diagnostic instead of masking it with a generic
+			// read error.
+			if firstErr != nil {
+				return firstErr
+			}
 			return fmt.Errorf("failed to read message: %w", err)
 		}
 
@@ -304,8 +313,18 @@ func (c *Conn) processQueryResponses(ctx context.Context, callback func(ctx cont
 
 		case protocol.MsgErrorResponse:
 			// Capture the error but continue draining until ReadyForQuery.
+			diag := parseDiagnosticFields(protocol.MsgErrorResponse, body)
 			if firstErr == nil {
-				firstErr = c.parseError(body)
+				firstErr = diag
+			}
+			// FATAL/PANIC severities terminate the connection immediately and
+			// are never followed by ReadyForQuery (e.g. a session killing its
+			// own backend via pg_terminate_backend, or an admin shutdown).
+			// Waiting for a ReadyForQuery that isn't coming would just turn the
+			// eventual socket-close read error into the returned error,
+			// discarding the diagnostic we just parsed.
+			if diag.IsFatal() {
+				return firstErr
 			}
 
 		case protocol.MsgNoticeResponse:

--- a/go/common/pgprotocol/client/query_test.go
+++ b/go/common/pgprotocol/client/query_test.go
@@ -49,6 +49,34 @@ func TestQueryStreaming_FatalErrorWithoutReadyForQuery_PreservesDiagnostic(t *te
 	assert.Equal(t, "57P01", diag.Code)
 }
 
+// TestQueryStreaming_ReadFailureWrapsErrorWhenNothingCaptured covers
+// processQueryResponses' read-failure fallback: when the socket fails before
+// any diagnostic was ever parsed, QueryStreaming must return a wrapped read
+// error rather than a nil or swallowed failure.
+func TestQueryStreaming_ReadFailureWrapsErrorWhenNothingCaptured(t *testing.T) {
+	c := newTestReadOnlyConn(nil) // empty input: the first read fails immediately
+	err := c.QueryStreaming(context.Background(), "SELECT 1", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read message")
+}
+
+// TestQueryStreaming_NonFatalErrorThenReadFailure_PreservesFirstError covers
+// processQueryResponses' other read-failure branch: a non-fatal ErrorResponse
+// leaves the loop draining toward ReadyForQuery, and if the socket then fails
+// (e.g. the server crashed after sending the error but before the trailing
+// RFQ), QueryStreaming must still return the diagnostic already captured
+// rather than masking it with the read failure that follows.
+func TestQueryStreaming_NonFatalErrorThenReadFailure_PreservesFirstError(t *testing.T) {
+	input := buildErrorResponse("42601", "syntax error at or near \"nonsense\"")
+
+	c := newTestReadOnlyConn(input)
+	err := c.QueryStreaming(context.Background(), "SELECT nonsense", nil)
+
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag), "expected a *mterrors.PgDiagnostic, got %T: %v", err, err)
+	assert.Equal(t, "42601", diag.Code)
+}
+
 func TestParseRowsAffected(t *testing.T) {
 	tests := []struct {
 		tag      string

--- a/go/common/pgprotocol/client/query_test.go
+++ b/go/common/pgprotocol/client/query_test.go
@@ -17,6 +17,7 @@ package client
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"testing"
 
@@ -26,6 +27,27 @@ import (
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 )
+
+// TestQueryStreaming_FatalErrorWithoutReadyForQuery_PreservesDiagnostic
+// reproduces a self pg_terminate_backend(pg_backend_pid()): PostgreSQL sends
+// a FATAL ErrorResponse and immediately closes the connection, without ever
+// sending ReadyForQuery. processQueryResponses must not keep reading past
+// that ErrorResponse looking for a ReadyForQuery that will never arrive —
+// doing so turns the read failure that follows (EOF) into the returned
+// error, discarding the real diagnostic it already parsed.
+func TestQueryStreaming_FatalErrorWithoutReadyForQuery_PreservesDiagnostic(t *testing.T) {
+	input := buildErrorResponseWithSeverity("FATAL", "57P01", "terminating connection due to administrator command")
+	// No ReadyForQuery follows: the input ends here, exactly like PostgreSQL
+	// closing the socket right after a FATAL.
+
+	c := newTestReadOnlyConn(input)
+	err := c.QueryStreaming(context.Background(), "SELECT pg_terminate_backend(pg_backend_pid())", nil)
+
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag), "expected a *mterrors.PgDiagnostic, got %T: %v", err, err)
+	assert.Equal(t, "FATAL", diag.Severity)
+	assert.Equal(t, "57P01", diag.Code)
+}
 
 func TestParseRowsAffected(t *testing.T) {
 	tests := []struct {

--- a/go/services/multigateway/scatterconn/scatter_conn_test.go
+++ b/go/services/multigateway/scatterconn/scatter_conn_test.go
@@ -948,7 +948,7 @@ func TestScatterConn_CopyAbort_ConnectionDestroyed(t *testing.T) {
 // TestIsCancellationError exercises every branch of isCancellationError: nil,
 // the two context sentinels (direct and wrapped), a query-canceled PgDiagnostic
 // (57014, the statement_timeout / explicit-cancel code), a non-cancellation
-// PgDiagnostic (40001), and a plain error.
+// PgDiagnostic (08006 connection_failure), and a plain error.
 func TestIsCancellationError(t *testing.T) {
 	require.False(t, isCancellationError(nil))
 	require.True(t, isCancellationError(context.Canceled))
@@ -957,7 +957,7 @@ func TestIsCancellationError(t *testing.T) {
 	require.True(t, isCancellationError(mterrors.NewQueryCanceled()), "query_canceled (57014)")
 	require.True(t, isCancellationError(mterrors.NewStatementTimeout()), "statement_timeout (57014)")
 	require.False(t, isCancellationError(mterrors.NewReservedConnectionTerminated(42)),
-		"serialization_failure (40001) is not a cancellation")
+		"connection_failure (08006) is not a cancellation")
 	require.False(t, isCancellationError(errors.New("connection refused")))
 }
 

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -508,6 +508,10 @@ func (e *Executor) reserveAndStreamExecute(
 			if beginTx {
 				_ = reservedConn.Rollback(ctx)
 			}
+			if mterrors.IsConnectionError(err) {
+				reservedConn.Release(reserved.ReleaseError, nil)
+				return nil, reservedConnTerminatedError(reservedConn.ConnID(), err)
+			}
 			reservedConn.Release(reserved.ReleaseError, nil)
 			return nil, fmt.Errorf("failed to materialize SQL EXECUTE prepared statement: %w", err)
 		}
@@ -537,6 +541,9 @@ func (e *Executor) reserveAndStreamExecute(
 			_ = reservedConn.Rollback(ctx)
 		}
 		reservedConn.Release(reserved.ReleaseError, nil)
+		if mterrors.IsConnectionError(err) {
+			return nil, reservedConnTerminatedError(reservedConn.ConnID(), err)
+		}
 		return nil, wrapQueryError(err)
 	}
 
@@ -619,7 +626,7 @@ func (e *Executor) streamExecuteOnReservedConnWithPostState(
 				beginQuery = reservationOptions.GetBeginQuery()
 			}
 			if err := rc.BeginWithQuery(ctx, beginQuery); err != nil {
-				return e.buildReservedStateFromAPI(rc), fmt.Errorf("failed to begin transaction on reserved connection: %w", err)
+				return e.reservedConnError(rc, "failed to begin transaction on reserved connection", err)
 			}
 		}
 		// Add all requested non-transaction reasons to the reservation
@@ -961,7 +968,7 @@ func (e *Executor) portalExecuteWithReserved(
 					reservedConn.Release(reserved.ReleaseError, nil)
 					return nil, err
 				}
-				return e.buildReservedState(reservedConn), fmt.Errorf("failed to begin transaction on reserved connection: %w", err)
+				return e.reservedConnError(reservedConn, "failed to begin transaction on reserved connection", err)
 			}
 		}
 		// OR the requested reasons onto the connection. AddReservationReason is
@@ -1038,7 +1045,7 @@ func (e *Executor) portalExecuteWithReserved(
 func (e *Executor) portalReservedError(reservedConn *reserved.Conn, portalName string, options *query.ExecuteOptions, newlyReserved bool, err error) (*query.ReservedState, error) {
 	if mterrors.IsConnectionError(err) {
 		reservedConn.Release(reserved.ReleaseError, nil)
-		return nil, wrapQueryError(err)
+		return nil, reservedConnTerminatedError(reservedConn.ConnID(), err)
 	}
 
 	shouldRelease := reservedConn.ReleasePortal(portalName)
@@ -1119,6 +1126,24 @@ func (e *Executor) portalExecuteWithRegular(
 	return nil, nil
 }
 
+// reservedConnTerminatedError returns the diagnostic to hand back to the client once
+// IsConnectionError(err) has already fired and the reservation is being released. If
+// err carries a genuine *mterrors.PgDiagnostic — Postgres itself sent an ErrorResponse
+// or FATAL (e.g. 57P01 admin_shutdown, 57P02 crash_shutdown, an idle-session timeout)
+// before the connection died — that diagnostic is returned verbatim so unmodified PG
+// clients, ORMs, and connection poolers see Postgres's real SQLSTATE and apply their
+// normal class-08/57P reconnect logic instead of a Multigres-specific convention they
+// don't know about. Only when err is a raw I/O failure with no diagnostic at all (a
+// hard crash, network partition, or SIGKILL — nothing was ever sent) does this
+// synthesize NewReservedConnectionTerminated.
+func reservedConnTerminatedError(connID int64, err error) error {
+	var diag *mterrors.PgDiagnostic
+	if errors.As(err, &diag) {
+		return diag
+	}
+	return mterrors.NewReservedConnectionTerminated(uint64(connID))
+}
+
 // reservedConnError converts an error from an operation on an EXISTING reserved
 // connection into the (ReservedState, error) pair the RPC should return, so call sites
 // never repeat the connection-vs-ordinary-error decision.
@@ -1129,7 +1154,8 @@ func (e *Executor) portalExecuteWithRegular(
 // a fresh socket, so release the reservation and return (nil, terminated) — a clean,
 // retryable "reserved connection terminated" error (the same signal already returned
 // when the reservation is already gone) instead of wrapping the raw broken pipe into an
-// opaque, non-retryable error.
+// opaque, non-retryable error. See reservedConnTerminatedError for why that signal
+// prefers Postgres's own diagnostic when one was actually received.
 //
 // Any other error leaves the backend usable (e.g. an aborted-transaction PG
 // ErrorResponse), so return (buildReservedState, wrapped-error) — keep the reservation
@@ -1138,7 +1164,7 @@ func (e *Executor) portalExecuteWithRegular(
 func (e *Executor) reservedConnError(rc reservedConnAPI, wrap string, err error) (*query.ReservedState, error) {
 	if mterrors.IsConnectionError(err) {
 		rc.Release(reserved.ReleaseError, nil)
-		return nil, mterrors.NewReservedConnectionTerminated(uint64(rc.ConnID()))
+		return nil, reservedConnTerminatedError(rc.ConnID(), err)
 	}
 	return e.buildReservedStateFromAPI(rc), mterrors.Wrap(err, wrap)
 }
@@ -1353,7 +1379,7 @@ func (e *Executor) CopyReady(
 			// in CopyFinalize for the same rationale.
 			if mterrors.IsConnectionError(err) {
 				reservedConn.Release(reserved.ReleaseError, nil)
-				return 0, nil, nil, err
+				return 0, nil, nil, reservedConnTerminatedError(reservedConn.ConnID(), err)
 			}
 			return 0, nil, e.buildReservedState(reservedConn), err
 		}
@@ -1491,6 +1517,9 @@ func (e *Executor) CopyFinalize(
 			e.logger.ErrorContext(ctx, "failed to write final COPY data", "error", err)
 			// Connection is in bad state - close it instead of recycling
 			reservedConn.Release(reserved.ReleaseError, nil)
+			if mterrors.IsConnectionError(err) {
+				return nil, nil, reservedConnTerminatedError(reservedConn.ConnID(), err)
+			}
 			return nil, nil, fmt.Errorf("failed to write final COPY data: %w", err)
 		}
 		e.logger.DebugContext(ctx, "sent final COPY data", "size", len(finalData))
@@ -1501,6 +1530,9 @@ func (e *Executor) CopyFinalize(
 		e.logger.ErrorContext(ctx, "failed to write CopyDone", "error", err)
 		// Connection is in bad state - close it instead of recycling
 		reservedConn.Release(reserved.ReleaseError, nil)
+		if mterrors.IsConnectionError(err) {
+			return nil, nil, reservedConnTerminatedError(reservedConn.ConnID(), err)
+		}
 		return nil, nil, fmt.Errorf("failed to write CopyDone: %w", err)
 	}
 
@@ -1543,7 +1575,7 @@ func (e *Executor) CopyFinalize(
 			return noticeResult, e.buildReservedState(reservedConn), err
 		}
 		reservedConn.Release(reserved.ReleaseError, nil)
-		return nil, nil, err
+		return nil, nil, reservedConnTerminatedError(reservedConn.ConnID(), err)
 	}
 
 	e.logger.DebugContext(ctx, "COPY DONE successful",
@@ -1707,7 +1739,7 @@ func (e *Executor) CopyOutReady(
 			// gateway can re-emit the verbatim ErrorResponse.
 			if mterrors.IsConnectionError(err) {
 				reservedConn.Release(reserved.ReleaseError, nil)
-				return 0, nil, notices, nil, err
+				return 0, nil, notices, nil, reservedConnTerminatedError(reservedConn.ConnID(), err)
 			}
 			return 0, nil, notices, e.buildReservedState(reservedConn), err
 		}
@@ -1828,7 +1860,7 @@ func (e *Executor) CopyOutStream(
 				return nil, e.buildReservedState(reservedConn), err
 			}
 			reservedConn.Release(reserved.ReleaseError, nil)
-			return nil, nil, err
+			return nil, nil, reservedConnTerminatedError(reservedConn.ConnID(), err)
 		}
 
 		if msg.Done {
@@ -1851,7 +1883,7 @@ func (e *Executor) CopyOutStream(
 			return nil, e.buildReservedState(reservedConn), err
 		}
 		reservedConn.Release(reserved.ReleaseError, nil)
-		return nil, nil, err
+		return nil, nil, reservedConnTerminatedError(reservedConn.ConnID(), err)
 	}
 
 	result := &sqltypes.Result{
@@ -1975,6 +2007,9 @@ func (e *Executor) ConcludeTransaction(
 		}
 		if err != nil {
 			reservedConn.Release(reserved.ReleaseError, nil)
+			if mterrors.IsConnectionError(err) {
+				return nil, nil, reservedConnTerminatedError(reservedConn.ConnID(), err)
+			}
 			return nil, nil, err
 		}
 	case multipoolerpb.TransactionConclusion_TRANSACTION_CONCLUSION_ROLLBACK:
@@ -1988,6 +2023,9 @@ func (e *Executor) ConcludeTransaction(
 		}
 		if err != nil {
 			reservedConn.Release(reserved.ReleaseError, nil)
+			if mterrors.IsConnectionError(err) {
+				return nil, nil, reservedConnTerminatedError(reservedConn.ConnID(), err)
+			}
 			return nil, nil, err
 		}
 		// PostgreSQL closes the cursors created inside this transaction
@@ -2065,6 +2103,9 @@ func (e *Executor) DiscardTempTables(
 	// Send DISCARD TEMP to PostgreSQL to drop all temp tables on this backend.
 	if _, err := reservedConn.Query(ctx, "DISCARD TEMP"); err != nil {
 		reservedConn.Release(reserved.ReleaseError, nil)
+		if mterrors.IsConnectionError(err) {
+			return nil, nil, reservedConnTerminatedError(reservedConn.ConnID(), err)
+		}
 		return nil, nil, fmt.Errorf("DISCARD TEMP failed: %w", err)
 	}
 

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multipoolerpb "github.com/multigres/multigres/go/pb/multipoolerservice"
 	"github.com/multigres/multigres/go/pb/query"
 	"github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager"
 	"github.com/multigres/multigres/go/services/multipooler/internal/connstate"
@@ -1522,7 +1523,7 @@ func TestCopyOutReady_ReservedConnectionNotFound(t *testing.T) {
 		nil,
 	)
 	require.Error(t, err)
-	assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSSerializationFailure), "expected 40001, got: %v", err)
+	assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSConnectionFailure), "expected 08006, got: %v", err)
 	require.Contains(t, err.Error(), "terminated during a planned failover")
 }
 
@@ -1546,7 +1547,7 @@ func TestConcludeTransaction_ReservedConnTerminated(t *testing.T) {
 		false,
 	)
 	require.Error(t, err)
-	assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSSerializationFailure), "expected 40001, got: %v", err)
+	assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSConnectionFailure), "expected 08006, got: %v", err)
 	assert.False(t, mterrors.IsErrorCode(err, mterrors.MTF01.ID), "must not surface MTF01: %v", err)
 	require.Contains(t, err.Error(), "terminated during a planned failover")
 }
@@ -1574,7 +1575,7 @@ func TestCopyOutStream_ValidationAndNotFound(t *testing.T) {
 			func(client.CopyOutMessage) error { return nil },
 		)
 		require.Error(t, err)
-		assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSSerializationFailure), "expected 40001, got: %v", err)
+		assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSConnectionFailure), "expected 08006, got: %v", err)
 		require.Contains(t, err.Error(), "terminated during a planned failover")
 	})
 }
@@ -2059,7 +2060,12 @@ func TestPortalStreamExecute_ExistingReservationStatementErrorKeepsConnection(t 
 
 // TestPortalStreamExecute_ExistingReservationConnectionErrorReleases verifies
 // that a genuine connection failure (unlike a plain statement error) still
-// destroys the reserved connection, since the backend is actually gone.
+// destroys the reserved connection, since the backend is actually gone, and
+// that the client sees Postgres's own diagnostic (57P01 admin_shutdown, here)
+// preserved verbatim rather than a raw/wrapped Go connection error —
+// portalReservedError previously detected the connection error and released
+// correctly, but returned wrapQueryError(err) (an opaque wrap of the same
+// diagnostic) instead of surfacing it directly.
 func TestPortalStreamExecute_ExistingReservationConnectionErrorReleases(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
@@ -2081,16 +2087,330 @@ func TestPortalStreamExecute_ExistingReservationConnectionErrorReleases(t *testi
 	ctx := context.Background()
 	rconn, err := pool.NewConn(ctx, nil)
 	require.NoError(t, err)
+	connID := rconn.ConnID()
 
 	e := NewExecutor(slog.Default(), &stubPoolManager{reservedConn: rconn, reservedConnOK: true}, &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"}, false)
 
 	state, err := e.PortalStreamExecute(ctx, &query.Target{},
 		&query.PreparedStatement{Name: "stmt0", Query: "SELECT 1"},
 		&query.Portal{Name: "p0"},
-		&query.ExecuteOptions{User: "postgres", ReservedConnectionId: uint64(rconn.ConnID())},
+		&query.ExecuteOptions{User: "postgres", ReservedConnectionId: uint64(connID)},
 		nil, nil, noopCallback)
 
 	require.Error(t, err)
 	require.Nil(t, state)
 	assert.True(t, rconn.IsReleased(), "a genuine connection failure must still destroy the reserved connection")
+	assert.NotContains(t, err.Error(), "query execution failed",
+		"must not leak the raw wrap/connection error")
+	assert.Equal(t, mterrors.NewPgError("FATAL", "57P01", "terminating connection due to administrator command", ""), err,
+		"Postgres's own diagnostic must be preserved verbatim, not replaced with a synthesized one")
+}
+
+// TestReserveAndStreamExecuteDeadSocket_BeginTxQueryError covers
+// reserveAndStreamExecute's beginTx branch: BEGIN succeeds via the validate
+// hook on a freshly reserved connection, but the client's actual statement
+// then hits a connection-level failure. The beginTx-gated branch previously
+// checked IsConnectionError only to decide whether to preserve the
+// reservation for ROLLBACK routing, then fell through to wrapQueryError(err)
+// regardless of the check's result.
+func TestReserveAndStreamExecuteDeadSocket_BeginTxQueryError(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+	server.AddRejectedQuery("select 1", mterrors.NewPgError("FATAL", "57P01", "terminating connection due to administrator command", ""))
+
+	pool := reserved.NewPool(context.Background(), &reserved.PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig: server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{
+				Capacity:     2,
+				MaxIdleCount: 2,
+			},
+		},
+	})
+	defer pool.Close()
+
+	e := NewExecutor(slog.Default(), &stubPoolManager{reservedPool: pool}, &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"}, false)
+
+	state, err := e.StreamExecute(context.Background(), &query.Target{}, "select 1",
+		&query.ExecuteOptions{User: "postgres"},
+		&query.ReservationOptions{Reasons: protoutil.ReasonTransaction},
+		noopCallback)
+
+	require.Nil(t, state)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "query execution failed",
+		"must not leak the raw wrap/connection error")
+	var pgDiag *mterrors.PgDiagnostic
+	require.ErrorAs(t, err, &pgDiag)
+	assert.Equal(t, "57P01", pgDiag.Code, "Postgres's own diagnostic must be preserved verbatim, not replaced with a synthesized one")
+}
+
+// TestPortalExecuteWithReservedDeadSocket_BeginError covers
+// portalExecuteWithReserved's BEGIN branch on an EXISTING reservation
+// (!newlyReserved): previously this branch never checked IsConnectionError at
+// all, so a BEGIN failure due to a dead backend was reported as
+// buildReservedState (still reserved/alive) instead of releasing the
+// connection and returning a clean terminated error — the connection leaked
+// in the pool as "still active".
+func TestPortalExecuteWithReservedDeadSocket_BeginError(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+	server.AddRejectedQuery("BEGIN", mterrors.NewPgError("FATAL", "57P01", "terminating connection due to administrator command", ""))
+
+	pool := reserved.NewPool(context.Background(), &reserved.PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig: server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{
+				Capacity:     2,
+				MaxIdleCount: 2,
+			},
+		},
+	})
+	defer pool.Close()
+
+	ctx := context.Background()
+	rconn, err := pool.NewConn(ctx, nil)
+	require.NoError(t, err)
+	connID := rconn.ConnID()
+
+	e := NewExecutor(slog.Default(), &stubPoolManager{reservedConn: rconn, reservedConnOK: true}, &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"}, false)
+
+	stmt := &query.PreparedStatement{Name: "s1", Query: "SELECT 1"}
+	portal := &query.Portal{Name: "p1"}
+	options := &query.ExecuteOptions{User: "postgres", ReservedConnectionId: uint64(connID)}
+	reservationOptions := &query.ReservationOptions{Reasons: protoutil.ReasonTransaction}
+
+	state, err := e.portalExecuteWithReserved(ctx, stmt, portal, options, reservationOptions, nil, "postgres", 0, false, nil, nil, noopCallback)
+
+	require.Nil(t, state, "a dead backend must not be reported as still reserved")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "failed to begin transaction on reserved connection",
+		"must not leak the raw wrap/connection error")
+	assert.Equal(t, mterrors.NewPgError("FATAL", "57P01", "terminating connection due to administrator command", ""), err,
+		"Postgres's own diagnostic must be preserved verbatim, not replaced with a synthesized one")
+
+	_, stillActive := pool.Get(connID)
+	assert.False(t, stillActive, "dead reserved connection must be released, not left dangling")
+}
+
+// TestCopyReadyReservedConnDeadSocket_InitiateCopyFromStdinError covers
+// CopyReady's InitiateCopyFromStdin call on an existing reservation. The
+// connection-level branch already released correctly but returned the raw
+// connection error instead of NewReservedConnectionTerminated.
+func TestCopyReadyReservedConnDeadSocket_InitiateCopyFromStdinError(t *testing.T) {
+	e, pool, rconn := newDeadReservedConnTestExecutor(t)
+	connID := rconn.ConnID()
+	options := &query.ExecuteOptions{ReservedConnectionId: uint64(connID)}
+
+	rconn.Conn().RawConn().ForceClose()
+
+	format, columnFormats, state, err := e.CopyReady(context.Background(), &query.Target{}, "COPY t FROM STDIN", options, nil)
+
+	assert.Zero(t, format)
+	assert.Nil(t, columnFormats)
+	require.Nil(t, state)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "closed network connection",
+		"must not leak the raw wrap/connection error")
+	assert.Equal(t, mterrors.NewReservedConnectionTerminated(uint64(connID)), err)
+
+	_, stillActive := pool.Get(connID)
+	assert.False(t, stillActive, "dead reserved connection must be released, not left dangling")
+}
+
+// TestCopyOutReadyReservedConnDeadSocket_InitiateCopyToStdoutError mirrors
+// TestCopyReadyReservedConnDeadSocket_InitiateCopyFromStdinError for the COPY
+// TO STDOUT direction.
+func TestCopyOutReadyReservedConnDeadSocket_InitiateCopyToStdoutError(t *testing.T) {
+	e, pool, rconn := newDeadReservedConnTestExecutor(t)
+	connID := rconn.ConnID()
+	options := &query.ExecuteOptions{ReservedConnectionId: uint64(connID)}
+
+	rconn.Conn().RawConn().ForceClose()
+
+	format, columnFormats, notices, state, err := e.CopyOutReady(context.Background(), &query.Target{}, "COPY t TO STDOUT", options, nil)
+
+	assert.Zero(t, format)
+	assert.Nil(t, columnFormats)
+	assert.Nil(t, notices)
+	require.Nil(t, state)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "closed network connection",
+		"must not leak the raw wrap/connection error")
+	assert.Equal(t, mterrors.NewReservedConnectionTerminated(uint64(connID)), err)
+
+	_, stillActive := pool.Get(connID)
+	assert.False(t, stillActive, "dead reserved connection must be released, not left dangling")
+}
+
+// TestCopyFinalizeReservedConnDeadSocket covers CopyFinalize's write/read
+// failures against a dead backend socket, mirroring
+// TestCopySendDataReservedConnDeadSocket.
+func TestCopyFinalizeReservedConnDeadSocket(t *testing.T) {
+	e, pool, rconn := newDeadReservedConnTestExecutor(t)
+	connID := rconn.ConnID()
+	options := &query.ExecuteOptions{ReservedConnectionId: uint64(connID)}
+
+	rconn.Conn().RawConn().ForceClose()
+
+	result, state, err := e.CopyFinalize(context.Background(), &query.Target{}, []byte("1\t2\n"), options)
+
+	require.Nil(t, result)
+	require.Nil(t, state)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "closed network connection",
+		"must not leak the raw wrap/connection error")
+	assert.Equal(t, mterrors.NewReservedConnectionTerminated(uint64(connID)), err)
+
+	_, stillActive := pool.Get(connID)
+	assert.False(t, stillActive, "dead reserved connection must be released, not left dangling")
+}
+
+// TestCopyOutStreamReservedConnDeadSocket covers CopyOutStream's
+// ReadCopyOutMessage failure against a dead backend socket. CopyOutStream was
+// not covered by any prior fix in this family.
+func TestCopyOutStreamReservedConnDeadSocket(t *testing.T) {
+	e, pool, rconn := newDeadReservedConnTestExecutor(t)
+	connID := rconn.ConnID()
+	options := &query.ExecuteOptions{ReservedConnectionId: uint64(connID)}
+
+	rconn.Conn().RawConn().ForceClose()
+
+	result, state, err := e.CopyOutStream(context.Background(), &query.Target{}, options, func(client.CopyOutMessage) error { return nil })
+
+	require.Nil(t, result)
+	require.Nil(t, state)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "closed network connection",
+		"must not leak the raw wrap/connection error")
+	assert.Equal(t, mterrors.NewReservedConnectionTerminated(uint64(connID)), err)
+
+	_, stillActive := pool.Get(connID)
+	assert.False(t, stillActive, "dead reserved connection must be released, not left dangling")
+}
+
+// TestConcludeTransactionReservedConnDeadSocket_CommitError covers
+// ConcludeTransaction's COMMIT path against a dead backend socket — a
+// plausible planned-failover scenario (backend gone mid-transaction). Neither
+// the COMMIT nor ROLLBACK branch checked IsConnectionError at all.
+func TestConcludeTransactionReservedConnDeadSocket_CommitError(t *testing.T) {
+	e, pool, rconn := newDeadReservedConnTestExecutor(t)
+	connID := rconn.ConnID()
+	require.NoError(t, rconn.BeginWithQuery(context.Background(), "BEGIN"))
+	options := &query.ExecuteOptions{ReservedConnectionId: uint64(connID)}
+
+	rconn.Conn().RawConn().ForceClose()
+
+	result, state, err := e.ConcludeTransaction(context.Background(), &query.Target{}, options,
+		multipoolerpb.TransactionConclusion_TRANSACTION_CONCLUSION_COMMIT, nil, false, false)
+
+	require.Nil(t, result)
+	require.Nil(t, state)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "closed network connection",
+		"must not leak the raw wrap/connection error")
+	assert.Equal(t, mterrors.NewReservedConnectionTerminated(uint64(connID)), err)
+
+	_, stillActive := pool.Get(connID)
+	assert.False(t, stillActive, "dead reserved connection must be released, not left dangling")
+}
+
+// TestConcludeTransactionReservedConnDeadSocket_RollbackError covers
+// ConcludeTransaction's ROLLBACK path against a dead backend socket. This
+// mirrors TestConcludeTransactionReservedConnDeadSocket_CommitError: the
+// ROLLBACK branch has its own separate IsConnectionError check, which the
+// COMMIT-only test above does not exercise.
+func TestConcludeTransactionReservedConnDeadSocket_RollbackError(t *testing.T) {
+	e, pool, rconn := newDeadReservedConnTestExecutor(t)
+	connID := rconn.ConnID()
+	require.NoError(t, rconn.BeginWithQuery(context.Background(), "BEGIN"))
+	options := &query.ExecuteOptions{ReservedConnectionId: uint64(connID)}
+
+	rconn.Conn().RawConn().ForceClose()
+
+	result, state, err := e.ConcludeTransaction(context.Background(), &query.Target{}, options,
+		multipoolerpb.TransactionConclusion_TRANSACTION_CONCLUSION_ROLLBACK, nil, false, false)
+
+	require.Nil(t, result)
+	require.Nil(t, state)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "closed network connection",
+		"must not leak the raw wrap/connection error")
+	assert.Equal(t, mterrors.NewReservedConnectionTerminated(uint64(connID)), err)
+
+	_, stillActive := pool.Get(connID)
+	assert.False(t, stillActive, "dead reserved connection must be released, not left dangling")
+}
+
+// TestDiscardTempTablesReservedConnDeadSocket covers DiscardTempTables'
+// "DISCARD TEMP" query against a dead backend socket.
+func TestDiscardTempTablesReservedConnDeadSocket(t *testing.T) {
+	e, pool, rconn := newDeadReservedConnTestExecutor(t)
+	connID := rconn.ConnID()
+	options := &query.ExecuteOptions{ReservedConnectionId: uint64(connID)}
+
+	rconn.Conn().RawConn().ForceClose()
+
+	result, state, err := e.DiscardTempTables(context.Background(), &query.Target{}, options)
+
+	require.Nil(t, result)
+	require.Nil(t, state)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "DISCARD TEMP failed",
+		"must not leak the raw wrap/connection error")
+	assert.Equal(t, mterrors.NewReservedConnectionTerminated(uint64(connID)), err)
+
+	_, stillActive := pool.Get(connID)
+	assert.False(t, stillActive, "dead reserved connection must be released, not left dangling")
+}
+
+// TestStreamExecuteReservedConnDeadSocket_BeginError covers
+// streamExecuteOnReservedConnWithPostState's BEGIN branch (StreamExecute on an
+// EXISTING reservation, promoting it to a transaction): this branch never
+// checked IsConnectionError at all, so a BEGIN failure due to a dead backend
+// was reported as buildReservedStateFromAPI (still reserved/alive) instead of
+// releasing the connection and returning a clean terminated error.
+func TestStreamExecuteReservedConnDeadSocket_BeginError(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+	server.AddRejectedQuery("BEGIN", mterrors.NewPgError("FATAL", "57P01", "terminating connection due to administrator command", ""))
+
+	pool := reserved.NewPool(context.Background(), &reserved.PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig: server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{
+				Capacity:     2,
+				MaxIdleCount: 2,
+			},
+		},
+	})
+	defer pool.Close()
+
+	ctx := context.Background()
+	rconn, err := pool.NewConn(ctx, nil)
+	require.NoError(t, err)
+	connID := rconn.ConnID()
+
+	e := NewExecutor(slog.Default(), &stubPoolManager{reservedConn: rconn, reservedConnOK: true}, &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"}, false)
+
+	options := &query.ExecuteOptions{User: "postgres", ReservedConnectionId: uint64(connID)}
+	reservationOptions := &query.ReservationOptions{Reasons: protoutil.ReasonTransaction}
+
+	state, err := e.StreamExecute(ctx, &query.Target{}, "SELECT 1", options, reservationOptions, noopCallback)
+
+	require.Nil(t, state, "a dead backend must not be reported as still reserved")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "failed to begin transaction on reserved connection",
+		"must not leak the raw wrap/connection error")
+	assert.Equal(t, mterrors.NewPgError("FATAL", "57P01", "terminating connection due to administrator command", ""), err,
+		"Postgres's own diagnostic must be preserved verbatim, not replaced with a synthesized one")
+
+	_, stillActive := pool.Get(connID)
+	assert.False(t, stillActive, "dead reserved connection must be released, not left dangling")
 }

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -2270,6 +2270,31 @@ func TestCopyFinalizeReservedConnDeadSocket(t *testing.T) {
 	assert.False(t, stillActive, "dead reserved connection must be released, not left dangling")
 }
 
+// TestCopyFinalizeReservedConnDeadSocket_WriteCopyDoneError covers
+// CopyFinalize's WriteCopyDone branch specifically: with no finalData to
+// write, WriteCopyData is skipped entirely and WriteCopyDone is the first
+// write attempted against the dead socket. TestCopyFinalizeReservedConnDeadSocket
+// above only reaches the earlier WriteCopyData branch.
+func TestCopyFinalizeReservedConnDeadSocket_WriteCopyDoneError(t *testing.T) {
+	e, pool, rconn := newDeadReservedConnTestExecutor(t)
+	connID := rconn.ConnID()
+	options := &query.ExecuteOptions{ReservedConnectionId: uint64(connID)}
+
+	rconn.Conn().RawConn().ForceClose()
+
+	result, state, err := e.CopyFinalize(context.Background(), &query.Target{}, nil, options)
+
+	require.Nil(t, result)
+	require.Nil(t, state)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "closed network connection",
+		"must not leak the raw wrap/connection error")
+	assert.Equal(t, mterrors.NewReservedConnectionTerminated(uint64(connID)), err)
+
+	_, stillActive := pool.Get(connID)
+	assert.False(t, stillActive, "dead reserved connection must be released, not left dangling")
+}
+
 // TestCopyOutStreamReservedConnDeadSocket covers CopyOutStream's
 // ReadCopyOutMessage failure against a dead backend socket. CopyOutStream was
 // not covered by any prior fix in this family.

--- a/go/services/multipooler/internal/poolerserver/pooler.go
+++ b/go/services/multipooler/internal/poolerserver/pooler.go
@@ -181,7 +181,7 @@ func (s *QueryPoolerServer) ReplicationMetrics() *replication.Metrics {
 //  3. Set servingStatus to the not-serving target.
 //
 // If the shared deadline expires in either stage, all reserved connections are
-// force-closed (their transactions surface 40001) and the transition completes;
+// force-closed (their transactions surface 08006) and the transition completes;
 // any still-running single queries are killed by the postgres demotion that
 // follows. On timeout, errors are acceptable — that is what the grace period
 // bounds.
@@ -290,7 +290,7 @@ func (s *QueryPoolerServer) setDrainPhase(p drainPhase) {
 // ¹ ExistingReserved is always admitted regardless of serving status or
 // demotion — the reserved connection's existence is the real gate. If the
 // connection was force-closed during the drain, the executor returns an honest
-// 40001 (transaction aborted) rather than the misleading MTF01. Tablegroup/shard
+// 08006 (transaction aborted) rather than the misleading MTF01. Tablegroup/shard
 // mismatches (MTD01) are still rejected for every kind.
 //
 // The two-stage drain lets single autocommit queries keep flowing while
@@ -310,9 +310,10 @@ func (s *QueryPoolerServer) StartRequest(target *query.Target, kind RequestKind)
 	// connection itself is the real gate: if it still exists the operation
 	// completes on the live backend (postgres is demoted only after the drain
 	// finishes); if it was force-closed because the drain exceeded its grace
-	// period, the executor returns an honest 40001 so the client retries the
-	// whole transaction — rather than the misleading MTF01 signal, which is
-	// neither buffered nor retryable for a transaction that no longer exists.
+	// period, the executor returns an honest 08006 so the client opens a new
+	// connection and retries the whole transaction — rather than the misleading
+	// MTF01 signal, which is neither buffered nor retryable for a transaction
+	// that no longer exists.
 	if existingReserved {
 		return nil
 	}
@@ -350,7 +351,7 @@ func (s *QueryPoolerServer) StartRequest(target *query.Target, kind RequestKind)
 // reserved connection's existence is the real gate (see StartRequest), so a
 // demoted pooler whose reserved connection survived the drain can still conclude
 // its transaction, and one whose connection was force-closed surfaces an honest
-// 40001 from the executor rather than MTF01. Tablegroup/shard mismatches (real
+// 08006 from the executor rather than MTF01. Tablegroup/shard mismatches (real
 // routing bugs) are still rejected.
 //
 // Caller must hold s.mu.

--- a/go/services/multipooler/internal/poolerserver/pooler_test.go
+++ b/go/services/multipooler/internal/poolerserver/pooler_test.go
@@ -120,7 +120,7 @@ func TestStartRequest_NotServing(t *testing.T) {
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_DISABLED // drainPhase is drainNone (post-flip)
 
 	// Existing reserved ops are still admitted (the connection's existence is the
-	// gate; a force-closed connection surfaces an honest 40001 from the executor).
+	// gate; a force-closed connection surfaces an honest 08006 from the executor).
 	require.NoError(t, s.StartRequest(nil, RequestExistingReserved))
 	// Single queries and new reservations are rejected with MTF01 (gateway buffers).
 	requireMTF01(t, s.StartRequest(nil, RequestSingleQuery))
@@ -162,7 +162,7 @@ func TestStartRequest_PrimaryOpOnReplica_ReservedConnAllowed(t *testing.T) {
 	requireMTF01(t, s.StartRequest(target, RequestSingleQuery))
 	// ...but an in-flight op on an existing reserved connection (e.g. a COMMIT
 	// after a planned demotion) is admitted, so the executor can conclude the
-	// transaction on the live backend or return an honest 40001 if it was
+	// transaction on the live backend or return an honest 08006 if it was
 	// force-closed during the drain.
 	require.NoError(t, s.StartRequest(target, RequestExistingReserved))
 }

--- a/go/test/endtoend/queryserving/reserved_describe_deadconn_test.go
+++ b/go/test/endtoend/queryserving/reserved_describe_deadconn_test.go
@@ -27,9 +27,12 @@ import (
 
 // TestReservedDescribeDeadConnReturnsCleanError is the regression for MTD06
 // "describe failed … broken pipe". When the backend behind a reserved connection is
-// gone, a Describe must return a clean, retryable "reserved connection terminated"
-// error (SQLSTATE 40001) — not an opaque MTD06 broken-pipe — so the client reconnects
-// (and recreates any temp replication slot) rather than seeing an internal failure.
+// gone, a Describe must return a clean, retryable error — not an opaque MTD06
+// broken-pipe — so the client reconnects (and recreates any temp replication slot)
+// rather than seeing an internal failure. pg_terminate_backend makes Postgres itself
+// send a real 57P01 admin_shutdown FATAL before the socket closes, which multipooler
+// now preserves verbatim; a pure connection-level failure with no diagnostic at all
+// (e.g. a hard crash) would instead surface the synthesized 08006 connection_failure.
 func TestReservedDescribeDeadConnReturnsCleanError(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping end-to-end tests in short mode")
@@ -81,6 +84,10 @@ func TestReservedDescribeDeadConnReturnsCleanError(t *testing.T) {
 	assert.NotContains(t, msg, "MTD06", "must not be the opaque describe-failed code")
 	assert.NotContains(t, msg, "broken pipe", "must not surface the raw write error")
 	assert.True(t,
-		strings.Contains(msg, "reserved connection terminated") || strings.Contains(msg, "40001"),
-		"expected a clean retryable reserved-connection-terminated error, got: %s", msg)
+		strings.Contains(msg, "reserved connection terminated") ||
+			strings.Contains(msg, "08006") ||
+			strings.Contains(msg, "57P01") ||
+			strings.Contains(msg, "administrator command"),
+		"expected either Postgres's own admin_shutdown (57P01) preserved verbatim or the "+
+			"synthesized connection_failure (08006), got: %s", msg)
 }

--- a/go/test/endtoend/queryserving/self_terminate_diagnostic_test.go
+++ b/go/test/endtoend/queryserving/self_terminate_diagnostic_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestSelfTerminateBackendPreservesDiagnostic guards against a regression in
+// go/common/pgprotocol/client's processQueryResponses: PostgreSQL sends a
+// FATAL 57P01 ErrorResponse for pg_terminate_backend(pg_backend_pid()) and
+// then closes the connection without ever sending ReadyForQuery. The client
+// must return that diagnostic as-is instead of discarding it in favor of the
+// EOF that follows, and multipooler must propagate it end-to-end instead of
+// masking it with the synthesized reserved-connection-terminated (08006)
+// fallback. Matches vanilla PostgreSQL's behavior for the same statement.
+func TestSelfTerminateBackendPreservesDiagnostic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping end-to-end tests in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 60*time.Second)
+
+	var port int
+	for _, target := range setup.GetComparisonTargets(t) {
+		if target.Name == "multigateway" {
+			port = target.Port
+		}
+	}
+	require.NotZero(t, port, "multigateway target port")
+
+	connStr := shardsetup.GetTestUserDSN("localhost", port, "sslmode=disable")
+	conn, err := pgx.Connect(ctx, connStr)
+	require.NoError(t, err)
+	defer conn.Close(context.Background())
+
+	_, err = conn.Exec(ctx, "BEGIN")
+	require.NoError(t, err)
+
+	res, err := conn.Query(ctx, "SELECT pg_backend_pid()")
+	require.NoError(t, err)
+	var pid int
+	require.True(t, res.Next())
+	require.NoError(t, res.Scan(&pid))
+	res.Close()
+	t.Logf("backend pid = %d", pid)
+
+	_, err = conn.Exec(ctx, "SELECT pg_terminate_backend(pg_backend_pid())")
+
+	var pgErr *pgconn.PgError
+	require.True(t, errors.As(err, &pgErr), "expected a *pgconn.PgError, got %T: %v", err, err)
+	t.Logf("pgErr Code=%s Severity=%s Message=%q Detail=%q",
+		pgErr.Code, pgErr.Severity, pgErr.Message, pgErr.Detail)
+
+	require.Equal(t, "57P01", pgErr.Code, "expected the real admin_shutdown SQLSTATE to be preserved end-to-end")
+}

--- a/go/test/endtoend/queryserving/transaction_failover_test.go
+++ b/go/test/endtoend/queryserving/transaction_failover_test.go
@@ -41,11 +41,12 @@ import (
 //
 // After the fix the pooler admits the in-flight reserved-connection operation
 // (the connection's existence is the real gate) and the executor returns an
-// honest 40001 (serialization_failure) so the client retries the whole
-// transaction.
+// honest 08006 (connection_failure) so the client knows to open a new
+// connection — the reservation (and the backend behind it) is gone, not just
+// the transaction.
 //
 // Before the fix this test FAILS: the post-failover statement returns SQLSTATE
-// "MTF01" instead of "40001".
+// "MTF01" instead of "08006".
 func TestTransactionAbortedOnFailoverGraceExpiry(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping transaction-failover test in short mode")
@@ -97,7 +98,7 @@ func TestTransactionAbortedOnFailoverGraceExpiry(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// The next statement on the now-dead transaction must surface an honest,
-	// retryable error — 40001, not MTF01.
+	// retryable error — 08006 (connection_failure), not MTF01.
 	_, err = conn.Exec(ctx, "INSERT INTO txn_failover_test (id, val) VALUES (2, 'after-failover')")
 	require.Error(t, err, "a statement on a transaction killed by failover must return an error")
 
@@ -107,8 +108,8 @@ func TestTransactionAbortedOnFailoverGraceExpiry(t *testing.T) {
 
 	assert.NotEqual(t, mterrors.MTF01.ID, pgErr.Code,
 		"MTF01 must not leak to the client for a transaction aborted by failover (regression)")
-	assert.Equal(t, mterrors.PgSSSerializationFailure, pgErr.Code,
-		"transaction aborted by failover should surface 40001 serialization_failure so the client retries")
+	assert.Equal(t, mterrors.PgSSConnectionFailure, pgErr.Code,
+		"transaction aborted by failover should surface 08006 connection_failure so the client opens a new connection")
 }
 
 // newFailoverTxnTestCluster creates a 3-node cluster with buffering enabled on


### PR DESCRIPTION
## Summary

- Reserved connections with a dead backend (killed via `pg_terminate_backend`, or force-closed during a planned-failover drain) leaked reservations or leaked raw Go errors instead of a clean signal, across 11 call sites in the multipooler executor.
- The clean signal itself was wrong: it discarded Postgres's real diagnostic (e.g. 57P01 admin_shutdown) and fabricated SQLSTATE 40001, telling clients to retry on a connection that's actually gone.
- The pgprotocol client also masked real diagnostics: every response loop (simple query + all 9 extended-protocol variants) waited for a `ReadyForQuery` that Postgres never sends after a FATAL error, turning the diagnostic into a generic EOF.

## Solution

- New `reservedConnTerminatedError` helper: return Postgres's real diagnostic verbatim when one exists; only synthesize a fallback (now SQLSTATE 08006 connection_failure, not 40001) when there's truly none.
- Fixed every pgprotocol response loop to return a FATAL/PANIC diagnostic immediately instead of waiting for a `ReadyForQuery` that never arrives.
- Added regression tests for every fixed call site and response loop.

Verified against a real cluster: `pg_terminate_backend` now surfaces the real 57P01 admin_shutdown end-to-end; a planned-failover force-close (no diagnostic available) surfaces the synthesized 08006.