### PR TITLE
test(multipooler): drop fragile term assertion

### DIFF
--- a/go/test/endtoend/multipooler/rpc_manager_api_test.go
+++ b/go/test/endtoend/multipooler/rpc_manager_api_test.go
@@ -58,7 +58,6 @@ func TestManagerStatus_NodeIdentityAndConsensus(t *testing.T) {
 
 		assert.Equal(t, setup.PrimaryMultipooler.Name, resp.GetConsensusStatus().GetId().GetName(), "PoolerId should match")
 		assert.Equal(t, "test-cell", resp.GetConsensusStatus().GetId().GetCell(), "Cell should match")
-		assert.GreaterOrEqual(t, resp.GetConsensusStatus().GetTermRevocation().GetRevokedBelowTerm(), int64(1), "TermNumber should be at least 1 (bootstrapped)")
 		assert.Equal(t, consensus.ConsensusRoleLeader, consensus.SelfConsensusRole(resp.GetConsensusStatus()), "Primary should be consensus leader")
 	})
 

--- a/go/test/endtoend/multipooler/rpc_manager_api_test.go
+++ b/go/test/endtoend/multipooler/rpc_manager_api_test.go
@@ -58,7 +58,7 @@ func TestManagerStatus_NodeIdentityAndConsensus(t *testing.T) {
 
 		assert.Equal(t, setup.PrimaryMultipooler.Name, resp.GetConsensusStatus().GetId().GetName(), "PoolerId should match")
 		assert.Equal(t, "test-cell", resp.GetConsensusStatus().GetId().GetCell(), "Cell should match")
-		assert.Equal(t, int64(1), resp.GetConsensusStatus().GetTermRevocation().GetRevokedBelowTerm(), "TermNumber should be 1")
+		assert.GreaterOrEqual(t, resp.GetConsensusStatus().GetTermRevocation().GetRevokedBelowTerm(), int64(1), "TermNumber should be at least 1 (bootstrapped)")
 		assert.Equal(t, consensus.ConsensusRoleLeader, consensus.SelfConsensusRole(resp.GetConsensusStatus()), "Primary should be consensus leader")
 	})
 


### PR DESCRIPTION
## Summary
- `TestManagerStatus_NodeIdentityAndConsensus` asserted the shared fixture's consensus term equals exactly 1, but term only ever increases and is never reset between tests sharing that fixture — several other tests bump it, and Go doesn't guarantee this test runs before them.
- Term revocation is also an internal consensus-protocol detail. Dropped the assertion entirely: the very next line already checks that the committed rule names this pooler as leader (`consensus.SelfConsensusRole`), which is the externally-meaningful proof that bootstrap completed.