### PR TITLE
test(e2e): categorize recovery scenarios and calibrate timing thresholds

### DIFF
--- a/go/test/endtoend/multiorch/bootstrap_test.go
+++ b/go/test/endtoend/multiorch/bootstrap_test.go
@@ -357,7 +357,7 @@ func TestBootstrapInitialization(t *testing.T) {
 		// freshly-restored standby that joins via SetPrimary/FixReplication never
 		// makes a revocation promise (Recruit isn't called on join), so term=0
 		// is the expected steady state for it.
-		const autoRestoreTimeout = 90 * time.Second
+		const autoRestoreTimeout = 15 * time.Second
 		restoreStart := time.Now()
 		shardsetup.EventuallyPoolerCondition(t,
 			[]*shardsetup.MultipoolerInstance{standbyInst}, autoRestoreTimeout, 1*time.Second,

--- a/go/test/endtoend/multiorch/cohort_rotation_test.go
+++ b/go/test/endtoend/multiorch/cohort_rotation_test.go
@@ -128,7 +128,7 @@ func TestCohortRotation_FullReplacement(t *testing.T) {
 	defer cleanup()
 
 	setup.StartMultiorchs(t.Context(), t)
-	setup.RequireRecovery(t, "multiorch", 30*time.Second, shardsetup.RecoveryScenarioInitialSettle)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioInitialSettle)
 	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
 
 	initialPrimary := setup.PrimaryName

--- a/go/test/endtoend/multiorch/cohort_rotation_test.go
+++ b/go/test/endtoend/multiorch/cohort_rotation_test.go
@@ -128,7 +128,7 @@ func TestCohortRotation_FullReplacement(t *testing.T) {
 	defer cleanup()
 
 	setup.StartMultiorchs(t.Context(), t)
-	setup.RequireRecovery(t, "multiorch", 30*time.Second)
+	setup.RequireRecovery(t, "multiorch", 30*time.Second, shardsetup.RecoveryScenarioInitialSettle)
 	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
 
 	initialPrimary := setup.PrimaryName

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -166,7 +166,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		// before the next iteration begins — otherwise the grace period would carry over.
 		// 45s budget: stale-primary demotion (via SetPrimary) is synchronous and
 		// includes a 5s drain + up to ~15s pg_rewind + ~5s postgres restart on slow CI.
-		setup.RequireRecovery(t, "multiorch", 45*time.Second, shardsetup.RecoveryScenarioStalePrimaryDemote)
+		setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioStalePrimaryDemote)
 
 		// Get the new primary's consensus term to verify rejoining nodes are on correct term
 		newPrimary := setup.GetMultipoolerInstance(newPrimaryName)
@@ -252,7 +252,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 	t.Logf("Waiting for multiorch to recover from emergency demotion (primary at term > %d with >= 2 standbys)...", oldPrimaryTerm)
 	newPrimaryName := shardsetup.WaitForHigherTermPrimary(t, setup, oldPrimaryTerm, 2, 45*time.Second)
 	t.Logf("Primary after emergency demotion: %s (was %s)", newPrimaryName, currentPrimaryName)
-	setup.RequireRecovery(t, "multiorch", 45*time.Second, shardsetup.RecoveryScenarioEmergencyDemotion)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioEmergencyDemotion)
 
 	newPrimary := setup.GetMultipoolerInstance(newPrimaryName)
 	require.NotNil(t, newPrimary, "new primary instance should exist")

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -166,7 +166,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		// before the next iteration begins — otherwise the grace period would carry over.
 		// 45s budget: stale-primary demotion (via SetPrimary) is synchronous and
 		// includes a 5s drain + up to ~15s pg_rewind + ~5s postgres restart on slow CI.
-		setup.RequireRecovery(t, "multiorch", 45*time.Second)
+		setup.RequireRecovery(t, "multiorch", 45*time.Second, shardsetup.RecoveryScenarioStalePrimaryDemote)
 
 		// Get the new primary's consensus term to verify rejoining nodes are on correct term
 		newPrimary := setup.GetMultipoolerInstance(newPrimaryName)
@@ -252,7 +252,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 	t.Logf("Waiting for multiorch to recover from emergency demotion (primary at term > %d with >= 2 standbys)...", oldPrimaryTerm)
 	newPrimaryName := shardsetup.WaitForHigherTermPrimary(t, setup, oldPrimaryTerm, 2, 45*time.Second)
 	t.Logf("Primary after emergency demotion: %s (was %s)", newPrimaryName, currentPrimaryName)
-	setup.RequireRecovery(t, "multiorch", 45*time.Second)
+	setup.RequireRecovery(t, "multiorch", 45*time.Second, shardsetup.RecoveryScenarioEmergencyDemotion)
 
 	newPrimary := setup.GetMultipoolerInstance(newPrimaryName)
 	require.NotNil(t, newPrimary, "new primary instance should exist")
@@ -474,7 +474,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		// make a simpler failover slow.
 		const (
 			maxRecruit = 500 * time.Millisecond
-			maxPromote = 3 * time.Second
+			maxPromote = 6 * time.Second
 		)
 		for _, p := range promotions {
 			recruitMs, ok := p["recruit_ms"].(float64)

--- a/go/test/endtoend/multiorch/demote_stale_primary_test.go
+++ b/go/test/endtoend/multiorch/demote_stale_primary_test.go
@@ -122,7 +122,7 @@ func TestDemoteStalePrimary_SIGKILL(t *testing.T) {
 	// sends SetPrimary. SetPrimary's isPrimary=true branch demotes via
 	// demoteStalePrimaryLocked, which runs pg_rewind and restarts as standby.
 	t.Log("Waiting for multiorch to detect stale primary, run pg_rewind, and configure replication...")
-	waitForDivergenceRepaired(t, setup, oldPrimaryName, newPrimaryName, 45*time.Second)
+	waitForDivergenceRepaired(t, setup, oldPrimaryName, newPrimaryName)
 
 	// Step 6: Verify old primary is now replicating from new primary
 	t.Log("Verifying old primary is now a replica...")
@@ -224,7 +224,7 @@ func TestDemoteStalePrimary_GracefulShutdown(t *testing.T) {
 	// sends SetPrimary. SetPrimary's isPrimary=true branch demotes via
 	// demoteStalePrimaryLocked, which runs pg_rewind and restarts as standby.
 	t.Log("Waiting for multiorch to detect stale primary, run pg_rewind, and configure replication...")
-	waitForDivergenceRepaired(t, setup, oldPrimaryName, newPrimaryName, 45*time.Second)
+	waitForDivergenceRepaired(t, setup, oldPrimaryName, newPrimaryName)
 
 	// Step 6: Verify old primary is now replicating from new primary
 	t.Log("Verifying old primary is now a replica...")
@@ -260,7 +260,7 @@ func writeDataToNewPrimary(t *testing.T, setup *shardsetup.ShardSetup, primaryNa
 }
 
 // waitForDivergenceRepaired waits for multiorch to repair the diverged node
-func waitForDivergenceRepaired(t *testing.T, setup *shardsetup.ShardSetup, oldPrimaryName, _ string, timeout time.Duration) {
+func waitForDivergenceRepaired(t *testing.T, setup *shardsetup.ShardSetup, oldPrimaryName, _ string) {
 	t.Helper()
 
 	oldPrimary := setup.GetMultipoolerInstance(oldPrimaryName)
@@ -268,7 +268,7 @@ func waitForDivergenceRepaired(t *testing.T, setup *shardsetup.ShardSetup, oldPr
 
 	// Trigger recovery and wait for it to complete
 	t.Log("Triggering recovery to detect and repair stale primary...")
-	setup.RequireRecovery(t, "multiorch", timeout, shardsetup.RecoveryScenarioStalePrimaryDemote)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioStalePrimaryDemote)
 
 	// Verify old primary is now a replica with replication configured
 	shardsetup.RequirePoolerCondition(t, []*shardsetup.MultipoolerInstance{oldPrimary},

--- a/go/test/endtoend/multiorch/demote_stale_primary_test.go
+++ b/go/test/endtoend/multiorch/demote_stale_primary_test.go
@@ -268,7 +268,7 @@ func waitForDivergenceRepaired(t *testing.T, setup *shardsetup.ShardSetup, oldPr
 
 	// Trigger recovery and wait for it to complete
 	t.Log("Triggering recovery to detect and repair stale primary...")
-	setup.RequireRecovery(t, "multiorch", timeout)
+	setup.RequireRecovery(t, "multiorch", timeout, shardsetup.RecoveryScenarioStalePrimaryDemote)
 
 	// Verify old primary is now a replica with replication configured
 	shardsetup.RequirePoolerCondition(t, []*shardsetup.MultipoolerInstance{oldPrimary},

--- a/go/test/endtoend/multiorch/fix_replication_test.go
+++ b/go/test/endtoend/multiorch/fix_replication_test.go
@@ -124,7 +124,7 @@ func TestFixReplication(t *testing.T) {
 	// Trigger recovery to fix the replication
 	// Use longer timeout for first recovery since multiorch needs to discover poolers
 	t.Log("Triggering recovery to fix replication...")
-	setup.RequireRecovery(t, "multiorch", 20*time.Second, shardsetup.RecoveryScenarioFixReplication)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioFixReplication)
 
 	// Verify data IS now visible on replica after fix
 	t.Log("Verifying data IS now visible on replica after fix...")
@@ -173,7 +173,7 @@ func TestFixReplication(t *testing.T) {
 
 	// Trigger recovery to detect and fix the broken replication
 	t.Log("Triggering recovery to detect and fix replication (second time)...")
-	setup.RequireRecovery(t, "multiorch", 20*time.Second, shardsetup.RecoveryScenarioFixReplication)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioFixReplication)
 
 	// Verify new data IS now visible on replica after second fix
 	t.Log("Verifying new data IS now visible on replica after second fix...")
@@ -226,7 +226,7 @@ func TestFixReplication(t *testing.T) {
 
 	// Trigger recovery to add replica back to standby list
 	t.Log("Triggering recovery to add replica back to standby list...")
-	setup.RequireRecovery(t, "multiorch", 20*time.Second, shardsetup.RecoveryScenarioFixReplication)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioFixReplication)
 
 	// Verify replica is back in standby list
 	// Since RequireRecovery() blocks until problems are resolved, this should be true immediately

--- a/go/test/endtoend/multiorch/fix_replication_test.go
+++ b/go/test/endtoend/multiorch/fix_replication_test.go
@@ -124,7 +124,7 @@ func TestFixReplication(t *testing.T) {
 	// Trigger recovery to fix the replication
 	// Use longer timeout for first recovery since multiorch needs to discover poolers
 	t.Log("Triggering recovery to fix replication...")
-	setup.RequireRecovery(t, "multiorch", 10*time.Second)
+	setup.RequireRecovery(t, "multiorch", 20*time.Second, shardsetup.RecoveryScenarioFixReplication)
 
 	// Verify data IS now visible on replica after fix
 	t.Log("Verifying data IS now visible on replica after fix...")
@@ -173,7 +173,7 @@ func TestFixReplication(t *testing.T) {
 
 	// Trigger recovery to detect and fix the broken replication
 	t.Log("Triggering recovery to detect and fix replication (second time)...")
-	setup.RequireRecovery(t, "multiorch", 10*time.Second)
+	setup.RequireRecovery(t, "multiorch", 20*time.Second, shardsetup.RecoveryScenarioFixReplication)
 
 	// Verify new data IS now visible on replica after second fix
 	t.Log("Verifying new data IS now visible on replica after second fix...")
@@ -226,7 +226,7 @@ func TestFixReplication(t *testing.T) {
 
 	// Trigger recovery to add replica back to standby list
 	t.Log("Triggering recovery to add replica back to standby list...")
-	setup.RequireRecovery(t, "multiorch", 10*time.Second)
+	setup.RequireRecovery(t, "multiorch", 20*time.Second, shardsetup.RecoveryScenarioFixReplication)
 
 	// Verify replica is back in standby list
 	// Since RequireRecovery() blocks until problems are resolved, this should be true immediately

--- a/go/test/endtoend/multiorch/graceful_shutdown_test.go
+++ b/go/test/endtoend/multiorch/graceful_shutdown_test.go
@@ -90,7 +90,7 @@ func TestPrimaryGracefulShutdownTriggersFailover(t *testing.T) {
 	// ManagerHealthStream, in which case the INELIGIBLE snapshot our SIGTERM
 	// produces never reaches multiorch and failover falls back to the slow
 	// LeaderIsDeadAnalyzer path. The streams check closes that window.
-	setup.RequireRecovery(t, "multiorch", 30*time.Second, shardsetup.RecoveryScenarioInitialSettle)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioInitialSettle)
 	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
 
 	oldPrimary := setup.GetPrimary(t)
@@ -195,7 +195,7 @@ func TestStandbyGracefulShutdownDoesNotTriggerFailover(t *testing.T) {
 	defer cleanup()
 
 	setup.StartMultiorchs(t.Context(), t)
-	setup.RequireRecovery(t, "multiorch", 30*time.Second, shardsetup.RecoveryScenarioInitialSettle)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioInitialSettle)
 	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
 
 	primaryName := setup.PrimaryName
@@ -282,7 +282,7 @@ func TestMultiReplicaContinuityAfterStandbyShutdown(t *testing.T) {
 	defer cleanup()
 
 	setup.StartMultiorchs(t.Context(), t)
-	setup.RequireRecovery(t, "multiorch", 30*time.Second, shardsetup.RecoveryScenarioInitialSettle)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioInitialSettle)
 	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
 
 	primaryName := setup.PrimaryName
@@ -389,7 +389,7 @@ func TestStandbyGracefulShutdownLifecycleShutdown(t *testing.T) {
 	defer cleanup()
 
 	setup.StartMultiorchs(t.Context(), t)
-	setup.RequireRecovery(t, "multiorch", 30*time.Second, shardsetup.RecoveryScenarioInitialSettle)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioInitialSettle)
 	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
 
 	primaryName := setup.PrimaryName
@@ -482,7 +482,7 @@ func TestSequentialGracefulShutdowns(t *testing.T) {
 	defer cleanup()
 
 	setup.StartMultiorchs(t.Context(), t)
-	setup.RequireRecovery(t, "multiorch", 30*time.Second, shardsetup.RecoveryScenarioInitialSettle)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioInitialSettle)
 	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
 
 	primaryName := setup.PrimaryName

--- a/go/test/endtoend/multiorch/graceful_shutdown_test.go
+++ b/go/test/endtoend/multiorch/graceful_shutdown_test.go
@@ -90,7 +90,7 @@ func TestPrimaryGracefulShutdownTriggersFailover(t *testing.T) {
 	// ManagerHealthStream, in which case the INELIGIBLE snapshot our SIGTERM
 	// produces never reaches multiorch and failover falls back to the slow
 	// LeaderIsDeadAnalyzer path. The streams check closes that window.
-	setup.RequireRecovery(t, "multiorch", 30*time.Second)
+	setup.RequireRecovery(t, "multiorch", 30*time.Second, shardsetup.RecoveryScenarioInitialSettle)
 	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
 
 	oldPrimary := setup.GetPrimary(t)
@@ -195,7 +195,7 @@ func TestStandbyGracefulShutdownDoesNotTriggerFailover(t *testing.T) {
 	defer cleanup()
 
 	setup.StartMultiorchs(t.Context(), t)
-	setup.RequireRecovery(t, "multiorch", 30*time.Second)
+	setup.RequireRecovery(t, "multiorch", 30*time.Second, shardsetup.RecoveryScenarioInitialSettle)
 	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
 
 	primaryName := setup.PrimaryName
@@ -282,7 +282,7 @@ func TestMultiReplicaContinuityAfterStandbyShutdown(t *testing.T) {
 	defer cleanup()
 
 	setup.StartMultiorchs(t.Context(), t)
-	setup.RequireRecovery(t, "multiorch", 30*time.Second)
+	setup.RequireRecovery(t, "multiorch", 30*time.Second, shardsetup.RecoveryScenarioInitialSettle)
 	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
 
 	primaryName := setup.PrimaryName
@@ -389,7 +389,7 @@ func TestStandbyGracefulShutdownLifecycleShutdown(t *testing.T) {
 	defer cleanup()
 
 	setup.StartMultiorchs(t.Context(), t)
-	setup.RequireRecovery(t, "multiorch", 30*time.Second)
+	setup.RequireRecovery(t, "multiorch", 30*time.Second, shardsetup.RecoveryScenarioInitialSettle)
 	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
 
 	primaryName := setup.PrimaryName
@@ -482,7 +482,7 @@ func TestSequentialGracefulShutdowns(t *testing.T) {
 	defer cleanup()
 
 	setup.StartMultiorchs(t.Context(), t)
-	setup.RequireRecovery(t, "multiorch", 30*time.Second)
+	setup.RequireRecovery(t, "multiorch", 30*time.Second, shardsetup.RecoveryScenarioInitialSettle)
 	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
 
 	primaryName := setup.PrimaryName

--- a/go/test/endtoend/multiorch/spurious_failover_recovery_test.go
+++ b/go/test/endtoend/multiorch/spurious_failover_recovery_test.go
@@ -153,5 +153,5 @@ func TestSpuriousFailoverRecovery(t *testing.T) {
 	// to a problem-free state. RequireRecovery loops TriggerRecoveryNow until
 	// no problem codes remain, or fails the test on timeout.
 	resumeRecovery()
-	setup.RequireRecovery(t, "multiorch", 90*time.Second, shardsetup.RecoveryScenarioEmergencyDemotion)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioEmergencyDemotion)
 }

--- a/go/test/endtoend/multiorch/spurious_failover_recovery_test.go
+++ b/go/test/endtoend/multiorch/spurious_failover_recovery_test.go
@@ -153,5 +153,5 @@ func TestSpuriousFailoverRecovery(t *testing.T) {
 	// to a problem-free state. RequireRecovery loops TriggerRecoveryNow until
 	// no problem codes remain, or fails the test on timeout.
 	resumeRecovery()
-	setup.RequireRecovery(t, "multiorch", 90*time.Second)
+	setup.RequireRecovery(t, "multiorch", 90*time.Second, shardsetup.RecoveryScenarioEmergencyDemotion)
 }

--- a/go/test/endtoend/multiorch/stuck_proposal_test.go
+++ b/go/test/endtoend/multiorch/stuck_proposal_test.go
@@ -475,7 +475,7 @@ func TestStuckProposalAutoRecovers(t *testing.T) {
 		&multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest{Enabled: true})
 	require.NoError(t, err)
 
-	setup.RequireRecovery(t, "multiorch", 20*time.Second, shardsetup.RecoveryScenarioStalePrimaryDemote)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioStalePrimaryDemote)
 
 	newPrimary := setup.RefreshPrimary(t)
 	require.NotNil(t, newPrimary)

--- a/go/test/endtoend/multiorch/stuck_proposal_test.go
+++ b/go/test/endtoend/multiorch/stuck_proposal_test.go
@@ -475,7 +475,7 @@ func TestStuckProposalAutoRecovers(t *testing.T) {
 		&multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest{Enabled: true})
 	require.NoError(t, err)
 
-	setup.RequireRecovery(t, "multiorch", 20*time.Second)
+	setup.RequireRecovery(t, "multiorch", 20*time.Second, shardsetup.RecoveryScenarioStalePrimaryDemote)
 
 	newPrimary := setup.RefreshPrimary(t)
 	require.NotNil(t, newPrimary)

--- a/go/test/endtoend/multipooler/backupfaults/backup_archive_lag_test.go
+++ b/go/test/endtoend/multipooler/backupfaults/backup_archive_lag_test.go
@@ -290,7 +290,7 @@ func TestPrimaryCrashWithUnarchivedWAL_NoDataLoss(t *testing.T) {
 	// demoted via SetPrimary (5s drain + ~15s pg_rewind + ~5s pg restart) and
 	// rejoined as a standby on the new primary's term. RequireRecovery blocks
 	// until all pending problems are resolved.
-	setup.RequireRecovery(t, "multiorch", 60*time.Second)
+	setup.RequireRecovery(t, "multiorch", 60*time.Second, shardsetup.RecoveryScenarioStalePrimaryDemote)
 
 	// --- Verify both non-primary nodes (the surviving original standby and the
 	// demoted-and-rejoined old primary) are healthy streaming replicas of the
@@ -328,7 +328,7 @@ func TestPrimaryCrashWithUnarchivedWAL_NoDataLoss(t *testing.T) {
 
 	// Drive multiorch's recovery loop synchronously so FixReplication wires
 	// pooler-4's replication to the current primary on the current term.
-	setup.RequireRecovery(t, "multiorch", 60*time.Second)
+	setup.RequireRecovery(t, "multiorch", 60*time.Second, shardsetup.RecoveryScenarioFixReplication)
 
 	// --- Verify the freshly-provisioned pooler-4 streams from the new primary
 	// AND has every committed id. The previous block already proved the

--- a/go/test/endtoend/multipooler/backupfaults/backup_archive_lag_test.go
+++ b/go/test/endtoend/multipooler/backupfaults/backup_archive_lag_test.go
@@ -290,7 +290,7 @@ func TestPrimaryCrashWithUnarchivedWAL_NoDataLoss(t *testing.T) {
 	// demoted via SetPrimary (5s drain + ~15s pg_rewind + ~5s pg restart) and
 	// rejoined as a standby on the new primary's term. RequireRecovery blocks
 	// until all pending problems are resolved.
-	setup.RequireRecovery(t, "multiorch", 60*time.Second, shardsetup.RecoveryScenarioStalePrimaryDemote)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioStalePrimaryDemote)
 
 	// --- Verify both non-primary nodes (the surviving original standby and the
 	// demoted-and-rejoined old primary) are healthy streaming replicas of the
@@ -328,7 +328,7 @@ func TestPrimaryCrashWithUnarchivedWAL_NoDataLoss(t *testing.T) {
 
 	// Drive multiorch's recovery loop synchronously so FixReplication wires
 	// pooler-4's replication to the current primary on the current term.
-	setup.RequireRecovery(t, "multiorch", 60*time.Second, shardsetup.RecoveryScenarioFixReplication)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioFixReplication)
 
 	// --- Verify the freshly-provisioned pooler-4 streams from the new primary
 	// AND has every committed id. The previous block already proved the

--- a/go/test/endtoend/queryserving/buffer_test.go
+++ b/go/test/endtoend/queryserving/buffer_test.go
@@ -410,7 +410,7 @@ func triggerFailover(t *testing.T, setup *shardsetup.ShardSetup) {
 	t.Logf("Recruit accepted, emergency demotion triggered")
 
 	// Trigger immediate recovery to elect a new primary and fully stabilize the cluster.
-	setup.RequireRecovery(t, "multiorch", 90*time.Second, shardsetup.RecoveryScenarioEmergencyDemotion)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioEmergencyDemotion)
 
 	newPrimary := setup.RefreshPrimary(t)
 	require.NotNil(t, newPrimary, "a primary should exist after recovery")

--- a/go/test/endtoend/queryserving/buffer_test.go
+++ b/go/test/endtoend/queryserving/buffer_test.go
@@ -410,7 +410,7 @@ func triggerFailover(t *testing.T, setup *shardsetup.ShardSetup) {
 	t.Logf("Recruit accepted, emergency demotion triggered")
 
 	// Trigger immediate recovery to elect a new primary and fully stabilize the cluster.
-	setup.RequireRecovery(t, "multiorch", 90*time.Second)
+	setup.RequireRecovery(t, "multiorch", 90*time.Second, shardsetup.RecoveryScenarioEmergencyDemotion)
 
 	newPrimary := setup.RefreshPrimary(t)
 	require.NotNil(t, newPrimary, "a primary should exist after recovery")

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -874,13 +874,27 @@ const (
 	RecoveryScenarioEmergencyDemotion RecoveryScenario = "emergency-demotion"
 )
 
+// recoveryScenarioTimeouts configures how long RequireRecovery waits per RecoveryScenario.
+var recoveryScenarioTimeouts = map[RecoveryScenario]time.Duration{
+	RecoveryScenarioInitialSettle:      5 * time.Second,
+	RecoveryScenarioStalePrimaryDemote: 30 * time.Second,
+	RecoveryScenarioFixReplication:     30 * time.Second,
+	RecoveryScenarioEmergencyDemotion:  30 * time.Second,
+}
+
 // RequireRecovery triggers immediate recovery and blocks until all problems are resolved or
-// timeout. Automatically fails the test if any problems remain after timeout.
+// the scenario's timeout (see recoveryScenarioTimeouts) elapses. Automatically fails the test
+// if any problems remain after timeout.
 //
 // Logs pooler diagnostics and multiorch status every 5 seconds while waiting, and dumps a
 // final cluster state snapshot if recovery times out, to aid flake investigation.
-func (s *ShardSetup) RequireRecovery(t *testing.T, orchName string, timeout time.Duration, scenario RecoveryScenario) {
+func (s *ShardSetup) RequireRecovery(t *testing.T, orchName string, scenario RecoveryScenario) {
 	t.Helper()
+
+	timeout, ok := recoveryScenarioTimeouts[scenario]
+	if !ok {
+		t.Fatalf("RequireRecovery: no timeout configured for scenario %q", scenario)
+	}
 
 	start := time.Now()
 	conn := s.connectToMultiorch(t, orchName)

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -838,12 +838,48 @@ func (s *ShardSetup) TriggerRecoveryOnce(t *testing.T, orchName string, timeout 
 	return resp.RemainingProblemCodes
 }
 
+// RecoveryScenario labels which kind of recovery a RequireRecovery call is
+// waiting on. Different scenarios have different expected latency profiles,
+// so tagging each call lets testtiming aggregate comparable timings together
+// instead of mixing them under one generic "recovery" bucket keyed only by
+// the (often-shared, and sometimes reused across unrelated scenarios) timeout
+// value.
+//
+// The label reflects what RequireRecovery is actually waiting for at that
+// call site, not the name of the enclosing test — many tests exercise a
+// fault through some other mechanism (WaitForNewPrimary, a manual Recruit
+// RPC, etc.) and then call RequireRecovery only for a shared cleanup/settle
+// step afterward, which belongs under one of these categories regardless of
+// which fault triggered it.
+type RecoveryScenario string
+
+const (
+	// RecoveryScenarioInitialSettle is the generic "let multiorch settle to a
+	// clean state right after StartMultiorchs" wait used at the top of many
+	// tests, before any fault has been injected.
+	RecoveryScenarioInitialSettle RecoveryScenario = "initial-settle"
+	// RecoveryScenarioStalePrimaryDemote is the wait for a former primary to
+	// be demoted via SetPrimary (drain + pg_rewind + restart) and rejoin as a
+	// standby, after some other mechanism already elected its replacement.
+	RecoveryScenarioStalePrimaryDemote RecoveryScenario = "stale-primary-demote"
+	// RecoveryScenarioFixReplication is the wait for multiorch to detect and
+	// repair a broken or misconfigured replication link (conninfo cleared,
+	// removed from the standby list, a freshly restored replica not yet
+	// wired up, etc.).
+	RecoveryScenarioFixReplication RecoveryScenario = "fix-replication"
+	// RecoveryScenarioEmergencyDemotion is the wait after a test manually
+	// issues Recruit (bypassing multiorch) to force an emergency demotion,
+	// then hands control back to multiorch to elect a new primary and
+	// stabilize the shard.
+	RecoveryScenarioEmergencyDemotion RecoveryScenario = "emergency-demotion"
+)
+
 // RequireRecovery triggers immediate recovery and blocks until all problems are resolved or
 // timeout. Automatically fails the test if any problems remain after timeout.
 //
 // Logs pooler diagnostics and multiorch status every 5 seconds while waiting, and dumps a
 // final cluster state snapshot if recovery times out, to aid flake investigation.
-func (s *ShardSetup) RequireRecovery(t *testing.T, orchName string, timeout time.Duration) {
+func (s *ShardSetup) RequireRecovery(t *testing.T, orchName string, timeout time.Duration, scenario RecoveryScenario) {
 	t.Helper()
 
 	start := time.Now()
@@ -901,7 +937,7 @@ func (s *ShardSetup) RequireRecovery(t *testing.T, orchName string, timeout time
 		t.Fatalf("RequireRecovery: recovery did not complete within %s", timeout)
 	}
 
-	testtiming.Record(t, "recovery: "+orchName, time.Since(start), timeout)
+	testtiming.Record(t, "recovery: "+string(scenario), time.Since(start), timeout)
 	t.Logf("Recovery completed successfully on multiorch '%s' - all problems resolved", orchName)
 }
 

--- a/go/test/endtoend/testconst/constants.go
+++ b/go/test/endtoend/testconst/constants.go
@@ -19,11 +19,10 @@ import "time"
 
 const (
 	// ManagerStartTimeout is the maximum time to wait for a multipooler manager
-	// to become ready. Generous to accommodate slow CI environments.
-	ManagerStartTimeout = 120 * time.Second
+	// to become ready.
+	ManagerStartTimeout = 40 * time.Second
 
 	// ShardBootstrapTimeout is the maximum time waitForShardBootstrap will wait
-	// for all poolers to report a primary and complete initialization. Generous
-	// to accommodate slow CI environments (e.g. GitHub Actions runners).
-	ShardBootstrapTimeout = 240 * time.Second
+	// for all poolers to report a primary and complete initialization.
+	ShardBootstrapTimeout = 60 * time.Second
 )


### PR DESCRIPTION
## Summary
- Add a `RecoveryScenario` enum (`initial-settle`, `stale-primary-demote`, `fix-replication`, `emergency-demotion`) and thread it through `RequireRecovery` and all 17 call sites, so `testtiming` aggregates comparable timings instead of mixing unrelated operations under one generic "recovery" bucket.
- Recalibrate three timeouts based on real observed values: `dead_primary_recovery_test.go`'s `maxRecruit`/`maxPromote` (500ms/6s), `fix-replication`'s `RequireRecovery` timeout (10s → 20s), and `bootstrap_test.go`'s standby auto-restore timeout (90s → 15s).