### PR TITLE
feat(multipooler): never let a cohort member trust archive-sourced WAL

### DIFF
--- a/go/cmd/pgctld/command/restore_wrapper.go
+++ b/go/cmd/pgctld/command/restore_wrapper.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// restoreWrapperGraceyPeriod is how long the wrapper waits for the wrapped
+// command's process group to exit after forwarding a signal before escalating
+// to SIGKILL.
+const restoreWrapperGracePeriod = 500 * time.Millisecond
+
+// AddRestoreWrapperCommand adds the internal restore-wrapper subcommand.
+func AddRestoreWrapperCommand(root *cobra.Command) {
+	root.AddCommand(&cobra.Command{
+		Use:                "restore-wrapper <pidfile> -- <command> [args...]",
+		Short:              "Internal: wraps a restore_command invocation for reliable stop detection",
+		Hidden:             true,
+		DisableFlagParsing: true,
+		SilenceUsage:       true,
+		RunE:               runRestoreWrapper,
+	})
+}
+
+// runRestoreWrapper is set as restore_command itself (see resetRestoreCommand
+// / the observer catch-up path in the multipooler manager). Postgres invokes
+// restore_command synchronously and has no way to cancel an in-flight
+// invocation on its own — only an external actor with OS-level process access
+// can. This wrapper makes that possible: it records its own PID (stable for
+// its whole lifetime, since it stays alive as a real parent rather than
+// exec-replacing itself) so StopRestoreCommand can check liveness or signal
+// it, and it owns making sure the wrapped command's entire process group is
+// actually dead before it exits — callers never need to know pgbackrest's own
+// process structure.
+func runRestoreWrapper(cmd *cobra.Command, args []string) error {
+	var pidfile string
+	if len(args) > 0 {
+		pidfile = args[0]
+		args = args[1:]
+	}
+	if len(args) > 0 && args[0] == "--" {
+		args = args[1:]
+	}
+	if pidfile == "" || len(args) == 0 {
+		return errors.New("usage: pgctld restore-wrapper <pidfile> -- <command> [args...]")
+	}
+
+	if err := os.WriteFile(pidfile, []byte(strconv.Itoa(os.Getpid())), 0o644); err != nil {
+		return fmt.Errorf("restore-wrapper: failed to write pidfile %s: %w", pidfile, err)
+	}
+
+	return runWrappedCommand(args[0], args[1:])
+}
+
+func runWrappedCommand(name string, args []string) error {
+	c := exec.Command(name, args...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	// Its own process group so a signal can be forwarded to it and any
+	// subprocesses it spawns (pgbackrest's archive-get can itself fork
+	// workers) in one shot, via a negative PID.
+	c.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := c.Start(); err != nil {
+		return fmt.Errorf("restore-wrapper: failed to start %s: %w", name, err)
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigCh)
+
+	done := make(chan error, 1)
+	go func() { done <- c.Wait() }()
+
+	select {
+	case sig := <-sigCh:
+		pgid := -c.Process.Pid
+		_ = syscall.Kill(pgid, sig.(syscall.Signal))
+		select {
+		case <-done:
+		case <-time.After(restoreWrapperGracePeriod):
+			_ = syscall.Kill(pgid, syscall.SIGKILL)
+			<-done
+		}
+		return fmt.Errorf("restore-wrapper: %s terminated by signal %s", name, sig)
+	case err := <-done:
+		return err
+	}
+}

--- a/go/cmd/pgctld/command/restore_wrapper.go
+++ b/go/cmd/pgctld/command/restore_wrapper.go
@@ -41,6 +41,11 @@ func AddRestoreWrapperCommand(root *cobra.Command) {
 		DisableFlagParsing: true,
 		SilenceUsage:       true,
 		RunE:               runRestoreWrapper,
+		// Opts out of root's telemetry init/shutdown.
+		// postgres invokes restore_command once per WAL segment during catch-up
+		// and this wrapper isn't itself instrumented, so the OpenTelemetry lifecycle
+		// overhead buys nothing here.
+		Annotations: map[string]string{skipTelemetryAnnotation: "true"},
 	})
 }
 

--- a/go/cmd/pgctld/command/restore_wrapper.go
+++ b/go/cmd/pgctld/command/restore_wrapper.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// restoreWrapperGraceyPeriod is how long the wrapper waits for the wrapped
+// restoreWrapperGracePeriod is how long the wrapper waits for the wrapped
 // command's process group to exit after forwarding a signal before escalating
 // to SIGKILL.
 const restoreWrapperGracePeriod = 500 * time.Millisecond
@@ -70,6 +70,10 @@ func runRestoreWrapper(cmd *cobra.Command, args []string) error {
 	if err := os.WriteFile(pidfile, []byte(strconv.Itoa(os.Getpid())), 0o644); err != nil {
 		return fmt.Errorf("restore-wrapper: failed to write pidfile %s: %w", pidfile, err)
 	}
+	// Best-effort: StopRestoreCommand's Signal(0) probe already handles a
+	// stale pidfile correctly, but removing it on a normal exit keeps the
+	// common case (no pidfile = nothing to check) the fast path.
+	defer os.Remove(pidfile)
 
 	return runWrappedCommand(args[0], args[1:])
 }

--- a/go/cmd/pgctld/command/restore_wrapper_test.go
+++ b/go/cmd/pgctld/command/restore_wrapper_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRestoreWrapperSkipsTelemetry guards the coupling between
+// restore_wrapper.go (which sets skipTelemetryAnnotation) and root.go's
+// PersistentPreRunE/PersistentPostRunE (which check it) — a typo or rename
+// on either side would silently re-enable telemetry init for every
+// restore_command invocation instead of failing loudly.
+func TestRestoreWrapperSkipsTelemetry(t *testing.T) {
+	root, _ := GetRootCommand()
+
+	cmd, _, err := root.Find([]string{"restore-wrapper"})
+	require.NoError(t, err)
+	assert.Equal(t, "true", cmd.Annotations[skipTelemetryAnnotation],
+		"restore-wrapper must carry the annotation root's hooks check")
+
+	// Running it with no args fails in RunE (missing pidfile/command), but
+	// PersistentPreRunE must still have run first — proving the shared
+	// logging/SilenceUsage setup isn't skipped, only telemetry init is.
+	root.SetArgs([]string{"restore-wrapper"})
+	err = root.Execute()
+	require.Error(t, err)
+	assert.True(t, root.SilenceUsage, "PersistentPreRunE should have run despite skipping telemetry")
+}

--- a/go/cmd/pgctld/command/root.go
+++ b/go/cmd/pgctld/command/root.go
@@ -36,6 +36,13 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// skipTelemetryAnnotation, when set to "true" in a (sub)command's
+// Annotations, opts it out of root's telemetry init/shutdown.
+// Used by restore-wrapper, which postgres invokes once per WAL
+// segment during catch-up and which isn't itself instrumented,
+// so the OpenTelemetry lifecycle overhead buys nothing there.
+const skipTelemetryAnnotation = "skip-telemetry"
+
 // PgCtlCommand holds the configuration for pgctld commands.
 // This contains all flags and information necessary to run any pgctld command.
 type PgCtlCommand struct {
@@ -168,6 +175,9 @@ management for PostgreSQL servers.`,
 			// runtime errors so the error message is not buried under the usage text.
 			cmd.Root().SilenceUsage = true
 			pc.lg.SetupLogging()
+			if cmd.Annotations[skipTelemetryAnnotation] == "true" {
+				return nil
+			}
 			// Initialize telemetry for CLI commands (server command will re-initialize via ServEnv.Init)
 			var err error
 			if span, err = pc.telemetry.InitForCommand(cmd, constants.ServicePgctld, cmd.Use != "server" /* startSpan */); err != nil {
@@ -177,6 +187,9 @@ management for PostgreSQL servers.`,
 			return nil
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Annotations[skipTelemetryAnnotation] == "true" {
+				return nil
+			}
 			span.End()
 
 			// Shutdown OpenTelemetry to flush all pending spans

--- a/go/cmd/pgctld/command/root.go
+++ b/go/cmd/pgctld/command/root.go
@@ -247,6 +247,7 @@ management for PostgreSQL servers.`,
 	AddStatusCommand(root, pc)
 	AddVersionCommand(root, pc)
 	AddReloadCommand(root, pc)
+	AddRestoreWrapperCommand(root)
 
 	return root, pc
 }

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -763,5 +765,56 @@ func (s *PgCtldService) PgRewind(ctx context.Context, req *pb.PgRewindRequest) (
 	return &pb.PgRewindResponse{
 		Message: result.Message,
 		Output:  result.Output,
+	}, nil
+}
+
+// stopRestoreCommandGracePeriod is how long StopRestoreCommand waits for a
+// signaled restore_command wrapper to exit on its own before escalating.
+const stopRestoreCommandGracePeriod = 200 * time.Millisecond
+
+// StopRestoreCommand checks whether the restore_command wrapper (see
+// `pgctld restore-wrapper`) is currently running, by reading the PID it
+// recorded at RestoreCommandPIDFile, and terminates it if so. Postgres itself
+// cannot cancel an in-flight restore_command invocation — a config change
+// only affects the next fetch decision — so this is the only way to
+// confidently stop one that is already running rather than just disabling it
+// for the future.
+func (s *PgCtldService) StopRestoreCommand(ctx context.Context, req *pb.StopRestoreCommandRequest) (*pb.StopRestoreCommandResponse, error) {
+	pidFile := pgctld.RestoreCommandPIDFile(s.pgConfig.PoolerDir)
+	s.logger.InfoContext(ctx, "gRPC StopRestoreCommand request", "pidfile", pidFile)
+
+	pidBytes, err := os.ReadFile(pidFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &pb.StopRestoreCommandResponse{Found: false, Message: "no restore_command pidfile found"}, nil
+		}
+		return nil, fmt.Errorf("failed to read restore_command pidfile %s: %w", pidFile, err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil {
+		return nil, fmt.Errorf("invalid PID in %s: %w", pidFile, err)
+	}
+
+	// findErr means the process doesn't exist (only possible FindProcess
+	// failure on Unix), which just means the pidfile is stale — not an RPC
+	// failure, so returning nil here alongside Found:false is intentional.
+	process, findErr := os.FindProcess(pid)
+	if findErr != nil {
+		return &pb.StopRestoreCommandResponse{Found: false, Message: fmt.Sprintf("pid %d from pidfile not found", pid)}, nil
+	}
+	if process.Signal(syscall.Signal(0)) != nil {
+		// Already exited on its own; the pidfile is just stale.
+		return &pb.StopRestoreCommandResponse{Found: false, Message: fmt.Sprintf("pid %d is not running", pid)}, nil
+	}
+
+	s.logger.InfoContext(ctx, "restore_command wrapper still running, stopping it", "pid", pid)
+	stopCtx, cancel := context.WithTimeout(ctx, stopRestoreCommandGracePeriod)
+	defer cancel()
+	if stopErr, stopped := executil.StopProcess(stopCtx, process); stopErr != nil || !stopped {
+		return nil, fmt.Errorf("failed to stop restore_command wrapper pid %d: %w", pid, stopErr)
+	}
+	return &pb.StopRestoreCommandResponse{
+		Found: true, Killed: true,
+		Message: fmt.Sprintf("pid %d stopped", pid),
 	}, nil
 }

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -810,8 +810,12 @@ func (s *PgCtldService) StopRestoreCommand(ctx context.Context, req *pb.StopRest
 	s.logger.InfoContext(ctx, "restore_command wrapper still running, stopping it", "pid", pid)
 	stopCtx, cancel := context.WithTimeout(ctx, stopRestoreCommandGracePeriod)
 	defer cancel()
-	if stopErr, stopped := executil.StopProcess(stopCtx, process); stopErr != nil || !stopped {
+	stopErr, stopped := executil.StopProcess(stopCtx, process)
+	if stopErr != nil {
 		return nil, fmt.Errorf("failed to stop restore_command wrapper pid %d: %w", pid, stopErr)
+	}
+	if !stopped {
+		return nil, fmt.Errorf("failed to stop restore_command wrapper pid %d: process did not exit after SIGKILL", pid)
 	}
 	return &pb.StopRestoreCommandResponse{
 		Found: true, Killed: true,

--- a/go/cmd/pgctld/command/server_test.go
+++ b/go/cmd/pgctld/command/server_test.go
@@ -20,7 +20,10 @@ import (
 	"log/slog"
 	"math"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
+	"syscall"
 	"testing"
 	"time"
 
@@ -32,7 +35,9 @@ import (
 	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
 	"github.com/multigres/multigres/go/common/constants"
 	pb "github.com/multigres/multigres/go/pb/pgctldservice"
+	"github.com/multigres/multigres/go/services/pgctld"
 	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/tools/executil"
 	"github.com/multigres/multigres/go/tools/viperutil"
 )
 
@@ -711,4 +716,74 @@ func TestPgCtldService_StopRewindStart(t *testing.T) {
 // testLogger returns a no-op logger for testing
 func testLogger() *slog.Logger {
 	return slog.New(slog.DiscardHandler)
+}
+
+func TestPgCtldServiceStopRestoreCommand(t *testing.T) {
+	t.Run("no pidfile", func(t *testing.T) {
+		baseDir, cleanup := testutil.TempDir(t, "pgctld_stop_restore_no_pidfile")
+		defer cleanup()
+		t.Setenv(constants.PgDataDirEnvVar, filepath.Join(baseDir, "pg_data"))
+
+		service, err := NewPgCtldService(testLogger(), testServiceConfig, 30, baseDir, "localhost", 0, "")
+		require.NoError(t, err)
+
+		resp, err := service.StopRestoreCommand(context.Background(), &pb.StopRestoreCommandRequest{})
+		require.NoError(t, err)
+		assert.False(t, resp.Found)
+		assert.False(t, resp.Killed)
+	})
+
+	t.Run("stale pidfile referencing an already-exited process", func(t *testing.T) {
+		baseDir, cleanup := testutil.TempDir(t, "pgctld_stop_restore_stale_pidfile")
+		defer cleanup()
+		t.Setenv(constants.PgDataDirEnvVar, filepath.Join(baseDir, "pg_data"))
+
+		// Spawn and fully wait on a short-lived process so its PID is guaranteed
+		// to no longer be running by the time we reference it.
+		cmd := exec.Command("true")
+		require.NoError(t, cmd.Run())
+		stalePID := cmd.Process.Pid
+
+		require.NoError(t, os.WriteFile(pgctld.RestoreCommandPIDFile(baseDir), []byte(strconv.Itoa(stalePID)), 0o644))
+
+		service, err := NewPgCtldService(testLogger(), testServiceConfig, 30, baseDir, "localhost", 0, "")
+		require.NoError(t, err)
+
+		resp, err := service.StopRestoreCommand(context.Background(), &pb.StopRestoreCommandRequest{})
+		require.NoError(t, err)
+		assert.False(t, resp.Found)
+		assert.False(t, resp.Killed)
+	})
+
+	t.Run("live process gets terminated", func(t *testing.T) {
+		baseDir, cleanup := testutil.TempDir(t, "pgctld_stop_restore_live")
+		defer cleanup()
+		t.Setenv(constants.PgDataDirEnvVar, filepath.Join(baseDir, "pg_data"))
+
+		// A process that ignores SIGTERM, to exercise the SIGKILL escalation path.
+		cmd := exec.Command("sh", "-c", "trap '' TERM; sleep 30")
+		require.NoError(t, cmd.Start())
+		t.Cleanup(func() { _, _ = executil.KillProcess(context.Background(), cmd.Process) })
+		// Reap it once killed. Our own exec.Cmd is this process's real OS-level
+		// parent (unlike production, where pgctld signals a process it did not
+		// start), so without a Wait() call here it becomes a zombie that still
+		// answers Signal(0) as "alive" forever, and StopRestoreCommand's wait
+		// loop below would never see it as gone.
+		go func() { _ = cmd.Wait() }()
+
+		require.NoError(t, os.WriteFile(pgctld.RestoreCommandPIDFile(baseDir), []byte(strconv.Itoa(cmd.Process.Pid)), 0o644))
+
+		service, err := NewPgCtldService(testLogger(), testServiceConfig, 30, baseDir, "localhost", 0, "")
+		require.NoError(t, err)
+
+		resp, err := service.StopRestoreCommand(context.Background(), &pb.StopRestoreCommandRequest{})
+		require.NoError(t, err)
+		assert.True(t, resp.Found)
+		assert.True(t, resp.Killed)
+
+		// Process must actually be gone (SIGTERM was ignored, so this only
+		// passes if the SIGKILL escalation ran).
+		err = cmd.Process.Signal(syscall.Signal(0))
+		assert.Error(t, err, "process should no longer exist after StopRestoreCommand")
+	})
 }

--- a/go/cmd/pgctld/testutil/grpc_helpers.go
+++ b/go/cmd/pgctld/testutil/grpc_helpers.go
@@ -32,35 +32,38 @@ import (
 // MockPgCtldService implements a mock version of the PgCtld gRPC service for testing
 type MockPgCtldService struct {
 	pb.UnimplementedPgCtldServer
-	mu            sync.Mutex
-	StartCalls    []*pb.StartRequest
-	StopCalls     []*pb.StopRequest
-	RestartCalls  []*pb.RestartRequest
-	ReloadCalls   []*pb.ReloadConfigRequest
-	StatusCalls   []*pb.StatusRequest
-	VersionCalls  []*pb.VersionRequest
-	InitDirCalls  []*pb.InitDataDirRequest
-	PgRewindCalls []*pb.PgRewindRequest
+	mu                      sync.Mutex
+	StartCalls              []*pb.StartRequest
+	StopCalls               []*pb.StopRequest
+	RestartCalls            []*pb.RestartRequest
+	ReloadCalls             []*pb.ReloadConfigRequest
+	StatusCalls             []*pb.StatusRequest
+	VersionCalls            []*pb.VersionRequest
+	InitDirCalls            []*pb.InitDataDirRequest
+	PgRewindCalls           []*pb.PgRewindRequest
+	StopRestoreCommandCalls []*pb.StopRestoreCommandRequest
 
 	// Response configurations
-	StartResponse    *pb.StartResponse
-	StopResponse     *pb.StopResponse
-	RestartResponse  *pb.RestartResponse
-	ReloadResponse   *pb.ReloadConfigResponse
-	StatusResponse   *pb.StatusResponse
-	VersionResponse  *pb.VersionResponse
-	InitDirResponse  *pb.InitDataDirResponse
-	PgRewindResponse *pb.PgRewindResponse
+	StartResponse              *pb.StartResponse
+	StopResponse               *pb.StopResponse
+	RestartResponse            *pb.RestartResponse
+	ReloadResponse             *pb.ReloadConfigResponse
+	StatusResponse             *pb.StatusResponse
+	VersionResponse            *pb.VersionResponse
+	InitDirResponse            *pb.InitDataDirResponse
+	PgRewindResponse           *pb.PgRewindResponse
+	StopRestoreCommandResponse *pb.StopRestoreCommandResponse
 
 	// Error configurations
-	StartError    error
-	StopError     error
-	RestartError  error
-	ReloadError   error
-	StatusError   error
-	VersionError  error
-	InitDirError  error
-	PgRewindError error
+	StartError              error
+	StopError               error
+	RestartError            error
+	ReloadError             error
+	StatusError             error
+	VersionError            error
+	InitDirError            error
+	PgRewindError           error
+	StopRestoreCommandError error
 }
 
 func (m *MockPgCtldService) Start(ctx context.Context, req *pb.StartRequest) (*pb.StartResponse, error) {
@@ -113,6 +116,19 @@ func (m *MockPgCtldService) ReloadConfig(ctx context.Context, req *pb.ReloadConf
 		return m.ReloadResponse, nil
 	}
 	return &pb.ReloadConfigResponse{Message: "Mock config reloaded"}, nil
+}
+
+func (m *MockPgCtldService) StopRestoreCommand(ctx context.Context, req *pb.StopRestoreCommandRequest) (*pb.StopRestoreCommandResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.StopRestoreCommandCalls = append(m.StopRestoreCommandCalls, req)
+	if m.StopRestoreCommandError != nil {
+		return nil, m.StopRestoreCommandError
+	}
+	if m.StopRestoreCommandResponse != nil {
+		return m.StopRestoreCommandResponse, nil
+	}
+	return &pb.StopRestoreCommandResponse{Message: "mock: nothing running"}, nil
 }
 
 func (m *MockPgCtldService) Status(ctx context.Context, req *pb.StatusRequest) (*pb.StatusResponse, error) {

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -116,4 +116,16 @@ const (
 	// released at transaction end), so a false result means the session has
 	// released all of its advisory locks and the backend can be unpinned.
 	PgLocksAdvisoryProbeSQL = "SELECT EXISTS (SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND pid = pg_backend_pid())"
+
+	// RestoreCommandPIDFile is the filename (joined onto the pooler directory)
+	// that `pgctld restore-wrapper` writes its own PID to, so pgctld's
+	// StopRestoreCommand RPC can check liveness or signal it. Shared between
+	// go/services/pgctld (which writes/reads it directly) and
+	// go/services/multipooler (which constructs the wrapped restore_command
+	// string embedding this path) — a plain constant here avoids
+	// go/services/multipooler needing to import go/services/pgctld, which
+	// pgctld-isolation forbids. Lives in the pooler dir, not PGDATA, so it
+	// survives restore_command being cleared and PGDATA being wiped by a
+	// subsequent restore.
+	RestoreCommandPIDFile = "restore_command.pid"
 )

--- a/go/pb/pgctldservice/pgctldservice.pb.go
+++ b/go/pb/pgctldservice/pgctldservice.pb.go
@@ -1127,6 +1127,108 @@ func (x *PgRewindResponse) GetOutput() string {
 	return ""
 }
 
+type StopRestoreCommandRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StopRestoreCommandRequest) Reset() {
+	*x = StopRestoreCommandRequest{}
+	mi := &file_pgctldservice_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StopRestoreCommandRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StopRestoreCommandRequest) ProtoMessage() {}
+
+func (x *StopRestoreCommandRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_pgctldservice_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StopRestoreCommandRequest.ProtoReflect.Descriptor instead.
+func (*StopRestoreCommandRequest) Descriptor() ([]byte, []int) {
+	return file_pgctldservice_proto_rawDescGZIP(), []int{17}
+}
+
+type StopRestoreCommandResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// True if a restore_command invocation was found running (whether or not it
+	// needed to be signaled to stop).
+	Found bool `protobuf:"varint,1,opt,name=found,proto3" json:"found,omitempty"`
+	// True if the found process had to be signaled (SIGTERM, escalating to
+	// SIGKILL) to stop it. False if nothing was found, or it had already
+	// exited on its own by the time this returned.
+	Killed bool `protobuf:"varint,2,opt,name=killed,proto3" json:"killed,omitempty"`
+	// Status message
+	Message       string `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StopRestoreCommandResponse) Reset() {
+	*x = StopRestoreCommandResponse{}
+	mi := &file_pgctldservice_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StopRestoreCommandResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StopRestoreCommandResponse) ProtoMessage() {}
+
+func (x *StopRestoreCommandResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_pgctldservice_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StopRestoreCommandResponse.ProtoReflect.Descriptor instead.
+func (*StopRestoreCommandResponse) Descriptor() ([]byte, []int) {
+	return file_pgctldservice_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *StopRestoreCommandResponse) GetFound() bool {
+	if x != nil {
+		return x.Found
+	}
+	return false
+}
+
+func (x *StopRestoreCommandResponse) GetKilled() bool {
+	if x != nil {
+		return x.Killed
+	}
+	return false
+}
+
+func (x *StopRestoreCommandResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
 var File_pgctldservice_proto protoreflect.FileDescriptor
 
 const file_pgctldservice_proto_rawDesc = "" +
@@ -1203,14 +1305,19 @@ const file_pgctldservice_proto_rawDesc = "" +
 	"\x10application_name\x18\x05 \x01(\tR\x0fapplicationName\"D\n" +
 	"\x10PgRewindResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x12\x16\n" +
-	"\x06output\x18\x02 \x01(\tR\x06output*f\n" +
+	"\x06output\x18\x02 \x01(\tR\x06output\"\x1b\n" +
+	"\x19StopRestoreCommandRequest\"d\n" +
+	"\x1aStopRestoreCommandResponse\x12\x14\n" +
+	"\x05found\x18\x01 \x01(\bR\x05found\x12\x16\n" +
+	"\x06killed\x18\x02 \x01(\bR\x06killed\x12\x18\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage*f\n" +
 	"\fServerStatus\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\v\n" +
 	"\aSTOPPED\x10\x01\x12\f\n" +
 	"\bSTARTING\x10\x02\x12\v\n" +
 	"\aRUNNING\x10\x03\x12\f\n" +
 	"\bSTOPPING\x10\x04\x12\x13\n" +
-	"\x0fNOT_INITIALIZED\x10\x052\xe4\x04\n" +
+	"\x0fNOT_INITIALIZED\x10\x052\xcf\x05\n" +
 	"\x06PgCtld\x12B\n" +
 	"\x05Start\x12\x1b.pgctldservice.StartRequest\x1a\x1c.pgctldservice.StartResponse\x12?\n" +
 	"\x04Stop\x12\x1a.pgctldservice.StopRequest\x1a\x1b.pgctldservice.StopResponse\x12H\n" +
@@ -1219,7 +1326,8 @@ const file_pgctldservice_proto_rawDesc = "" +
 	"\x06Status\x12\x1c.pgctldservice.StatusRequest\x1a\x1d.pgctldservice.StatusResponse\x12H\n" +
 	"\aVersion\x12\x1d.pgctldservice.VersionRequest\x1a\x1e.pgctldservice.VersionResponse\x12T\n" +
 	"\vInitDataDir\x12!.pgctldservice.InitDataDirRequest\x1a\".pgctldservice.InitDataDirResponse\x12K\n" +
-	"\bPgRewind\x12\x1e.pgctldservice.PgRewindRequest\x1a\x1f.pgctldservice.PgRewindResponseB4Z2github.com/multigres/multigres/go/pb/pgctldserviceb\x06proto3"
+	"\bPgRewind\x12\x1e.pgctldservice.PgRewindRequest\x1a\x1f.pgctldservice.PgRewindResponse\x12i\n" +
+	"\x12StopRestoreCommand\x12(.pgctldservice.StopRestoreCommandRequest\x1a).pgctldservice.StopRestoreCommandResponseB4Z2github.com/multigres/multigres/go/pb/pgctldserviceb\x06proto3"
 
 var (
 	file_pgctldservice_proto_rawDescOnce sync.Once
@@ -1234,36 +1342,38 @@ func file_pgctldservice_proto_rawDescGZIP() []byte {
 }
 
 var file_pgctldservice_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_pgctldservice_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_pgctldservice_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
 var file_pgctldservice_proto_goTypes = []any{
-	(ServerStatus)(0),             // 0: pgctldservice.ServerStatus
-	(*StartRequest)(nil),          // 1: pgctldservice.StartRequest
-	(*StartResponse)(nil),         // 2: pgctldservice.StartResponse
-	(*StopRequest)(nil),           // 3: pgctldservice.StopRequest
-	(*StopResponse)(nil),          // 4: pgctldservice.StopResponse
-	(*RestartRequest)(nil),        // 5: pgctldservice.RestartRequest
-	(*RestartResponse)(nil),       // 6: pgctldservice.RestartResponse
-	(*ReloadConfigRequest)(nil),   // 7: pgctldservice.ReloadConfigRequest
-	(*ReloadConfigResponse)(nil),  // 8: pgctldservice.ReloadConfigResponse
-	(*StatusRequest)(nil),         // 9: pgctldservice.StatusRequest
-	(*StatusResponse)(nil),        // 10: pgctldservice.StatusResponse
-	(*PgBackRestStatus)(nil),      // 11: pgctldservice.PgBackRestStatus
-	(*VersionRequest)(nil),        // 12: pgctldservice.VersionRequest
-	(*VersionResponse)(nil),       // 13: pgctldservice.VersionResponse
-	(*InitDataDirRequest)(nil),    // 14: pgctldservice.InitDataDirRequest
-	(*InitDataDirResponse)(nil),   // 15: pgctldservice.InitDataDirResponse
-	(*PgRewindRequest)(nil),       // 16: pgctldservice.PgRewindRequest
-	(*PgRewindResponse)(nil),      // 17: pgctldservice.PgRewindResponse
-	(*durationpb.Duration)(nil),   // 18: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil), // 19: google.protobuf.Timestamp
+	(ServerStatus)(0),                  // 0: pgctldservice.ServerStatus
+	(*StartRequest)(nil),               // 1: pgctldservice.StartRequest
+	(*StartResponse)(nil),              // 2: pgctldservice.StartResponse
+	(*StopRequest)(nil),                // 3: pgctldservice.StopRequest
+	(*StopResponse)(nil),               // 4: pgctldservice.StopResponse
+	(*RestartRequest)(nil),             // 5: pgctldservice.RestartRequest
+	(*RestartResponse)(nil),            // 6: pgctldservice.RestartResponse
+	(*ReloadConfigRequest)(nil),        // 7: pgctldservice.ReloadConfigRequest
+	(*ReloadConfigResponse)(nil),       // 8: pgctldservice.ReloadConfigResponse
+	(*StatusRequest)(nil),              // 9: pgctldservice.StatusRequest
+	(*StatusResponse)(nil),             // 10: pgctldservice.StatusResponse
+	(*PgBackRestStatus)(nil),           // 11: pgctldservice.PgBackRestStatus
+	(*VersionRequest)(nil),             // 12: pgctldservice.VersionRequest
+	(*VersionResponse)(nil),            // 13: pgctldservice.VersionResponse
+	(*InitDataDirRequest)(nil),         // 14: pgctldservice.InitDataDirRequest
+	(*InitDataDirResponse)(nil),        // 15: pgctldservice.InitDataDirResponse
+	(*PgRewindRequest)(nil),            // 16: pgctldservice.PgRewindRequest
+	(*PgRewindResponse)(nil),           // 17: pgctldservice.PgRewindResponse
+	(*StopRestoreCommandRequest)(nil),  // 18: pgctldservice.StopRestoreCommandRequest
+	(*StopRestoreCommandResponse)(nil), // 19: pgctldservice.StopRestoreCommandResponse
+	(*durationpb.Duration)(nil),        // 20: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),      // 21: google.protobuf.Timestamp
 }
 var file_pgctldservice_proto_depIdxs = []int32{
-	18, // 0: pgctldservice.StopRequest.timeout:type_name -> google.protobuf.Duration
-	18, // 1: pgctldservice.RestartRequest.timeout:type_name -> google.protobuf.Duration
+	20, // 0: pgctldservice.StopRequest.timeout:type_name -> google.protobuf.Duration
+	20, // 1: pgctldservice.RestartRequest.timeout:type_name -> google.protobuf.Duration
 	0,  // 2: pgctldservice.StatusResponse.status:type_name -> pgctldservice.ServerStatus
-	18, // 3: pgctldservice.StatusResponse.uptime:type_name -> google.protobuf.Duration
+	20, // 3: pgctldservice.StatusResponse.uptime:type_name -> google.protobuf.Duration
 	11, // 4: pgctldservice.StatusResponse.pgbackrest_status:type_name -> pgctldservice.PgBackRestStatus
-	19, // 5: pgctldservice.PgBackRestStatus.last_started:type_name -> google.protobuf.Timestamp
+	21, // 5: pgctldservice.PgBackRestStatus.last_started:type_name -> google.protobuf.Timestamp
 	1,  // 6: pgctldservice.PgCtld.Start:input_type -> pgctldservice.StartRequest
 	3,  // 7: pgctldservice.PgCtld.Stop:input_type -> pgctldservice.StopRequest
 	5,  // 8: pgctldservice.PgCtld.Restart:input_type -> pgctldservice.RestartRequest
@@ -1272,16 +1382,18 @@ var file_pgctldservice_proto_depIdxs = []int32{
 	12, // 11: pgctldservice.PgCtld.Version:input_type -> pgctldservice.VersionRequest
 	14, // 12: pgctldservice.PgCtld.InitDataDir:input_type -> pgctldservice.InitDataDirRequest
 	16, // 13: pgctldservice.PgCtld.PgRewind:input_type -> pgctldservice.PgRewindRequest
-	2,  // 14: pgctldservice.PgCtld.Start:output_type -> pgctldservice.StartResponse
-	4,  // 15: pgctldservice.PgCtld.Stop:output_type -> pgctldservice.StopResponse
-	6,  // 16: pgctldservice.PgCtld.Restart:output_type -> pgctldservice.RestartResponse
-	8,  // 17: pgctldservice.PgCtld.ReloadConfig:output_type -> pgctldservice.ReloadConfigResponse
-	10, // 18: pgctldservice.PgCtld.Status:output_type -> pgctldservice.StatusResponse
-	13, // 19: pgctldservice.PgCtld.Version:output_type -> pgctldservice.VersionResponse
-	15, // 20: pgctldservice.PgCtld.InitDataDir:output_type -> pgctldservice.InitDataDirResponse
-	17, // 21: pgctldservice.PgCtld.PgRewind:output_type -> pgctldservice.PgRewindResponse
-	14, // [14:22] is the sub-list for method output_type
-	6,  // [6:14] is the sub-list for method input_type
+	18, // 14: pgctldservice.PgCtld.StopRestoreCommand:input_type -> pgctldservice.StopRestoreCommandRequest
+	2,  // 15: pgctldservice.PgCtld.Start:output_type -> pgctldservice.StartResponse
+	4,  // 16: pgctldservice.PgCtld.Stop:output_type -> pgctldservice.StopResponse
+	6,  // 17: pgctldservice.PgCtld.Restart:output_type -> pgctldservice.RestartResponse
+	8,  // 18: pgctldservice.PgCtld.ReloadConfig:output_type -> pgctldservice.ReloadConfigResponse
+	10, // 19: pgctldservice.PgCtld.Status:output_type -> pgctldservice.StatusResponse
+	13, // 20: pgctldservice.PgCtld.Version:output_type -> pgctldservice.VersionResponse
+	15, // 21: pgctldservice.PgCtld.InitDataDir:output_type -> pgctldservice.InitDataDirResponse
+	17, // 22: pgctldservice.PgCtld.PgRewind:output_type -> pgctldservice.PgRewindResponse
+	19, // 23: pgctldservice.PgCtld.StopRestoreCommand:output_type -> pgctldservice.StopRestoreCommandResponse
+	15, // [15:24] is the sub-list for method output_type
+	6,  // [6:15] is the sub-list for method input_type
 	6,  // [6:6] is the sub-list for extension type_name
 	6,  // [6:6] is the sub-list for extension extendee
 	0,  // [0:6] is the sub-list for field type_name
@@ -1298,7 +1410,7 @@ func file_pgctldservice_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pgctldservice_proto_rawDesc), len(file_pgctldservice_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   17,
+			NumMessages:   19,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/pb/pgctldservice/pgctldservice.pb.gw.go
+++ b/go/pb/pgctldservice/pgctldservice.pb.gw.go
@@ -251,6 +251,33 @@ func local_request_PgCtld_PgRewind_0(ctx context.Context, marshaler runtime.Mars
 	return msg, metadata, err
 }
 
+func request_PgCtld_StopRestoreCommand_0(ctx context.Context, marshaler runtime.Marshaler, client PgCtldClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq StopRestoreCommandRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.StopRestoreCommand(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_PgCtld_StopRestoreCommand_0(ctx context.Context, marshaler runtime.Marshaler, server PgCtldServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq StopRestoreCommandRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.StopRestoreCommand(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterPgCtldHandlerServer registers the http handlers for service PgCtld to "mux".
 // UnaryRPC     :call PgCtldServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -416,6 +443,26 @@ func RegisterPgCtldHandlerServer(ctx context.Context, mux *runtime.ServeMux, ser
 			return
 		}
 		forward_PgCtld_PgRewind_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_PgCtld_StopRestoreCommand_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/pgctldservice.PgCtld/StopRestoreCommand", runtime.WithHTTPPathPattern("/pgctldservice.PgCtld/StopRestoreCommand"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_PgCtld_StopRestoreCommand_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_PgCtld_StopRestoreCommand_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -593,27 +640,46 @@ func RegisterPgCtldHandlerClient(ctx context.Context, mux *runtime.ServeMux, cli
 		}
 		forward_PgCtld_PgRewind_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_PgCtld_StopRestoreCommand_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/pgctldservice.PgCtld/StopRestoreCommand", runtime.WithHTTPPathPattern("/pgctldservice.PgCtld/StopRestoreCommand"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_PgCtld_StopRestoreCommand_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_PgCtld_StopRestoreCommand_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
 var (
-	pattern_PgCtld_Start_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Start"}, ""))
-	pattern_PgCtld_Stop_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Stop"}, ""))
-	pattern_PgCtld_Restart_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Restart"}, ""))
-	pattern_PgCtld_ReloadConfig_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "ReloadConfig"}, ""))
-	pattern_PgCtld_Status_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Status"}, ""))
-	pattern_PgCtld_Version_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Version"}, ""))
-	pattern_PgCtld_InitDataDir_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "InitDataDir"}, ""))
-	pattern_PgCtld_PgRewind_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "PgRewind"}, ""))
+	pattern_PgCtld_Start_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Start"}, ""))
+	pattern_PgCtld_Stop_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Stop"}, ""))
+	pattern_PgCtld_Restart_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Restart"}, ""))
+	pattern_PgCtld_ReloadConfig_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "ReloadConfig"}, ""))
+	pattern_PgCtld_Status_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Status"}, ""))
+	pattern_PgCtld_Version_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Version"}, ""))
+	pattern_PgCtld_InitDataDir_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "InitDataDir"}, ""))
+	pattern_PgCtld_PgRewind_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "PgRewind"}, ""))
+	pattern_PgCtld_StopRestoreCommand_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "StopRestoreCommand"}, ""))
 )
 
 var (
-	forward_PgCtld_Start_0        = runtime.ForwardResponseMessage
-	forward_PgCtld_Stop_0         = runtime.ForwardResponseMessage
-	forward_PgCtld_Restart_0      = runtime.ForwardResponseMessage
-	forward_PgCtld_ReloadConfig_0 = runtime.ForwardResponseMessage
-	forward_PgCtld_Status_0       = runtime.ForwardResponseMessage
-	forward_PgCtld_Version_0      = runtime.ForwardResponseMessage
-	forward_PgCtld_InitDataDir_0  = runtime.ForwardResponseMessage
-	forward_PgCtld_PgRewind_0     = runtime.ForwardResponseMessage
+	forward_PgCtld_Start_0              = runtime.ForwardResponseMessage
+	forward_PgCtld_Stop_0               = runtime.ForwardResponseMessage
+	forward_PgCtld_Restart_0            = runtime.ForwardResponseMessage
+	forward_PgCtld_ReloadConfig_0       = runtime.ForwardResponseMessage
+	forward_PgCtld_Status_0             = runtime.ForwardResponseMessage
+	forward_PgCtld_Version_0            = runtime.ForwardResponseMessage
+	forward_PgCtld_InitDataDir_0        = runtime.ForwardResponseMessage
+	forward_PgCtld_PgRewind_0           = runtime.ForwardResponseMessage
+	forward_PgCtld_StopRestoreCommand_0 = runtime.ForwardResponseMessage
 )

--- a/go/pb/pgctldservice/pgctldservice_grpc.pb.go
+++ b/go/pb/pgctldservice/pgctldservice_grpc.pb.go
@@ -33,14 +33,15 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	PgCtld_Start_FullMethodName        = "/pgctldservice.PgCtld/Start"
-	PgCtld_Stop_FullMethodName         = "/pgctldservice.PgCtld/Stop"
-	PgCtld_Restart_FullMethodName      = "/pgctldservice.PgCtld/Restart"
-	PgCtld_ReloadConfig_FullMethodName = "/pgctldservice.PgCtld/ReloadConfig"
-	PgCtld_Status_FullMethodName       = "/pgctldservice.PgCtld/Status"
-	PgCtld_Version_FullMethodName      = "/pgctldservice.PgCtld/Version"
-	PgCtld_InitDataDir_FullMethodName  = "/pgctldservice.PgCtld/InitDataDir"
-	PgCtld_PgRewind_FullMethodName     = "/pgctldservice.PgCtld/PgRewind"
+	PgCtld_Start_FullMethodName              = "/pgctldservice.PgCtld/Start"
+	PgCtld_Stop_FullMethodName               = "/pgctldservice.PgCtld/Stop"
+	PgCtld_Restart_FullMethodName            = "/pgctldservice.PgCtld/Restart"
+	PgCtld_ReloadConfig_FullMethodName       = "/pgctldservice.PgCtld/ReloadConfig"
+	PgCtld_Status_FullMethodName             = "/pgctldservice.PgCtld/Status"
+	PgCtld_Version_FullMethodName            = "/pgctldservice.PgCtld/Version"
+	PgCtld_InitDataDir_FullMethodName        = "/pgctldservice.PgCtld/InitDataDir"
+	PgCtld_PgRewind_FullMethodName           = "/pgctldservice.PgCtld/PgRewind"
+	PgCtld_StopRestoreCommand_FullMethodName = "/pgctldservice.PgCtld/StopRestoreCommand"
 )
 
 // PgCtldClient is the client API for PgCtld service.
@@ -66,6 +67,12 @@ type PgCtldClient interface {
 	// PgRewind rewinds a PostgreSQL data directory to an earlier point in the timeline
 	// This is used to resynchronize a server that diverged from the primary after a failback
 	PgRewind(ctx context.Context, in *PgRewindRequest, opts ...grpc.CallOption) (*PgRewindResponse, error)
+	// StopRestoreCommand checks whether a restore_command invocation (run via
+	// the `pgctld restore-wrapper`, see RestoreCommandPIDFile) is currently
+	// running and, if so, terminates it. Postgres cannot cancel an in-flight
+	// restore_command call on its own — this is the only way to guarantee one
+	// has actually stopped rather than just disabling it for future segments.
+	StopRestoreCommand(ctx context.Context, in *StopRestoreCommandRequest, opts ...grpc.CallOption) (*StopRestoreCommandResponse, error)
 }
 
 type pgCtldClient struct {
@@ -156,6 +163,16 @@ func (c *pgCtldClient) PgRewind(ctx context.Context, in *PgRewindRequest, opts .
 	return out, nil
 }
 
+func (c *pgCtldClient) StopRestoreCommand(ctx context.Context, in *StopRestoreCommandRequest, opts ...grpc.CallOption) (*StopRestoreCommandResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(StopRestoreCommandResponse)
+	err := c.cc.Invoke(ctx, PgCtld_StopRestoreCommand_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // PgCtldServer is the server API for PgCtld service.
 // All implementations must embed UnimplementedPgCtldServer
 // for forward compatibility.
@@ -179,6 +196,12 @@ type PgCtldServer interface {
 	// PgRewind rewinds a PostgreSQL data directory to an earlier point in the timeline
 	// This is used to resynchronize a server that diverged from the primary after a failback
 	PgRewind(context.Context, *PgRewindRequest) (*PgRewindResponse, error)
+	// StopRestoreCommand checks whether a restore_command invocation (run via
+	// the `pgctld restore-wrapper`, see RestoreCommandPIDFile) is currently
+	// running and, if so, terminates it. Postgres cannot cancel an in-flight
+	// restore_command call on its own — this is the only way to guarantee one
+	// has actually stopped rather than just disabling it for future segments.
+	StopRestoreCommand(context.Context, *StopRestoreCommandRequest) (*StopRestoreCommandResponse, error)
 	mustEmbedUnimplementedPgCtldServer()
 }
 
@@ -212,6 +235,9 @@ func (UnimplementedPgCtldServer) InitDataDir(context.Context, *InitDataDirReques
 }
 func (UnimplementedPgCtldServer) PgRewind(context.Context, *PgRewindRequest) (*PgRewindResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PgRewind not implemented")
+}
+func (UnimplementedPgCtldServer) StopRestoreCommand(context.Context, *StopRestoreCommandRequest) (*StopRestoreCommandResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method StopRestoreCommand not implemented")
 }
 func (UnimplementedPgCtldServer) mustEmbedUnimplementedPgCtldServer() {}
 func (UnimplementedPgCtldServer) testEmbeddedByValue()                {}
@@ -378,6 +404,24 @@ func _PgCtld_PgRewind_Handler(srv interface{}, ctx context.Context, dec func(int
 	return interceptor(ctx, in, info, handler)
 }
 
+func _PgCtld_StopRestoreCommand_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StopRestoreCommandRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PgCtldServer).StopRestoreCommand(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PgCtld_StopRestoreCommand_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PgCtldServer).StopRestoreCommand(ctx, req.(*StopRestoreCommandRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // PgCtld_ServiceDesc is the grpc.ServiceDesc for PgCtld service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -416,6 +460,10 @@ var PgCtld_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "PgRewind",
 			Handler:    _PgCtld_PgRewind_Handler,
+		},
+		{
+			MethodName: "StopRestoreCommand",
+			Handler:    _PgCtld_StopRestoreCommand_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/go/pb/pgctldservice/pgctldserviceconnect/pgctldservice.connect.go
+++ b/go/pb/pgctldservice/pgctldserviceconnect/pgctldservice.connect.go
@@ -63,6 +63,9 @@ const (
 	PgCtldInitDataDirProcedure = "/pgctldservice.PgCtld/InitDataDir"
 	// PgCtldPgRewindProcedure is the fully-qualified name of the PgCtld's PgRewind RPC.
 	PgCtldPgRewindProcedure = "/pgctldservice.PgCtld/PgRewind"
+	// PgCtldStopRestoreCommandProcedure is the fully-qualified name of the PgCtld's StopRestoreCommand
+	// RPC.
+	PgCtldStopRestoreCommandProcedure = "/pgctldservice.PgCtld/StopRestoreCommand"
 )
 
 // PgCtldClient is a client for the pgctldservice.PgCtld service.
@@ -84,6 +87,12 @@ type PgCtldClient interface {
 	// PgRewind rewinds a PostgreSQL data directory to an earlier point in the timeline
 	// This is used to resynchronize a server that diverged from the primary after a failback
 	PgRewind(context.Context, *connect.Request[pgctldservice.PgRewindRequest]) (*connect.Response[pgctldservice.PgRewindResponse], error)
+	// StopRestoreCommand checks whether a restore_command invocation (run via
+	// the `pgctld restore-wrapper`, see RestoreCommandPIDFile) is currently
+	// running and, if so, terminates it. Postgres cannot cancel an in-flight
+	// restore_command call on its own — this is the only way to guarantee one
+	// has actually stopped rather than just disabling it for future segments.
+	StopRestoreCommand(context.Context, *connect.Request[pgctldservice.StopRestoreCommandRequest]) (*connect.Response[pgctldservice.StopRestoreCommandResponse], error)
 }
 
 // NewPgCtldClient constructs a client for the pgctldservice.PgCtld service. By default, it uses the
@@ -145,19 +154,26 @@ func NewPgCtldClient(httpClient connect.HTTPClient, baseURL string, opts ...conn
 			connect.WithSchema(pgCtldMethods.ByName("PgRewind")),
 			connect.WithClientOptions(opts...),
 		),
+		stopRestoreCommand: connect.NewClient[pgctldservice.StopRestoreCommandRequest, pgctldservice.StopRestoreCommandResponse](
+			httpClient,
+			baseURL+PgCtldStopRestoreCommandProcedure,
+			connect.WithSchema(pgCtldMethods.ByName("StopRestoreCommand")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
 // pgCtldClient implements PgCtldClient.
 type pgCtldClient struct {
-	start        *connect.Client[pgctldservice.StartRequest, pgctldservice.StartResponse]
-	stop         *connect.Client[pgctldservice.StopRequest, pgctldservice.StopResponse]
-	restart      *connect.Client[pgctldservice.RestartRequest, pgctldservice.RestartResponse]
-	reloadConfig *connect.Client[pgctldservice.ReloadConfigRequest, pgctldservice.ReloadConfigResponse]
-	status       *connect.Client[pgctldservice.StatusRequest, pgctldservice.StatusResponse]
-	version      *connect.Client[pgctldservice.VersionRequest, pgctldservice.VersionResponse]
-	initDataDir  *connect.Client[pgctldservice.InitDataDirRequest, pgctldservice.InitDataDirResponse]
-	pgRewind     *connect.Client[pgctldservice.PgRewindRequest, pgctldservice.PgRewindResponse]
+	start              *connect.Client[pgctldservice.StartRequest, pgctldservice.StartResponse]
+	stop               *connect.Client[pgctldservice.StopRequest, pgctldservice.StopResponse]
+	restart            *connect.Client[pgctldservice.RestartRequest, pgctldservice.RestartResponse]
+	reloadConfig       *connect.Client[pgctldservice.ReloadConfigRequest, pgctldservice.ReloadConfigResponse]
+	status             *connect.Client[pgctldservice.StatusRequest, pgctldservice.StatusResponse]
+	version            *connect.Client[pgctldservice.VersionRequest, pgctldservice.VersionResponse]
+	initDataDir        *connect.Client[pgctldservice.InitDataDirRequest, pgctldservice.InitDataDirResponse]
+	pgRewind           *connect.Client[pgctldservice.PgRewindRequest, pgctldservice.PgRewindResponse]
+	stopRestoreCommand *connect.Client[pgctldservice.StopRestoreCommandRequest, pgctldservice.StopRestoreCommandResponse]
 }
 
 // Start calls pgctldservice.PgCtld.Start.
@@ -200,6 +216,11 @@ func (c *pgCtldClient) PgRewind(ctx context.Context, req *connect.Request[pgctld
 	return c.pgRewind.CallUnary(ctx, req)
 }
 
+// StopRestoreCommand calls pgctldservice.PgCtld.StopRestoreCommand.
+func (c *pgCtldClient) StopRestoreCommand(ctx context.Context, req *connect.Request[pgctldservice.StopRestoreCommandRequest]) (*connect.Response[pgctldservice.StopRestoreCommandResponse], error) {
+	return c.stopRestoreCommand.CallUnary(ctx, req)
+}
+
 // PgCtldHandler is an implementation of the pgctldservice.PgCtld service.
 type PgCtldHandler interface {
 	// Start PostgreSQL server
@@ -219,6 +240,12 @@ type PgCtldHandler interface {
 	// PgRewind rewinds a PostgreSQL data directory to an earlier point in the timeline
 	// This is used to resynchronize a server that diverged from the primary after a failback
 	PgRewind(context.Context, *connect.Request[pgctldservice.PgRewindRequest]) (*connect.Response[pgctldservice.PgRewindResponse], error)
+	// StopRestoreCommand checks whether a restore_command invocation (run via
+	// the `pgctld restore-wrapper`, see RestoreCommandPIDFile) is currently
+	// running and, if so, terminates it. Postgres cannot cancel an in-flight
+	// restore_command call on its own — this is the only way to guarantee one
+	// has actually stopped rather than just disabling it for future segments.
+	StopRestoreCommand(context.Context, *connect.Request[pgctldservice.StopRestoreCommandRequest]) (*connect.Response[pgctldservice.StopRestoreCommandResponse], error)
 }
 
 // NewPgCtldHandler builds an HTTP handler from the service implementation. It returns the path on
@@ -276,6 +303,12 @@ func NewPgCtldHandler(svc PgCtldHandler, opts ...connect.HandlerOption) (string,
 		connect.WithSchema(pgCtldMethods.ByName("PgRewind")),
 		connect.WithHandlerOptions(opts...),
 	)
+	pgCtldStopRestoreCommandHandler := connect.NewUnaryHandler(
+		PgCtldStopRestoreCommandProcedure,
+		svc.StopRestoreCommand,
+		connect.WithSchema(pgCtldMethods.ByName("StopRestoreCommand")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/pgctldservice.PgCtld/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case PgCtldStartProcedure:
@@ -294,6 +327,8 @@ func NewPgCtldHandler(svc PgCtldHandler, opts ...connect.HandlerOption) (string,
 			pgCtldInitDataDirHandler.ServeHTTP(w, r)
 		case PgCtldPgRewindProcedure:
 			pgCtldPgRewindHandler.ServeHTTP(w, r)
+		case PgCtldStopRestoreCommandProcedure:
+			pgCtldStopRestoreCommandHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -333,4 +368,8 @@ func (UnimplementedPgCtldHandler) InitDataDir(context.Context, *connect.Request[
 
 func (UnimplementedPgCtldHandler) PgRewind(context.Context, *connect.Request[pgctldservice.PgRewindRequest]) (*connect.Response[pgctldservice.PgRewindResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("pgctldservice.PgCtld.PgRewind is not implemented"))
+}
+
+func (UnimplementedPgCtldHandler) StopRestoreCommand(context.Context, *connect.Request[pgctldservice.StopRestoreCommandRequest]) (*connect.Response[pgctldservice.StopRestoreCommandResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("pgctldservice.PgCtld.StopRestoreCommand is not implemented"))
 }

--- a/go/services/multipooler/internal/manager/backup/archive.go
+++ b/go/services/multipooler/internal/manager/backup/archive.go
@@ -17,6 +17,7 @@ package backup
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -66,6 +67,51 @@ func (e *Engine) RemoveArchiveConfig() error {
 	}
 
 	return os.WriteFile(autoConfPath, []byte(strings.Join(filtered, "\n")), 0o644)
+}
+
+// WrapRestoreCommand rewrites postgresql.auto.conf's restore_command line by
+// applying wrap to whatever raw value is currently configured there.
+//
+// Direct file manipulation, mirroring RemoveArchiveConfig/ConfigureArchiveMode:
+// this runs immediately after Restore(), before postgres has ever started, so
+// there is no live SQL connection to run ALTER SYSTEM through.
+//
+// Returns an error if no restore_command line is found — pgbackrest's own
+// restore --type=standby is expected to always write one.
+func (e *Engine) WrapRestoreCommand(wrap func(raw string) string) error {
+	autoConfPath, err := e.autoConfPath()
+	if err != nil {
+		return err
+	}
+
+	content, err := os.ReadFile(autoConfPath)
+	if err != nil {
+		return fmt.Errorf("failed to read postgresql.auto.conf: %w", err)
+	}
+
+	lines := strings.Split(string(content), "\n")
+	found := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "restore_command") {
+			continue
+		}
+		start := strings.IndexByte(trimmed, '\'')
+		end := strings.LastIndexByte(trimmed, '\'')
+		if start == -1 || end <= start {
+			return fmt.Errorf("restore_command line in postgresql.auto.conf is not quoted as expected: %q", trimmed)
+		}
+		raw := strings.ReplaceAll(trimmed[start+1:end], "''", "'")
+		lines[i] = fmt.Sprintf("restore_command = '%s'", strings.ReplaceAll(wrap(raw), "'", "''"))
+		found = true
+		break
+	}
+	if !found {
+		return errors.New("no restore_command found in postgresql.auto.conf; expected pgbackrest's restore to have written one")
+	}
+
+	// #nosec G703 -- autoConfPath is postgresql.auto.conf under the pooler's own data dir, not external input.
+	return os.WriteFile(autoConfPath, []byte(strings.Join(lines, "\n")), 0o644)
 }
 
 // ConfigureArchiveMode configures archive_mode in postgresql.auto.conf for pgbackrest

--- a/go/services/multipooler/internal/manager/backup/archive.go
+++ b/go/services/multipooler/internal/manager/backup/archive.go
@@ -17,7 +17,6 @@ package backup
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -67,51 +66,6 @@ func (e *Engine) RemoveArchiveConfig() error {
 	}
 
 	return os.WriteFile(autoConfPath, []byte(strings.Join(filtered, "\n")), 0o644)
-}
-
-// WrapRestoreCommand rewrites postgresql.auto.conf's restore_command line by
-// applying wrap to whatever raw value is currently configured there.
-//
-// Direct file manipulation, mirroring RemoveArchiveConfig/ConfigureArchiveMode:
-// this runs immediately after Restore(), before postgres has ever started, so
-// there is no live SQL connection to run ALTER SYSTEM through.
-//
-// Returns an error if no restore_command line is found — pgbackrest's own
-// restore --type=standby is expected to always write one.
-func (e *Engine) WrapRestoreCommand(wrap func(raw string) string) error {
-	autoConfPath, err := e.autoConfPath()
-	if err != nil {
-		return err
-	}
-
-	content, err := os.ReadFile(autoConfPath)
-	if err != nil {
-		return fmt.Errorf("failed to read postgresql.auto.conf: %w", err)
-	}
-
-	lines := strings.Split(string(content), "\n")
-	found := false
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if !strings.HasPrefix(trimmed, "restore_command") {
-			continue
-		}
-		start := strings.IndexByte(trimmed, '\'')
-		end := strings.LastIndexByte(trimmed, '\'')
-		if start == -1 || end <= start {
-			return fmt.Errorf("restore_command line in postgresql.auto.conf is not quoted as expected: %q", trimmed)
-		}
-		raw := strings.ReplaceAll(trimmed[start+1:end], "''", "'")
-		lines[i] = fmt.Sprintf("restore_command = '%s'", strings.ReplaceAll(wrap(raw), "'", "''"))
-		found = true
-		break
-	}
-	if !found {
-		return errors.New("no restore_command found in postgresql.auto.conf; expected pgbackrest's restore to have written one")
-	}
-
-	// #nosec G703 -- autoConfPath is postgresql.auto.conf under the pooler's own data dir, not external input.
-	return os.WriteFile(autoConfPath, []byte(strings.Join(lines, "\n")), 0o644)
 }
 
 // ConfigureArchiveMode configures archive_mode in postgresql.auto.conf for pgbackrest

--- a/go/services/multipooler/internal/manager/backup/restore.go
+++ b/go/services/multipooler/internal/manager/backup/restore.go
@@ -23,9 +23,18 @@ import (
 	commonbackup "github.com/multigres/multigres/go/common/backup"
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
-	"github.com/multigres/multigres/go/common/parser/ast"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 )
+
+// shellQuoteSingle quotes s for safe embedding as a single argument in a
+// command line executed by /bin/sh (as postgres does for restore_command).
+// Not the same as SQL/postgres-config quoting (ast.QuoteStringLiteral): in
+// shell, a doubled ” is two adjacent empty strings, not an escaped quote —
+// an embedded quote must close the quoted section, escape a literal quote,
+// then reopen it.
+func shellQuoteSingle(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
 
 // Restore runs pgbackrest restore to recreate PGDATA from the given backup.
 // The manager orchestrates the surrounding PG lifecycle (archive config,
@@ -44,13 +53,13 @@ func (e *Engine) Restore(ctx context.Context, backupID, poolerDir string) error 
 	// The wrapper stores the PID to a file on disk so later on consensus operations
 	// for any cohort member or recruited cohort candidate can be sure that they're never
 	// pulling WAL from the archive, only the consensus leader.
-	wrappedRestoreCommand := fmt.Sprintf("pgctld restore-wrapper %s -- %s", ast.QuoteStringLiteral(pidFile), rawRestoreCommand)
+	wrappedRestoreCommand := fmt.Sprintf("pgctld restore-wrapper %s -- %s", shellQuoteSingle(pidFile), rawRestoreCommand)
 
 	// pgbackrest writes --recovery-option values verbatim between single quotes
 	// in postgresql.auto.conf, without escaping the embedded single quotes
-	// ast.QuoteStringLiteral just added around pidFile — so those must be
-	// escaped here the same way postgres itself escapes a quote inside a
-	// quoted config value (' -> ''), or the resulting line fails to parse.
+	// shellQuoteSingle just added around pidFile — so those must be escaped
+	// here the same way postgres itself escapes a quote inside a quoted
+	// config value (' -> ''), or the resulting line fails to parse.
 	escapedRestoreCommand := strings.ReplaceAll(wrappedRestoreCommand, "'", "''")
 
 	args := []string{

--- a/go/services/multipooler/internal/manager/backup/restore.go
+++ b/go/services/multipooler/internal/manager/backup/restore.go
@@ -48,7 +48,7 @@ func (e *Engine) Restore(ctx context.Context, backupID, poolerDir string) error 
 	restoreCtx, cancel := context.WithTimeout(ctx, commonbackup.RestoreTimeout)
 	defer cancel()
 
-	rawRestoreCommand := fmt.Sprintf(`pgbackrest --stanza=%s --config=%s archive-get %%f "%%p"`, stanzaName, configPath)
+	rawRestoreCommand := fmt.Sprintf(`pgbackrest --stanza=%s --config=%s archive-get %%f "%%p"`, shellQuoteSingle(stanzaName), shellQuoteSingle(configPath))
 	pidFile := filepath.Join(poolerDir, constants.RestoreCommandPIDFile)
 	// The wrapper stores the PID to a file on disk so later on consensus operations
 	// for any cohort member or recruited cohort candidate can be sure that they're never

--- a/go/services/multipooler/internal/manager/backup/restore.go
+++ b/go/services/multipooler/internal/manager/backup/restore.go
@@ -17,16 +17,20 @@ package backup
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	commonbackup "github.com/multigres/multigres/go/common/backup"
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/parser/ast"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 )
 
 // Restore runs pgbackrest restore to recreate PGDATA from the given backup.
 // The manager orchestrates the surrounding PG lifecycle (archive config,
 // starting postgres, reopening the pooler).
-func (e *Engine) Restore(ctx context.Context, backupID string) error {
+func (e *Engine) Restore(ctx context.Context, backupID, poolerDir string) error {
 	configPath, err := e.requireConfigPath()
 	if err != nil {
 		return mterrors.Wrap(err, "pgbackrest config not found")
@@ -35,10 +39,25 @@ func (e *Engine) Restore(ctx context.Context, backupID string) error {
 	restoreCtx, cancel := context.WithTimeout(ctx, commonbackup.RestoreTimeout)
 	defer cancel()
 
+	rawRestoreCommand := fmt.Sprintf(`pgbackrest --stanza=%s --config=%s archive-get %%f "%%p"`, stanzaName, configPath)
+	pidFile := filepath.Join(poolerDir, constants.RestoreCommandPIDFile)
+	// The wrapper stores the PID to a file on disk so later on consensus operations
+	// for any cohort member or recruited cohort candidate can be sure that they're never
+	// pulling WAL from the archive, only the consensus leader.
+	wrappedRestoreCommand := fmt.Sprintf("pgctld restore-wrapper %s -- %s", ast.QuoteStringLiteral(pidFile), rawRestoreCommand)
+
+	// pgbackrest writes --recovery-option values verbatim between single quotes
+	// in postgresql.auto.conf, without escaping the embedded single quotes
+	// ast.QuoteStringLiteral just added around pidFile — so those must be
+	// escaped here the same way postgres itself escapes a quote inside a
+	// quoted config value (' -> ''), or the resulting line fails to parse.
+	escapedRestoreCommand := strings.ReplaceAll(wrappedRestoreCommand, "'", "''")
+
 	args := []string{
 		"--stanza=" + stanzaName,
 		"--config=" + configPath,
 		"--type=standby",
+		"--recovery-option=restore_command=" + escapedRestoreCommand,
 	}
 
 	if backupID != "" {

--- a/go/services/multipooler/internal/manager/backup/restore_test.go
+++ b/go/services/multipooler/internal/manager/backup/restore_test.go
@@ -44,7 +44,7 @@ func TestRestore_ExecPaths(t *testing.T) {
 			e, _ := newTestEngine(t, poolerDir, "", "", "/tmp/backups")
 			e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
 
-			err := e.Restore(context.Background(), tt.backupID)
+			err := e.Restore(context.Background(), tt.backupID, poolerDir)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.errContains)
@@ -56,8 +56,9 @@ func TestRestore_ExecPaths(t *testing.T) {
 }
 
 func TestRestore_ErrorsWhenConfigPathMissing(t *testing.T) {
-	e, _ := newTestEngine(t, t.TempDir(), "", "", "/tmp/backups")
-	err := e.Restore(context.Background(), "20250104-100000F")
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "", "", "/tmp/backups")
+	err := e.Restore(context.Background(), "20250104-100000F", poolerDir)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pgbackrest config not found")
 }

--- a/go/services/multipooler/internal/manager/backup/restore_test.go
+++ b/go/services/multipooler/internal/manager/backup/restore_test.go
@@ -17,11 +17,31 @@ package backup
 import (
 	"context"
 	"fmt"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestShellQuoteSingle round-trips values through an actual shell (not just
+// string comparison against a hand-computed expectation), since a bug in the
+// escaping logic could just as easily be mirrored in a hardcoded expectation.
+func TestShellQuoteSingle(t *testing.T) {
+	tests := []string{
+		"/tmp/pooler/restore_command.pid",
+		"/tmp/pooler's dir/restore_command.pid",
+		"'leading and trailing quotes'",
+		"has spaces and\ttabs",
+	}
+	for _, raw := range tests {
+		t.Run(raw, func(t *testing.T) {
+			out, err := exec.Command("sh", "-c", "printf '%s' "+shellQuoteSingle(raw)).Output()
+			require.NoError(t, err)
+			assert.Equal(t, raw, string(out))
+		})
+	}
+}
 
 // TestRestore_ExecPaths drives Restore against a stubbed pgbackrest, covering
 // the success and failure paths both with and without an explicit backup ID.

--- a/go/services/multipooler/internal/manager/consensus/cohort_membership_test.go
+++ b/go/services/multipooler/internal/manager/consensus/cohort_membership_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consensus
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+)
+
+// fakeCohortRuleStore is a minimal RuleStorer that only supports CachedPosition,
+// enough to exercise IsPotentialCohortMember without a real postgres connection.
+type fakeCohortRuleStore struct {
+	pos *clustermetadatapb.PoolerPosition
+}
+
+func (f *fakeCohortRuleStore) ObservePosition(context.Context) (*clustermetadatapb.PoolerPosition, error) {
+	return f.pos, nil
+}
+
+func (f *fakeCohortRuleStore) UpdateRule(context.Context, *RuleUpdateBuilder) (*clustermetadatapb.PoolerPosition, error) {
+	return f.pos, nil
+}
+
+func (f *fakeCohortRuleStore) CreateRuleTables(context.Context, *clustermetadatapb.DurabilityPolicy, *clustermetadatapb.ID) error {
+	return nil
+}
+
+func (f *fakeCohortRuleStore) CachedPosition() *clustermetadatapb.PoolerPosition {
+	return f.pos
+}
+
+func (f *fakeCohortRuleStore) HasInconsistentGUC(context.Context) bool { return false }
+
+func (f *fakeCohortRuleStore) ReconcileGUC(context.Context, bool) error { return nil }
+
+func (f *fakeCohortRuleStore) ClearSyncStandby(context.Context) error { return nil }
+
+func idAt(name string) *clustermetadatapb.ID {
+	return &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "zone1",
+		Name:      name,
+	}
+}
+
+func ruleWithCohort(term int64, members ...string) *clustermetadatapb.ShardRule {
+	ids := make([]*clustermetadatapb.ID, len(members))
+	for i, m := range members {
+		ids[i] = idAt(m)
+	}
+	return &clustermetadatapb.ShardRule{
+		RuleNumber:    &clustermetadatapb.RuleNumber{CoordinatorTerm: term},
+		CohortMembers: ids,
+	}
+}
+
+func TestIsPotentialCohortMember(t *testing.T) {
+	tests := []struct {
+		name     string
+		position *clustermetadatapb.PoolerPosition
+		self     *clustermetadatapb.ID
+		want     bool
+	}{
+		{
+			name:     "no known position",
+			position: nil,
+			self:     idAt("self"),
+			want:     false,
+		},
+		{
+			name: "member of decided rule",
+			position: &clustermetadatapb.PoolerPosition{
+				Position: &clustermetadatapb.RulePosition{Decision: ruleWithCohort(1, "self", "other")},
+			},
+			self: idAt("self"),
+			want: true,
+		},
+		{
+			name: "not a member of decided rule, no proposal",
+			position: &clustermetadatapb.PoolerPosition{
+				Position: &clustermetadatapb.RulePosition{Decision: ruleWithCohort(1, "other")},
+			},
+			self: idAt("self"),
+			want: false,
+		},
+		{
+			name: "confirmed member of decision, excluded from a still-undecided newer proposal",
+			position: &clustermetadatapb.PoolerPosition{
+				Position: &clustermetadatapb.RulePosition{
+					Decision: ruleWithCohort(1, "self", "other"),
+					Proposal: ruleWithCohort(2, "other", "third"),
+				},
+			},
+			self: idAt("self"),
+			// Still a decided member — must not read as "no longer a member"
+			// just because a newer, unconfirmed proposal excludes them.
+			want: true,
+		},
+		{
+			name: "not yet a decided member, but named in an outstanding proposal",
+			position: &clustermetadatapb.PoolerPosition{
+				Position: &clustermetadatapb.RulePosition{
+					Decision: ruleWithCohort(1, "other"),
+					Proposal: ruleWithCohort(2, "other", "self"),
+				},
+			},
+			self: idAt("self"),
+			// Treated as a potential member pre-emptively, before the proposal decides.
+			want: true,
+		},
+		{
+			name: "named in neither decision nor proposal",
+			position: &clustermetadatapb.PoolerPosition{
+				Position: &clustermetadatapb.RulePosition{
+					Decision: ruleWithCohort(1, "other"),
+					Proposal: ruleWithCohort(2, "other", "third"),
+				},
+			},
+			self: idAt("self"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			promises := NewConsensusPromises(t.TempDir(), tt.self)
+			cm := NewManagerForTesting(t, tt.self, promises, &fakeCohortRuleStore{pos: tt.position}, nil)
+			got := cm.IsPotentialCohortMember(tt.self)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRuleNamesCohortMember_NilRule(t *testing.T) {
+	require.False(t, ruleNamesCohortMember(nil, idAt("self")))
+}

--- a/go/services/multipooler/internal/manager/consensus/cohort_membership_test.go
+++ b/go/services/multipooler/internal/manager/consensus/cohort_membership_test.go
@@ -122,7 +122,7 @@ func TestIsPotentialCohortMember(t *testing.T) {
 				},
 			},
 			self: idAt("self"),
-			// Treated as a potential member pre-emptively, before the proposal decides.
+			// Treated as a potential member preemptively, before the proposal decides.
 			want: true,
 		},
 		{

--- a/go/services/multipooler/internal/manager/consensus/manager.go
+++ b/go/services/multipooler/internal/manager/consensus/manager.go
@@ -516,7 +516,7 @@ func (cm *ConsensusManager) SetSuspectedDivergence(ctx context.Context, suspecte
 // decided rule remains the operative truth, so a currently-confirmed member
 // must not read as "no longer a member" just because a newer, not-yet-decided
 // proposal happens to exclude them. Conversely, a pooler named in an upcoming
-// proposal should be treated as a potential member pre-emptively, before it's
+// proposal should be treated as a potential member preemptively, before it's
 // decided — callers of this (restore_command safety) must err conservative,
 // so this checks both and returns true if either says yes.
 //

--- a/go/services/multipooler/internal/manager/consensus/manager.go
+++ b/go/services/multipooler/internal/manager/consensus/manager.go
@@ -507,6 +507,36 @@ func (cm *ConsensusManager) SetSuspectedDivergence(ctx context.Context, suspecte
 	return cm.suspectedDivergence.Swap(suspected) != suspected, nil
 }
 
+// IsPotentialCohortMember reports whether selfID is named in the cohort of
+// either the decided rule or an outstanding (not yet decided) proposal at the
+// highest known position.
+//
+// Checking only whichever of decision/proposal PossiblyUndecidedRule would
+// pick is not safe here: while a newer proposal is still undecided, the
+// decided rule remains the operative truth, so a currently-confirmed member
+// must not read as "no longer a member" just because a newer, not-yet-decided
+// proposal happens to exclude them. Conversely, a pooler named in an upcoming
+// proposal should be treated as a potential member pre-emptively, before it's
+// decided — callers of this (restore_command safety) must err conservative,
+// so this checks both and returns true if either says yes.
+//
+// Distinct from CohortEligibility/SetCohortEligibility, which is this node's
+// own self-reported willingness to serve as a cohort member, not whether a
+// rule actually names it as one.
+func (cm *ConsensusManager) IsPotentialCohortMember(selfID *clustermetadatapb.ID) bool {
+	position := consensus.HighestKnownRule([]*clustermetadatapb.ConsensusStatus{cm.CachedConsensusStatus()})
+	return ruleNamesCohortMember(position.GetDecision(), selfID) || ruleNamesCohortMember(position.GetProposal(), selfID)
+}
+
+func ruleNamesCohortMember(rule *clustermetadatapb.ShardRule, selfID *clustermetadatapb.ID) bool {
+	for _, member := range rule.GetCohortMembers() {
+		if member.GetCell() == selfID.GetCell() && member.GetName() == selfID.GetName() {
+			return true
+		}
+	}
+	return false
+}
+
 // RewindWaitEmittedFor returns the leaderObservedAt value the rewind-wait metric
 // was last emitted for.
 func (cm *ConsensusManager) RewindWaitEmittedFor() time.Time {

--- a/go/services/multipooler/internal/manager/pg_replication.go
+++ b/go/services/multipooler/internal/manager/pg_replication.go
@@ -18,12 +18,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
@@ -35,6 +37,7 @@ import (
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
 )
 
 // ============================================================================
@@ -475,6 +478,85 @@ func (pm *MultipoolerManager) resetPrimaryConnInfo(ctx context.Context) error {
 	}
 
 	return pm.reloadPostgresConfig(ctx)
+}
+
+// readRestoreCommand reads the currently configured restore_command, or ""
+// if unset.
+func (pm *MultipoolerManager) readRestoreCommand(ctx context.Context) (string, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	result, err := pm.query(queryCtx, "SELECT current_setting('restore_command', true)")
+	if err != nil {
+		return "", mterrors.Wrap(err, "failed to read restore_command")
+	}
+	var value *string
+	if err := executor.ScanSingleRow(result, &value); err != nil {
+		return "", mterrors.Wrap(err, "failed to scan restore_command")
+	}
+	if value == nil {
+		return "", nil
+	}
+	return *value, nil
+}
+
+// resetRestoreCommand clears restore_command and reloads PostgreSQL configuration.
+//
+// restore_command is written implicitly by pgbackrest's initial "restore
+// --type=standby" (into postgresql.auto.conf), not set explicitly anywhere in
+// this codebase, and nothing has cleared it since. A cohort member (an active
+// consensus participant, as opposed to an observer) must never resume WAL
+// playback from the archive: only streaming from the current leader is
+// trusted. Left enabled, a subsequent restart-as-standby can resolve
+// recovery_target_timeline=latest via restore_command's archive-get to a
+// timeline this node's own checkpoint doesn't descend from and FATAL at
+// startup — exactly the divergence suspectedDivergence exists to flag, but
+// discovered by postgres itself before pg_rewind ever gets a chance to run.
+//
+// Call this while postgres is still reachable (e.g. still primary, before
+// restarting it as standby) — once it FATALs on that startup it can no
+// longer run this ALTER SYSTEM to fix itself.
+func (pm *MultipoolerManager) resetRestoreCommand(ctx context.Context) error {
+	pm.logger.InfoContext(ctx, "Clearing restore_command")
+
+	execCtx, execCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer execCancel()
+	if err := pm.exec(execCtx, "ALTER SYSTEM RESET restore_command"); err != nil {
+		pm.logger.ErrorContext(ctx, "Failed to clear restore_command", "error", err)
+		return mterrors.Wrap(err, "failed to clear restore_command")
+	}
+
+	return pm.reloadPostgresConfig(ctx)
+}
+
+// wrapRestoreCommand wraps a raw restore_command (e.g. what pgbackrest itself
+// generates during Restore) with `pgctld restore-wrapper`, so a subsequent
+// call can confirm whether it is still running and terminate it if needed
+// (see StopRestoreCommand). Relies on pgctld being resolvable on PATH, the
+// same convention every other subprocess invocation in this codebase already
+// depends on (pg_ctl, pg_isready, pgbackrest, ...) — postgres inherits its
+// environment from pgctld, which started it, so this holds without needing
+// multipooler to know pgctld's absolute binary location.
+func wrapRestoreCommand(poolerDir, rawCommand string) string {
+	pidFile := filepath.Join(poolerDir, constants.RestoreCommandPIDFile)
+	return fmt.Sprintf("pgctld restore-wrapper %s -- %s", ast.QuoteStringLiteral(pidFile), rawCommand)
+}
+
+// stopRestoreCommand asks pgctld to stop any in-flight restore_command
+// invocation (see pgctld.StopRestoreCommand) — postgres cannot cancel one on
+// its own, a config change only affects the next fetch decision. Requires the
+// action lock (asserted by protectedPgctldClient).
+func (pm *MultipoolerManager) stopRestoreCommand(ctx context.Context) error {
+	if pm.pgctldClient == nil {
+		return nil
+	}
+	resp, err := pm.pgctldClient.StopRestoreCommand(ctx, &pgctldpb.StopRestoreCommandRequest{})
+	if err != nil {
+		return mterrors.Wrap(err, "failed to stop restore_command")
+	}
+	if resp.GetFound() {
+		pm.logger.InfoContext(ctx, "Stopped in-flight restore_command", "killed", resp.GetKilled(), "message", resp.GetMessage())
+	}
+	return nil
 }
 
 // waitForReplayStabilize waits, best effort, for WAL replay to stop making

--- a/go/services/multipooler/internal/manager/pg_replication.go
+++ b/go/services/multipooler/internal/manager/pg_replication.go
@@ -18,14 +18,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
@@ -526,19 +524,6 @@ func (pm *MultipoolerManager) resetRestoreCommand(ctx context.Context) error {
 	}
 
 	return pm.reloadPostgresConfig(ctx)
-}
-
-// wrapRestoreCommand wraps a raw restore_command (e.g. what pgbackrest itself
-// generates during Restore) with `pgctld restore-wrapper`, so a subsequent
-// call can confirm whether it is still running and terminate it if needed
-// (see StopRestoreCommand). Relies on pgctld being resolvable on PATH, the
-// same convention every other subprocess invocation in this codebase already
-// depends on (pg_ctl, pg_isready, pgbackrest, ...) — postgres inherits its
-// environment from pgctld, which started it, so this holds without needing
-// multipooler to know pgctld's absolute binary location.
-func wrapRestoreCommand(poolerDir, rawCommand string) string {
-	pidFile := filepath.Join(poolerDir, constants.RestoreCommandPIDFile)
-	return fmt.Sprintf("pgctld restore-wrapper %s -- %s", ast.QuoteStringLiteral(pidFile), rawCommand)
 }
 
 // stopRestoreCommand asks pgctld to stop any in-flight restore_command

--- a/go/services/multipooler/internal/manager/pgctld_client.go
+++ b/go/services/multipooler/internal/manager/pgctld_client.go
@@ -93,6 +93,15 @@ func (p *protectedPgctldClient) PgRewind(ctx context.Context, req *pgctldpb.PgRe
 	return p.client.PgRewind(ctx, req, opts...)
 }
 
+// StopRestoreCommand stops any in-flight restore_command invocation. Requires
+// action lock to be held by caller (it can signal a running process).
+func (p *protectedPgctldClient) StopRestoreCommand(ctx context.Context, req *pgctldpb.StopRestoreCommandRequest, opts ...grpc.CallOption) (*pgctldpb.StopRestoreCommandResponse, error) {
+	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
+		return nil, fmt.Errorf("StopRestoreCommand requires action lock to be held: %w", err)
+	}
+	return p.client.StopRestoreCommand(ctx, req, opts...)
+}
+
 // Status returns PostgreSQL status. Does not require action lock (read-only operation).
 func (p *protectedPgctldClient) Status(ctx context.Context, req *pgctldpb.StatusRequest, opts ...grpc.CallOption) (*pgctldpb.StatusResponse, error) {
 	return p.client.Status(ctx, req, opts...)

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -552,6 +552,21 @@ func (pm *MultipoolerManager) determineReplicationSettingsAction(ctx context.Con
 	// catch-up either. Recruit already clears this the moment a pooler
 	// becomes a cohort member; this is the ongoing backstop for anything
 	// that slips past that.
+	//
+	// TODO: the converse — re-enabling restore_command — isn't implemented.
+	// An observer (never a cohort member) that appears unable to replicate
+	// for reasons that might be due to out-of-date WAL (e.g. the timestamp
+	// on this pooler's most recently received WAL entry is old enough that
+	// the primary has likely since recycled the segment it needs) should be
+	// allowed to fall back to archive catch-up. There's no clean SQL-queryable
+	// signal for "the primary no longer has the WAL this standby needs" —
+	// pg_stat_wal_receiver's row just disappears on a failed connection
+	// rather than recording why, and pg_stat_activity never sees it since
+	// archive-get opens no DB connection. The actual error ("requested WAL
+	// segment ... has already been removed") only appears in the standby's
+	// own postgresql.log, which multipooler can't read directly — pgctld
+	// would need a new capability to check for it, similar in shape to
+	// StopRestoreCommand.
 	if !state.pgMode.OutOfRecovery() && pm.shouldDisableRestoreCommand(ctx) {
 		return remedialActionDisableRestoreCommand
 	}

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -169,6 +169,20 @@ const (
 	// and broadcast so a diverged follower's recovery (orch's gated pg_rewind) can
 	// proceed. Purely a state-publication step — no postgres mutation.
 	remedialActionMarkRewindReady
+	// remedialActionDisableRestoreCommand means restore_command is currently
+	// set on a standby that must not be relying on the archive: either it is
+	// a cohort member (only ever trusted to advance via streaming — see
+	// consensus.ConsensusManager.IsPotentialCohortMember), or it is actively
+	// streaming successfully and so has no need for archive catch-up. Recruit
+	// already clears this at the moment a pooler becomes a cohort member, but
+	// this is the ongoing, locally-driven backstop for anything that slips
+	// past that (e.g. a hand edit, or a race with a concurrent rule change).
+	//
+	// Re-enabling restore_command for a stuck, non-cohort observer is a
+	// deliberate follow-up, not implemented here: the only case handled today
+	// is restore-from-backup leaving it enabled for a freshly-restored
+	// observer (see WrapRestoreCommand).
+	remedialActionDisableRestoreCommand
 )
 
 // monitorPostgresIteration performs one iteration of PostgreSQL monitoring.
@@ -485,6 +499,28 @@ func (pm *MultipoolerManager) determineRoleAction(role commonconsensus.Consensus
 	return remedialActionNone
 }
 
+// shouldDisableRestoreCommand reports whether restore_command is currently
+// set on this standby despite it having no legitimate need for archive
+// catch-up: it is a cohort member (only ever trusted to advance via
+// streaming — see consensus.ConsensusManager.IsPotentialCohortMember), or it
+// is already streaming successfully. Fails closed (false) on any read error,
+// so a transient query failure doesn't fire a disable action against a
+// possibly-legitimate value.
+func (pm *MultipoolerManager) shouldDisableRestoreCommand(ctx context.Context) bool {
+	current, err := pm.readRestoreCommand(ctx)
+	if err != nil || current == "" {
+		return false
+	}
+	if pm.consensusMgr.IsPotentialCohortMember(pm.serviceID) {
+		return true
+	}
+	status, err := pm.queryReplicationStatus(ctx)
+	if err != nil {
+		return false
+	}
+	return status.GetWalReceiverStatus() == "streaming"
+}
+
 // determineReplicationSettingsAction reconciles postgres replication settings to
 // the recorded consensus state.
 func (pm *MultipoolerManager) determineReplicationSettingsAction(ctx context.Context, state postgresState) remedialAction {
@@ -508,6 +544,16 @@ func (pm *MultipoolerManager) determineReplicationSettingsAction(ctx context.Con
 		// remedialActionFixPrimaryConnInfo iteration runs
 		// pg_rewind dry-run before re-establishing replication. Cheap
 		// when no divergence, conclusive when there is.
+	}
+
+	// restore_command is a standby concern: a cohort member must only ever
+	// advance via streaming, never the archive, and an observer that's
+	// already streaming successfully has no remaining need for archive
+	// catch-up either. Recruit already clears this the moment a pooler
+	// becomes a cohort member; this is the ongoing backstop for anything
+	// that slips past that.
+	if !state.pgMode.OutOfRecovery() && pm.shouldDisableRestoreCommand(ctx) {
+		return remedialActionDisableRestoreCommand
 	}
 
 	// synchronous_standby_names is a primary concern: it has no effect on a
@@ -736,6 +782,13 @@ func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action rem
 			if err := pm.restoreAndStartPostgres(ctx); err != nil {
 				pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to restore from backup, will retry", "error", err)
 			}
+		}
+
+	case remedialActionDisableRestoreCommand:
+		pm.setMonitorReason(ctx, reasonPostgresRunning, "MonitorPostgres: PostgreSQL is running")
+		pm.logger.InfoContext(ctx, "MonitorPostgres: disabling restore_command")
+		if err := pm.resetRestoreCommand(ctx); err != nil {
+			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to disable restore_command", "error", err)
 		}
 
 	case remedialActionReconcileGUC:

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -805,6 +805,9 @@ func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action rem
 		if err := pm.resetRestoreCommand(ctx); err != nil {
 			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to disable restore_command", "error", err)
 		}
+		if err := pm.stopRestoreCommand(ctx); err != nil {
+			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to stop in-flight restore_command", "error", err)
+		}
 
 	case remedialActionReconcileGUC:
 		pm.setMonitorReason(ctx, reasonPostgresRunning, "MonitorPostgres: PostgreSQL is running")

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -26,8 +26,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
 	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/common/servenv"
+	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor/mock"
@@ -36,6 +39,7 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus/consensustest"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pgmode"
+	"github.com/multigres/multigres/go/tools/viperutil"
 )
 
 func TestDiscoverPostgresState_PgctldUnavailable(t *testing.T) {
@@ -1025,6 +1029,141 @@ func TestTakeRemedialAction_ReconcileGUC(t *testing.T) {
 
 	assert.True(t, frs.reconcileGUCCalled, "ReconcileGUC should have been called")
 	assert.Equal(t, "postgres_running", pm.pgMonitorLastLoggedReason)
+}
+
+// setupManagerWithMockDBAndPgctld is setupManagerWithMockDB, but also returns
+// the mock pgctld service so a test can assert on calls made through it (e.g.
+// StopRestoreCommandCalls) — setupManagerWithMockDB discards that reference.
+func setupManagerWithMockDBAndPgctld(t *testing.T, mockQueryService *mock.QueryService, rules consensus.RuleStorer) (*MultipoolerManager, *testutil.MockPgCtldService) {
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+	t.Cleanup(func() { ts.Close() })
+
+	mockPgctld := &testutil.MockPgCtldService{}
+	pgctldAddr, cleanupPgctld := testutil.StartMockPgctldServer(t, mockPgctld)
+	t.Cleanup(cleanupPgctld)
+
+	database := "testdb"
+	addDatabaseToTopo(t, ts, database)
+
+	serviceID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "test-pooler"}
+	multipooler := &clustermetadatapb.Multipooler{
+		Id:            serviceID,
+		Hostname:      "localhost",
+		PortMap:       map[string]int32{"grpc": 8080},
+		Type:          clustermetadatapb.PoolerType_REPLICA,
+		ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   database,
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
+		},
+	}
+	require.NoError(t, ts.CreateMultipooler(ctx, multipooler))
+
+	tmpDir := t.TempDir()
+	multipooler.PoolerDir = tmpDir
+	config := &Config{
+		TopoClient: ts,
+		PgctldAddr: pgctldAddr,
+	}
+	pm, err := NewMultipoolerManagerForTesting(t, logger, multipooler, config,
+		withMockController(&mockPoolerController{queryService: mockQueryService}),
+		withFakeRules(rules),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { pm.ShutdownForTest(context.Background()) })
+
+	senv := servenv.NewServEnv(viperutil.NewRegistry())
+	pm.Start(senv)
+
+	require.Eventually(t, func() bool {
+		return pm.GetState() == ManagerStateReady
+	}, 5*time.Second, 100*time.Millisecond, "Manager should reach Ready state")
+
+	return pm, mockPgctld
+}
+
+// TestShouldDisableRestoreCommand exercises the pure decision logic (no
+// mutation) that gates remedialActionDisableRestoreCommand: a cohort member
+// must never trust archive-sourced WAL, and an observer that's already
+// streaming successfully has no remaining need for archive catch-up either.
+func TestShouldDisableRestoreCommand(t *testing.T) {
+	selfID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "test-pooler"}
+	cohortRule := &clustermetadatapb.ShardRule{
+		CohortMembers: []*clustermetadatapb.ID{selfID},
+	}
+
+	tests := []struct {
+		name           string
+		cohortMember   bool
+		restoreCommand string
+		restoreCmdErr  error
+		walReceiver    string
+		replStatusErr  error
+		want           bool
+	}{
+		{name: "cohort member with restore_command set", cohortMember: true, restoreCommand: "pgctld restore-wrapper ...", want: true},
+		{name: "observer streaming with restore_command set", restoreCommand: "pgctld restore-wrapper ...", walReceiver: "streaming", want: true},
+		{name: "observer not streaming leaves restore_command alone", restoreCommand: "pgctld restore-wrapper ...", walReceiver: "waiting", want: false},
+		{name: "restore_command already unset", restoreCommand: "", want: false},
+		{name: "cohort member but restore_command already unset", cohortMember: true, restoreCommand: "", want: false},
+		{name: "fails closed on read error", restoreCommand: "pgctld restore-wrapper ...", restoreCmdErr: errors.New("boom"), want: false},
+		{name: "fails closed on replication status error", restoreCommand: "pgctld restore-wrapper ...", replStatusErr: errors.New("boom"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := mock.NewQueryService()
+			if tt.restoreCmdErr != nil {
+				m.AddQueryPatternOnceWithError("current_setting.*restore_command", tt.restoreCmdErr)
+			} else {
+				m.AddQueryPatternOnce("current_setting.*restore_command", mock.MakeQueryResult([]string{"current_setting"}, [][]any{{tt.restoreCommand}}))
+			}
+			if tt.restoreCmdErr == nil && tt.restoreCommand != "" && !tt.cohortMember {
+				// Only queried when a cohort-member short-circuit didn't already decide it.
+				cols := []string{"replay_lsn", "receive_lsn", "is_paused", "pause_state", "last_xact_replay_ts", "primary_conninfo", "status", "last_msg_receive_time", "wal_receiver_status_interval", "wal_receiver_timeout"}
+				if tt.replStatusErr != nil {
+					m.AddQueryPatternOnceWithError("pg_last_wal_replay_lsn", tt.replStatusErr)
+				} else {
+					m.AddQueryPatternOnce("pg_last_wal_replay_lsn", mock.MakeQueryResult(cols, [][]any{{nil, nil, false, "not paused", nil, "", tt.walReceiver, nil, nil, nil}}))
+				}
+			}
+
+			var frs *fakeRuleStore
+			if tt.cohortMember {
+				frs = &fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Position: &clustermetadatapb.RulePosition{Decision: cohortRule}}}
+			} else {
+				frs = &fakeRuleStore{}
+			}
+
+			pm, _ := setupManagerWithMockDBAndPgctld(t, m, frs)
+
+			assert.Equal(t, tt.want, pm.shouldDisableRestoreCommand(t.Context()))
+		})
+	}
+}
+
+// TestTakeRemedialAction_DisableRestoreCommand verifies the monitor's backstop
+// clears restore_command AND stops any in-flight invocation — a config change
+// alone only affects the next fetch decision, so a backstop that only reset
+// the GUC would leave exactly the gap it exists to close (see Recruit and
+// SetPrimary, which both pair resetRestoreCommand with stopRestoreCommand).
+func TestTakeRemedialAction_DisableRestoreCommand(t *testing.T) {
+	m := mock.NewQueryService()
+	m.AddQueryPatternOnce("ALTER SYSTEM RESET restore_command", mock.MakeQueryResult(nil, nil))
+	expectReloadConfig(m)
+
+	pm, mockPgctld := setupManagerWithMockDBAndPgctld(t, m, &fakeRuleStore{})
+
+	lockCtx, err := pm.actionLock.Acquire(t.Context(), "test")
+	require.NoError(t, err)
+	defer pm.actionLock.Release(lockCtx)
+
+	pm.takeRemedialAction(lockCtx, remedialActionDisableRestoreCommand, postgresState{pgMode: pgmode.InRecovery})
+
+	assert.NoError(t, m.ExpectationsWereMet(), "resetRestoreCommand's queries should have run")
+	assert.Len(t, mockPgctld.StopRestoreCommandCalls, 1, "stopRestoreCommand should have called the pgctld RPC")
 }
 
 // TestTakeRemedialAction_ReconcileRole_AppliesRuleDerivedRole verifies that

--- a/go/services/multipooler/internal/manager/rpc_backup.go
+++ b/go/services/multipooler/internal/manager/rpc_backup.go
@@ -306,19 +306,9 @@ func (pm *MultipoolerManager) restoreFromBackupLocked(ctx context.Context, backu
 			"cannot restore to a primary pooler; restore is only supported for standby poolers")
 	}
 
-	// Restore is archive-based catch-up, which only an observer may do — a
-	// cohort member must only ever advance via streaming from the current
-	// leader (see consensus.ConsensusManager.IsPotentialCohortMember and
-	// resetRestoreCommand/setRestoreCommand). This is a distinct, stronger
-	// check than the PoolerType one above: a pooler can be topology-typed
-	// REPLICA while still being named in the shard's current cohort.
-	//
-	// This check is best effort, and a pooler with no data directory should have been
-	// removed from the cohort anyway.
-	if pm.consensusMgr.IsPotentialCohortMember(pm.serviceID) {
-		return mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION,
-			"cannot restore from backup: pooler is a cohort member of the highest known rule")
-	}
+	// TODO: restore is archive-based catch-up, which only an observer should
+	// do — a cohort member should only ever advance via streaming from the
+	// current leader. Might be good to add a best-effort check of this.
 
 	// Check that PGDATA doesn't exist (caller must remove it before restore)
 	if pm.hasDataDirectory() {

--- a/go/services/multipooler/internal/manager/rpc_backup.go
+++ b/go/services/multipooler/internal/manager/rpc_backup.go
@@ -312,6 +312,9 @@ func (pm *MultipoolerManager) restoreFromBackupLocked(ctx context.Context, backu
 	// resetRestoreCommand/setRestoreCommand). This is a distinct, stronger
 	// check than the PoolerType one above: a pooler can be topology-typed
 	// REPLICA while still being named in the shard's current cohort.
+	//
+	// This check is best effort, and a pooler with no data directory should have been
+	// removed from the cohort anyway.
 	if pm.consensusMgr.IsPotentialCohortMember(pm.serviceID) {
 		return mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION,
 			"cannot restore from backup: pooler is a cohort member of the highest known rule")

--- a/go/services/multipooler/internal/manager/rpc_backup.go
+++ b/go/services/multipooler/internal/manager/rpc_backup.go
@@ -318,7 +318,7 @@ func (pm *MultipoolerManager) restoreFromBackupLocked(ctx context.Context, backu
 
 	// Restore the backup
 	if err := telemetry.WithSpan(ctx, "restore/pgbackrest", func(ctx context.Context) error {
-		return pm.backup.Restore(ctx, backupID)
+		return pm.backup.Restore(ctx, backupID, pm.record.PoolerDir())
 	}); err != nil {
 		return err
 	}
@@ -332,21 +332,6 @@ func (pm *MultipoolerManager) restoreFromBackupLocked(ctx context.Context, backu
 			return mterrors.Wrap(err, "failed to remove old archive configuration")
 		}
 		return mterrors.Wrap(pm.backup.ConfigureArchiveMode(ctx), "failed to configure archive mode")
-	}); err != nil {
-		return err
-	}
-
-	// Wrap restore_command (pgbackrest's own, just written by Restore above)
-	// with `pgctld restore-wrapper`, so a later Recruit/monitor stop request
-	// can confirm whether it's still running and terminate it if needed (see
-	// StopRestoreCommand). Direct file manipulation, not SQL: postgres hasn't
-	// started yet at this point.
-	if err := telemetry.WithSpan(ctx, "restore/wrap-restore-command", func(ctx context.Context) error {
-		return mterrors.Wrap(
-			pm.backup.WrapRestoreCommand(func(raw string) string {
-				return wrapRestoreCommand(pm.record.PoolerDir(), raw)
-			}),
-			"failed to wrap restore_command")
 	}); err != nil {
 		return err
 	}

--- a/go/services/multipooler/internal/manager/rpc_backup.go
+++ b/go/services/multipooler/internal/manager/rpc_backup.go
@@ -306,6 +306,17 @@ func (pm *MultipoolerManager) restoreFromBackupLocked(ctx context.Context, backu
 			"cannot restore to a primary pooler; restore is only supported for standby poolers")
 	}
 
+	// Restore is archive-based catch-up, which only an observer may do — a
+	// cohort member must only ever advance via streaming from the current
+	// leader (see consensus.ConsensusManager.IsPotentialCohortMember and
+	// resetRestoreCommand/setRestoreCommand). This is a distinct, stronger
+	// check than the PoolerType one above: a pooler can be topology-typed
+	// REPLICA while still being named in the shard's current cohort.
+	if pm.consensusMgr.IsPotentialCohortMember(pm.serviceID) {
+		return mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION,
+			"cannot restore from backup: pooler is a cohort member of the highest known rule")
+	}
+
 	// Check that PGDATA doesn't exist (caller must remove it before restore)
 	if pm.hasDataDirectory() {
 		return mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION,
@@ -328,6 +339,21 @@ func (pm *MultipoolerManager) restoreFromBackupLocked(ctx context.Context, backu
 			return mterrors.Wrap(err, "failed to remove old archive configuration")
 		}
 		return mterrors.Wrap(pm.backup.ConfigureArchiveMode(ctx), "failed to configure archive mode")
+	}); err != nil {
+		return err
+	}
+
+	// Wrap restore_command (pgbackrest's own, just written by Restore above)
+	// with `pgctld restore-wrapper`, so a later Recruit/monitor stop request
+	// can confirm whether it's still running and terminate it if needed (see
+	// StopRestoreCommand). Direct file manipulation, not SQL: postgres hasn't
+	// started yet at this point.
+	if err := telemetry.WithSpan(ctx, "restore/wrap-restore-command", func(ctx context.Context) error {
+		return mterrors.Wrap(
+			pm.backup.WrapRestoreCommand(func(raw string) string {
+				return wrapRestoreCommand(pm.record.PoolerDir(), raw)
+			}),
+			"failed to wrap restore_command")
 	}); err != nil {
 		return err
 	}

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -678,6 +678,17 @@ func (pm *MultipoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 		}
 	}
 
+	// If this pooler is being asked to serve a cohort member, it should not be accepting any WAL
+	// from the restore_command / pgbackrest WAL archive, only from the indicated primary.
+	if pm.consensusMgr.IsPotentialCohortMember(pm.serviceID) {
+		if err := pm.resetRestoreCommand(ctx); err != nil {
+			pm.logger.WarnContext(ctx, "SetPrimary: failed to clear restore_command for cohort member", "error", err)
+		}
+		if err := pm.stopRestoreCommand(ctx); err != nil {
+			pm.logger.WarnContext(ctx, "SetPrimary: failed to confirm restore_command stopped for cohort member", "error", err)
+		}
+	}
+
 	if pm.consensusMgr.SuspectedDivergence() {
 		// Demoting a (likely diverged) stale primary restarts it as a standby of the
 		// new leader, which requires a pg_rewind. Defer that until the leader is
@@ -718,27 +729,6 @@ func (pm *MultipoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 		if err := pm.setPrimaryConnInfoLocked(ctx, leader.GetHost(), port,
 			true /* stopReplicationBefore */, true /* startReplicationAfter */); err != nil {
 			return nil, err
-		}
-	}
-
-	// This pooler now follows a rule via SetPrimary — if that rule names it a
-	// cohort member (RecordTermPrimary above already recorded it, so
-	// IsPotentialCohortMember reflects the incoming rule), it must only ever
-	// advance via streaming from here on, never the archive. By this point the
-	// pooler is confirmed a standby (either just restarted as one, or already
-	// one), so restore_command could genuinely still be running if it was
-	// previously an observer catching up — clearing the GUC alone doesn't stop
-	// an in-flight invocation, so confirm/stop it too. Best-effort like the
-	// rest of SetPrimary (an FYI the cohort reconverges around, not the
-	// authoritative point of cohort transition — that's Recruit, which hard-
-	// fails on both of these): the postgres monitor's ongoing backstop will
-	// catch anything missed here.
-	if pm.consensusMgr.IsPotentialCohortMember(pm.serviceID) {
-		if err := pm.resetRestoreCommand(ctx); err != nil {
-			pm.logger.WarnContext(ctx, "SetPrimary: failed to clear restore_command for cohort member", "error", err)
-		}
-		if err := pm.stopRestoreCommand(ctx); err != nil {
-			pm.logger.WarnContext(ctx, "SetPrimary: failed to confirm restore_command stopped for cohort member", "error", err)
 		}
 	}
 

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -175,6 +175,24 @@ func (pm *MultipoolerManager) Recruit(ctx context.Context, req *consensusdatapb.
 			_, err = pm.pauseReplication(stopCtx,
 				multipoolermanagerdatapb.ReplicationPauseMode_REPLICATION_PAUSE_MODE_RECEIVER_ONLY,
 				true /* wait */)
+			if err == nil {
+				// This pooler is becoming a cohort member: from here on it must
+				// only ever advance via streaming from the current leader, never
+				// the archive (an observer catching up may have had it enabled).
+				// Clear restore_command and confirm any in-flight invocation has
+				// actually stopped before waitForReplayStabilize below is allowed
+				// to declare replay settled — postgres cannot cancel an in-flight
+				// invocation on its own, so clearing the config alone only stops
+				// future fetches.
+				//
+				// A failure here is a hard error, not a warning: consensus
+				// correctness depends on a cohort member never trusting
+				// archive-sourced WAL, so proceeding without confirming this
+				// would put that at risk.
+				if err = pm.resetRestoreCommand(stopCtx); err == nil {
+					err = pm.stopRestoreCommand(stopCtx)
+				}
+			}
 		}
 		stopSpan.End()
 		if err != nil {
@@ -700,6 +718,27 @@ func (pm *MultipoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 		if err := pm.setPrimaryConnInfoLocked(ctx, leader.GetHost(), port,
 			true /* stopReplicationBefore */, true /* startReplicationAfter */); err != nil {
 			return nil, err
+		}
+	}
+
+	// This pooler now follows a rule via SetPrimary — if that rule names it a
+	// cohort member (RecordTermPrimary above already recorded it, so
+	// IsPotentialCohortMember reflects the incoming rule), it must only ever
+	// advance via streaming from here on, never the archive. By this point the
+	// pooler is confirmed a standby (either just restarted as one, or already
+	// one), so restore_command could genuinely still be running if it was
+	// previously an observer catching up — clearing the GUC alone doesn't stop
+	// an in-flight invocation, so confirm/stop it too. Best-effort like the
+	// rest of SetPrimary (an FYI the cohort reconverges around, not the
+	// authoritative point of cohort transition — that's Recruit, which hard-
+	// fails on both of these): the postgres monitor's ongoing backstop will
+	// catch anything missed here.
+	if pm.consensusMgr.IsPotentialCohortMember(pm.serviceID) {
+		if err := pm.resetRestoreCommand(ctx); err != nil {
+			pm.logger.WarnContext(ctx, "SetPrimary: failed to clear restore_command for cohort member", "error", err)
+		}
+		if err := pm.stopRestoreCommand(ctx); err != nil {
+			pm.logger.WarnContext(ctx, "SetPrimary: failed to confirm restore_command stopped for cohort member", "error", err)
 		}
 	}
 

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -149,6 +149,11 @@ func expectStandbyRecruitMocks(m *mock.QueryService, lsn string, savedConnInfo s
 	m.AddQueryPatternOnce("SELECT COUNT.*pg_stat_wal_receiver", mock.MakeQueryResult([]string{"count", "status", "primary_conninfo"}, [][]any{{int64(0), "", ""}}))
 	// queryReplicationStatus (from waitForReceiverDisconnect)
 	m.AddQueryPatternOnce("pg_last_wal_replay_lsn", mock.MakeQueryResult(replStatusCols, replStatusRow))
+	// resetRestoreCommand: this pooler is becoming a cohort member again
+	m.AddQueryPatternOnce("ALTER SYSTEM RESET restore_command", mock.MakeQueryResult(nil, nil))
+	expectReloadConfig(m)
+	// stopRestoreCommand goes through the mock pgctld gRPC server, not the SQL mock;
+	// its default response (nothing found running) requires no setup here.
 	// waitForReplayStabilize: three consecutive polls with same replay_lsn = stable
 	m.AddQueryPatternOnce("^SELECT pg_last_wal_replay_lsn", mock.MakeQueryResult(replayStateCols, replayStateRow))
 	m.AddQueryPatternOnce("^SELECT pg_last_wal_replay_lsn", mock.MakeQueryResult(replayStateCols, replayStateRow))

--- a/go/services/multipooler/internal/manager/rpc_first_backup_test.go
+++ b/go/services/multipooler/internal/manager/rpc_first_backup_test.go
@@ -74,6 +74,10 @@ func (s *stubPgctldClient) PgRewind(_ context.Context, _ *pgctldpb.PgRewindReque
 	return nil, mterrors.New(mtrpcpb.Code_UNAVAILABLE, "stub: not available")
 }
 
+func (s *stubPgctldClient) StopRestoreCommand(_ context.Context, _ *pgctldpb.StopRestoreCommandRequest, _ ...grpc.CallOption) (*pgctldpb.StopRestoreCommandResponse, error) {
+	return nil, mterrors.New(mtrpcpb.Code_UNAVAILABLE, "stub: not available")
+}
+
 var _ pgctldpb.PgCtldClient = (*stubPgctldClient)(nil)
 
 // successStubPgctldClient is a pgctld stub that succeeds for all calls.
@@ -115,6 +119,10 @@ func (s *successStubPgctldClient) InitDataDir(context.Context, *pgctldpb.InitDat
 
 func (s *successStubPgctldClient) PgRewind(context.Context, *pgctldpb.PgRewindRequest, ...grpc.CallOption) (*pgctldpb.PgRewindResponse, error) {
 	return &pgctldpb.PgRewindResponse{}, nil
+}
+
+func (s *successStubPgctldClient) StopRestoreCommand(context.Context, *pgctldpb.StopRestoreCommandRequest, ...grpc.CallOption) (*pgctldpb.StopRestoreCommandResponse, error) {
+	return &pgctldpb.StopRestoreCommandResponse{}, nil
 }
 
 var _ pgctldpb.PgCtldClient = (*successStubPgctldClient)(nil)

--- a/go/services/multipooler/internal/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/internal/manager/rpc_initialization_test.go
@@ -389,6 +389,10 @@ func (m *mockPgctldClient) PgRewind(ctx context.Context, req *pgctldpb.PgRewindR
 	return &pgctldpb.PgRewindResponse{}, nil
 }
 
+func (m *mockPgctldClient) StopRestoreCommand(ctx context.Context, req *pgctldpb.StopRestoreCommandRequest, opts ...grpc.CallOption) (*pgctldpb.StopRestoreCommandResponse, error) {
+	return &pgctldpb.StopRestoreCommandResponse{}, nil
+}
+
 // mockPgctldClientWithCounter extends mockPgctldClient with call counters
 type mockPgctldClientWithCounter struct {
 	mockPgctldClient

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -752,6 +752,15 @@ func (pm *MultipoolerManager) demoteToStandbyLocked(ctx context.Context, consens
 		}
 	}
 
+	// restore_command should never be set on a cohort member in recovery mode, so make sure
+	// it's cleared just in case. The reload inside resetRestoreCommand is redundant here
+	// specifically — restartPostgresAsStandby below does a full restart, which re-reads
+	// postgresql.auto.conf from disk regardless — but harmless, so not worth a separate
+	// no-reload variant just for this one call site.
+	if err := pm.resetRestoreCommand(ctx); err != nil {
+		return mterrors.Wrap(err, "failed to clear restore_command before demote restart")
+	}
+
 	// Restart PostgreSQL as standby. Unlike the old stop-only path, this keeps
 	// the node in the cluster as a replication target, avoiding timeline divergence
 	// in most cases. The coordinator still uses pg_rewind for nodes that diverged.

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -760,6 +760,8 @@ func (pm *MultipoolerManager) demoteToStandbyLocked(ctx context.Context, consens
 	if err := pm.resetRestoreCommand(ctx); err != nil {
 		return mterrors.Wrap(err, "failed to clear restore_command before demote restart")
 	}
+	// NOTE: No need to explicitly kill the restore command because postgres is not in recovery
+	// mode, so it should not be running the restore command.
 
 	// Restart PostgreSQL as standby. Unlike the old stop-only path, this keeps
 	// the node in the cluster as a replication target, avoiding timeline divergence

--- a/go/services/multipooler/internal/manager/rpc_set_primary_test.go
+++ b/go/services/multipooler/internal/manager/rpc_set_primary_test.go
@@ -671,3 +671,57 @@ func TestSetPrimary_ApplyPathErrors(t *testing.T) {
 		})
 	}
 }
+
+// TestSetPrimary_ClearsRestoreCommandForCohortMember verifies that when the
+// incoming rule names this pooler as a cohort member, SetPrimary clears
+// restore_command (and asks pgctld to confirm/stop any in-flight invocation)
+// as a backstop — a cohort member must only ever advance via streaming, never
+// the archive, regardless of what it was doing as an observer beforehand.
+func TestSetPrimary_ClearsRestoreCommandForCohortMember(t *testing.T) {
+	mockQueryService := mock.NewQueryService()
+
+	mockQueryService.AddQueryPatternOnce("SELECT pg_is_in_recovery",
+		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
+	mockQueryService.AddQueryPatternOnce("SELECT pg_is_in_recovery",
+		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
+	mockQueryService.AddQueryPatternOnce("SELECT pg_wal_replay_pause",
+		mock.MakeQueryResult(nil, nil))
+	mockQueryService.AddQueryPattern("^SELECT pg_last_wal_replay_lsn",
+		mock.MakeQueryResult([]string{"replay_lsn", "is_paused"}, [][]any{{"0/100", true}}))
+	mockQueryService.AddQueryPatternOnce("ALTER SYSTEM SET primary_conninfo",
+		mock.MakeQueryResult(nil, nil))
+	expectReloadConfig(mockQueryService)
+	mockQueryService.AddQueryPattern("^SELECT 1$", mock.MakeQueryResult(nil, nil))
+	mockQueryService.AddQueryPatternOnce("SELECT pg_wal_replay_resume",
+		mock.MakeQueryResult(nil, nil))
+
+	// The restore_command clear-and-confirm this test exists to check.
+	var resetCalled bool
+	mockQueryService.AddQueryPatternWithCallback(
+		"ALTER SYSTEM RESET restore_command",
+		mock.MakeQueryResult(nil, nil),
+		func(string) { resetCalled = true },
+	)
+	expectReloadConfig(mockQueryService)
+
+	leader := newLeaderAddress("new-primary", "primary-host", 5432)
+	rule := ruleAtTermForLeader(leader, 10)
+	rule.CohortMembers = []*clustermetadatapb.ID{
+		{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "test-pooler"},
+		leader.GetId(),
+	}
+
+	pm, _ := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(3)})
+
+	req := &consensusdatapb.SetPrimaryRequest{
+		ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
+			Position: &clustermetadatapb.RulePosition{Decision: rule},
+			Primary:  leader,
+		},
+	}
+	resp, err := pm.SetPrimary(t.Context(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.True(t, resetCalled, "restore_command should be cleared when the incoming rule names this pooler a cohort member")
+}

--- a/go/services/pgctld/postgresconfig_gen.go
+++ b/go/services/pgctld/postgresconfig_gen.go
@@ -187,6 +187,14 @@ func PostgresSocketDir(poolerDir string) string {
 	return path.Join(poolerDir, "pg_sockets")
 }
 
+// RestoreCommandPIDFile returns the path the restore_command wrapper (see
+// `pgctld restore-wrapper`) writes its own PID to. See
+// constants.RestoreCommandPIDFile for why the filename lives there instead of
+// here: go/services/multipooler needs it too, and can't import this package.
+func RestoreCommandPIDFile(poolerDir string) string {
+	return path.Join(poolerDir, constants.RestoreCommandPIDFile)
+}
+
 // PostgresConfigFile returns the location of the postgresql.conf file within PGDATA.
 func PostgresConfigFile() string {
 	return path.Join(PostgresDataDir(), "postgresql.conf")

--- a/proto/pgctldservice.proto
+++ b/proto/pgctldservice.proto
@@ -50,6 +50,13 @@ service PgCtld {
   // PgRewind rewinds a PostgreSQL data directory to an earlier point in the timeline
   // This is used to resynchronize a server that diverged from the primary after a failback
   rpc PgRewind(PgRewindRequest) returns (PgRewindResponse);
+
+  // StopRestoreCommand checks whether a restore_command invocation (run via
+  // the `pgctld restore-wrapper`, see RestoreCommandPIDFile) is currently
+  // running and, if so, terminates it. Postgres cannot cancel an in-flight
+  // restore_command call on its own — this is the only way to guarantee one
+  // has actually stopped rather than just disabling it for future segments.
+  rpc StopRestoreCommand(StopRestoreCommandRequest) returns (StopRestoreCommandResponse);
 }
 
 // Start PostgreSQL server
@@ -235,4 +242,21 @@ message PgRewindResponse {
   // Status message
   string message = 1;
   string output = 2;
+}
+
+message StopRestoreCommandRequest {
+}
+
+message StopRestoreCommandResponse {
+  // True if a restore_command invocation was found running (whether or not it
+  // needed to be signaled to stop).
+  bool found = 1;
+
+  // True if the found process had to be signaled (SIGTERM, escalating to
+  // SIGKILL) to stop it. False if nothing was found, or it had already
+  // exited on its own by the time this returned.
+  bool killed = 2;
+
+  // Status message
+  string message = 3;
 }


### PR DESCRIPTION
## Summary

`restore_command` is written implicitly by pgbackrest's initial `restore --type=standby` and never touched again today. A cohort member must only ever advance via streaming from the current leader — left enabled, a subsequent restart-as-standby can resolve `recovery_target_timeline=latest` via `restore_command`'s archive-get to a timeline the local checkpoint doesn't descend from and FATAL at startup, crash-looping with no way for the RPC-driven self-heal (`FixReplicationAction`) to even reach the node.

- `pgctld` gains a `restore-wrapper` subcommand and a `StopRestoreCommand` RPC: postgres cannot cancel an in-flight `restore_command` invocation on its own, so disabling the GUC alone only stops future fetches. The wrapper records its own PID so `StopRestoreCommand` can check liveness and terminate it (SIGTERM, then SIGKILL after a bounded grace period) if still running.
- `ConsensusManager.IsPotentialCohortMember` checks both the decided rule and an outstanding proposal, not just whichever one is "current" — a confirmed member must not read as "no longer a member" just because a newer, undecided proposal excludes them.
- `Recruit` clears `restore_command` and confirms it has actually stopped for both branches (a demoted primary restarting as standby, and an already-standby being recruited), as a hard error — this is a correctness invariant, not best-effort.
- `SetPrimary` also clears/confirms it whenever the incoming rule names this pooler a cohort member, best-effort.
- Restore-from-backup asserts the pooler is not a cohort member, and wraps the `restore_command` pgbackrest just wrote so it's confirmable/stoppable later — this is the one case `restore_command` is actually expected to be in active use.
- The postgres monitor disables `restore_command` as an ongoing backstop whenever it's set on a cohort member or an already-successfully-streaming standby.

Re-enabling `restore_command` for a stuck, non-cohort observer that was previously caught up is deliberately not implemented: a replica lagging enough to need archive catch-up shouldn't still be in the cohort, and there's no existing structured signal for "stuck because the primary lacks the WAL" to trigger on.