### PR TITLE
feat(scram): negotiate SCRAM channel binding to postgres

### DIFF
--- a/go/common/pgprotocol/client/channel_binding_test.go
+++ b/go/common/pgprotocol/client/channel_binding_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+	"github.com/multigres/multigres/go/common/pgprotocol/scram"
+)
+
+func TestParseChannelBinding(t *testing.T) {
+	cases := map[string]struct {
+		want    ChannelBindingMode
+		wantErr bool
+	}{
+		"":         {ChannelBindingPrefer, false}, // libpq default
+		"prefer":   {ChannelBindingPrefer, false},
+		"disable":  {ChannelBindingDisable, false},
+		"require":  {ChannelBindingRequire, false},
+		"PREFER":   {ChannelBindingPrefer, false}, // case-insensitive
+		"  prefer": {ChannelBindingPrefer, false}, // trimmed
+		"bogus":    {"", true},
+	}
+	for in, want := range cases {
+		got, err := ParseChannelBinding(in)
+		if want.wantErr {
+			assert.Error(t, err, "input %q", in)
+			continue
+		}
+		require.NoError(t, err, "input %q", in)
+		assert.Equal(t, want.want, got, "input %q", in)
+	}
+}
+
+func TestDecideChannelBinding(t *testing.T) {
+	const (
+		overTLS   = true
+		plaintext = false
+	)
+	plusAndPlain := []string{scram.ScramSHA256PlusMechanism, scram.ScramSHA256Mechanism}
+	plainOnly := []string{scram.ScramSHA256Mechanism}
+	plusOnly := []string{scram.ScramSHA256PlusMechanism}
+
+	tests := []struct {
+		name       string
+		mode       ChannelBindingMode
+		isTLS      bool
+		mechanisms []string
+		wantPlus   bool
+		wantErr    string
+	}{
+		// prefer: opportunistic upgrade over TLS, graceful fallback otherwise.
+		{"prefer/tls/offered → PLUS", ChannelBindingPrefer, overTLS, plusAndPlain, true, ""},
+		{"prefer/tls/not-offered → plain", ChannelBindingPrefer, overTLS, plainOnly, false, ""},
+		{"prefer/no-tls/offered → plain (cannot bind without TLS)", ChannelBindingPrefer, plaintext, plusAndPlain, false, ""},
+		{"prefer/no-tls/plain-only → plain", ChannelBindingPrefer, plaintext, plainOnly, false, ""},
+		{"prefer/tls/plus-only-no-plain → PLUS", ChannelBindingPrefer, overTLS, plusOnly, true, ""},
+		{"prefer/no-usable-mechanism → err", ChannelBindingPrefer, plaintext, plusOnly, false, "does not support SCRAM-SHA-256"},
+		// empty mode is treated as prefer (libpq default).
+		{"empty(=prefer)/tls/offered → PLUS", ChannelBindingMode(""), overTLS, plusAndPlain, true, ""},
+
+		// require: must actually bind, or fail.
+		{"require/tls/offered → PLUS", ChannelBindingRequire, overTLS, plusAndPlain, true, ""},
+		{"require/no-tls → err", ChannelBindingRequire, plaintext, plusAndPlain, false, "not using TLS"},
+		{"require/tls/not-offered → err", ChannelBindingRequire, overTLS, plainOnly, false, "did not offer SCRAM-SHA-256-PLUS"},
+
+		// disable: never bind, even when offered over TLS.
+		{"disable/tls/offered → plain", ChannelBindingDisable, overTLS, plusAndPlain, false, ""},
+		{"disable/plain-only → plain", ChannelBindingDisable, overTLS, plainOnly, false, ""},
+		{"disable/no-plain → err", ChannelBindingDisable, overTLS, plusOnly, false, "does not support SCRAM-SHA-256"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			usePlus, err := decideChannelBinding(tt.mode, tt.isTLS, tt.mechanisms)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPlus, usePlus)
+		})
+	}
+}
+
+// TestScramClient_MechanismNameFollowsChannelBinding verifies the announced
+// SASL mechanism name tracks the channel-binding state: the SASLInitialResponse
+// announces SCRAM-SHA-256-PLUS with a p=tls-server-end-point gs2 header when
+// channel binding is enabled, and plain SCRAM-SHA-256 with an n,, header otherwise.
+func TestScramClient_MechanismNameFollowsChannelBinding(t *testing.T) {
+	tests := []struct {
+		name          string
+		enableBinding bool
+		wantMechanism string
+		wantGS2Prefix string
+	}{
+		{"binding enabled", true, scram.ScramSHA256PlusMechanism, "p=tls-server-end-point,,"},
+		{"binding disabled", false, scram.ScramSHA256Mechanism, "n,,"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientEnd, serverEnd := net.Pipe()
+			t.Cleanup(func() { _ = clientEnd.Close(); _ = serverEnd.Close() })
+
+			ctx, cancel := context.WithCancel(t.Context())
+			t.Cleanup(cancel)
+			c := &Conn{ctx: ctx, cancel: cancel}
+			c.resetConn(clientEnd)
+
+			var cbHash []byte
+			if tt.enableBinding {
+				cbHash = make([]byte, 32) // 32-byte tls-server-end-point hash
+			}
+			s := newScramClient(c, "alice", "secret", cbHash)
+
+			// net.Pipe is synchronous: send from a goroutine while we read.
+			errCh := make(chan error, 1)
+			go func() { errCh <- s.sendClientFirst() }()
+
+			mechanism, clientFirst := readSASLInitialResponse(t, serverEnd)
+			require.NoError(t, <-errCh)
+
+			assert.Equal(t, tt.wantMechanism, mechanism)
+			assert.True(t, len(clientFirst) >= len(tt.wantGS2Prefix) && clientFirst[:len(tt.wantGS2Prefix)] == tt.wantGS2Prefix,
+				"client-first %q should start with gs2 header %q", clientFirst, tt.wantGS2Prefix)
+		})
+	}
+}
+
+// readSASLInitialResponse reads one PasswordMessage frame carrying a SASLInitialResponse
+// and returns the mechanism name and the client-first message body.
+func readSASLInitialResponse(t *testing.T, r io.Reader) (mechanism, clientFirst string) {
+	t.Helper()
+	header := make([]byte, 5) // 1-byte type + int32 length
+	_, err := io.ReadFull(r, header)
+	require.NoError(t, err)
+	require.Equal(t, byte(protocol.MsgPasswordMsg), header[0])
+
+	bodyLen := int(binary.BigEndian.Uint32(header[1:5])) - 4
+	body := make([]byte, bodyLen)
+	_, err = io.ReadFull(r, body)
+	require.NoError(t, err)
+
+	// body = mechanism (null-terminated) | int32 client-first-len | client-first
+	nul := -1
+	for i, b := range body {
+		if b == 0 {
+			nul = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, nul, 0, "mechanism must be null-terminated")
+	mechanism = string(body[:nul])
+
+	rest := body[nul+1:]
+	require.GreaterOrEqual(t, len(rest), 4)
+	cfLen := int(binary.BigEndian.Uint32(rest[:4]))
+	require.Equal(t, cfLen, len(rest)-4)
+	clientFirst = string(rest[4:])
+	return mechanism, clientFirst
+}

--- a/go/common/pgprotocol/client/conn.go
+++ b/go/common/pgprotocol/client/conn.go
@@ -94,6 +94,12 @@ type Config struct {
 	// verify-ca/verify-full this must be non-nil. Built via BuildTLSConfig.
 	TLSConfig *tls.Config
 
+	// ChannelBinding controls `SCRAM-SHA-256-PLUS` negotiation.
+	// Empty string is treated as ChannelBindingPrefer.
+	// Only takes effect when the connection is TLS and the server offers
+	// `SCRAM-SHA-256-PLUS`.
+	ChannelBinding ChannelBindingMode
+
 	// DialTimeout is the timeout for establishing the connection.
 	DialTimeout time.Duration
 }

--- a/go/common/pgprotocol/client/scram.go
+++ b/go/common/pgprotocol/client/scram.go
@@ -29,21 +29,23 @@ type scramClient struct {
 }
 
 // newScramClient creates a new SCRAM client using password-based authentication.
-func newScramClient(conn *Conn, username, password string) *scramClient {
-	return &scramClient{
-		conn:   conn,
-		client: scram.NewSCRAMClientWithPassword(username, password),
+func newScramClient(conn *Conn, username, password string, channelBindingHash []byte) *scramClient {
+	client := scram.NewSCRAMClientWithPassword(username, password)
+	if channelBindingHash != nil {
+		client.EnableChannelBinding(channelBindingHash)
 	}
+	return &scramClient{conn: conn, client: client}
 }
 
 // newScramClientWithKeys creates a SCRAM client using pre-computed keys.
 // This enables SCRAM passthrough authentication where keys were extracted during
 // client authentication and are reused for backend authentication.
-func newScramClientWithKeys(conn *Conn, username string, clientKey, serverKey []byte) *scramClient {
-	return &scramClient{
-		conn:   conn,
-		client: scram.NewSCRAMClientWithKeys(username, clientKey, serverKey),
+func newScramClientWithKeys(conn *Conn, username string, clientKey, serverKey, channelBindingHash []byte) *scramClient {
+	client := scram.NewSCRAMClientWithKeys(username, clientKey, serverKey)
+	if channelBindingHash != nil {
+		client.EnableChannelBinding(channelBindingHash)
 	}
+	return &scramClient{conn: conn, client: client}
 }
 
 // authenticate performs the full SCRAM-SHA-256 authentication exchange.
@@ -86,9 +88,10 @@ func (s *scramClient) sendClientFirst() error {
 	//   - mechanism (null-terminated string)
 	//   - client-first-message length (int32)
 	//   - client-first-message bytes
-	bodyLen := len(scram.ScramSHA256Mechanism) + 1 + 4 + len(clientFirstMessage)
+	mechanism := s.client.Mechanism()
+	bodyLen := len(mechanism) + 1 + 4 + len(clientFirstMessage)
 	buf, pos := s.conn.startPacket(protocol.MsgPasswordMsg, bodyLen)
-	pos = writeStringAt(buf, pos, scram.ScramSHA256Mechanism)
+	pos = writeStringAt(buf, pos, mechanism)
 	pos = writeInt32At(buf, pos, int32(len(clientFirstMessage)))
 	pos = writeBytesAt(buf, pos, []byte(clientFirstMessage))
 	if err := s.conn.writePacket(buf, pos); err != nil {

--- a/go/common/pgprotocol/client/ssl.go
+++ b/go/common/pgprotocol/client/ssl.go
@@ -80,6 +80,43 @@ func ParseSSLMode(s string) (SSLMode, error) {
 	}
 }
 
+// ChannelBindingMode mirrors libpq's channel_binding connection parameter.
+// It controls whether SCRAM-SHA-256-PLUS is negotiated on the multipooler → PostgreSQL leg.
+//
+// Ref: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-CHANNEL-BINDING
+type ChannelBindingMode string
+
+const (
+	// ChannelBindingDisable never negotiates channel binding. It always uses
+	// plain SCRAM-SHA-256 even when the server offers SCRAM-SHA-256-PLUS.
+	ChannelBindingDisable ChannelBindingMode = "disable"
+
+	// ChannelBindingPrefer negotiates SCRAM-SHA-256-PLUS when the connection
+	// is TLS and the server advertises it, otherwise falls back to plain SCRAM-SHA-256.
+	ChannelBindingPrefer ChannelBindingMode = "prefer"
+
+	// ChannelBindingRequire fails the connection unless channel binding is
+	// actually used. It requires both TLS and a server that offers SCRAM-SHA-256-PLUS.
+	ChannelBindingRequire ChannelBindingMode = "require"
+)
+
+// ParseChannelBinding parses the string form of a channel_binding value.
+// Empty input returns ChannelBindingPrefer (libpq default).
+func ParseChannelBinding(s string) (ChannelBindingMode, error) {
+	switch ChannelBindingMode(strings.ToLower(strings.TrimSpace(s))) {
+	case "":
+		return ChannelBindingPrefer, nil
+	case ChannelBindingDisable:
+		return ChannelBindingDisable, nil
+	case ChannelBindingPrefer:
+		return ChannelBindingPrefer, nil
+	case ChannelBindingRequire:
+		return ChannelBindingRequire, nil
+	default:
+		return "", fmt.Errorf("invalid channel_binding %q (want disable|prefer|require)", s)
+	}
+}
+
 // SSLNegotiation mirrors libpq's sslnegotiation connection parameter
 // (PostgreSQL 17+). It selects how the TLS layer is established on a TCP
 // connection; it does not change whether TLS is attempted (that remains

--- a/go/common/pgprotocol/client/startup.go
+++ b/go/common/pgprotocol/client/startup.go
@@ -23,7 +23,41 @@ import (
 	"slices"
 
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+	"github.com/multigres/multigres/go/common/pgprotocol/scram"
 )
+
+// decideChannelBinding reports whether to negotiate SCRAM-SHA-256-PLUS.
+// It errors when the mode's requirements cannot be met.
+func decideChannelBinding(mode ChannelBindingMode, isTLS bool, mechanisms []string) (usePlus bool, err error) {
+	offersPlus := slices.Contains(mechanisms, scram.ScramSHA256PlusMechanism)
+	offersPlain := slices.Contains(mechanisms, scram.ScramSHA256Mechanism)
+
+	switch mode {
+	case "", ChannelBindingPrefer:
+		if isTLS && offersPlus {
+			return true, nil
+		}
+		if !offersPlain {
+			return false, fmt.Errorf("server does not support SCRAM-SHA-256 (available: %v)", mechanisms)
+		}
+		return false, nil
+	case ChannelBindingRequire:
+		if !isTLS {
+			return false, errors.New("channel_binding=require but the connection is not using TLS")
+		}
+		if !offersPlus {
+			return false, fmt.Errorf("channel_binding=require but the server did not offer SCRAM-SHA-256-PLUS (available: %v)", mechanisms)
+		}
+		return true, nil
+	case ChannelBindingDisable:
+		if !offersPlain {
+			return false, fmt.Errorf("server does not support SCRAM-SHA-256 (available: %v)", mechanisms)
+		}
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid channel_binding %q", mode)
+	}
+}
 
 // startup performs the connection startup handshake.
 // This includes SSL negotiation (if configured), sending the startup message,
@@ -309,19 +343,47 @@ func (c *Conn) handleAuthenticationRequest(body []byte) error {
 			mechanisms = append(mechanisms, mech)
 		}
 
-		// Check if SCRAM-SHA-256 is supported.
-		if !slices.Contains(mechanisms, "SCRAM-SHA-256") {
-			return fmt.Errorf("server does not support SCRAM-SHA-256 (available: %v)", mechanisms)
+		// Decide whether to negotiate channel binding (SCRAM-SHA-256-PLUS)
+		// per the configured channel_binding mode.
+		cbMode := c.config.ChannelBinding
+		tlsConn, isTLS := c.conn.(*tls.Conn)
+		usePlus, err := decideChannelBinding(cbMode, isTLS, mechanisms)
+		if err != nil {
+			return err
+		}
+
+		// When negotiating PLUS, compute the tls-server-end-point binding.
+		var cbHash []byte
+		if usePlus {
+			state := tlsConn.ConnectionState()
+			if len(state.PeerCertificates) == 0 {
+				return errors.New("cannot compute channel binding: server presented no TLS certificate")
+			}
+			hash, hashErr := scram.ComputeTLSServerEndPointHash(state.PeerCertificates[0])
+			if hashErr != nil {
+				// require must fail. prefer falls back to plain SCRAM-SHA-256.
+				if cbMode == ChannelBindingRequire {
+					return fmt.Errorf("channel_binding=require: %w", hashErr)
+				}
+				if !slices.Contains(mechanisms, scram.ScramSHA256Mechanism) {
+					return fmt.Errorf("server does not support SCRAM-SHA-256 (available: %v)", mechanisms)
+				}
+				usePlus = false
+			} else {
+				cbHash = hash
+			}
 		}
 
 		// Prefer SCRAM passthrough when keys are present; otherwise fall back
 		// to password-based SCRAM. Passthrough lets a proxy authenticate on a
-		// session's behalf without ever holding the plaintext password.
+		// session's behalf without ever holding the plaintext password. cbHash
+		// is nil unless channel binding was negotiated above, in which case the
+		// client speaks SCRAM-SHA-256-PLUS.
 		var scramClient *scramClient
 		if len(c.config.ScramClientKey) > 0 && len(c.config.ScramServerKey) > 0 {
-			scramClient = newScramClientWithKeys(c, c.config.User, c.config.ScramClientKey, c.config.ScramServerKey)
+			scramClient = newScramClientWithKeys(c, c.config.User, c.config.ScramClientKey, c.config.ScramServerKey, cbHash)
 		} else {
-			scramClient = newScramClient(c, c.config.User, c.config.Password)
+			scramClient = newScramClient(c, c.config.User, c.config.Password, cbHash)
 		}
 		return scramClient.authenticate()
 

--- a/go/common/pgprotocol/client/startup.go
+++ b/go/common/pgprotocol/client/startup.go
@@ -368,7 +368,6 @@ func (c *Conn) handleAuthenticationRequest(body []byte) error {
 				if !slices.Contains(mechanisms, scram.ScramSHA256Mechanism) {
 					return fmt.Errorf("server does not support SCRAM-SHA-256 (available: %v)", mechanisms)
 				}
-				usePlus = false
 			} else {
 				cbHash = hash
 			}

--- a/go/common/pgprotocol/server/scram_plus_roundtrip_test.go
+++ b/go/common/pgprotocol/server/scram_plus_roundtrip_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/client"
+)
+
+// TestSCRAMPlus_ClientRoundTrip_Require stands up the real server over
+// direct TLS and connects with the production client configured for
+// channel_binding=require. Because require fails the connection unless
+// SCRAM-SHA-256-PLUS is actually negotiated, a successful Connect proves the
+// client computed the tls-server-end-point binding from the server's cert and
+// completed the PLUS handshake end to end.
+func TestSCRAMPlus_ClientRoundTrip_Require(t *testing.T) {
+	serverTLS, caPool := generateTestTLSConfig(t)
+	ln, errCh := startDirectTLSServer(t, serverTLS, nil)
+
+	host, portStr, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cfg := &client.Config{
+		Host:           host,
+		Port:           port,
+		User:           "tlsuser",
+		Password:       "postgres",
+		Database:       "tlsdb",
+		SSLMode:        client.SSLModeVerifyFull,
+		SSLNegotiation: client.SSLNegotiationDirect,
+		TLSConfig: &tls.Config{
+			RootCAs:    caPool,
+			ServerName: "localhost",
+			MinVersion: tls.VersionTLS12,
+		},
+		ChannelBinding: client.ChannelBindingRequire,
+		DialTimeout:    5 * time.Second,
+	}
+
+	conn, err := client.Connect(ctx, ctx, cfg)
+	require.NoError(t, err, "client should negotiate SCRAM-SHA-256-PLUS and authenticate")
+	t.Cleanup(func() { _ = conn.Close() })
+
+	require.NoError(t, <-errCh, "server-side startup should succeed")
+}

--- a/go/services/multipooler/internal/connpoolmanager/config.go
+++ b/go/services/multipooler/internal/connpoolmanager/config.go
@@ -539,7 +539,11 @@ func (c *Config) PgChannelBinding() (client.ChannelBindingMode, error) {
 // (which cannot be satisfied without TLS) is validated in that case.
 func (c *Config) ValidatePGSSL(host string) error {
 	if host == "" {
-		if cb, err := c.PgChannelBinding(); err == nil && cb == client.ChannelBindingRequire {
+		cb, err := c.PgChannelBinding()
+		if err != nil {
+			return fmt.Errorf("--pg-client-channel-binding: %w", err)
+		}
+		if cb == client.ChannelBindingRequire {
 			return errors.New("--pg-client-channel-binding=require cannot be satisfied over a Unix socket (channel binding needs TLS); use a TCP connection with a TLS-enabled --pg-client-sslmode")
 		}
 		return nil

--- a/go/services/multipooler/internal/connpoolmanager/config.go
+++ b/go/services/multipooler/internal/connpoolmanager/config.go
@@ -62,6 +62,10 @@ type ConnectionConfig struct {
 	// TLSConfig is the *tls.Config built from SSLMode + sslrootcert. Nil for
 	// disable/allow; non-nil otherwise. Only honored on TCP connections.
 	TLSConfig *tls.Config
+
+	// ChannelBinding controls SCRAM-SHA-256-PLUS negotiation (libpq channel_binding)
+	// on the multipooler to PostgreSQL leg. Only takes effect over TLS.
+	ChannelBinding client.ChannelBindingMode
 }
 
 type pgPasswordSource int
@@ -105,6 +109,7 @@ type Config struct {
 	pgSSLMode        viperutil.Value[string]
 	pgSSLRootCert    viperutil.Value[string]
 	pgSSLNegotiation viperutil.Value[string]
+	pgChannelBinding viperutil.Value[string]
 
 	// --- Pool sizing configuration ---
 
@@ -236,6 +241,11 @@ func NewConfig(reg *viperutil.Registry) *Config {
 			Default:  string(client.SSLNegotiationPostgres),
 			FlagName: "pg-client-sslnegotiation",
 		}),
+		// Default "prefer" mirrors libpq,
+		pgChannelBinding: viperutil.Configure(reg, "connpool.pg.channel-binding", viperutil.Options[string]{
+			Default:  string(client.ChannelBindingPrefer),
+			FlagName: "pg-client-channel-binding",
+		}),
 
 		// Admin pool (shared across all users)
 		adminCapacity: viperutil.Configure(reg, "connpool.admin.capacity", viperutil.Options[int64]{
@@ -326,6 +336,7 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 	fs.String("pg-client-sslmode", c.pgSSLMode.Default(), "TLS mode for connections to PostgreSQL: disable|prefer|require|verify-ca|verify-full (libpq parity; sslmode=allow is not supported)")
 	fs.String("pg-client-sslrootcert", c.pgSSLRootCert.Default(), "PEM CA bundle used to verify the PostgreSQL server certificate (required for verify-ca and verify-full)")
 	fs.String("pg-client-sslnegotiation", c.pgSSLNegotiation.Default(), "TLS negotiation style for connections to PostgreSQL: postgres (SSLRequest handshake) or direct (TLS-first, PostgreSQL 17+, requires sslmode require|verify-ca|verify-full)")
+	fs.String("pg-client-channel-binding", c.pgChannelBinding.Default(), "SCRAM-SHA-256-PLUS channel binding for connections to PostgreSQL: disable|prefer|require (libpq parity). Only applies over TLS; require needs a TLS-enforcing sslmode")
 
 	// Admin pool flags (shared across all users)
 	fs.Int64("connpool-admin-capacity", c.adminCapacity.Default(), "Maximum number of admin connections for control operations")
@@ -361,6 +372,7 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 		c.pgSSLMode,
 		c.pgSSLRootCert,
 		c.pgSSLNegotiation,
+		c.pgChannelBinding,
 		c.adminCapacity,
 		c.userRegularIdleTimeout,
 		c.userRegularMaxLifetime,
@@ -510,6 +522,13 @@ func (c *Config) PgSSLNegotiation() (client.SSLNegotiation, error) {
 	return client.ParseSSLNegotiation(c.pgSSLNegotiation.Get())
 }
 
+// PgChannelBinding parses and returns the configured libpq-style
+// channel_binding value. An invalid value returns the parser error so the
+// caller can fail startup rather than silently using the default.
+func (c *Config) PgChannelBinding() (client.ChannelBindingMode, error) {
+	return client.ParseChannelBinding(c.pgChannelBinding.Get())
+}
+
 // ValidatePGSSL checks the libpq-style sslmode + sslrootcert flags at startup
 // so a typo or missing CA bundle aborts the multipooler before the connection
 // pool manager opens — preventing a silent downgrade to plaintext.
@@ -535,6 +554,14 @@ func (c *Config) ValidatePGSSL(host string) error {
 	}
 	if err := client.ValidateSSLNegotiation(negotiation, mode); err != nil {
 		return fmt.Errorf("--pg-client-sslnegotiation=%s: %w", negotiation, err)
+	}
+	cb, err := client.ParseChannelBinding(c.pgChannelBinding.Get())
+	if err != nil {
+		return fmt.Errorf("--pg-client-channel-binding: %w", err)
+	}
+	// channel_binding=require needs TLS to bind to.
+	if cb == client.ChannelBindingRequire && !mode.AttemptsTLS() {
+		return fmt.Errorf("--pg-client-channel-binding=require needs a TLS-enabled --pg-client-sslmode (got %q)", mode)
 	}
 	return nil
 }

--- a/go/services/multipooler/internal/connpoolmanager/config.go
+++ b/go/services/multipooler/internal/connpoolmanager/config.go
@@ -535,10 +535,13 @@ func (c *Config) PgChannelBinding() (client.ChannelBindingMode, error) {
 //
 // host is the address the multipooler will dial postgres on (only used to
 // validate verify-full). Pass an empty host when the multipooler is configured
-// for a Unix socket; this function only runs the SSL validation when host is
-// non-empty.
+// for a Unix socket; a socket never runs TLS, so only channel_binding=require
+// (which cannot be satisfied without TLS) is validated in that case.
 func (c *Config) ValidatePGSSL(host string) error {
 	if host == "" {
+		if cb, err := c.PgChannelBinding(); err == nil && cb == client.ChannelBindingRequire {
+			return errors.New("--pg-client-channel-binding=require cannot be satisfied over a Unix socket (channel binding needs TLS); use a TCP connection with a TLS-enabled --pg-client-sslmode")
+		}
 		return nil
 	}
 	mode, err := client.ParseSSLMode(c.pgSSLMode.Get())

--- a/go/services/multipooler/internal/connpoolmanager/config_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/config_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/tools/viperutil"
 )
 
@@ -440,4 +441,53 @@ func TestConfig_PgUser_EnvVar(t *testing.T) {
 	config.RegisterFlags(fs)
 
 	assert.Equal(t, "multigres", config.PgUser())
+}
+
+func TestConfig_PgChannelBinding(t *testing.T) {
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	config.RegisterFlags(fs)
+
+	// Default mirrors libpq: prefer.
+	cb, err := config.PgChannelBinding()
+	require.NoError(t, err)
+	assert.Equal(t, client.ChannelBindingPrefer, cb)
+
+	require.NoError(t, fs.Set("pg-client-channel-binding", "require"))
+	cb, err = config.PgChannelBinding()
+	require.NoError(t, err)
+	assert.Equal(t, client.ChannelBindingRequire, cb)
+}
+
+func TestConfig_ValidatePGSSL_ChannelBinding(t *testing.T) {
+	tests := []struct {
+		name           string
+		sslmode        string
+		channelBinding string
+		wantErr        string
+	}{
+		{"require rejects non-TLS sslmode", "disable", "require", "needs a TLS-enabled"},
+		{"require ok with require sslmode", "require", "require", ""},
+		{"prefer ok with disable sslmode", "disable", "prefer", ""},
+		{"invalid channel-binding value", "require", "bogus", "channel-binding"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := viperutil.NewRegistry()
+			config := NewConfig(reg)
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			config.RegisterFlags(fs)
+			require.NoError(t, fs.Set("pg-client-sslmode", tt.sslmode))
+			require.NoError(t, fs.Set("pg-client-channel-binding", tt.channelBinding))
+
+			err := config.ValidatePGSSL("localhost")
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/go/services/multipooler/internal/connpoolmanager/config_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/config_test.go
@@ -474,6 +474,7 @@ func TestConfig_ValidatePGSSL_ChannelBinding(t *testing.T) {
 		{"invalid channel-binding value", "localhost", "require", "bogus", "channel-binding"},
 		{"require rejected on unix socket", "", "disable", "require", "Unix socket"},
 		{"prefer ok on unix socket", "", "disable", "prefer", ""},
+		{"invalid channel-binding on unix socket", "", "disable", "bogus", "channel-binding"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/go/services/multipooler/internal/connpoolmanager/config_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/config_test.go
@@ -463,14 +463,17 @@ func TestConfig_PgChannelBinding(t *testing.T) {
 func TestConfig_ValidatePGSSL_ChannelBinding(t *testing.T) {
 	tests := []struct {
 		name           string
+		host           string
 		sslmode        string
 		channelBinding string
 		wantErr        string
 	}{
-		{"require rejects non-TLS sslmode", "disable", "require", "needs a TLS-enabled"},
-		{"require ok with require sslmode", "require", "require", ""},
-		{"prefer ok with disable sslmode", "disable", "prefer", ""},
-		{"invalid channel-binding value", "require", "bogus", "channel-binding"},
+		{"require rejects non-TLS sslmode", "localhost", "disable", "require", "needs a TLS-enabled"},
+		{"require ok with require sslmode", "localhost", "require", "require", ""},
+		{"prefer ok with disable sslmode", "localhost", "disable", "prefer", ""},
+		{"invalid channel-binding value", "localhost", "require", "bogus", "channel-binding"},
+		{"require rejected on unix socket", "", "disable", "require", "Unix socket"},
+		{"prefer ok on unix socket", "", "disable", "prefer", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -481,7 +484,7 @@ func TestConfig_ValidatePGSSL_ChannelBinding(t *testing.T) {
 			require.NoError(t, fs.Set("pg-client-sslmode", tt.sslmode))
 			require.NoError(t, fs.Set("pg-client-channel-binding", tt.channelBinding))
 
-			err := config.ValidatePGSSL("localhost")
+			err := config.ValidatePGSSL(tt.host)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)

--- a/go/services/multipooler/internal/connpoolmanager/manager.go
+++ b/go/services/multipooler/internal/connpoolmanager/manager.go
@@ -276,6 +276,7 @@ func (m *Manager) buildClientConfig(user, password string) *client.Config {
 		SSLMode:        m.connConfig.SSLMode,
 		SSLNegotiation: m.connConfig.SSLNegotiation,
 		TLSConfig:      m.connConfig.TLSConfig,
+		ChannelBinding: m.connConfig.ChannelBinding,
 		DialTimeout:    m.config.DialTimeout(),
 	}
 }

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -738,6 +738,17 @@ func (pm *MultipoolerManager) openConnectionsLocked() {
 				sslNegotiation = client.SSLNegotiationPostgres
 			}
 			connConfig.SSLNegotiation = sslNegotiation
+
+			// libpq-style channel_binding (disable | prefer | require).
+			// Validated during startup (ValidatePGSSL); a post-startup parse
+			// failure here keeps the default (prefer), and the per-dial
+			// decision in client.startup surfaces any residual inconsistency.
+			channelBinding, err := pm.config.ConnPoolConfig.PgChannelBinding()
+			if err != nil {
+				pm.logger.ErrorContext(pm.ctx, "invalid --pg-client-channel-binding at pool open; using default \"prefer\"", "error", err)
+				channelBinding = client.ChannelBindingPrefer
+			}
+			connConfig.ChannelBinding = channelBinding
 		}
 		pm.connPoolMgr.Open(pm.ctx, connConfig)
 		pm.logger.Info("Connection pool manager opened")


### PR DESCRIPTION
Follow up to #986, for the pooler-to-Postgres leg.

If PG offers `SCRAM-SHA-256-PLUS` mechanism, it can now negotiate the same using server's TLS cert. This can be controlled by a new libpq-style `channel_binding` knob (`disable`/`prefer`/`require`), exposed as the `--pg-client-channel-binding` flag in the multipooler CLI.