### PR TITLE
feat(multigateway): add SHOW multigres_version command

### DIFF
--- a/docs/query_serving/gateway_managed_variables.md
+++ b/docs/query_serving/gateway_managed_variables.md
@@ -16,10 +16,11 @@ Both are registered in the single source of truth,
 `gatewayManagedVariables` in `handler/gateway_managed_variables.go` (see
 [Adding or changing a GMV](#adding-or-changing-a-gmv)).
 
-> **Not a GMV:** `SHOW multigres_version` is also answered by the gateway, but
-> it is a read-only pseudo-variable, not a GMV — it has no `SET`/`RESET`/
-> `set_config`/transaction behavior and is not in this registry. See
-> [`multigres_version.md`](./multigres_version.md). Don't add it here.
+> **Not a GMV:** `SHOW multigres_version` (and `SELECT multigres.version()`) is
+> also answered by the gateway, but it is a read-only pseudo-variable, not a
+> GMV — it has no `SET`/`RESET`/`set_config`/transaction behavior and is not in
+> this registry. See [`multigres_version.md`](./multigres_version.md). Don't add
+> it here.
 
 ## Why GMVs exist
 

--- a/docs/query_serving/gateway_managed_variables.md
+++ b/docs/query_serving/gateway_managed_variables.md
@@ -16,6 +16,11 @@ Both are registered in the single source of truth,
 `gatewayManagedVariables` in `handler/gateway_managed_variables.go` (see
 [Adding or changing a GMV](#adding-or-changing-a-gmv)).
 
+> **Not a GMV:** `SHOW multigres_version` is also answered by the gateway, but
+> it is a read-only pseudo-variable, not a GMV — it has no `SET`/`RESET`/
+> `set_config`/transaction behavior and is not in this registry. See
+> [`multigres_version.md`](./multigres_version.md). Don't add it here.
+
 ## Why GMVs exist
 
 Regular session settings are stored in `SessionSettings` and applied to pooled

--- a/docs/query_serving/multigres_version.md
+++ b/docs/query_serving/multigres_version.md
@@ -1,0 +1,78 @@
+# `SHOW multigres_version`
+
+## Overview
+
+`SHOW multigres_version` reports the build identity of the multigateway a
+client is connected to. It lets an operator check which gateway build is
+serving them without shell access to run a binary with `--version`, and
+makes it easy to include the gateway version in a bug report.
+
+```console
+psql> SHOW multigres_version;
+              multigres_version
+----------------------------------------------------
+ Multigres (cb4f578bfd76, modified, 2026-07-06) built with go1.26.0
+(1 row)
+```
+
+The command is answered entirely by the gateway and is **never forwarded to
+PostgreSQL**. It works in both the simple and extended (prepared-statement)
+query protocols.
+
+## `multigres_version` is not a gateway-managed variable
+
+Despite the `SHOW <name>` surface, `multigres_version` is **not** a
+[gateway-managed variable](./gateway_managed_variables.md). It is a read-only
+pseudo-variable:
+
+- It is not in the `gatewayManagedVariables` registry.
+- It has no `SET` / `RESET` / `set_config` / transaction behavior. A
+  `SET multigres_version = ...` falls through to PostgreSQL, which rejects it as
+  an unrecognized configuration parameter — matching how PostgreSQL treats its
+  own read-only `server_version`.
+- Its value is a process-wide constant, so it reads no per-connection state.
+
+## Version string
+
+The string comes from `servenv.AppVersion()`, formatted from the binary's
+build identity (`servenv.readBuildSnapshot()`, backed by
+`runtime/debug.BuildInfo`) — the same source already used by the `/version`
+HTTP endpoint and the OpenTelemetry `service.version` attribute. It contains
+the VCS revision, a `modified` marker when the working tree was dirty at build
+time, the commit date, and the Go toolchain version.
+
+Two things to know:
+
+- **Un-stamped builds.** If the binary was built without VCS stamping (notably
+  a build from a linked git worktree, where Go does not embed VCS settings),
+  the revision is unavailable and the string degrades to
+  `Multigres (unknown revision) built with <go>`. Normal checkouts and CI
+  builds stamp correctly.
+- **Release tag.** `servenv.version` is an empty seam reserved for a future
+  release tag stamped via `-ldflags "-X .../servenv.version=v0.1.0"`. When set,
+  it is prefixed: `Multigres v0.1.0 (<revision>, ...)`.
+
+## Code organization
+
+| File                             | Role                                                               |
+| -------------------------------- | ------------------------------------------------------------------ |
+| `common/servenv/buildinfo.go`    | `AppVersion()` / `formatAppVersion()` — the version string         |
+| `common/constants/gateway.go`    | `MultigresVersionVariable` — the pseudo-variable name              |
+| `planner/variable_show_stmt.go`  | Intercepts `SHOW multigres_version` before the backend fallthrough |
+| `engine/gateway_show_version.go` | `GatewayShowVersion` primitive; the `Describe` helpers             |
+| `executor/executor.go`           | Serves the extended-protocol `Describe` locally                    |
+
+## Extended protocol notes
+
+Serving a gateway-only pseudo-variable over the extended protocol needs two
+things beyond the simple-query path, because PostgreSQL has no such GUC:
+
+- **Describe** is normally forwarded straight to the backend. For
+  `multigres_version` the executor intercepts it and returns a synthetic
+  `StatementDescription` (no bind parameters, one text column); otherwise the
+  backend would reject the unknown parameter at `Describe` time.
+- **Execute** must not re-send `RowDescription`. The wire layer emits it
+  whenever a result carries `Fields`, so `GatewayShowVersion` attaches column
+  metadata only when a `Describe('P')` was folded into the `Execute`
+  (`includeDescribe`). Attaching it otherwise would send an illegal second
+  `RowDescription` mid-`Execute`.

--- a/docs/query_serving/multigres_version.md
+++ b/docs/query_serving/multigres_version.md
@@ -1,78 +1,123 @@
-# `SHOW multigres_version`
+# Multigres version
 
-## Overview
+The gateway reports its own version two ways, mirroring how PostgreSQL reports
+its own — a short GUC and a full-string function. This lets an operator check
+which multigateway build is serving them without shell access to a binary, and
+makes the version easy to include in a bug report.
 
-`SHOW multigres_version` reports the build identity of the multigateway a
-client is connected to. It lets an operator check which gateway build is
-serving them without shell access to run a binary with `--version`, and
-makes it easy to include the gateway version in a bug report.
+| Surface                      | Analogous to     | Returns               |
+| ---------------------------- | ---------------- | --------------------- |
+| `SHOW multigres_version`     | `server_version` | Short release version |
+| `SELECT multigres.version()` | `version()`      | Full build string     |
 
 ```console
 psql> SHOW multigres_version;
-              multigres_version
-----------------------------------------------------
- Multigres (cb4f578bfd76, modified, 2026-07-06) built with go1.26.0
+ multigres_version
+-------------------
+ 0.1.0-SNAPSHOT
+(1 row)
+
+psql> SELECT multigres.version();
+                       version
+------------------------------------------------------
+ Multigres 0.1.0-SNAPSHOT (cb4f578bfd76, 2026-07-06) built with go1.26.0
 (1 row)
 ```
 
-The command is answered entirely by the gateway and is **never forwarded to
-PostgreSQL**. It works in both the simple and extended (prepared-statement)
-query protocols.
+Both work in the simple and extended (prepared-statement) query protocols.
+`SHOW multigres_version` is answered entirely by the gateway;
+`SELECT multigres.version()` is folded to a literal and then runs on PostgreSQL
+(see below), so it composes into any query.
+
+## How the function works: constant folding
+
+`multigres.version()` has no backend implementation (PostgreSQL has no
+`multigres` schema), so the gateway **folds it into a text literal of the version
+before the query reaches the backend** — `multigres.version()` becomes
+`'Multigres 0.1.0-SNAPSHOT (...)'`. The query then runs on PostgreSQL unchanged,
+which means the function works in **any expression position**, not just as a
+standalone target:
+
+```sql
+SELECT multigres.version();
+SELECT id FROM t WHERE created_by = multigres.version();
+SELECT length(multigres.version());
+```
+
+The fold runs in the handler (`handler/gateway_functions.go`), applied once the
+query is parsed so that the planner, the plan cache, and the extended protocol's
+Describe/Execute — which reuse the stored statement text — all see the same
+already-substituted query. `HandleQuery` (simple protocol) folds the statements
+it already parsed and refreshes the query text from the rewritten AST;
+`HandleParse` (extended protocol), which only has a string, folds that. A cheap
+substring check skips the work for queries that don't mention the `multigres`
+schema. When the sole target is a bare `multigres.version()` with no alias, the
+fold also sets the column label to `version`, matching what PostgreSQL would
+label a `version()` call (a bare literal is otherwise labelled `?column?`).
+
+## Why a namespaced function
+
+The function is `multigres.version()`, **not** `version()`. A bare `version()`
+already exists in PostgreSQL, and tools and ORMs call it expecting the
+_PostgreSQL_ version string — so the gateway leaves it alone and routes it to the
+backend. `multigres.version()` lives in its own `multigres` schema and does not
+shadow it. A `SELECT version()` still reports PostgreSQL; `SELECT
+multigres.version()` reports multigres.
 
 ## `multigres_version` is not a gateway-managed variable
 
 Despite the `SHOW <name>` surface, `multigres_version` is **not** a
 [gateway-managed variable](./gateway_managed_variables.md). It is a read-only
-pseudo-variable:
+pseudo-variable: not in the `gatewayManagedVariables` registry, and with no
+`SET` / `RESET` / `set_config` / transaction behavior. A `SET multigres_version
+= ...` falls through to PostgreSQL, which rejects it as an unrecognized
+configuration parameter — matching how PostgreSQL treats its own read-only
+`server_version`.
 
-- It is not in the `gatewayManagedVariables` registry.
-- It has no `SET` / `RESET` / `set_config` / transaction behavior. A
-  `SET multigres_version = ...` falls through to PostgreSQL, which rejects it as
-  an unrecognized configuration parameter — matching how PostgreSQL treats its
-  own read-only `server_version`.
-- Its value is a process-wide constant, so it reads no per-connection state.
+## Where the version comes from
 
-## Version string
+The **short** version (`servenv.Version()`) is the `versionName` constant in
+`common/servenv/version.go` — a property of the source tree, bumped when cutting
+a release and carrying a `-SNAPSHOT` suffix in between. It is deliberately **not**
+derived from git tags at build time: a tag is created after (and often on a
+different branch from) the commit it names, so a build of a given commit can't
+reliably infer its own release version from `git describe`, and the result would
+depend on which branch it was built from. Keeping it in source makes the version
+a stable property of the commit.
 
-The string comes from `servenv.AppVersion()`, formatted from the binary's
-build identity (`servenv.readBuildSnapshot()`, backed by
-`runtime/debug.BuildInfo`) — the same source already used by the `/version`
-HTTP endpoint and the OpenTelemetry `service.version` attribute. It contains
-the VCS revision, a `modified` marker when the working tree was dirty at build
-time, the commit date, and the Go toolchain version.
-
-Two things to know:
-
-- **Un-stamped builds.** If the binary was built without VCS stamping (notably
-  a build from a linked git worktree, where Go does not embed VCS settings),
-  the revision is unavailable and the string degrades to
-  `Multigres (unknown revision) built with <go>`. Normal checkouts and CI
-  builds stamp correctly.
-- **Release tag.** `servenv.version` is an empty seam reserved for a future
-  release tag stamped via `-ldflags "-X .../servenv.version=v0.1.0"`. When set,
-  it is prefixed: `Multigres v0.1.0 (<revision>, ...)`.
+The **full** string (`servenv.AppVersion()`) prefixes that release version with
+the binary's VCS identity — revision, a `modified` marker for a dirty tree,
+commit date, and Go toolchain — read from `runtime/debug.BuildInfo`. This is the
+same build snapshot already used by the `/version` HTTP endpoint and the
+OpenTelemetry `service.version` attribute. Go does not embed VCS settings when
+building inside a linked git worktree, so worktree dev builds omit the VCS fields
+(`Multigres 0.1.0-SNAPSHOT (unknown revision) built with <go>`); normal checkouts
+and CI stamp them.
 
 ## Code organization
 
-| File                             | Role                                                               |
-| -------------------------------- | ------------------------------------------------------------------ |
-| `common/servenv/buildinfo.go`    | `AppVersion()` / `formatAppVersion()` — the version string         |
-| `common/constants/gateway.go`    | `MultigresVersionVariable` — the pseudo-variable name              |
-| `planner/variable_show_stmt.go`  | Intercepts `SHOW multigres_version` before the backend fallthrough |
-| `engine/gateway_show_version.go` | `GatewayShowVersion` primitive; the `Describe` helpers             |
-| `executor/executor.go`           | Serves the extended-protocol `Describe` locally                    |
+| File                             | Role                                                             |
+| -------------------------------- | ---------------------------------------------------------------- |
+| `common/servenv/version.go`      | `versionName` — the committed release version constant           |
+| `common/servenv/buildinfo.go`    | `Version()` (short) and `AppVersion()` (full) version strings    |
+| `common/constants/gateway.go`    | `MultigresVersionVariable`, `MultigresSchema`                    |
+| `handler/gateway_functions.go`   | Folds `multigres.version()` into a literal                       |
+| `planner/variable_show_stmt.go`  | Intercepts `SHOW multigres_version`                              |
+| `engine/gateway_show_version.go` | `GatewayShowVersion` primitive; SHOW matcher and Describe helper |
+| `executor/executor.go`           | Serves the extended-protocol `Describe` for SHOW locally         |
 
 ## Extended protocol notes
 
-Serving a gateway-only pseudo-variable over the extended protocol needs two
-things beyond the simple-query path, because PostgreSQL has no such GUC:
+`SHOW multigres_version` is served by the gateway, so it needs two things over
+the extended protocol that a backend-routed query gets for free:
 
-- **Describe** is normally forwarded straight to the backend. For
-  `multigres_version` the executor intercepts it and returns a synthetic
-  `StatementDescription` (no bind parameters, one text column); otherwise the
-  backend would reject the unknown parameter at `Describe` time.
-- **Execute** must not re-send `RowDescription`. The wire layer emits it
-  whenever a result carries `Fields`, so `GatewayShowVersion` attaches column
-  metadata only when a `Describe('P')` was folded into the `Execute`
-  (`includeDescribe`). Attaching it otherwise would send an illegal second
-  `RowDescription` mid-`Execute`.
+- **Describe** is normally forwarded straight to the backend, which has no such
+  GUC. The executor intercepts it and returns a synthetic `StatementDescription`
+  (no bind parameters, one text column).
+- **Execute** must not re-send `RowDescription`. The wire layer emits it whenever
+  a result carries `Fields`, so the primitive attaches column metadata only when
+  a `Describe('P')` was folded into the `Execute` (`includeDescribe`). Attaching
+  it otherwise would send an illegal second `RowDescription` mid-`Execute`.
+
+`SELECT multigres.version()` needs none of this: it is folded to a literal at
+parse time, so the backend describes and executes an ordinary `SELECT`.

--- a/go/common/constants/gateway.go
+++ b/go/common/constants/gateway.go
@@ -16,10 +16,22 @@ package constants
 
 const (
 	// MultigresVersionVariable is the pseudo-variable name that, via
-	// `SHOW multigres_version`, reports the running multigateway's build
-	// identity. It is not a real PostgreSQL GUC: the gateway answers it
-	// locally and never forwards it to a backend.
+	// `SHOW multigres_version`, reports the running multigateway's short release
+	// version. It is not a real PostgreSQL GUC: the gateway answers it locally
+	// and never forwards it to a backend.
 	MultigresVersionVariable = "multigres_version"
+
+	// MultigresSchema is the schema used to namespace gateway-provided functions
+	// (e.g. `multigres.version()`) so they do not shadow PostgreSQL's own
+	// built-ins of the same name.
+	MultigresSchema = "multigres"
+
+	// MultigresVersionFunction is the name of the gateway function
+	// `multigres.version()`, which reports the running multigateway's full build
+	// string. It doubles as the default output column label, matching
+	// PostgreSQL's convention of labelling a bare function-call target with the
+	// function name.
+	MultigresVersionFunction = "version"
 
 	// MaxBufferingRetries is the maximum number of times a query will be
 	// retried after failover buffering completes.

--- a/go/common/constants/gateway.go
+++ b/go/common/constants/gateway.go
@@ -15,6 +15,12 @@
 package constants
 
 const (
+	// MultigresVersionVariable is the pseudo-variable name that, via
+	// `SHOW multigres_version`, reports the running multigateway's build
+	// identity. It is not a real PostgreSQL GUC: the gateway answers it
+	// locally and never forwards it to a backend.
+	MultigresVersionVariable = "multigres_version"
+
 	// MaxBufferingRetries is the maximum number of times a query will be
 	// retried after failover buffering completes.
 	MaxBufferingRetries = 3

--- a/go/common/servenv/buildinfo.go
+++ b/go/common/servenv/buildinfo.go
@@ -15,10 +15,18 @@
 package servenv
 
 import (
+	"fmt"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"time"
 )
+
+// version is the release identity of the binary. It is intended to be stamped
+// at build time via -ldflags "-X .../servenv.version=v0.1.0" once multigres cuts
+// real releases. Un-stamped builds leave it empty, in which case AppVersion
+// falls back to the VCS revision the Go toolchain embeds.
+var version = ""
 
 // buildSnapshot is the parsed, cached view of the binary's build identity,
 // derived from runtime/debug.BuildInfo. All fields may be empty if
@@ -74,4 +82,49 @@ func loadBuildSnapshot() {
 			}
 		}
 	}
+}
+
+// AppVersion returns a one-line, human-readable description of the running
+// binary's Multigres version, suitable for display to operators (e.g. via
+// `SHOW multigres_version` or a future --version flag) and for pasting into bug
+// reports. It is derived from the release version (if stamped) plus the VCS
+// identity the Go toolchain embeds; missing fields are omitted so it degrades
+// gracefully on builds without VCS stamping.
+func AppVersion() string {
+	return formatAppVersion(version, readBuildSnapshot())
+}
+
+// formatAppVersion is the pure formatting core of AppVersion, split out so the
+// string layout can be unit-tested without depending on the ambient build info.
+func formatAppVersion(version string, snap buildSnapshot) string {
+	var b strings.Builder
+	b.WriteString("Multigres")
+	if version != "" {
+		fmt.Fprintf(&b, " %s", version)
+	}
+
+	switch {
+	case snap.revision != "":
+		short := snap.revision
+		if len(short) > 12 {
+			short = short[:12]
+		}
+		fmt.Fprintf(&b, " (%s", short)
+		if snap.modified {
+			b.WriteString(", modified")
+		}
+		if !snap.commitTime.IsZero() {
+			fmt.Fprintf(&b, ", %s", snap.commitTime.UTC().Format("2006-01-02"))
+		}
+		b.WriteByte(')')
+	case snap.modified:
+		b.WriteString(" (modified)")
+	default:
+		b.WriteString(" (unknown revision)")
+	}
+
+	if snap.goVersion != "" {
+		fmt.Fprintf(&b, " built with %s", snap.goVersion)
+	}
+	return b.String()
 }

--- a/go/common/servenv/buildinfo.go
+++ b/go/common/servenv/buildinfo.go
@@ -22,12 +22,6 @@ import (
 	"time"
 )
 
-// version is the release identity of the binary. It is intended to be stamped
-// at build time via -ldflags "-X .../servenv.version=v0.1.0" once multigres cuts
-// real releases. Un-stamped builds leave it empty, in which case AppVersion
-// falls back to the VCS revision the Go toolchain embeds.
-var version = ""
-
 // buildSnapshot is the parsed, cached view of the binary's build identity,
 // derived from runtime/debug.BuildInfo. All fields may be empty if
 // -buildvcs was disabled at build time.
@@ -84,14 +78,23 @@ func loadBuildSnapshot() {
 	}
 }
 
+// Version returns the short release version (versionName, e.g. "0.1.0-SNAPSHOT").
+// It is the value reported by `SHOW multigres_version`, mirroring PostgreSQL's
+// server_version. The full build string — release version plus VCS revision,
+// commit date, and Go toolchain — is AppVersion, reported by
+// `SELECT multigres.version()`.
+func Version() string {
+	return versionName
+}
+
 // AppVersion returns a one-line, human-readable description of the running
 // binary's Multigres version, suitable for display to operators (e.g. via
 // `SHOW multigres_version` or a future --version flag) and for pasting into bug
-// reports. It is derived from the release version (if stamped) plus the VCS
-// identity the Go toolchain embeds; missing fields are omitted so it degrades
-// gracefully on builds without VCS stamping.
+// reports. It is the release version plus the VCS identity the Go toolchain
+// embeds; VCS fields are omitted so it degrades gracefully on builds without VCS
+// stamping (e.g. inside a linked git worktree).
 func AppVersion() string {
-	return formatAppVersion(version, readBuildSnapshot())
+	return formatAppVersion(versionName, readBuildSnapshot())
 }
 
 // formatAppVersion is the pure formatting core of AppVersion, split out so the

--- a/go/common/servenv/buildinfo_test.go
+++ b/go/common/servenv/buildinfo_test.go
@@ -105,3 +105,14 @@ func TestAppVersion(t *testing.T) {
 		t.Errorf("AppVersion() = %q, expected it to start with \"Multigres\"", got)
 	}
 }
+
+// TestVersion checks the short release accessor returns the committed release
+// version constant.
+func TestVersion(t *testing.T) {
+	if got := Version(); got != versionName {
+		t.Errorf("Version() = %q, want %q", got, versionName)
+	}
+	if Version() == "" {
+		t.Error("Version() is empty; versionName must always be set")
+	}
+}

--- a/go/common/servenv/buildinfo_test.go
+++ b/go/common/servenv/buildinfo_test.go
@@ -17,6 +17,7 @@ package servenv
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestReadBuildSnapshot exercises readBuildSnapshot against the test
@@ -34,5 +35,73 @@ func TestReadBuildSnapshot(t *testing.T) {
 	}
 	if readBuildSnapshot() != snap {
 		t.Error("readBuildSnapshot returned a different value on second call; expected cached snapshot")
+	}
+}
+
+// TestFormatAppVersion pins the string layout of the version reported by
+// `SHOW multigres_version` across the combinations of build fields that may be
+// present or absent.
+func TestFormatAppVersion(t *testing.T) {
+	commit := time.Date(2026, 7, 10, 15, 4, 5, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		version string
+		snap    buildSnapshot
+		want    string
+	}{
+		{
+			name: "revision, commit time, and go version",
+			snap: buildSnapshot{revision: "a761b254c0ffeedeadbeef", commitTime: commit, goVersion: "go1.23.4"},
+			want: "Multigres (a761b254c0ff, 2026-07-10) built with go1.23.4",
+		},
+		{
+			name: "modified working tree",
+			snap: buildSnapshot{revision: "a761b254c0ffee", modified: true, commitTime: commit, goVersion: "go1.23.4"},
+			want: "Multigres (a761b254c0ff, modified, 2026-07-10) built with go1.23.4",
+		},
+		{
+			name:    "stamped release version",
+			version: "v0.1.0",
+			snap:    buildSnapshot{revision: "a761b254c0ffee", commitTime: commit, goVersion: "go1.23.4"},
+			want:    "Multigres v0.1.0 (a761b254c0ff, 2026-07-10) built with go1.23.4",
+		},
+		{
+			name: "short revision is not truncated",
+			snap: buildSnapshot{revision: "a761b25", goVersion: "go1.23.4"},
+			want: "Multigres (a761b25) built with go1.23.4",
+		},
+		{
+			name: "no vcs info at all",
+			snap: buildSnapshot{goVersion: "go1.23.4"},
+			want: "Multigres (unknown revision) built with go1.23.4",
+		},
+		{
+			name: "no vcs revision but modified flag",
+			snap: buildSnapshot{modified: true, goVersion: "go1.23.4"},
+			want: "Multigres (modified) built with go1.23.4",
+		},
+		{
+			name: "empty snapshot",
+			snap: buildSnapshot{},
+			want: "Multigres (unknown revision)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatAppVersion(tt.version, tt.snap); got != tt.want {
+				t.Errorf("formatAppVersion(%q, %+v) = %q, want %q", tt.version, tt.snap, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAppVersion smoke-tests the exported entry point against the test binary's
+// own build info: it must always start with "Multigres" and never be empty.
+func TestAppVersion(t *testing.T) {
+	got := AppVersion()
+	if !strings.HasPrefix(got, "Multigres") {
+		t.Errorf("AppVersion() = %q, expected it to start with \"Multigres\"", got)
 	}
 }

--- a/go/common/servenv/version.go
+++ b/go/common/servenv/version.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package servenv
+
+// versionName is the Multigres release version. It is a property of the source
+// tree — bumped in this file when cutting a release, carrying a "-SNAPSHOT"
+// suffix in between — deliberately NOT derived from git tags at build time: a
+// tag is created after (and often on a different branch from) the commit it
+// names, so a build of a given commit cannot reliably infer its own release
+// version from `git describe`. Keeping it in source makes the version a stable
+// property of the commit, independent of the build environment or branch.
+const versionName = "0.1.0-SNAPSHOT"

--- a/go/services/multigateway/engine/gateway_show_version.go
+++ b/go/services/multigateway/engine/gateway_show_version.go
@@ -29,74 +29,55 @@ import (
 	"github.com/multigres/multigres/go/services/multigateway/handler"
 )
 
-// multigresVersionField is the single result column returned by
-// `SHOW multigres_version`. Both the executed result and the extended-protocol
-// Describe must present identical column metadata, so they share this builder.
-func multigresVersionField() *query.Field {
+// The gateway exposes its version two ways, mirroring PostgreSQL:
+//
+//   - `SHOW multigres_version` returns the short release version (like
+//     `server_version`), served locally by the GatewayShowVersion primitive
+//     below because postgres has no such GUC.
+//   - `SELECT multigres.version()` returns the full build string (like
+//     `version()`). It is NOT served here — the handler folds it into a text
+//     literal before the query reaches the backend, so it works in any position
+//     (see handler/gateway_functions.go).
+
+// textField builds a single text result column with the given label.
+func textField(name string) *query.Field {
 	return &query.Field{
-		Name:        constants.MultigresVersionVariable,
+		Name:        name,
 		Type:        "text",
 		DataTypeOid: uint32(ast.TEXTOID),
 	}
 }
 
-// IsMultigresVersionShow reports whether stmt is `SHOW multigres_version`, the
-// gateway-only pseudo-variable served locally by GatewayShowVersion. The name
-// compares case-insensitively, matching PostgreSQL's handling of unquoted
-// (lowercased) and quoted (case-preserving) identifiers.
-func IsMultigresVersionShow(stmt ast.Stmt) bool {
-	show, ok := stmt.(*ast.VariableShowStmt)
-	return ok && strings.ToLower(show.Name) == constants.MultigresVersionVariable
-}
-
-// MultigresVersionDescription is the extended-protocol Describe response for
-// `SHOW multigres_version`: no bind parameters and one text column. It lets the
-// gateway answer Describe locally, since postgres has no such GUC to describe
-// (forwarding would fail with "unrecognized configuration parameter").
-func MultigresVersionDescription() *query.StatementDescription {
-	return &query.StatementDescription{
-		Parameters: []*query.ParameterDescription{},
-		Fields:     []*query.Field{multigresVersionField()},
-		HasFields:  true,
-	}
-}
-
-// GatewayShowVersion handles `SHOW multigres_version`, returning the running
-// multigateway's build identity as a single-row result. Unlike
-// GatewayShowVariable it reads no per-connection state — the value is a
-// process-wide constant — so it answers without a PostgreSQL round-trip. This
-// lets a client discover which multigateway build it is connected to without
-// shell access to run `--version`.
+// GatewayShowVersion handles `SHOW multigres_version`, returning the gateway's
+// short release version as a single-row result. The value is a process-wide
+// constant, so it answers without a PostgreSQL round trip.
 type GatewayShowVersion struct {
 	sql string // Original SQL for debugging
 }
 
-// NewGatewayShowVersion creates a primitive that returns the multigateway
-// version string.
+// NewGatewayShowVersion creates the primitive for `SHOW multigres_version`.
 func NewGatewayShowVersion(sql string) *GatewayShowVersion {
 	return &GatewayShowVersion{sql: sql}
 }
 
-// versionResult builds the single-row SHOW result. withFields controls whether
-// the column metadata is attached: the simple protocol always needs it (one
-// RowDescription precedes the row), but in the extended protocol RowDescription
-// is delivered by Describe, so Execute must omit Fields unless a Describe('P')
-// was folded into it.
-func (g *GatewayShowVersion) versionResult(withFields bool) *sqltypes.Result {
+// result builds the single-row result. withFields controls whether the column
+// metadata is attached: the simple protocol always needs it (one RowDescription
+// precedes the row), but in the extended protocol RowDescription is delivered by
+// Describe, so Execute must omit Fields unless a Describe('P') was folded into it.
+func (g *GatewayShowVersion) result(withFields bool) *sqltypes.Result {
 	result := &sqltypes.Result{
 		Rows: []*sqltypes.Row{
-			sqltypes.MakeRow([][]byte{[]byte(servenv.AppVersion())}),
+			sqltypes.MakeRow([][]byte{[]byte(servenv.Version())}),
 		},
 		CommandTag: "SHOW",
 	}
 	if withFields {
-		result.Fields = []*query.Field{multigresVersionField()}
+		result.Fields = []*query.Field{textField(constants.MultigresVersionVariable)}
 	}
 	return result
 }
 
-// StreamExecute returns the version string as a single-row result, matching
-// PostgreSQL's SHOW output format (one text column named after the variable).
+// StreamExecute returns the version as a single-row result (simple protocol).
 func (g *GatewayShowVersion) StreamExecute(
 	ctx context.Context,
 	_ IExecute,
@@ -106,14 +87,14 @@ func (g *GatewayShowVersion) StreamExecute(
 	_ PlanExecInfo,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	return callback(ctx, g.versionResult(true))
+	return callback(ctx, g.result(true))
 }
 
-// PortalStreamExecute serves the extended-protocol path. SHOW multigres_version
-// carries no parameter binds, so it just emits the row. It attaches column
-// metadata only when includeDescribe is set (a folded Describe('P')); otherwise
-// the RowDescription was already sent by the separate Describe and emitting
-// Fields here would send an illegal second one mid-Execute.
+// PortalStreamExecute serves the extended-protocol path. SHOW carries no
+// parameter binds, so it just emits the row. It attaches column metadata only
+// when includeDescribe is set (a folded Describe('P')); otherwise the
+// RowDescription was already sent by the separate Describe and emitting Fields
+// here would send an illegal second one mid-Execute.
 func (g *GatewayShowVersion) PortalStreamExecute(
 	ctx context.Context,
 	_ IExecute,
@@ -125,7 +106,7 @@ func (g *GatewayShowVersion) PortalStreamExecute(
 	_ PlanExecInfo,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	return callback(ctx, g.versionResult(includeDescribe))
+	return callback(ctx, g.result(includeDescribe))
 }
 
 // GetTableGroup returns empty string as this primitive doesn't target a tablegroup.
@@ -145,3 +126,23 @@ func (g *GatewayShowVersion) String() string {
 
 // Ensure GatewayShowVersion implements Primitive interface.
 var _ Primitive = (*GatewayShowVersion)(nil)
+
+// IsMultigresVersionShow reports whether stmt is `SHOW multigres_version`, the
+// gateway-only pseudo-variable served locally. The name compares
+// case-insensitively, matching PostgreSQL's handling of unquoted (lowercased)
+// and quoted (case-preserving) identifiers.
+func IsMultigresVersionShow(stmt ast.Stmt) bool {
+	show, ok := stmt.(*ast.VariableShowStmt)
+	return ok && strings.ToLower(show.Name) == constants.MultigresVersionVariable
+}
+
+// MultigresVersionShowDescription is the extended-protocol Describe response for
+// `SHOW multigres_version`: no bind parameters, one text column. It lets the
+// gateway answer Describe locally, since postgres has no such GUC to describe.
+func MultigresVersionShowDescription() *query.StatementDescription {
+	return &query.StatementDescription{
+		Parameters: []*query.ParameterDescription{},
+		Fields:     []*query.Field{textField(constants.MultigresVersionVariable)},
+		HasFields:  true,
+	}
+}

--- a/go/services/multigateway/engine/gateway_show_version.go
+++ b/go/services/multigateway/engine/gateway_show_version.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/common/preparedstatement"
+	"github.com/multigres/multigres/go/common/servenv"
+	"github.com/multigres/multigres/go/common/sqltypes"
+	"github.com/multigres/multigres/go/pb/query"
+	"github.com/multigres/multigres/go/services/multigateway/handler"
+)
+
+// multigresVersionField is the single result column returned by
+// `SHOW multigres_version`. Both the executed result and the extended-protocol
+// Describe must present identical column metadata, so they share this builder.
+func multigresVersionField() *query.Field {
+	return &query.Field{
+		Name:        constants.MultigresVersionVariable,
+		Type:        "text",
+		DataTypeOid: uint32(ast.TEXTOID),
+	}
+}
+
+// IsMultigresVersionShow reports whether stmt is `SHOW multigres_version`, the
+// gateway-only pseudo-variable served locally by GatewayShowVersion. The name
+// compares case-insensitively, matching PostgreSQL's handling of unquoted
+// (lowercased) and quoted (case-preserving) identifiers.
+func IsMultigresVersionShow(stmt ast.Stmt) bool {
+	show, ok := stmt.(*ast.VariableShowStmt)
+	return ok && strings.ToLower(show.Name) == constants.MultigresVersionVariable
+}
+
+// MultigresVersionDescription is the extended-protocol Describe response for
+// `SHOW multigres_version`: no bind parameters and one text column. It lets the
+// gateway answer Describe locally, since postgres has no such GUC to describe
+// (forwarding would fail with "unrecognized configuration parameter").
+func MultigresVersionDescription() *query.StatementDescription {
+	return &query.StatementDescription{
+		Parameters: []*query.ParameterDescription{},
+		Fields:     []*query.Field{multigresVersionField()},
+		HasFields:  true,
+	}
+}
+
+// GatewayShowVersion handles `SHOW multigres_version`, returning the running
+// multigateway's build identity as a single-row result. Unlike
+// GatewayShowVariable it reads no per-connection state — the value is a
+// process-wide constant — so it answers without a PostgreSQL round-trip. This
+// lets a client discover which multigateway build it is connected to without
+// shell access to run `--version`.
+type GatewayShowVersion struct {
+	sql string // Original SQL for debugging
+}
+
+// NewGatewayShowVersion creates a primitive that returns the multigateway
+// version string.
+func NewGatewayShowVersion(sql string) *GatewayShowVersion {
+	return &GatewayShowVersion{sql: sql}
+}
+
+// versionResult builds the single-row SHOW result. withFields controls whether
+// the column metadata is attached: the simple protocol always needs it (one
+// RowDescription precedes the row), but in the extended protocol RowDescription
+// is delivered by Describe, so Execute must omit Fields unless a Describe('P')
+// was folded into it.
+func (g *GatewayShowVersion) versionResult(withFields bool) *sqltypes.Result {
+	result := &sqltypes.Result{
+		Rows: []*sqltypes.Row{
+			sqltypes.MakeRow([][]byte{[]byte(servenv.AppVersion())}),
+		},
+		CommandTag: "SHOW",
+	}
+	if withFields {
+		result.Fields = []*query.Field{multigresVersionField()}
+	}
+	return result
+}
+
+// StreamExecute returns the version string as a single-row result, matching
+// PostgreSQL's SHOW output format (one text column named after the variable).
+func (g *GatewayShowVersion) StreamExecute(
+	ctx context.Context,
+	_ IExecute,
+	_ *server.Conn,
+	_ *handler.MultigatewayConnectionState,
+	_ []*ast.A_Const,
+	_ PlanExecInfo,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	return callback(ctx, g.versionResult(true))
+}
+
+// PortalStreamExecute serves the extended-protocol path. SHOW multigres_version
+// carries no parameter binds, so it just emits the row. It attaches column
+// metadata only when includeDescribe is set (a folded Describe('P')); otherwise
+// the RowDescription was already sent by the separate Describe and emitting
+// Fields here would send an illegal second one mid-Execute.
+func (g *GatewayShowVersion) PortalStreamExecute(
+	ctx context.Context,
+	_ IExecute,
+	_ *server.Conn,
+	_ *handler.MultigatewayConnectionState,
+	_ *preparedstatement.PortalInfo,
+	_ int32,
+	includeDescribe bool,
+	_ PlanExecInfo,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	return callback(ctx, g.versionResult(includeDescribe))
+}
+
+// GetTableGroup returns empty string as this primitive doesn't target a tablegroup.
+func (g *GatewayShowVersion) GetTableGroup() string {
+	return ""
+}
+
+// GetQuery returns empty string as this primitive doesn't execute a query.
+func (g *GatewayShowVersion) GetQuery() string {
+	return ""
+}
+
+// String returns a description for logging/debugging.
+func (g *GatewayShowVersion) String() string {
+	return fmt.Sprintf("GatewayShowVersion(%s)", g.sql)
+}
+
+// Ensure GatewayShowVersion implements Primitive interface.
+var _ Primitive = (*GatewayShowVersion)(nil)

--- a/go/services/multigateway/engine/gateway_show_version_test.go
+++ b/go/services/multigateway/engine/gateway_show_version_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/sqltypes"
+)
+
+func collectResults(t *testing.T, run func(func(context.Context, *sqltypes.Result) error) error) []*sqltypes.Result {
+	t.Helper()
+	var results []*sqltypes.Result
+	err := run(func(_ context.Context, r *sqltypes.Result) error {
+		results = append(results, r)
+		return nil
+	})
+	require.NoError(t, err)
+	return results
+}
+
+// TestGatewayShowVersion_StreamExecute checks the simple-protocol result: a
+// single text column named multigres_version whose value identifies Multigres.
+func TestGatewayShowVersion_StreamExecute(t *testing.T) {
+	prim := NewGatewayShowVersion("SHOW multigres_version")
+
+	results := collectResults(t, func(cb func(context.Context, *sqltypes.Result) error) error {
+		return prim.StreamExecute(context.Background(), nil, nil, nil, nil, PlanExecInfo{}, cb)
+	})
+
+	require.Len(t, results, 1)
+	require.Len(t, results[0].Fields, 1)
+	assert.Equal(t, "multigres_version", results[0].Fields[0].Name)
+	assert.Equal(t, uint32(ast.TEXTOID), results[0].Fields[0].DataTypeOid)
+	assert.Equal(t, "SHOW", results[0].CommandTag)
+	require.Len(t, results[0].Rows, 1)
+	require.Len(t, results[0].Rows[0].Values, 1)
+	assert.Contains(t, string(results[0].Rows[0].Values[0]), "Multigres")
+}
+
+// TestGatewayShowVersion_PortalStreamExecute pins the extended-protocol contract:
+// RowDescription is delivered by Describe, so Execute must attach Fields only
+// when a Describe('P') was folded into it (includeDescribe). Attaching Fields
+// otherwise would emit an illegal second RowDescription mid-Execute.
+func TestGatewayShowVersion_PortalStreamExecute(t *testing.T) {
+	prim := NewGatewayShowVersion("SHOW multigres_version")
+
+	run := func(includeDescribe bool) *sqltypes.Result {
+		results := collectResults(t, func(cb func(context.Context, *sqltypes.Result) error) error {
+			return prim.PortalStreamExecute(context.Background(), nil, nil, nil, nil, 0, includeDescribe, PlanExecInfo{}, cb)
+		})
+		require.Len(t, results, 1)
+		return results[0]
+	}
+
+	t.Run("without folded describe omits fields", func(t *testing.T) {
+		res := run(false)
+		assert.Nil(t, res.Fields, "Execute must not carry Fields when RowDescription came from a separate Describe")
+		require.Len(t, res.Rows, 1)
+		assert.Contains(t, string(res.Rows[0].Values[0]), "Multigres")
+	})
+
+	t.Run("with folded describe carries fields", func(t *testing.T) {
+		res := run(true)
+		require.Len(t, res.Fields, 1)
+		assert.Equal(t, "multigres_version", res.Fields[0].Name)
+		require.Len(t, res.Rows, 1)
+	})
+}
+
+// TestIsMultigresVersionShow covers the statement matcher used by both the
+// planner (routing) and the executor (Describe interception).
+func TestIsMultigresVersionShow(t *testing.T) {
+	assert.True(t, IsMultigresVersionShow(&ast.VariableShowStmt{Name: "multigres_version"}))
+	// Quoted identifiers preserve case; the matcher lowercases.
+	assert.True(t, IsMultigresVersionShow(&ast.VariableShowStmt{Name: "Multigres_Version"}))
+	assert.False(t, IsMultigresVersionShow(&ast.VariableShowStmt{Name: "statement_timeout"}))
+	assert.False(t, IsMultigresVersionShow(&ast.SelectStmt{}))
+	assert.False(t, IsMultigresVersionShow(nil))
+}
+
+// TestMultigresVersionDescription verifies the synthetic Describe response:
+// no bind parameters and a single text column, so the extended-protocol
+// Describe can be answered without a backend round-trip.
+func TestMultigresVersionDescription(t *testing.T) {
+	desc := MultigresVersionDescription()
+	assert.Empty(t, desc.Parameters, "SHOW takes no bind parameters")
+	require.NotNil(t, desc.Parameters, "Parameters must be a non-nil empty slice for Describe('S')")
+	require.Len(t, desc.Fields, 1)
+	assert.Equal(t, "multigres_version", desc.Fields[0].Name)
+	assert.Equal(t, uint32(ast.TEXTOID), desc.Fields[0].DataTypeOid)
+	assert.True(t, desc.HasFields)
+}

--- a/go/services/multigateway/engine/gateway_show_version_test.go
+++ b/go/services/multigateway/engine/gateway_show_version_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/servenv"
 	"github.com/multigres/multigres/go/common/sqltypes"
 )
 
@@ -36,8 +37,8 @@ func collectResults(t *testing.T, run func(func(context.Context, *sqltypes.Resul
 	return results
 }
 
-// TestGatewayShowVersion_StreamExecute checks the simple-protocol result: a
-// single text column named multigres_version whose value identifies Multigres.
+// TestGatewayShowVersion_StreamExecute checks the GUC surface: a single text
+// column named multigres_version carrying the short release version.
 func TestGatewayShowVersion_StreamExecute(t *testing.T) {
 	prim := NewGatewayShowVersion("SHOW multigres_version")
 
@@ -52,7 +53,7 @@ func TestGatewayShowVersion_StreamExecute(t *testing.T) {
 	assert.Equal(t, "SHOW", results[0].CommandTag)
 	require.Len(t, results[0].Rows, 1)
 	require.Len(t, results[0].Rows[0].Values, 1)
-	assert.Contains(t, string(results[0].Rows[0].Values[0]), "Multigres")
+	assert.Equal(t, servenv.Version(), string(results[0].Rows[0].Values[0]))
 }
 
 // TestGatewayShowVersion_PortalStreamExecute pins the extended-protocol contract:
@@ -74,7 +75,6 @@ func TestGatewayShowVersion_PortalStreamExecute(t *testing.T) {
 		res := run(false)
 		assert.Nil(t, res.Fields, "Execute must not carry Fields when RowDescription came from a separate Describe")
 		require.Len(t, res.Rows, 1)
-		assert.Contains(t, string(res.Rows[0].Values[0]), "Multigres")
 	})
 
 	t.Run("with folded describe carries fields", func(t *testing.T) {
@@ -85,24 +85,22 @@ func TestGatewayShowVersion_PortalStreamExecute(t *testing.T) {
 	})
 }
 
-// TestIsMultigresVersionShow covers the statement matcher used by both the
-// planner (routing) and the executor (Describe interception).
+// TestIsMultigresVersionShow covers the SHOW matcher.
 func TestIsMultigresVersionShow(t *testing.T) {
 	assert.True(t, IsMultigresVersionShow(&ast.VariableShowStmt{Name: "multigres_version"}))
-	// Quoted identifiers preserve case; the matcher lowercases.
 	assert.True(t, IsMultigresVersionShow(&ast.VariableShowStmt{Name: "Multigres_Version"}))
 	assert.False(t, IsMultigresVersionShow(&ast.VariableShowStmt{Name: "statement_timeout"}))
 	assert.False(t, IsMultigresVersionShow(&ast.SelectStmt{}))
 	assert.False(t, IsMultigresVersionShow(nil))
 }
 
-// TestMultigresVersionDescription verifies the synthetic Describe response:
-// no bind parameters and a single text column, so the extended-protocol
-// Describe can be answered without a backend round-trip.
-func TestMultigresVersionDescription(t *testing.T) {
-	desc := MultigresVersionDescription()
+// TestMultigresVersionShowDescription verifies the synthetic Describe response:
+// no bind parameters and a single text column, so the extended-protocol Describe
+// can be answered without a backend round-trip.
+func TestMultigresVersionShowDescription(t *testing.T) {
+	desc := MultigresVersionShowDescription()
+	require.NotNil(t, desc.Parameters)
 	assert.Empty(t, desc.Parameters, "SHOW takes no bind parameters")
-	require.NotNil(t, desc.Parameters, "Parameters must be a non-nil empty slice for Describe('S')")
 	require.Len(t, desc.Fields, 1)
 	assert.Equal(t, "multigres_version", desc.Fields[0].Name)
 	assert.Equal(t, uint32(ast.TEXTOID), desc.Fields[0].DataTypeOid)

--- a/go/services/multigateway/executor/executor.go
+++ b/go/services/multigateway/executor/executor.go
@@ -336,12 +336,35 @@ func (e *Executor) Describe(
 		"database", conn.Database(),
 		"connection_id", conn.ConnectionID())
 
+	// SHOW multigres_version is a gateway-only pseudo-variable with no backing
+	// postgres GUC. Answer Describe locally rather than forwarding it, which the
+	// backend would reject as an unrecognized configuration parameter. Execute
+	// is already served locally via the planner (planVariableShowStmt).
+	if stmt := describeAST(portalInfo, preparedStatementInfo); stmt != nil && engine.IsMultigresVersionShow(stmt) {
+		return engine.MultigresVersionDescription(), nil
+	}
+
 	// TODO: We will need to plan the query to find whether it can
 	// be served by a single shard or not. For now, since we only
 	// support unsharded, we don't have to do much.
 	// We just send the query to the default table group.
 
 	return e.exec.Describe(ctx, e.planner.GetDefaultTableGroup(), constants.DefaultShard, conn, state, portalInfo, preparedStatementInfo)
+}
+
+// describeAST returns the parsed statement being described, from whichever of
+// the portal or prepared-statement info the caller supplied (exactly one is
+// non-nil: portal for Describe('P'), statement for Describe('S')). Returns nil
+// when neither carries an AST (e.g. an empty statement).
+func describeAST(portalInfo *preparedstatement.PortalInfo, preparedStatementInfo *preparedstatement.PreparedStatementInfo) ast.Stmt {
+	switch {
+	case portalInfo != nil:
+		return portalInfo.AstStmt()
+	case preparedStatementInfo != nil:
+		return preparedStatementInfo.AstStmt()
+	default:
+		return nil
+	}
 }
 
 // ReleaseAll releases all reserved connections, regardless of reservation reason.

--- a/go/services/multigateway/executor/executor.go
+++ b/go/services/multigateway/executor/executor.go
@@ -341,7 +341,7 @@ func (e *Executor) Describe(
 	// backend would reject as an unrecognized configuration parameter. Execute
 	// is already served locally via the planner (planVariableShowStmt).
 	if stmt := describeAST(portalInfo, preparedStatementInfo); stmt != nil && engine.IsMultigresVersionShow(stmt) {
-		return engine.MultigresVersionDescription(), nil
+		return engine.MultigresVersionShowDescription(), nil
 	}
 
 	// TODO: We will need to plan the query to find whether it can

--- a/go/services/multigateway/handler/gateway_functions.go
+++ b/go/services/multigateway/handler/gateway_functions.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"strings"
+
+	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/common/parser"
+	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/servenv"
+)
+
+// Gateway-provided SQL functions have no backend implementation, so the gateway
+// folds them into constants before the query reaches PostgreSQL. Currently only
+// `multigres.version()`, folded to a text literal of the version — which means it
+// works in ANY expression position (target list, WHERE, function argument, ...)
+// in both the simple and extended protocols, unlike a standalone-only
+// interception.
+//
+// Folding happens once the query is parsed, so every downstream consumer — the
+// planner, the plan cache, and the extended protocol's Describe/Execute, which
+// reuse the stored statement text — sees the same already-substituted query.
+// Callers that already hold the parse (the simple-query path) fold the
+// statements directly; the extended-protocol Parse path, which only has a
+// string, uses foldGatewayFunctions.
+
+// containsGatewayFunction is a cheap pre-check: the only gateway function lives
+// in the `multigres` schema, so a query that never names it can't contain one.
+// It lets callers skip the AST walk (and, for foldGatewayFunctions, the parse)
+// for the overwhelming majority of queries.
+func containsGatewayFunction(sql string) bool {
+	return strings.Contains(strings.ToLower(sql), constants.MultigresSchema)
+}
+
+// foldGatewayFunctionsInStatements folds gateway functions in the already-parsed
+// statements, returning whether anything changed. Used by the simple-query path
+// to fold without re-parsing. Callers should gate on containsGatewayFunction to
+// skip the walk when no gateway function can be present.
+func foldGatewayFunctionsInStatements(stmts []ast.Stmt) bool {
+	version := servenv.AppVersion()
+	changed := false
+	for _, stmt := range stmts {
+		if foldMultigresVersion(stmt, version) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+// foldGatewayFunctions folds gateway functions in a raw SQL string, returning the
+// rewritten SQL (or the input unchanged). Used where only the string is
+// available — the extended-protocol Parse path. It returns sql unchanged when it
+// contains no gateway function (detected before any parse) or does not parse (the
+// normal path then reports the syntax error with the correct position).
+func foldGatewayFunctions(sql string) string {
+	if !containsGatewayFunction(sql) {
+		return sql
+	}
+	stmts, err := parser.ParseSQL(sql)
+	if err != nil || len(stmts) == 0 {
+		return sql
+	}
+	if !foldGatewayFunctionsInStatements(stmts) {
+		return sql
+	}
+	return renderStatements(stmts)
+}
+
+// renderStatements re-renders parsed statements back to a single SQL string,
+// joining a multi-statement batch with "; " as PostgreSQL's simple protocol does.
+func renderStatements(stmts []ast.Stmt) string {
+	parts := make([]string, len(stmts))
+	for i, stmt := range stmts {
+		parts[i] = stmt.SqlString()
+	}
+	return strings.Join(parts, "; ")
+}
+
+// foldMultigresVersion replaces every `multigres.version()` call in stmt with a
+// text literal of version, returning whether it changed anything. When the call
+// is a bare top-level target with no alias it also sets the column label to
+// `version`, so the result matches what a real `version()` would be labelled
+// (a bare literal would otherwise be labelled `?column?`).
+func foldMultigresVersion(stmt ast.Stmt, version string) bool {
+	changed := false
+	ast.Rewrite(stmt, func(cursor *ast.Cursor) bool {
+		switch n := cursor.Node().(type) {
+		case *ast.ResTarget:
+			if fc, ok := n.Val.(*ast.FuncCall); ok && isMultigresVersionFunc(fc) {
+				if n.Name == "" {
+					n.Name = constants.MultigresVersionFunction
+				}
+				n.Val = ast.NewA_Const(ast.NewString(version), 0)
+				changed = true
+				return false
+			}
+		case *ast.FuncCall:
+			if isMultigresVersionFunc(n) {
+				cursor.Replace(ast.NewA_Const(ast.NewString(version), 0))
+				changed = true
+				return false
+			}
+		}
+		return true
+	}, nil)
+	return changed
+}
+
+// isMultigresVersionFunc reports whether fc is a zero-argument, schema-qualified
+// `multigres.version()` call (case-insensitive). The `multigres` schema
+// qualification is required so a bare `version()` still routes to PostgreSQL and
+// reports the backend version.
+func isMultigresVersionFunc(fc *ast.FuncCall) bool {
+	if fc == nil || (fc.Args != nil && fc.Args.Len() > 0) {
+		return false
+	}
+	fn := fc.Funcname
+	if fn == nil || fn.Len() != 2 {
+		return false
+	}
+	return funcNamePart(fn.Items[0]) == constants.MultigresSchema &&
+		funcNamePart(fn.Items[1]) == constants.MultigresVersionFunction
+}
+
+// funcNamePart returns the lowercased value if n is a *ast.String, else "".
+func funcNamePart(n ast.Node) string {
+	s, ok := n.(*ast.String)
+	if !ok {
+		return ""
+	}
+	return strings.ToLower(s.SVal)
+}

--- a/go/services/multigateway/handler/gateway_functions_test.go
+++ b/go/services/multigateway/handler/gateway_functions_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/parser"
+)
+
+// foldOne parses sql, folds multigres.version() with the given version, and
+// returns the re-rendered SQL — the transform foldGatewayFunctions applies.
+func foldOne(t *testing.T, sql, version string) string {
+	t.Helper()
+	stmts, err := parser.ParseSQL(sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	foldMultigresVersion(stmts[0], version)
+	return stmts[0].SqlString()
+}
+
+// TestFoldMultigresVersion covers folding multigres.version() into a literal
+// across the expression positions users can write it in.
+func TestFoldMultigresVersion(t *testing.T) {
+	const v = "Multigres 0.1.0-SNAPSHOT"
+
+	tests := []struct {
+		name string
+		sql  string
+		// wantContains are substrings the folded SQL must contain.
+		wantContains []string
+		// wantAbsent are substrings the folded SQL must NOT contain.
+		wantAbsent []string
+	}{
+		{
+			name:         "bare target gets version label",
+			sql:          "SELECT multigres.version()",
+			wantContains: []string{"'Multigres 0.1.0-SNAPSHOT'", "AS version"},
+			wantAbsent:   []string{"multigres.version"},
+		},
+		{
+			name:         "explicit alias preserved",
+			sql:          "SELECT multigres.version() AS v",
+			wantContains: []string{"'Multigres 0.1.0-SNAPSHOT'", "AS v"},
+			wantAbsent:   []string{"multigres.version", "AS version"},
+		},
+		{
+			name:         "in WHERE clause",
+			sql:          "SELECT id FROM t WHERE created_by = multigres.version()",
+			wantContains: []string{"'Multigres 0.1.0-SNAPSHOT'", "FROM t", "WHERE"},
+			wantAbsent:   []string{"multigres.version"},
+		},
+		{
+			name:         "mixed with a real column",
+			sql:          "SELECT multigres.version(), id FROM t",
+			wantContains: []string{"'Multigres 0.1.0-SNAPSHOT'", "AS version", "id", "FROM t"},
+			wantAbsent:   []string{"multigres.version"},
+		},
+		{
+			name:         "case-insensitive",
+			sql:          "SELECT MULTIGRES.VERSION()",
+			wantContains: []string{"'Multigres 0.1.0-SNAPSHOT'"},
+			wantAbsent:   []string{"MULTIGRES.VERSION", "multigres.version"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := foldOne(t, tt.sql, v)
+			for _, sub := range tt.wantContains {
+				assert.Contains(t, got, sub, "folded: %s", got)
+			}
+			for _, sub := range tt.wantAbsent {
+				assert.NotContains(t, got, sub, "folded: %s", got)
+			}
+		})
+	}
+}
+
+// TestFoldMultigresVersion_NotFolded checks the cases that must route to
+// PostgreSQL untouched.
+func TestFoldMultigresVersion_NotFolded(t *testing.T) {
+	const v = "Multigres 0.1.0-SNAPSHOT"
+
+	for _, sql := range []string{
+		"SELECT version()",            // bare version() → PostgreSQL's own
+		"SELECT pg_catalog.version()", // pg_catalog qualified → PostgreSQL's own
+		"SELECT multigres.version(1)", // args → not our niladic function
+		"SELECT other.version()",      // wrong schema
+		"SELECT multigres.other()",    // wrong function
+	} {
+		t.Run(sql, func(t *testing.T) {
+			stmts, err := parser.ParseSQL(sql)
+			require.NoError(t, err)
+			changed := foldMultigresVersion(stmts[0], v)
+			assert.False(t, changed, "should not fold %q", sql)
+		})
+	}
+}
+
+// TestFoldGatewayFunctionsInStatements covers the parsed-statement entry point
+// used by the simple-query path (which reuses its parse rather than re-parsing).
+func TestFoldGatewayFunctionsInStatements(t *testing.T) {
+	t.Run("folds and reports change", func(t *testing.T) {
+		stmts, err := parser.ParseSQL("SELECT multigres.version(); SELECT 1")
+		require.NoError(t, err)
+		require.Len(t, stmts, 2)
+
+		assert.True(t, foldGatewayFunctionsInStatements(stmts))
+		assert.NotContains(t, renderStatements(stmts), "multigres.version")
+	})
+
+	t.Run("no change when absent", func(t *testing.T) {
+		stmts, err := parser.ParseSQL("SELECT 1; SELECT version()")
+		require.NoError(t, err)
+		assert.False(t, foldGatewayFunctionsInStatements(stmts))
+	})
+}
+
+// TestFoldGatewayFunctions covers the string-level entry point, including the
+// cheap substring gate and its pass-through behaviour.
+func TestFoldGatewayFunctions(t *testing.T) {
+	t.Run("query without the schema is returned unchanged (no parse)", func(t *testing.T) {
+		sql := "SELECT id FROM t WHERE name = 'x'"
+		assert.Equal(t, sql, foldGatewayFunctions(sql))
+	})
+
+	t.Run("unparseable input is returned unchanged", func(t *testing.T) {
+		sql := "SELECT multigres.version() FROM" // trailing FROM → syntax error
+		assert.Equal(t, sql, foldGatewayFunctions(sql))
+	})
+
+	t.Run("folds the real function", func(t *testing.T) {
+		got := foldGatewayFunctions("SELECT multigres.version()")
+		assert.NotContains(t, got, "multigres.version")
+		assert.Contains(t, got, "AS version")
+	})
+}

--- a/go/services/multigateway/handler/gateway_functions_test.go
+++ b/go/services/multigateway/handler/gateway_functions_test.go
@@ -140,7 +140,7 @@ func TestFoldGatewayFunctions(t *testing.T) {
 		assert.Equal(t, sql, foldGatewayFunctions(sql))
 	})
 
-	t.Run("unparseable input is returned unchanged", func(t *testing.T) {
+	t.Run("unparsable input is returned unchanged", func(t *testing.T) {
 		sql := "SELECT multigres.version() FROM" // trailing FROM → syntax error
 		assert.Equal(t, sql, foldGatewayFunctions(sql))
 	})

--- a/go/services/multigateway/handler/handler.go
+++ b/go/services/multigateway/handler/handler.go
@@ -244,6 +244,15 @@ func (h *MultigatewayHandler) HandleQuery(ctx context.Context, conn *server.Conn
 		return callback(ctx, nil)
 	}
 
+	// Fold gateway-provided functions (e.g. multigres.version()) into constants
+	// in the statements we just parsed — reusing the parse rather than re-parsing.
+	// The batch execution paths re-render each statement via SqlString, so the
+	// rewritten AST flows through; only the single-statement path below sends
+	// queryStr, so refresh it from the rewritten AST when a fold happened.
+	if containsGatewayFunction(queryStr) && foldGatewayFunctionsInStatements(asts) {
+		queryStr = renderStatements(asts)
+	}
+
 	// TODO: For multi-statement batches, this only captures the first statement's
 	// operation name. Consider recording per-statement metrics or using "MULTI" as
 	// the operation name when len(asts) > 1.
@@ -417,6 +426,12 @@ func (h *MultigatewayHandler) getConnectionState(conn *server.Conn) *Multigatewa
 // Creates and stores a prepared statement.
 func (h *MultigatewayHandler) HandleParse(ctx context.Context, conn *server.Conn, name, queryStr string, paramTypes []uint32) error {
 	h.logger.DebugContext(ctx, "parse", "name", name, "query", queryStr, "param_count", len(paramTypes))
+
+	// Fold gateway-provided functions (e.g. multigres.version()) into constants
+	// before storing the prepared statement, so the folded text is what Describe
+	// and Execute later forward to the backend. A no-op for queries that don't
+	// use one.
+	queryStr = foldGatewayFunctions(queryStr)
 
 	// An empty or comment-only query string parses to zero statements;
 	// AddPreparedStatement produces an empty PreparedStatementInfo for it, which

--- a/go/services/multigateway/planner/variable_show_stmt.go
+++ b/go/services/multigateway/planner/variable_show_stmt.go
@@ -17,6 +17,7 @@ package planner
 import (
 	"strings"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/services/multigateway/engine"
@@ -37,6 +38,16 @@ func (p *Planner) planVariableShowStmt(
 	// the executor's case-sensitive switch from missing it (which would panic)
 	// and matches the column label PostgreSQL returns.
 	name := strings.ToLower(stmt.Name)
+
+	// multigres_version is a gateway-only pseudo-variable that reports the
+	// multigateway build identity. It has no backing PostgreSQL GUC, so answer
+	// it here rather than falling through to planDefault (which postgres would
+	// reject as an unrecognized configuration parameter).
+	if name == constants.MultigresVersionVariable {
+		p.logger.Debug("planning SHOW multigres_version")
+		return engine.NewPlan(sql, engine.NewGatewayShowVersion(sql)), nil
+	}
+
 	if !isGatewayManagedVariable(name) {
 		return p.planDefault(sql, stmt, conn, PlanOptions{})
 	}

--- a/go/services/multigateway/planner/variable_show_stmt_test.go
+++ b/go/services/multigateway/planner/variable_show_stmt_test.go
@@ -69,3 +69,43 @@ func TestPlanVariableShowStmt_QuotedGatewayManagedName(t *testing.T) {
 	assert.Equal(t, "statement_timeout", results[0].Fields[0].Name)
 	require.Len(t, results[0].Rows, 1)
 }
+
+// TestPlanVariableShowStmt_MultigresVersion verifies that SHOW multigres_version
+// is handled locally by the gateway (never routed to a backend) and produces a
+// single-row result whose column is labelled multigres_version.
+func TestPlanVariableShowStmt_MultigresVersion(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	p := NewPlanner("default", logger, nil)
+	testConn := server.NewTestConn(&bytes.Buffer{})
+
+	// The parser lowercases unquoted identifiers; assert the executor also
+	// matches a case-preserving quoted spelling.
+	for _, name := range []string{"multigres_version", "Multigres_Version"} {
+		t.Run(name, func(t *testing.T) {
+			stmt := &ast.VariableShowStmt{Name: name}
+
+			plan, err := p.planVariableShowStmt("SHOW "+name, stmt, testConn.Conn)
+			require.NoError(t, err)
+			require.NotNil(t, plan)
+
+			prim, ok := plan.Primitive.(*engine.GatewayShowVersion)
+			require.True(t, ok, "expected GatewayShowVersion primitive, got %T", plan.Primitive)
+
+			var results []*sqltypes.Result
+			err = prim.StreamExecute(context.Background(), nil, testConn.Conn, &handler.MultigatewayConnectionState{}, nil, engine.PlanExecInfo{},
+				func(_ context.Context, r *sqltypes.Result) error {
+					results = append(results, r)
+					return nil
+				})
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			require.Len(t, results[0].Fields, 1)
+			assert.Equal(t, "multigres_version", results[0].Fields[0].Name)
+			require.Len(t, results[0].Rows, 1)
+			// The value is the running binary's version string, which always
+			// starts with "Multigres".
+			require.Len(t, results[0].Rows[0].Values, 1)
+			assert.Contains(t, string(results[0].Rows[0].Values[0]), "Multigres")
+		})
+	}
+}

--- a/go/services/multigateway/planner/variable_show_stmt_test.go
+++ b/go/services/multigateway/planner/variable_show_stmt_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/common/servenv"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/services/multigateway/engine"
 	"github.com/multigres/multigres/go/services/multigateway/handler"
@@ -102,10 +103,9 @@ func TestPlanVariableShowStmt_MultigresVersion(t *testing.T) {
 			require.Len(t, results[0].Fields, 1)
 			assert.Equal(t, "multigres_version", results[0].Fields[0].Name)
 			require.Len(t, results[0].Rows, 1)
-			// The value is the running binary's version string, which always
-			// starts with "Multigres".
 			require.Len(t, results[0].Rows[0].Values, 1)
-			assert.Contains(t, string(results[0].Rows[0].Values[0]), "Multigres")
+			// The GUC returns the short release version.
+			assert.Equal(t, servenv.Version(), string(results[0].Rows[0].Values[0]))
 		})
 	}
 }

--- a/go/test/endtoend/queryserving/multigres_version_test.go
+++ b/go/test/endtoend/queryserving/multigres_version_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq" // PostgreSQL driver
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestMultigateway_ShowMultigresVersion verifies that `SHOW multigres_version`
+// is answered locally by the multigateway (postgres has no such GUC) and
+// returns the gateway's build identity over the wire in both the simple and
+// extended query protocols.
+func TestMultigateway_ShowMultigresVersion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping multigres_version test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping multigres_version test")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err, "failed to open database connection")
+	defer db.Close()
+
+	ctx := utils.WithTimeout(t, 30*time.Second)
+	require.NoError(t, db.PingContext(ctx), "failed to ping database - multigateway may not be ready")
+
+	// Simple query protocol.
+	t.Run("simple protocol", func(t *testing.T) {
+		var version string
+		err := db.QueryRowContext(ctx, "SHOW multigres_version").Scan(&version)
+		require.NoError(t, err, "failed to execute SHOW multigres_version")
+		assert.Contains(t, version, "Multigres", "version string should identify Multigres, got %q", version)
+	})
+
+	// Extended query protocol: a prepared statement drives Parse/Bind/Execute,
+	// exercising the primitive's PortalStreamExecute path.
+	t.Run("extended protocol", func(t *testing.T) {
+		stmt, err := db.PrepareContext(ctx, "SHOW multigres_version")
+		require.NoError(t, err, "failed to prepare SHOW multigres_version")
+		defer stmt.Close()
+
+		var version string
+		err = stmt.QueryRowContext(ctx).Scan(&version)
+		require.NoError(t, err, "failed to execute prepared SHOW multigres_version")
+		assert.Contains(t, version, "Multigres", "version string should identify Multigres, got %q", version)
+	})
+}

--- a/go/test/endtoend/queryserving/multigres_version_test.go
+++ b/go/test/endtoend/queryserving/multigres_version_test.go
@@ -16,6 +16,7 @@ package queryserving
 
 import (
 	"database/sql"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,11 +28,14 @@ import (
 	"github.com/multigres/multigres/go/test/utils"
 )
 
-// TestMultigateway_ShowMultigresVersion verifies that `SHOW multigres_version`
-// is answered locally by the multigateway (postgres has no such GUC) and
-// returns the gateway's build identity over the wire in both the simple and
-// extended query protocols.
-func TestMultigateway_ShowMultigresVersion(t *testing.T) {
+// TestMultigateway_MultigresVersion verifies both version surfaces:
+//
+//   - SHOW multigres_version   → short release version (like server_version),
+//     answered locally by the gateway.
+//   - SELECT multigres.version() → full build string (like version()), folded to
+//     a literal before it reaches PostgreSQL, so it works in any expression
+//     position and in both the simple and extended query protocols.
+func TestMultigateway_MultigresVersion(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping multigres_version test in short mode")
 	}
@@ -50,24 +54,54 @@ func TestMultigateway_ShowMultigresVersion(t *testing.T) {
 	ctx := utils.WithTimeout(t, 30*time.Second)
 	require.NoError(t, db.PingContext(ctx), "failed to ping database - multigateway may not be ready")
 
-	// Simple query protocol.
-	t.Run("simple protocol", func(t *testing.T) {
-		var version string
-		err := db.QueryRowContext(ctx, "SHOW multigres_version").Scan(&version)
-		require.NoError(t, err, "failed to execute SHOW multigres_version")
-		assert.Contains(t, version, "Multigres", "version string should identify Multigres, got %q", version)
+	// simpleQuery runs sql via the simple query protocol; preparedQuery runs it
+	// via the extended protocol (Parse/Bind/Execute).
+	simpleQuery := func(t *testing.T, sql string) string {
+		t.Helper()
+		var out string
+		require.NoError(t, db.QueryRowContext(ctx, sql).Scan(&out), "simple query %q failed", sql)
+		return out
+	}
+	preparedQuery := func(t *testing.T, sql string) string {
+		t.Helper()
+		stmt, err := db.PrepareContext(ctx, sql)
+		require.NoError(t, err, "failed to prepare %q", sql)
+		defer stmt.Close()
+		var out string
+		require.NoError(t, stmt.QueryRowContext(ctx).Scan(&out), "prepared query %q failed", sql)
+		return out
+	}
+	bothProtocols := map[string]func(*testing.T, string) string{"simple": simpleQuery, "extended": preparedQuery}
+
+	t.Run("SHOW multigres_version returns the short version", func(t *testing.T) {
+		for _, run := range bothProtocols {
+			version := run(t, "SHOW multigres_version")
+			assert.NotEmpty(t, version, "version should not be empty")
+			assert.NotContains(t, version, "built with", "SHOW should return the short version, got %q", version)
+		}
 	})
 
-	// Extended query protocol: a prepared statement drives Parse/Bind/Execute,
-	// exercising the primitive's PortalStreamExecute path.
-	t.Run("extended protocol", func(t *testing.T) {
-		stmt, err := db.PrepareContext(ctx, "SHOW multigres_version")
-		require.NoError(t, err, "failed to prepare SHOW multigres_version")
-		defer stmt.Close()
+	t.Run("SELECT multigres.version() returns the full build string", func(t *testing.T) {
+		for _, run := range bothProtocols {
+			version := run(t, "SELECT multigres.version()")
+			assert.Contains(t, version, "Multigres", "function should return the full build string, got %q", version)
+		}
+	})
 
-		var version string
-		err = stmt.QueryRowContext(ctx).Scan(&version)
-		require.NoError(t, err, "failed to execute prepared SHOW multigres_version")
-		assert.Contains(t, version, "Multigres", "version string should identify Multigres, got %q", version)
+	// The function is folded to a literal before reaching PostgreSQL, so it works
+	// inside a larger expression that PostgreSQL then evaluates — proving it is
+	// not limited to a standalone target.
+	t.Run("multigres.version() works inside an expression", func(t *testing.T) {
+		for _, run := range bothProtocols {
+			out := run(t, "SELECT length(multigres.version()) > 0")
+			assert.Equal(t, "true", out, "expected the folded literal to be evaluated by PostgreSQL")
+		}
+	})
+
+	// A bare version() must still route to PostgreSQL and report the backend
+	// version — the gateway function is namespaced so it does not shadow this.
+	t.Run("bare version() still reports PostgreSQL", func(t *testing.T) {
+		version := simpleQuery(t, "SELECT version()")
+		assert.True(t, strings.Contains(version, "PostgreSQL"), "bare version() should report PostgreSQL, got %q", version)
 	})
 }


### PR DESCRIPTION
## Summary

- Adds a `SHOW multigres_version` SQL command so a client connected to multigateway can read the running build's version without shell access to run `--version` — handy for bug reports.
- The gateway answers it locally and never forwards it to postgres, in both the simple and extended (prepared-statement) query protocols.
- The version string is derived from the existing build snapshot in `servenv` (VCS revision, modified flag, commit date, Go version); no new source of truth is introduced.

## Description

`SHOW multigres_version` mirrors `SHOW server_version` and is intercepted in the existing `planVariableShowStmt` path, so it reuses the gateway's synthetic-result machinery. It is intentionally **not** added to the `gatewayManagedVariables` registry, which mandates SET/RESET semantics that don't fit a read-only value.

The extended protocol needed two extra touches beyond the simple path:

- **Describe** forwards straight to the backend with no planning, and postgres has no `multigres_version` GUC to describe — so `executor.Describe` now answers it locally with a synthetic `StatementDescription` (empty parameters, one text column).
- **Execute** must not re-send `RowDescription`: the wire callback emits it whenever `result.Fields` is set, so `PortalStreamExecute` attaches column metadata only when a `Describe('P')` was folded into the Execute (`includeDescribe`). Otherwise it would send an illegal second `RowDescription` mid-Execute.

A new exported `servenv.AppVersion()` formats the build snapshot, with a `version` seam reserved for a future ldflags-stamped release tag.

Covered by unit tests (servenv formatting, the primitive's protocol contract, planner routing) and an end-to-end test exercising both protocols against a real cluster.

Note: `MultigresVersionVariable` lives in `go/common/constants`. In a linked git worktree Go does not stamp VCS info, so local worktree dev builds show `(unknown revision)`; normal checkouts and CI stamp correctly — this affects the whole existing version stack, not just this command.