### PR TITLE
test(multipooler): widen WaitForLSN_Standby_Success's replay wait to 10s

### DIFF
--- a/go/test/endtoend/multipooler/rpc_manager_replication_api_test.go
+++ b/go/test/endtoend/multipooler/rpc_manager_replication_api_test.go
@@ -78,9 +78,12 @@ func TestReplicationAPIs(t *testing.T) {
 		targetLSN := primaryPosResp.GetConsensusStatus().GetCurrentPosition().GetLsn()
 		t.Logf("Target LSN from primary: %s", targetLSN)
 
-		// Wait for standby to reach the target LSN
+		// Wait for standby to reach the target LSN. Unlike the Status() calls
+		// above, this genuinely waits on WAL replay catching up — an
+		// I/O-bound operation subject to CI variance — so it gets a more
+		// generous budget than the quick RPCs elsewhere in this test.
 		t.Log("Waiting for standby to reach target LSN...")
-		ctx = utils.WithTimeout(t, 1*time.Second)
+		ctx = utils.WithTimeout(t, 10*time.Second)
 
 		waitReq := &multipoolermanagerdatapb.WaitForLSNRequest{
 			TargetLsn: targetLSN,


### PR DESCRIPTION
## Summary
- `WaitForLSN_Standby_Success` waited only 1s for the standby's WAL replay to catch up to a target LSN — a real, I/O-bound wait subject to CI variance, not a fixed-cost RPC. Under CI load this occasionally timed out with a spurious `DeadlineExceeded` even though nothing was broken.
- Widened just this subtest's wait to 10s. The sibling subtests using the same 1s pattern are intentionally unaffected: `Primary_Fails` returns immediately regardless of timeout, and `Timeout` uses 1s as the actual test parameter (an unreachable LSN that's supposed to time out).