### PR TITLE
fix(multipooler): confirm WAL replay completion before recruit proceeds

### DIFF
--- a/docs/ha/decision-log/2026-02-12-wait-for-replay-stabilize-during-revoke.md
+++ b/docs/ha/decision-log/2026-02-12-wait-for-replay-stabilize-during-revoke.md
@@ -29,43 +29,151 @@ This matters during revoke because we need to query the audit table and rely on 
 
 ## Decision
 
-After disconnecting the WAL receiver during standby revoke, poll `pg_last_wal_replay_lsn()` until it stabilizes (same value for 3 consecutive polls at 10ms intervals), then report the final position. The full sequence is:
+**Updated:** 2026-07-21
 
-1. Reset `primary_conninfo` and reload config (breaks the connection to the old primary)
+After disconnecting the WAL receiver during standby revoke, wait until replay has applied all received WAL, then report the final position. The full sequence is:
+
+1. Reset `primary_conninfo` and `restore_command` and reload config (breaks the connection to the old primary)
 2. Wait for the WAL receiver process to fully disconnect (`pg_stat_wal_receiver` shows no rows)
-3. Poll `pg_last_wal_replay_lsn()` until it stops advancing (3 consecutive identical readings, approximately 30ms of stability)
+3. Poll until replay has applied all available WAL, decided by two positive signals only (see the update below).
 4. Query and report the final replication status
 
-The overall timeout for the stabilization wait is 10 seconds.
+The overall timeout for the wait is 10 seconds.
 
-This is a heuristic, not a guarantee. A stable reading can also occur if replay is stalled. We have not found a better approach in PostgreSQL. Alternatives considered:
+### Update: positive-signal completion (`waitForReplayComplete`)
 
-- **Wait for receive LSN to equal replay LSN:** does not work because they track different units (byte position vs record boundary) and may never match exactly.
+The original implementation waited for `pg_last_wal_replay_lsn()` to stop
+advancing (3 identical readings ≈30ms apart). Reported evidence showed this can
+declare completion prematurely: anything that freezes the replay LSN below the
+received position — a recovery conflict, an I/O stall, `recovery_min_apply_delay`
+— looks identical to "replay finished" over the stability window, so `Recruit()`
+could proceed before WAL was fully replayed and report a stale position.
+
+The **stability heuristic was removed as a completion criterion.** Completion is
+now decided by two positive signals, and every other state means "not done, keep
+waiting" until the deadline:
+
+1. **`pg_last_wal_replay_lsn() >= pg_last_wal_receive_lsn()`** — replay has applied
+   every received byte. The receiver is already stopped so `receive_lsn` is
+   frozen; the comparison is done in SQL for a single consistent snapshot and
+   PostgreSQL's native `pg_lsn` ordering (LSN strings do not compare
+   lexicographically).
+
+2. **The startup (recovery) process is parked in an end-of-WAL wait** —
+   `wait_event` is `RecoveryRetrieveRetryInterval` or `RecoveryWalStream` in
+   `pg_stat_activity` for `backend_type = 'startup'`. This means recovery looked
+   for more WAL and found none, so every _complete_ received record has been
+   applied. This is necessary because streamed WAL normally ends in an _incomplete_
+   record (a partial cross-page record): `pg_last_wal_receive_lsn()` counts those
+   trailing bytes but replay stops at the last complete record, so `replay_lsn`
+   legitimately settles below `receive_lsn`. Signal 1 alone would never fire in
+   that (common) case. To avoid acting on a transient sample, the end-of-WAL wait
+   must be observed on 2 consecutive polls (the startup process passes briefly
+   through I/O / running states while cycling WAL sources).
+
+Any other observed state — replay actively applying, a stall on I/O
+(`DataFileRead` / `WalRead` / `WalSync`), a recovery conflict (`Lock` /
+`BufferPin` / `RecoveryConflict*`), an apply delay, a `NULL`/uninstrumented wait,
+or an unrecognized wait — is treated as "not done". A genuine stall therefore
+rides out the 10s deadline and surfaces as a `DEADLINE_EXCEEDED` Recruit error
+(the safe, loud failure) instead of a premature, unsafe "done".
+
+Alternatives considered and rejected:
+
+- **Stop when the replay LSN stops advancing (the original heuristic):** a stalled
+  I/O or a recovery conflict freezes the LSN below `receive_lsn` while WAL is still
+  pending, and is indistinguishable from completion. This is the bug this update fixes.
+- **Require exact `replay_lsn == receive_lsn`:** rejected — they track different
+  units (byte position vs record boundary), so with a trailing incomplete record
+  they never match and Recruit would always time out.
+
+Version note: the recovery wait-event names are stable across PostgreSQL 13+
+(well below the multigres floor). Before 13 they were renamed and `RecoveryWalStream`
+meant something different, and in a future major the `BufferPin` wait-event _class_
+is renamed to `Buffer`; the completion logic keys on a small allow-list of
+end-of-WAL events and biases every unrecognized state toward "keep waiting", so
+name drift can only cost latency (up to the deadline), never a premature "done".
+
+### What can move the startup process out of `RecoveryRetrieveRetryInterval`
+
+Signal 2's soundness rests on the fact that, in our context, once the startup
+process reaches the end-of-WAL retry wait it cannot resume applying WAL. That wait
+is a `WaitLatch` (`xlogrecovery.c`, `WaitForWALToBecomeAvailable`) that returns on:
+
+- **timeout** — every `wal_retrieve_retry_interval` (5s default);
+- **latch set** (`WakeupRecovery()`) — a running walreceiver started/flushed WAL,
+  or a `SIGHUP` (config reload) / `SIGUSR2` (promote) / `SIGTERM` (shutdown) /
+  `pg_wal_replay_pause()`;
+- **postmaster death**.
+
+Crucially, waking is not the same as resuming replay: after any wake, recovery
+just retries the sources (archive → pg_wal → stream) and re-enters the wait unless
+a source now actually has the next record. Replay therefore resumes only via one
+of two paths:
+
+1. **Streaming (re)starts** — a walreceiver connects and delivers WAL. Requires
+   `primary_conninfo` to be set.
+2. **The archive grows** — `restore_command` succeeds on a retry because a new
+   segment appeared. Requires a live primary still archiving to the repo.
+
+Both callers stop the receiver before the wait, so path 1 is closed — and
+`waitForReplayComplete` additionally verifies `primary_conninfo` is empty
+(`checkNoWALSource`) as a defensive guard. Path 2 is closed in the failover and
+rewind scenarios because the source primary is dead or demoted, leaving a static
+archive; a set `restore_command` is therefore harmless there (recovery replays the
+archive to exhaustion and then parks). This is why the recruit path clears
+`restore_command` for a _consensus_ reason (a cohort member must not chase a
+possibly-foreign archive) rather than for signal-2 timing, and why the rewind path
+may legitimately run with `restore_command` set.
+
+Residual limitation: if the archive were _growing_ (a live primary archiving to the
+same repo) while `restore_command` is set, a new segment could be fetched between
+two polls and replay would resume, making signal 2 premature. This does not arise
+in the failover/rewind scenarios (dead/demoted primary), but it is the reason the
+recruit path does not rely on it.
 
 ## Consensus Implications and What Could Go Wrong
 
-In the worst case, replay is stalled but the standby has already received WAL that includes commits affecting the audit table. In that situation, the standby may report stale cohort or primary term information.
+With positive-signal completion (see the update above), neither a stalled
+replay nor a trailing incomplete record can be mistaken for completion: the former
+keeps us waiting until the deadline (then errors), and the latter is recognized
+explicitly via the end-of-WAL wait event. The residual failure modes are now:
 
-- A stale cohort could yield an election that assumes the wrong quorum and triggers failover without discovering a more advanced replica.
-- A stale primary term could prevent multiorch from detecting conflicting timelines across multiple failovers.
+- **A false end-of-WAL reading.** If the startup process reported an end-of-WAL
+  wait on 2 consecutive polls but WAL was in fact still pending, we could report a
+  stale position. This requires the recovery process to misreport its wait state,
+  which we treat as not credible.
+- **A slow-but-progressing replay near the deadline** times out and fails Recruit.
+  This is the safe direction (fail loud); the orchestrator retries.
 
-Both failure modes are theoretical and unlikely in practice, especially for our 3 node deployment across Availability Zones.
+If a stale position were ever reported, the standby could publish stale cohort or
+primary term information:
+
+- A stale cohort could yield an election that assumes the wrong quorum and triggers
+  failover without discovering a more advanced replica.
+- A stale primary term could prevent multiorch from detecting conflicting timelines
+  across multiple failovers.
+
+Both are theoretical and unlikely in practice, especially for our 3 node deployment
+across Availability Zones.
 
 ## Rationale
 
-- The 3 poll (30ms) stability window reduces false positives from brief pauses between replay progress while keeping revoke latency low.
-- Waiting for the receiver to disconnect first ensures no new WAL arrives during the stabilization check.
-- The 10 second overall timeout prevents unbounded waits if replay is not catching up.
-- With `synchronous_commit=on`, commits acknowledged via this standby should be durably present in its WAL storage, so under normal conditions replay catches up quickly.
+- Completion is decided only by positive signals (`replay_lsn >= receive_lsn` or an end-of-WAL wait event); a frozen replay LSN is never itself treated as completion, so stalls cannot be mistaken for "done".
+- Requiring the end-of-WAL wait on 2 consecutive polls avoids acting on a transient sample while keeping revoke latency low (polls are 100ms apart).
+- Waiting for the receiver to disconnect first freezes `receive_lsn`, which is what makes signal 1 a stable target.
+- The 10 second overall timeout prevents unbounded waits: a genuine stall surfaces as a `DEADLINE_EXCEEDED` error rather than blocking indefinitely or completing prematurely.
+- With `synchronous_commit=on`, commits acknowledged via this standby should be durably present in its WAL storage, so under normal conditions replay completes quickly.
 
 ## Scope
 
 **In scope:**
 
-- Wait for replay stabilization during standby revoke in BeginTerm
-- Report replay LSN after stabilization
+- Wait for replay to complete during standby revoke in BeginTerm
+- Report replay LSN after completion
 
 **Not in scope:**
 
-- PostgreSQL changes to expose an explicit replay idle signal
+- PostgreSQL changes to expose an explicit replay-idle signal
 - Handling replay that is stuck for extended periods (the 10s timeout surfaces this as an error)
+- Eliminating the recovery conflicts that can stall replay (e.g. stopping read serving before the wait); out of scope here — the completion check refuses to complete during such a stall, which is sufficient for correctness.

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -1370,6 +1370,17 @@ func (pm *MultipoolerManager) promoteStandbyToPrimary(ctx context.Context, state
 		// Log but don't fail - promotion already succeeded
 	}
 
+	// Clear restore_command on becoming primary. pgbackrest's initial "restore
+	// --type=standby" wrote it into postgresql.auto.conf and nothing has cleared
+	// it since; a promoted node must not carry it forward. This is the
+	// root-cause reset: a primary with a clean auto.conf means pg_rewind on a
+	// rejoining follower won't copy restore_command back over, and this node
+	// won't resume archive playback if it is later restarted as a standby.
+	if err := pm.resetRestoreCommand(ctx); err != nil {
+		pm.logger.WarnContext(ctx, "Failed to clear restore_command after promotion", "error", err)
+		// Log but don't fail - promotion already succeeded
+	}
+
 	go func() {
 		// After a failover PostgreSQL resets user-created unlogged tables to empty.
 		// Best-effort drop them asynchronously so clients get a clear "relation does

--- a/go/services/multipooler/internal/manager/pg_replication.go
+++ b/go/services/multipooler/internal/manager/pg_replication.go
@@ -30,7 +30,9 @@ import (
 	backupengine "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pgmode"
+	"github.com/multigres/multigres/go/tools/pgutil"
 	"github.com/multigres/multigres/go/tools/retry"
+	"github.com/multigres/multigres/go/tools/telemetry"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
@@ -544,91 +546,257 @@ func (pm *MultipoolerManager) stopRestoreCommand(ctx context.Context) error {
 	return nil
 }
 
-// waitForReplayStabilize waits, best effort, for WAL replay to stop making
-// observable progress. The intent is to approximate replay is idle given the WAL
-// that is currently available to this standby.
+// waitForReplayComplete waits until WAL replay has applied every complete WAL
+// record available to this standby and returns the replication status at that
+// point. The WAL receiver is stopped before this runs (see Recruit), so the
+// received LSN is frozen and completion is decided by two positive signals
+// only:
 //
-// WARNING: This function is not perfect and has some theoretical limitations.
-// See decision: 2026-02-12-wait-for-replay-stabilize-during-revoke.md for more context.
-func (pm *MultipoolerManager) waitForReplayStabilize(ctx context.Context) (*multipoolermanagerdatapb.StandbyReplicationStatus, error) {
-	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+//  1. replay_lsn >= receive_lsn — replay has applied every received byte.
+//     This is not the normal case since a crash leaves an incomplete record
+//     last in the WAL, but it is possible if the source primary was cleanly
+//     shut down and the last record was complete.
+//
+//  2. The startup (recovery) process is parked in an end-of-WAL wait
+//     (RecoveryRetrieveRetryInterval / RecoveryWalStream): it looked for more
+//     WAL and found none, so every complete received record has been applied
+//     and any trailing bytes are an incomplete record it cannot replay.
+//
+// This is the normal way streamed WAL ends (the tail is usually a partial
+// cross-page record), so replay_lsn legitimately settling below receive_lsn is
+// expected. Signal 2 is only sound if the server cannot move out of the
+// end-of-WAL wait by obtaining more WAL. Two sources could do that:
+//
+//  1. The WAL receiver could stream more if primary_conninfo were set. Both
+//     callers stop the receiver first; checkNoWALSource below verifies
+//     primary_conninfo is empty and fails loudly if not.
+//  2. Recovery could fetch more segments from the archive if restore_command is
+//     set. This is tolerated: once the archive is exhausted recovery parks in the
+//     end-of-WAL wait, which is sound as long as the archive is static — true in
+//     the failover/rewind scenarios here, where the source primary is dead or
+//     demoted. The rewind path legitimately catches up from the archive with
+//     restore_command set, so we must not reject it. See the decision log,
+//     "What can move the startup process out of RecoveryRetrieveRetryInterval".
+//
+// The action lock the callers hold keeps primary_conninfo static for the wait,
+// so one check up front suffices.
+//
+// Every other observed state — replay actively applying, a stall on I/O
+// (DataFileRead/WalRead/WalSync), a recovery conflict (Lock / BufferPin /
+// RecoveryConflict*), an apply delay, a NULL/uninstrumented wait, or any
+// unrecognized wait — is treated as "not done, keep waiting". We deliberately
+// do NOT infer completion from "replay_lsn stopped advancing": a stalled I/O or
+// a conflict freezes replay_lsn below receive_lsn while WAL is still pending,
+// and mistaking that for completion is exactly the bug this guards against. A
+// genuine stall therefore rides out the deadline and surfaces as a
+// DEADLINE_EXCEEDED error rather than a premature (and unsafe) "done".
+//
+// See decision: 2026-02-12-wait-for-replay-stabilize-during-revoke.md.
+func (pm *MultipoolerManager) waitForReplayComplete(ctx context.Context) (*multipoolermanagerdatapb.StandbyReplicationStatus, error) {
+	completeCtx, completeSpan := telemetry.Tracer().Start(ctx, "consensus/replay_completion_wait")
+	defer completeSpan.End()
+
+	waitCtx, cancel := context.WithTimeout(completeCtx, 10*time.Second)
 	defer cancel()
 
-	ticker := time.NewTicker(10 * time.Millisecond)
+	// The end-of-WAL completion signal is only sound if nothing can feed more
+	// WAL to replay; verify that before we start trusting it.
+	if err := pm.checkNoWALSource(waitCtx); err != nil {
+		return nil, err
+	}
+
+	// Poll every 100ms: frequent enough to keep revoke latency low, but not so
+	// tight that we hammer postgres while waiting out a slow replay.
+	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
-	// TODO: short-circuit when replay has provably caught up. On the recruit path
-	// the receiver is stopped before this runs, so the received LSN is fixed; if
-	// pg_last_wal_replay_lsn() == pg_last_wal_receive_lsn() we are maximally
-	// applied and can return immediately instead of waiting out requiredStablePolls.
-	// That needs queryReplayState to also return the receive LSN. Until then the
-	// stability heuristic below is a safe (if slightly slower) fallback.
-	//
-	// requiredStablePolls: number of consecutive polls showing the same replay_lsn
-	// before we declare stability. At 10ms per tick, 3 polls = 30ms of stability.
-	const requiredStablePolls = 3
-	var prevReplayLsn string
-	consecutive := 0
+	// The startup process passes briefly through IO/NULL while cycling WAL
+	// sources before it settles into the end-of-WAL retry sleep, so we require
+	// the end-of-WAL wait to persist across a couple of polls before trusting
+	// it — never act on a single-sample flicker. This is not likely to be a
+	// problem, so it is more of a precaution.
+	const requiredEndOfWalPolls = 2
+	endOfWalPolls := 0
+
+	// Track the latest wait-event sample so a timeout carries diagnostic detail.
+	var lastWaitEventType, lastWaitEvent string
 
 	for {
 		select {
 		case <-waitCtx.Done():
 			if waitCtx.Err() == context.DeadlineExceeded {
-				return nil, mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, "timeout waiting for WAL replay to stabilize")
+				pm.logger.ErrorContext(ctx, "Timeout waiting for WAL replay to complete",
+					"last_startup_wait_event_type", lastWaitEventType,
+					"last_startup_wait_event", lastWaitEvent)
+				return nil, mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, "timeout waiting for WAL replay to complete")
 			}
-			return nil, mterrors.Wrap(waitCtx.Err(), "context cancelled while waiting for replay to stabilize")
+			return nil, mterrors.Wrap(waitCtx.Err(), "context cancelled while waiting for replay to complete")
 
 		case <-ticker.C:
-			replayLsn, isPaused, err := pm.queryReplayState(waitCtx)
+			prog, err := pm.queryReplayProgress(waitCtx)
 			if err != nil {
 				return nil, err
 			}
+			lastWaitEventType, lastWaitEvent = prog.waitEventType, prog.waitEvent
 
-			if isPaused {
+			if prog.isPaused {
 				return nil, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION,
 					"WAL replay is paused during revoke — unexpected state")
 			}
 
-			if replayLsn == prevReplayLsn {
-				consecutive++
-			} else {
-				consecutive = 1
+			// Signal 1: replay has applied every received byte. hasReceive guards
+			// the case where the receiver never ran (receive LSN is NULL).
+			if prog.hasReceive && prog.replayLSN >= prog.receiveLSN {
+				pm.logger.InfoContext(ctx, "WAL replay caught up to received WAL (fully applied)",
+					"replay_lsn", prog.replayLSN.String())
+				return pm.queryReplicationStatus(waitCtx)
 			}
-			prevReplayLsn = replayLsn
 
-			if consecutive >= requiredStablePolls {
-				pm.logger.InfoContext(ctx, "WAL replay stabilized (maximally applied)",
-					"replay_lsn", replayLsn)
-
-				status, err := pm.queryReplicationStatus(waitCtx)
-				if err != nil {
-					return nil, err
+			// Signal 2: startup process idle at the end of available WAL, observed
+			// on consecutive polls so a single-sample flicker never trips it.
+			if isNoMoreWalToReplay(prog.waitEvent) {
+				endOfWalPolls++
+				if endOfWalPolls >= requiredEndOfWalPolls {
+					pm.logger.InfoContext(ctx, "WAL replay reached end of available WAL (fully applied; trailing bytes are an incomplete record)",
+						"replay_lsn", prog.replayLSN.String(),
+						"startup_wait_event", prog.waitEvent)
+					return pm.queryReplicationStatus(waitCtx)
 				}
-				return status, nil
+			} else {
+				// Applying, stalled (I/O or conflict), or unrecognized: not done.
+				endOfWalPolls = 0
 			}
 		}
 	}
 }
 
-// queryReplayState returns the current replay LSN and pause state.
-// Returns FAILED_PRECONDITION if the server is not in recovery (replay LSN is NULL).
-func (pm *MultipoolerManager) queryReplayState(ctx context.Context) (replayLsn string, isPaused bool, err error) {
+// isNoMoreWalToReplay reports whether the given startup-process wait_event
+// means the recovery process is idle waiting for WAL that will not arrive (the
+// receiver is stopped), i.e. it has applied every complete record it has.
+//
+// These names are stable across PostgreSQL 13+ (the multigres floor is well
+// above that). Before 13 the recovery wait events were renamed and the string
+// "RecoveryWalStream" meant something else, so this must not be relied upon on
+// older majors. See the WAL-replay-completion decision log.
+func isNoMoreWalToReplay(waitEvent string) bool {
+	return waitEvent == "RecoveryRetrieveRetryInterval" || waitEvent == "RecoveryWalStream"
+}
+
+// checkNoWALSource verifies the streaming precondition that makes
+// waitForReplayComplete's end-of-WAL signal sound: primary_conninfo must be empty
+// so the WAL receiver cannot (re)start and stream more WAL during the wait. Both
+// callers stop the receiver first; this is a defensive assertion that fails loudly
+// if that was not done, rather than silently mis-detecting completion.
+//
+// restore_command is intentionally NOT checked. The rewind path legitimately
+// catches up from the archive with restore_command set, and once the archive is
+// exhausted recovery parks in the end-of-WAL wait — sound as long as the archive
+// is static (the source primary is dead/demoted in the scenarios this runs in).
+// See the decision log, "What can move the startup process out of
+// RecoveryRetrieveRetryInterval". The recruit path additionally clears
+// restore_command, but for a consensus reason (a cohort member must not replay a
+// possibly-foreign archive), not for signal-2 timing.
+func (pm *MultipoolerManager) checkNoWALSource(ctx context.Context) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	result, err := pm.query(queryCtx, "SELECT pg_last_wal_replay_lsn(), pg_is_wal_replay_paused()")
+	result, err := pm.query(queryCtx, "SELECT current_setting('primary_conninfo', true), current_setting('restore_command', true)")
 	if err != nil {
-		return "", false, mterrors.Wrap(err, "failed to query replay state")
+		return mterrors.Wrap(err, "failed to read WAL-source settings")
+	}
+	var primaryConnInfo, restoreCommand string
+	if err := executor.ScanSingleRow(result, &primaryConnInfo, &restoreCommand); err != nil {
+		return mterrors.Wrap(err, "failed to scan WAL-source settings")
+	}
+	if primaryConnInfo != "" {
+		return mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION,
+			"primary_conninfo is set: cannot determine WAL replay completion (could stream more WAL)")
+	}
+	if restoreCommand != "" {
+		return mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION,
+			"restore_command is set: cannot determine WAL replay completion (could read more WAL segments)")
+	}
+	return nil
+}
+
+// replayProgress is a single-snapshot view of standby WAL replay, read by
+// queryReplayProgress and consumed by waitForReplayComplete.
+type replayProgress struct {
+	replayLSN  pgutil.LSN // end of the last replayed record
+	receiveLSN pgutil.LSN // last received WAL byte; only valid when hasReceive
+	hasReceive bool       // false when pg_last_wal_receive_lsn() is NULL
+	isPaused   bool       // pg_is_wal_replay_paused()
+
+	// Startup (recovery) process wait state from pg_stat_activity. Empty when the
+	// process is not in an instrumented wait (actively running) or is not visible;
+	// callers must treat empty as inconclusive, never as "done".
+	waitEventType string
+	waitEvent     string
+}
+
+// queryReplayProgress reads a single consistent snapshot of standby WAL replay:
+// the replay and receive LSNs, the pause state, and the startup (recovery)
+// process's wait state — all from one query, so the values cannot drift between
+// reads. LSNs are parsed here (their text form "X/Y" hex does not sort
+// lexicographically) so callers compare the numeric values directly.
+//
+// The query selects from pg_stat_activity restricted to the startup process, so
+// it returns ZERO rows when no startup process exists — i.e. the server is not
+// in recovery (it is a primary, or recovery has already ended). A standby in
+// recovery always has exactly one startup process, which is the only state
+// waitForReplayComplete runs in, so a zero-row result is treated as a
+// FAILED_PRECONDITION rather than a valid reading.
+//
+// hasReceive is false when pg_last_wal_receive_lsn() is NULL (the receiver never
+// ran this postmaster lifetime). wait_event_type/wait_event are NULL — scanned
+// as "" — when the startup process is not in an instrumented wait.
+func (pm *MultipoolerManager) queryReplayProgress(ctx context.Context) (replayProgress, error) {
+	emptyProg := replayProgress{}
+
+	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+
+	result, err := pm.query(queryCtx, `SELECT
+		pg_last_wal_replay_lsn(),
+		pg_last_wal_receive_lsn(),
+		pg_is_wal_replay_paused(),
+		wait_event_type,
+		wait_event
+		FROM pg_stat_activity WHERE backend_type = 'startup' LIMIT 1`)
+	if err != nil {
+		return emptyProg, mterrors.Wrap(err, "failed to query replay progress")
+	}
+	// Zero rows means there is no startup process, i.e. the server is not in
+	// recovery (see the doc comment) — unexpected on the revoke/rewind paths.
+	if len(result.Rows) == 0 {
+		return emptyProg, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION,
+			"no startup process found (not in recovery) — unexpected during revoke")
 	}
 
-	var lsn *string
-	if err := executor.ScanSingleRow(result, &lsn, &isPaused); err != nil {
-		return "", false, mterrors.Wrap(err, "failed to scan replay state")
+	var replay, receive *string
+	var prog replayProgress
+	if err := executor.ScanSingleRow(result, &replay, &receive, &prog.isPaused, &prog.waitEventType, &prog.waitEvent); err != nil {
+		return emptyProg, mterrors.Wrap(err, "failed to scan replay progress")
 	}
-	if lsn == nil {
-		return "", false, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION,
-			"pg_last_wal_replay_lsn is NULL (not in recovery) — unexpected during revoke")
+	// Defensive: a startup row with a NULL replay LSN would mean recovery has not
+	// applied anything yet. It should not happen once the standby is streaming,
+	// but guard the *replay dereference below and fail cleanly if it does.
+	if replay == nil {
+		return emptyProg, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION,
+			"pg_last_wal_replay_lsn is NULL — replay has not started")
 	}
-	return *lsn, isPaused, nil
+
+	if prog.replayLSN, err = pgutil.ParseLSN(*replay); err != nil {
+		return emptyProg, mterrors.Wrapf(err, "failed to parse replay LSN %q", *replay)
+	}
+	// A NULL receive LSN means the receiver never ran; leave hasReceive false so
+	// the caller cannot mistake it for caught up.
+	if receive != nil {
+		if prog.receiveLSN, err = pgutil.ParseLSN(*receive); err != nil {
+			return emptyProg, mterrors.Wrapf(err, "failed to parse receive LSN %q", *receive)
+		}
+		prog.hasReceive = true
+	}
+	return prog, nil
 }
 
 // waitForReceiverDisconnect waits for the WAL receiver to fully disconnect after clearing primary_conninfo.

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -167,12 +167,10 @@ func (pm *MultipoolerManager) Recruit(ctx context.Context, req *consensusdatapb.
 	}
 
 	if !pgMode.OutOfRecovery() {
-		stabilizeCtx, stabilizeSpan := telemetry.Tracer().Start(ctx, "consensus/stabilize")
-		_, err = pm.waitForReplayStabilize(stabilizeCtx)
-		stabilizeSpan.End()
+		_, err = pm.waitForReplayComplete(ctx)
 		if err != nil {
 			eventlog.Emit(ctx, pm.logger, eventlog.Failed, termEvent, "error", err)
-			return nil, mterrors.Wrap(err, "failed waiting for replay to stabilize during recruit")
+			return nil, mterrors.Wrap(err, "failed waiting for replay to complete during recruit")
 		}
 	}
 
@@ -246,7 +244,7 @@ func (pm *MultipoolerManager) stopReplicationForRecruit(ctx context.Context, pgM
 	// advance via streaming from the current leader, never the archive (an
 	// observer catching up may have had it enabled). Clear restore_command
 	// and confirm any in-flight invocation has actually stopped before the
-	// caller's waitForReplayStabilize is allowed to declare replay settled —
+	// caller's waitForReplayComplete is allowed to declare replay complete —
 	// postgres cannot cancel an in-flight invocation on its own, so clearing
 	// the config alone only stops future fetches.
 	//

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -94,7 +94,8 @@ func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService, r
 	// Build through the real constructor with the mock query service and fake
 	// rule store injected, so the consensus manager (promises rooted at tmpDir
 	// via PoolerDir, rule store = the fake) is wired correctly from the start.
-	pm, err := NewMultipoolerManagerForTesting(t, logger, multipooler, config,
+	pm, err := NewMultipoolerManagerForTesting(
+		t, logger, multipooler, config,
 		withMockController(&mockPoolerController{queryService: mockQueryService}),
 		withFakeRules(rules),
 	)
@@ -125,13 +126,17 @@ func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService, r
 // ============================================================================
 
 // expectStandbyRecruitMocks sets up mock expectations for the standby Recruit path:
-// saves primary_conninfo, disconnects receiver, and waits for replay to stabilize.
+// saves primary_conninfo, disconnects receiver, and waits for replay to complete.
 func expectStandbyRecruitMocks(m *mock.QueryService, lsn string, savedConnInfo string) {
 	replStatusCols := []string{"replay_lsn", "receive_lsn", "is_paused", "pause_state", "last_xact_replay_ts", "primary_conninfo", "status", "last_msg_receive_time", "wal_receiver_status_interval", "wal_receiver_timeout"}
 	replStatusRow := [][]any{{lsn, lsn, false, "not paused", nil, "", nil, nil, nil, nil}}
 
-	replayStateCols := []string{"replay_lsn", "is_paused"}
-	replayStateRow := [][]any{{lsn, false}}
+	// queryReplayProgress reads replay_lsn, receive_lsn, is_paused, and the startup
+	// wait event in one query; waitForReplayComplete compares the LSNs in Go.
+	// Since the receiver is stopped before this runs, replay == receive here (and
+	// no startup wait event), so it is caught up on the first poll.
+	progressCols := []string{"replay_lsn", "receive_lsn", "is_paused", "wait_event_type", "wait_event"}
+	progressRow := [][]any{{lsn, lsn, false, nil, nil}}
 
 	// isPrimary check
 	m.AddQueryPatternOnce("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
@@ -155,11 +160,17 @@ func expectStandbyRecruitMocks(m *mock.QueryService, lsn string, savedConnInfo s
 	expectReloadConfig(m)
 	// stopRestoreCommand goes through the mock pgctld gRPC server, not the SQL mock;
 	// its default response (nothing found running) requires no setup here.
-	// waitForReplayStabilize: three consecutive polls with same replay_lsn = stable
-	m.AddQueryPatternOnce("^SELECT pg_last_wal_replay_lsn", mock.MakeQueryResult(replayStateCols, replayStateRow))
-	m.AddQueryPatternOnce("^SELECT pg_last_wal_replay_lsn", mock.MakeQueryResult(replayStateCols, replayStateRow))
-	m.AddQueryPatternOnce("^SELECT pg_last_wal_replay_lsn", mock.MakeQueryResult(replayStateCols, replayStateRow))
-	// Final queryReplicationStatus after stability confirmed
+	// waitForReplayComplete: checkNoWALSource confirms primary_conninfo is empty.
+	// Its query is identical to readPrimaryConnInfo's, so this anchored pattern is
+	// a second AddQueryPatternOnce (readPrimaryConnInfo consumed the first match
+	// above; this one is consumed here).
+	m.AddQueryPatternOnce(`^SELECT current_setting\('primary_conninfo', true\)`, mock.MakeQueryResult(
+		[]string{"primary_conninfo", "restore_command"}, [][]any{{"", ""}},
+	))
+	// queryReplayProgress (the only query with pg_stat_activity) reports
+	// replay == receive, so signal 1 fires on the first poll.
+	m.AddQueryPatternOnce("pg_stat_activity", mock.MakeQueryResult(progressCols, progressRow))
+	// Final queryReplicationStatus after replay confirmed caught up
 	m.AddQueryPatternOnce("pg_last_wal_replay_lsn", mock.MakeQueryResult(replStatusCols, replStatusRow))
 }
 
@@ -608,6 +619,9 @@ func expectLeaderPromoteMocksWithUnlogged(m *mock.QueryService, unloggedTables [
 		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"f"}}))
 	// resetPrimaryConnInfo: clear conninfo + reload
 	m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
+	expectReloadConfig(m)
+	// resetRestoreCommand: clear restore_command + reload
+	m.AddQueryPatternOnce("ALTER SYSTEM RESET restore_command", mock.MakeQueryResult(nil, nil))
 	expectReloadConfig(m)
 	// dropUnloggedTablesAfterPromotion: list unlogged tables to inspect.
 	rows := make([][]any, len(unloggedTables))
@@ -1230,4 +1244,171 @@ func TestSetResignedLeaderAtTerm_BroadcastsOnChange(t *testing.T) {
 
 	require.NoError(t, pm.consensusMgr.SetResignedLeaderAtTerm(lockCtx, &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 0}}}))
 	assert.Equal(t, 1, drain(), "clearing the term is also a change and should broadcast")
+}
+
+// TestWaitForReplayComplete covers the WAL-replay completion check used during
+// standby Recruit. Completion is decided by two positive signals only:
+// replay_lsn >= receive_lsn, or the startup process idle in an end-of-WAL wait.
+// Every other state (stalled I/O, recovery conflict, running) means keep waiting.
+func TestWaitForReplayComplete(t *testing.T) {
+	// queryReplayProgress reads all of this in one query; it is the only query
+	// containing pg_stat_activity, so tests match it on that. Row order is
+	// replay_lsn, receive_lsn, is_paused, wait_event_type, wait_event.
+	progressCols := []string{"replay_lsn", "receive_lsn", "is_paused", "wait_event_type", "wait_event"}
+	replStatusCols := []string{"replay_lsn", "receive_lsn", "is_paused", "pause_state", "last_xact_replay_ts", "primary_conninfo", "status", "last_msg_receive_time", "wal_receiver_status_interval", "wal_receiver_timeout"}
+	replStatusRow := func(replay, receive string) [][]any {
+		return [][]any{{replay, receive, false, "not paused", nil, "", nil, nil, nil, nil}}
+	}
+
+	t.Run("CaughtUpReturnsImmediately", func(t *testing.T) {
+		m := mock.NewQueryService()
+		pm, _ := setupManagerWithMockDB(t, m, &fakeRuleStore{})
+		// checkNoWALSource precondition: no WAL source configured.
+		m.AddQueryPattern(`^SELECT current_setting\('primary_conninfo', true\)`, mock.MakeQueryResult(
+			[]string{"primary_conninfo", "restore_command"}, [][]any{{"", ""}},
+		))
+		// replay == receive (caught up), so signal 1 fires on the first poll. The
+		// progress query is registered before the status query because both contain
+		// pg_last_wal_replay_lsn; only the progress query contains pg_stat_activity.
+		m.AddQueryPatternOnce("pg_stat_activity", mock.MakeQueryResult(progressCols, [][]any{{"0/5000000", "0/5000000", false, nil, nil}}))
+		m.AddQueryPatternOnce("pg_last_wal_replay_lsn", mock.MakeQueryResult(replStatusCols, replStatusRow("0/5000000", "0/5000000")))
+
+		status, err := pm.waitForReplayComplete(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, "0/5000000", status.LastReplayLsn)
+		require.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("EndOfWalWaitCompletesBelowReceive", func(t *testing.T) {
+		m := mock.NewQueryService()
+		pm, _ := setupManagerWithMockDB(t, m, &fakeRuleStore{})
+		// checkNoWALSource precondition: no WAL source configured.
+		m.AddQueryPattern(`^SELECT current_setting\('primary_conninfo', true\)`, mock.MakeQueryResult(
+			[]string{"primary_conninfo", "restore_command"}, [][]any{{"", ""}},
+		))
+		// Replay never reaches receive_lsn (trailing incomplete record). The startup
+		// process idle in an end-of-WAL wait is the positive completion signal;
+		// it must be observed on 2 consecutive polls.
+		m.AddQueryPattern("pg_stat_activity", mock.MakeQueryResult(progressCols, [][]any{{"0/4000000", "0/5000000", false, "Timeout", "RecoveryRetrieveRetryInterval"}}))
+		m.AddQueryPattern("pg_last_wal_replay_lsn", mock.MakeQueryResult(replStatusCols, replStatusRow("0/4000000", "0/4000018")))
+
+		status, err := pm.waitForReplayComplete(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, "0/4000000", status.LastReplayLsn)
+	})
+
+	t.Run("IoStallDoesNotComplete", func(t *testing.T) {
+		m := mock.NewQueryService()
+		pm, _ := setupManagerWithMockDB(t, m, &fakeRuleStore{})
+		// checkNoWALSource precondition: no WAL source configured.
+		m.AddQueryPattern(`^SELECT current_setting\('primary_conninfo', true\)`, mock.MakeQueryResult(
+			[]string{"primary_conninfo", "restore_command"}, [][]any{{"", ""}},
+		))
+		// Replay frozen below receive_lsn while the startup process is stalled on
+		// I/O. This is NOT completion: the wait must run to the deadline and error,
+		// never mistaking the frozen LSN for "done".
+		m.AddQueryPattern("pg_stat_activity", mock.MakeQueryResult(progressCols, [][]any{{"0/4000000", "0/5000000", false, "IO", "DataFileRead"}}))
+
+		ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+		defer cancel()
+		_, err := pm.waitForReplayComplete(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "timeout")
+	})
+
+	t.Run("RecoveryConflictDoesNotComplete", func(t *testing.T) {
+		m := mock.NewQueryService()
+		pm, _ := setupManagerWithMockDB(t, m, &fakeRuleStore{})
+		// checkNoWALSource precondition: no WAL source configured.
+		m.AddQueryPattern(`^SELECT current_setting\('primary_conninfo', true\)`, mock.MakeQueryResult(
+			[]string{"primary_conninfo", "restore_command"}, [][]any{{"", ""}},
+		))
+		// A recovery conflict (not paused) also keeps replay frozen below receive;
+		// it must not be accepted as complete.
+		m.AddQueryPattern("pg_stat_activity", mock.MakeQueryResult(progressCols, [][]any{{"0/4000000", "0/5000000", false, "IPC", "RecoveryConflictSnapshot"}}))
+
+		ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+		defer cancel()
+		_, err := pm.waitForReplayComplete(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "timeout")
+	})
+
+	t.Run("NullReceiveAndWaitEventDoesNotComplete", func(t *testing.T) {
+		m := mock.NewQueryService()
+		pm, _ := setupManagerWithMockDB(t, m, &fakeRuleStore{})
+		// checkNoWALSource precondition: no WAL source configured.
+		m.AddQueryPattern(`^SELECT current_setting\('primary_conninfo', true\)`, mock.MakeQueryResult(
+			[]string{"primary_conninfo", "restore_command"}, [][]any{{"", ""}},
+		))
+		// A NULL receive LSN (receiver never ran) leaves hasReceive false, and the
+		// NULL wait event means the startup process is running/uninstrumented:
+		// both inconclusive, never "done".
+		m.AddQueryPattern("pg_stat_activity", mock.MakeQueryResult(progressCols, [][]any{{"0/4000000", nil, false, nil, nil}}))
+
+		ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+		defer cancel()
+		_, err := pm.waitForReplayComplete(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "timeout")
+	})
+
+	t.Run("PausedReplayIsError", func(t *testing.T) {
+		m := mock.NewQueryService()
+		pm, _ := setupManagerWithMockDB(t, m, &fakeRuleStore{})
+		// checkNoWALSource precondition: no WAL source configured.
+		m.AddQueryPattern(`^SELECT current_setting\('primary_conninfo', true\)`, mock.MakeQueryResult(
+			[]string{"primary_conninfo", "restore_command"}, [][]any{{"", ""}},
+		))
+		m.AddQueryPattern("pg_stat_activity", mock.MakeQueryResult(progressCols, [][]any{{"0/4000000", "0/4000000", true, nil, nil}}))
+
+		_, err := pm.waitForReplayComplete(t.Context())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "paused")
+	})
+
+	t.Run("RestoreCommandSetIsError", func(t *testing.T) {
+		m := mock.NewQueryService()
+		pm, _ := setupManagerWithMockDB(t, m, &fakeRuleStore{})
+		// restore_command set: recovery could pull more WAL from the archive, so an
+		// end-of-WAL wait would not mean done. A cohort member must advance only by
+		// streaming from the leader; callers (e.g. restartAsStandbyLocked) clear it
+		// before this runs, so checkNoWALSource rejects it if still set.
+		m.AddQueryPattern(`^SELECT current_setting\('primary_conninfo', true\)`, mock.MakeQueryResult(
+			[]string{"primary_conninfo", "restore_command"}, [][]any{{"", "pgbackrest archive-get %f %p"}},
+		))
+
+		_, err := pm.waitForReplayComplete(t.Context())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "restore_command is set")
+	})
+
+	t.Run("PrimaryConnInfoSetIsError", func(t *testing.T) {
+		m := mock.NewQueryService()
+		pm, _ := setupManagerWithMockDB(t, m, &fakeRuleStore{})
+		// primary_conninfo set: the receiver could stream more WAL. checkNoWALSource
+		// rejects it up front.
+		m.AddQueryPattern(`^SELECT current_setting\('primary_conninfo', true\)`, mock.MakeQueryResult(
+			[]string{"primary_conninfo", "restore_command"}, [][]any{{"host=primary port=5432", ""}},
+		))
+
+		_, err := pm.waitForReplayComplete(t.Context())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "primary_conninfo is set")
+	})
+
+	t.Run("NotInRecoveryIsError", func(t *testing.T) {
+		m := mock.NewQueryService()
+		pm, _ := setupManagerWithMockDB(t, m, &fakeRuleStore{})
+		m.AddQueryPattern(`^SELECT current_setting\('primary_conninfo', true\)`, mock.MakeQueryResult(
+			[]string{"primary_conninfo", "restore_command"}, [][]any{{"", ""}},
+		))
+		// No startup process row: queryReplayProgress's pg_stat_activity select
+		// returns zero rows, which means the server is not in recovery.
+		m.AddQueryPattern("pg_stat_activity", mock.MakeQueryResult(progressCols, nil))
+
+		_, err := pm.waitForReplayComplete(t.Context())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not in recovery")
+	})
 }

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -940,8 +940,21 @@ func (pm *MultipoolerManager) restartAsStandbyLocked(
 				true /* wait */); err != nil {
 				return false, mterrors.Wrap(err, "failed to pause replication before rewind")
 			}
-			if _, err := pm.waitForReplayStabilize(ctx); err != nil {
-				return false, mterrors.Wrap(err, "failed waiting for replay to stabilize before rewind")
+			// Clear restore_command (and stop any in-flight archive-get) so the
+			// completion measurement replays only local WAL. A rewinding node is
+			// (re)joining as a cohort member, which must advance only by streaming
+			// from the leader, never from the archive — and waitForReplayComplete
+			// asserts this via checkNoWALSource. Resetting the GUC alone only
+			// affects the next fetch decision, so an already-running restore_command
+			// must be stopped too.
+			if err := pm.resetRestoreCommand(ctx); err != nil {
+				return false, mterrors.Wrap(err, "failed to clear restore_command before replay-completion wait")
+			}
+			if err := pm.stopRestoreCommand(ctx); err != nil {
+				return false, mterrors.Wrap(err, "failed to stop in-flight restore_command before replay-completion wait")
+			}
+			if _, err := pm.waitForReplayComplete(ctx); err != nil {
+				return false, mterrors.Wrap(err, "failed waiting for replay to complete before rewind")
 			}
 		}
 		status, err := pm.consensusMgr.ConsensusStatus(ctx)
@@ -1003,6 +1016,14 @@ func (pm *MultipoolerManager) restartAsStandbyLocked(
 		// continue on error rather than abort the demote.
 		if err := pm.fixPgBackRestPaths(ctx); err != nil {
 			pm.logger.ErrorContext(ctx, "Failed to fix pgbackrest paths after pg_rewind; WAL archiving may fail until next rewind", "error", err)
+		}
+		// pg_rewind copied the source's postgresql.auto.conf, which may carry a
+		// (previously inert) restore_command. Strip it so the restarted standby
+		// cannot replay from the archive — it must stream only from the leader.
+		// Postgres is stopped here, so this edits the file directly rather than
+		// using ALTER SYSTEM.
+		if err := pm.dropRestoreCommandFromAutoConf(ctx); err != nil {
+			pm.logger.ErrorContext(ctx, "Failed to remove restore_command after pg_rewind; standby may replay from archive until next reset", "error", err)
 		}
 	}
 
@@ -1110,6 +1131,47 @@ func (pm *MultipoolerManager) runPgRewind(ctx context.Context, sourceHost string
 // fixPgBackRestPaths fixes the pgbackrest paths in postgresql.auto.conf
 // After pg_rewind, the restore_command and archive_command may have paths from another pooler
 // This function updates them to point to the current pooler's directories
+// dropRestoreCommandFromAutoConf removes any restore_command entry from
+// postgresql.auto.conf by editing the file directly. Used after pg_rewind, which
+// overwrites the target's postgresql.auto.conf with the source's copy — and the
+// source (a primary that was once restored from a backup) may carry an inert
+// restore_command. Left in place it would become active on the restarted standby,
+// letting recovery pull WAL from the archive; a cohort member must advance only by
+// streaming from the leader. Editing the file (rather than ALTER SYSTEM RESET) is
+// required here because postgres is stopped at this point in restartAsStandbyLocked.
+func (pm *MultipoolerManager) dropRestoreCommandFromAutoConf(ctx context.Context) error {
+	autoConfPath := filepath.Join(postgresDataDir(), "postgresql.auto.conf")
+
+	content, err := os.ReadFile(autoConfPath)
+	if err != nil {
+		return mterrors.Wrap(err, "failed to read postgresql.auto.conf")
+	}
+
+	// Drop any line whose setting name is restore_command. postgresql.auto.conf
+	// holds one "name = 'value'" ALTER SYSTEM entry per line, so a line-oriented
+	// filter is sufficient and matches how fixPgBackRestPaths treats the file.
+	lines := strings.Split(string(content), "\n")
+	kept := lines[:0]
+	dropped := false
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "restore_command") {
+			dropped = true
+			continue
+		}
+		kept = append(kept, line)
+	}
+	if !dropped {
+		return nil
+	}
+
+	pm.logger.InfoContext(ctx, "Removing restore_command from postgresql.auto.conf so the standby streams only from the leader", "file", autoConfPath)
+	// #nosec G703 -- autoConfPath is postgresql.auto.conf under the pooler's own data dir, not external input.
+	if err := os.WriteFile(autoConfPath, []byte(strings.Join(kept, "\n")), 0o600); err != nil {
+		return mterrors.Wrap(err, "failed to write postgresql.auto.conf")
+	}
+	return nil
+}
+
 func (pm *MultipoolerManager) fixPgBackRestPaths(ctx context.Context) error {
 	pm.mu.Lock()
 	poolerDir := pm.record.PoolerDir()

--- a/go/services/multipooler/internal/manager/rpc_manager_test.go
+++ b/go/services/multipooler/internal/manager/rpc_manager_test.go
@@ -58,7 +58,7 @@ func addDatabaseToTopo(t *testing.T, ts topoclient.Store, database string) {
 // pause-replication/wait-stabilize/measure-position sequence that
 // restartAsStandbyLocked's wantRewind branch now runs before pg_rewind (see
 // ConsensusPromises.SetRecruitBlockedUntil) — pauseReplication(REPLAY_AND_RECEIVER),
-// waitForReplayStabilize, and ConsensusStatus's rule-store read. Most patterns
+// waitForReplayComplete, and ConsensusStatus's rule-store read. Most patterns
 // are added via AddQueryPattern (repeatable), so callers don't need to track
 // exact poll counts. The reload-config pair is the exception: it's added via
 // AddQueryPatternOnce (this reload fires exactly once, before pg_rewind), so
@@ -77,6 +77,19 @@ func expectRewindPositionFloorMocks(m *mock.QueryService) {
 	m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult([]string{"pg_reload_conf"}, [][]any{{true}}))
 	m.AddQueryPatternOnce("SELECT pg_conf_load_time",
 		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"1970-01-01 00:00:01"}}))
+
+	// restartAsStandbyLocked clears restore_command before the replay-completion
+	// wait (a rewinding cohort member must replay only local WAL / stream from the
+	// leader). resetRestoreCommand does ALTER SYSTEM RESET + a second reload cycle;
+	// register it after the pause reload above so the Once load-time pairs are
+	// consumed in execution order. (stopRestoreCommand goes through the mock pgctld
+	// gRPC server, so it needs no SQL mock here.)
+	m.AddQueryPattern("ALTER SYSTEM RESET restore_command", mock.MakeQueryResult(nil, nil))
+	m.AddQueryPatternOnce("SELECT pg_conf_load_time",
+		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"1970-01-01 00:00:02"}}))
+	m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult([]string{"pg_reload_conf"}, [][]any{{true}}))
+	m.AddQueryPatternOnce("SELECT pg_conf_load_time",
+		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"1970-01-01 00:00:03"}}))
 
 	// ConsensusStatus -> Rules().ObservePosition -> readCurrentRule's SELECT.
 	// Column shape mirrors consensus.mockDecidedReadResult (a decided rule,
@@ -108,17 +121,30 @@ func expectRewindPositionFloorMocks(m *mock.QueryService) {
 	// queryReplicationStatus once the receiver shows disconnected.
 	m.AddQueryPattern("SELECT COUNT.*pg_stat_wal_receiver", mock.MakeQueryResult(
 		[]string{"count", "status", "primary_conninfo"}, [][]any{{int64(0), "", ""}}))
+
+	// waitForReplayComplete's checkNoWALSource precondition: primary_conninfo empty
+	// (not streaming). Anchored so it matches only this query, not the other
+	// current_setting('primary_conninfo') reads in this path.
+	m.AddQueryPattern(`^SELECT current_setting\('primary_conninfo', true\)`, mock.MakeQueryResult(
+		[]string{"primary_conninfo", "restore_command"}, [][]any{{"", ""}}))
+
+	// waitForReplayComplete's queryReplayProgress reads replay_lsn, receive_lsn,
+	// is_paused, and the startup wait event in one query. It is the only query
+	// containing pg_stat_activity, so it is matched on that; it also contains
+	// pg_last_wal_receive_lsn(), so it must be registered BEFORE the broad
+	// "pg_last_wal_receive_lsn" pattern below or that one would shadow it.
+	// replay == receive (and no wait event) → caught up, so waitForReplayComplete
+	// returns via signal 1 on the first poll.
+	m.AddQueryPattern("pg_stat_activity", mock.MakeQueryResult(
+		[]string{"pg_last_wal_replay_lsn", "pg_last_wal_receive_lsn", "pg_is_wal_replay_paused", "wait_event_type", "wait_event"},
+		[][]any{{"0/100", "0/100", false, nil, nil}}))
+
+	// queryReplicationStatus (10-column) for waitForReceiverDisconnect's final
+	// read and waitForReplayComplete's returned status.
 	m.AddQueryPattern("pg_last_wal_receive_lsn", mock.MakeQueryResult(replStatusCols, replStatusRow))
 
 	// Pause replay, then waitForReplicationPause's queryReplicationStatus poll.
 	m.AddQueryPattern("pg_wal_replay_pause", mock.MakeQueryResult(nil, nil))
-
-	// waitForReplayStabilize polls this simpler 2-column query repeatedly
-	// (distinct from the 10-column queryReplicationStatus above, which also
-	// contains "pg_last_wal_replay_lsn" — matched by adjacency to
-	// pg_is_wal_replay_paused with nothing in between).
-	m.AddQueryPattern(`pg_last_wal_replay_lsn\(\),\s*pg_is_wal_replay_paused`, mock.MakeQueryResult(
-		[]string{"pg_last_wal_replay_lsn", "pg_is_wal_replay_paused"}, [][]any{{"0/100", false}}))
 }
 
 func TestPrimaryPosition(t *testing.T) {

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -360,6 +360,15 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		defer func() { _ = tx.Rollback() }()
 		_, err = tx.Exec("CREATE TEMP TABLE final_primary_write_check (id int)")
 		require.NoError(t, err, "final primary should accept writes; a standby would reject this during recovery")
+
+		// A promoted primary must not carry restore_command: promoteStandbyToPrimary
+		// clears it (alongside primary_conninfo) so the node never resumes archive
+		// playback, and a later pg_rewind against this primary won't copy
+		// restore_command onto the rewinding follower.
+		var restoreCommand string
+		err = db.QueryRow("SHOW restore_command").Scan(&restoreCommand)
+		require.NoError(t, err, "should read restore_command on final primary")
+		require.Empty(t, restoreCommand, "restore_command must be cleared on the promoted primary")
 	})
 
 	// Verify sync replication is configured on the final primary

--- a/go/test/endtoend/multiorch/rewind_diverged_replica_test.go
+++ b/go/test/endtoend/multiorch/rewind_diverged_replica_test.go
@@ -183,6 +183,18 @@ func TestRewindDivergedReplica(t *testing.T) {
 	err = row.Scan(&divergedCount)
 	require.NoError(t, err, "should query R1 for diverged row")
 	require.Equal(t, 0, divergedCount, "diverged row should NOT be present on R1 after pg_rewind")
+
+	// After pg_rewind + rejoin, R1 must not carry restore_command. pg_rewind
+	// copies the source primary's postgresql.auto.conf; the promoted primary
+	// clears restore_command on promotion, and the rewind path additionally
+	// strips it from the copied auto.conf. Either way a cohort member must never
+	// resume WAL playback from the archive — only streaming from the leader is
+	// trusted.
+	var r1RestoreCommand string
+	err = r1DBAfter.QueryRow("SHOW restore_command").Scan(&r1RestoreCommand)
+	require.NoError(t, err, "should read restore_command on R1 after pg_rewind")
+	require.Empty(t, r1RestoreCommand, "restore_command must be cleared on R1 after pg_rewind")
+
 	// Verify R1 is streaming from P and added to P's synchronous standby list
 	verifyReplicaReplicating(t, setup, r1Name, pName)
 

--- a/go/test/endtoend/multipooler/backupfaults/backup_archive_lag_test.go
+++ b/go/test/endtoend/multipooler/backupfaults/backup_archive_lag_test.go
@@ -337,6 +337,16 @@ func TestPrimaryCrashWithUnarchivedWAL_NoDataLoss(t *testing.T) {
 	verifyReplicasStreaming(t, setup, newPrimaryName, 60*time.Second)
 	verifyReplicasHaveAllIDs(t, setup, newPrimaryName, validator.TableName(), committedIDs, 60*time.Second)
 
+	// --- No cohort member may carry restore_command once the cluster has
+	// settled. This is the load-bearing check for the clear-restore_command
+	// invariant across every path exercised above: RestoreFromBackup SET it on
+	// pooler-4, and FixReplication/SetPrimary must have cleared it when pooler-4
+	// joined the cohort; the demoted old primary went through the pg_rewind
+	// path; and the newly promoted primary cleared it on promotion. A cohort
+	// member that still had restore_command set could resume WAL playback from
+	// the archive instead of streaming from the leader.
+	verifyRestoreCommandCleared(t, setup)
+
 	// --- Sanity: timeline incremented. Cheap evidence that failover actually
 	// happened. pg_control_checkpoint() reflects the last checkpoint's
 	// timeline — stale immediately after promotion until the next checkpoint
@@ -386,6 +396,32 @@ func logWALState(t *testing.T, setup *shardsetup.ShardSetup, primaryName string)
 		}
 		cancel()
 		_ = db.Close()
+	}
+}
+
+// verifyRestoreCommandCleared asserts every pooler in the cluster has an empty
+// restore_command. A cohort member (streaming standby or primary) must never be
+// able to resume WAL playback from the archive — only streaming from the leader
+// is trusted. restore_command is set implicitly by pgbackrest's "restore
+// --type=standby" (RestoreFromBackup); recruit/SetPrimary clear it when a node
+// joins the cohort, the pg_rewind path strips it from the copied auto.conf, and
+// promotion clears it on the new primary. This must hold only after the cluster
+// has fully settled (all recovery scenarios resolved).
+func verifyRestoreCommandCleared(t *testing.T, setup *shardsetup.ShardSetup) {
+	t.Helper()
+
+	for name, inst := range setup.Multipoolers {
+		socketDir := filepath.Join(inst.Pgctld.PoolerDir, "pg_sockets")
+		db := connectToPostgresViaSocket(t, socketDir, inst.Pgctld.PgPort)
+
+		queryCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		var restoreCommand string
+		err := db.QueryRowContext(queryCtx, "SHOW restore_command").Scan(&restoreCommand)
+		cancel()
+		_ = db.Close()
+
+		require.NoError(t, err, "read restore_command on %s", name)
+		require.Empty(t, restoreCommand, "restore_command must be cleared on cohort member %s", name)
 	}
 }
 


### PR DESCRIPTION
## Problem

During standby revoke (`Recruit`) and the pre-`pg_rewind` position measurement, the node stops its WAL receiver and waits for replay to "settle" before reporting its WAL position. The old heuristic waited for `pg_last_wal_replay_lsn()` to **stop advancing** (3 identical readings ~30 ms apart).

That is unsafe: anything that freezes the replay LSN *below* the received position — a recovery conflict, an I/O stall, `recovery_min_apply_delay` — looks identical to "replay finished" over the stability window. So `Recruit` could proceed before the received WAL was fully replayed and report a **stale position**, which feeds the coordinator's leader selection and the audit-table-derived cohort/term.

## Fix

Replace the stability heuristic with two **positive** completion signals, decided per poll now that the receiver is stopped and `receive_lsn` is frozen:

1. **`replay_lsn >= receive_lsn`** — replay has applied every received byte. The two LSNs are read by the query and compared numerically in Go via `pgutil.ParseLSN` (their `X/Y` hex text does not sort lexicographically).
2. **Startup process idle at end-of-WAL** — `pg_stat_activity.wait_event` is `RecoveryRetrieveRetryInterval` / `RecoveryWalStream` for `backend_type = 'startup'`, observed on **2 consecutive polls**. That state is reached only after recovery has exhausted every WAL source, so every *complete* received record is applied; any trailing bytes are an incomplete record it cannot replay (the normal way streamed WAL ends, where `replay_lsn` legitimately settles below `receive_lsn`).

Every other observed state — actively applying, an I/O or recovery-conflict stall, an apply delay, a `NULL`/uninstrumented wait, or an unrecognized wait — is treated as **"not done, keep waiting"**. A genuine stall therefore rides out the 10 s deadline and surfaces as a `DEADLINE_EXCEEDED` error instead of a premature, unsafe "done".

## Preconditions

Signal 2 is only sound if the startup process cannot leave the end-of-WAL wait by obtaining more WAL. Two sources could do that, and `checkNoWALSource` requires **both** to be unset up front, failing loudly otherwise:

1. **`primary_conninfo`** — a WAL receiver could stream more. Both callers stop the receiver first; the check confirms it is empty.
2. **`restore_command`** — recovery could fetch more segments from the archive. The check confirms it is empty.

Rejecting `restore_command` upholds a consensus invariant, not just signal-2 timing: a **cohort member** (an active consensus participant) must advance only by streaming from the current leader, never by replaying a possibly-foreign archive. Left enabled, a subsequent restart-as-standby can resolve `recovery_target_timeline=latest` through the archive to a timeline this node's own checkpoint doesn't descend from and `FATAL` at startup. So `restore_command` is now cleared on **every** path that makes a node a cohort member:

- **Recruit** and the cohort-member **`SetPrimary`** clear it (pre-existing).
- **`restartAsStandbyLocked`** (the `pg_rewind` path) clears it before the replay-completion wait, and strips it from the `postgresql.auto.conf` that `pg_rewind` copies from the source.
- **Promotion** clears it on the new primary — the root-cause reset. `restore_command` is set implicitly by pgBackRest's initial `restore --type=standby` and was never cleared on promotion, so a promoted primary carried it in its `auto.conf` and `pg_rewind` copied it back onto every rejoining follower. A clean primary `auto.conf` stops that at the source.

## Changes

- Rename `waitForReplayStabilize` → `waitForReplayComplete`; remove the LSN-stability completion heuristic.
- Add `queryReplayProgress` returning a `replayProgress` struct — reads the replay/receive LSNs, pause state, and startup wait state in a single query. Zero rows means no startup process (not in recovery) and is rejected; a NULL replay LSN is guarded defensively.
- Add `checkNoWALSource` (enforces `primary_conninfo` **and** `restore_command` empty) and the end-of-WAL wait-event recognizer.
- Clear `restore_command` on the `pg_rewind` path (`restartAsStandbyLocked`, including stripping it from the copied `auto.conf`) and on promotion.
- Move the trace span from `Recruit` into `waitForReplayComplete` (`consensus/replay_completion_wait`) so both the recruit and rewind callers are instrumented.
- Extend the HA decision log with the positive-signal design, the wait-event taxonomy and version-drift notes (names are stable across PG 13+; unknown states bias toward "keep waiting"), and a section on what can move the startup process out of `RecoveryRetrieveRetryInterval`.

## Testing

- **Unit** (`TestWaitForReplayComplete`): caught-up, end-of-WAL-below-receive, I/O stall → timeout, recovery-conflict → timeout, NULL-receive/NULL-wait, paused → error, `primary_conninfo` set → error, `restore_command` set → error, not-in-recovery → error. Promote-path mock asserts the post-promotion `restore_command` reset.
- **End-to-end** against real PostgreSQL 18:
  - `multipooler/backupfaults` `TestPrimaryCrashWithUnarchivedWAL_NoDataLoss` — the load-bearing check. `RestoreFromBackup` genuinely **sets** `restore_command` on the freshly provisioned pooler; a new `verifyRestoreCommandCleared` then asserts every cohort member (including that restored node, the `pg_rewind`-demoted old primary, and the promoted new primary) has it **cleared** once the cluster settles.
  - `multiorch` `TestRewindDivergedReplica` (rewind) and `TestDeadPrimaryRecovery` (promote) — assert the rewound / promoted node reports an empty `restore_command`.

## Notes for reviewers

- A recovery-conflict stall is bounded by `max_standby_streaming_delay` (30 s default), which exceeds the 10 s wait, so such a stall fails `Recruit` and is retried rather than waited out. If these prove common, neutralizing conflicts at the source (stopping read serving before the wait) would be a follow-up.
- The `pg_rewind`-path `auto.conf` strip is defense-in-depth alongside the promote-side reset: it still cleans up a source primary whose `auto.conf` predates this fix. `auto.conf` is stripped surgically (only `restore_command`) rather than deleted, because it also carries `archive_command`/`archive_mode` (path-fixed by `fixPgBackRestPaths`) and other `ALTER SYSTEM` settings that must survive the rewind.
