### PR TITLE
fix(pgctld): read postgres-config-template path from env var

### DIFF
--- a/go/cmd/pgctld/command/root.go
+++ b/go/cmd/pgctld/command/root.go
@@ -122,6 +122,7 @@ func GetRootCommand() (*cobra.Command, *PgCtlCommand) {
 		postgresConfigTmpl: viperutil.Configure(reg, "postgres-config-template", viperutil.Options[string]{
 			Default:  "",
 			FlagName: "postgres-config-template",
+			EnvVars:  []string{constants.PgConfigTemplateEnvVar},
 			Dynamic:  false,
 		}),
 		pgInitdbArgs: viperutil.Configure(reg, "pg-initdb-args", viperutil.Options[string]{
@@ -196,7 +197,7 @@ management for PostgreSQL servers.`,
 	root.PersistentFlags().IntP("pg-port", "p", pc.pgPort.Default(), "PostgreSQL port")
 	root.PersistentFlags().String("pg-listen-addresses", pc.pgListenAddresses.Default(), "PostgreSQL listen addresses")
 	root.PersistentFlags().String("pg-hba-template", pc.pgHbaTemplate.Default(), "Path to custom pg_hba.conf template file")
-	root.PersistentFlags().String("postgres-config-template", pc.postgresConfigTmpl.Default(), "Path to custom postgresql.conf template file")
+	root.PersistentFlags().String("postgres-config-template", pc.postgresConfigTmpl.Default(), "Path to custom postgresql.conf template file (overrides "+constants.PgConfigTemplateEnvVar+" env var)")
 	root.PersistentFlags().String("pg-password-file", pc.pgPasswordFile.Default(), "Path to a file containing the PostgreSQL password (plaintext, docker-library/postgres convention). Takes precedence over "+constants.PgPasswordEnvVar+". Also reads "+constants.PgPasswordFileEnvVar+" env var.")
 	root.PersistentFlags().String("pg-initdb-args", pc.pgInitdbArgs.Default(), "Extra arguments passed to initdb (overrides "+constants.PgInitdbArgsEnvVar+" env var)")
 	root.PersistentFlags().StringSlice("pg-initdb-sql-files", pc.pgInitdbSQLFiles.Default(), "Path to an .sql file to run against the target database after data directory initialization. Repeat the flag to run multiple files in order (overrides "+constants.PgInitdbSQLFilesEnvVar+" env var).")

--- a/go/cmd/pgctld/command/root_test.go
+++ b/go/cmd/pgctld/command/root_test.go
@@ -206,6 +206,34 @@ work_mem = {{.WorkMem}}
 		assert.NotEqual(t, originalTemplate, config.PostgresConfigDefaultTmpl)
 	})
 
+	t.Run("env var sets template path", func(t *testing.T) {
+		// A base image (e.g. one bundling supautils/pgaudit/pg_cron) has no way
+		// to pass pgctld a CLI flag, only to set env vars or drop files at a
+		// known path. PgConfigTemplateEnvVar lets it opt in to a custom
+		// template without a wrapper script that injects --postgres-config-template.
+		baseDir, cleanup := testutil.TempDir(t, "pgctld_pg_config_test")
+		defer cleanup()
+		t.Setenv(constants.PgDataDirEnvVar, baseDir+"/pg_data")
+
+		customTemplate := "max_connections = {{.MaxConnections}}\nshared_preload_libraries = 'supautils'\n"
+		templatePath := filepath.Join(baseDir, "custom_postgresql.conf")
+		require.NoError(t, os.WriteFile(templatePath, []byte(customTemplate), 0o644))
+		t.Setenv(constants.PgConfigTemplateEnvVar, templatePath)
+
+		// Reset template before test
+		config.PostgresConfigDefaultTmpl = originalTemplate
+
+		// Create command and test validateGlobalFlags directly, without
+		// setting the --postgres-config-template flag.
+		_, pc := GetRootCommand()
+		pc.poolerDir.Set(baseDir)
+
+		err := pc.validateGlobalFlags(nil, nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, customTemplate, config.PostgresConfigDefaultTmpl)
+	})
+
 	t.Run("non-existent template file returns error", func(t *testing.T) {
 		baseDir, cleanup := testutil.TempDir(t, "pgctld_pg_config_test")
 		defer cleanup()

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -60,6 +60,18 @@ const (
 	// extras override values from the templated defaults.
 	PgInitdbExtraConfEnvVar = "POSTGRES_INITDB_EXTRA_CONF"
 
+	// PgConfigTemplateEnvVar is the environment variable for the path to a
+	// custom postgresql.conf Go template, replacing pgctld's embedded default
+	// (config/postgres/template.cnf). Some settings the embedded default
+	// deliberately leaves unset for compatibility with stock PostgreSQL
+	// images -- e.g. shared_preload_libraries for extensions a custom base
+	// image bundles (supautils, pgaudit, pg_cron, ...) -- can be set
+	// correctly here instead. Unlike PgInitdbExtraConfEnvVar (which is
+	// appended verbatim, unrendered), this file is rendered through the same
+	// template engine as the embedded default, so it must use the same
+	// {{.Field}} placeholders (see PostgresServerConfig's template fields).
+	PgConfigTemplateEnvVar = "POSTGRES_CONFIG_TEMPLATE_PATH"
+
 	// DefaultPostgresDatabase is the default database that always exists in PostgreSQL.
 	// This database is created during cluster initialization.
 	DefaultPostgresDatabase = "postgres"


### PR DESCRIPTION
## Problem

The embedded default postgresql.conf template intentionally omits some settings (like `shared_preload_libraries`) so stock PostgreSQL images keep working. `pgctld` already has a `--postgres-config-template` flag for overriding it, but a custom base image (e.g. one bundling supautils/pgaudit/pg_cron) controls only the image's filesystem and environment, not the CLI args pgctld is invoked with — so the flag alone isn't reachable from a Dockerfile.

## Solution

Added `PgConfigTemplateEnvVar` (`POSTGRES_CONFIG_TEMPLATE_PATH`) and wired it into the existing `postgres-config-template` viper flag's `EnvVars`, matching the pattern already used for `pg-initdb-extra-conf` and friends. A base image can now just `ENV POSTGRES_CONFIG_TEMPLATE_PATH=/path/to/template.tmpl` and pgctld picks it up automatically.