### PR TITLE
refactor(multigateway): rename SHOW multigres_version to multigres.server_version

### DIFF
--- a/docs/query_serving/gateway_managed_variables.md
+++ b/docs/query_serving/gateway_managed_variables.md
@@ -16,7 +16,7 @@ Both are registered in the single source of truth,
 `gatewayManagedVariables` in `handler/gateway_managed_variables.go` (see
 [Adding or changing a GMV](#adding-or-changing-a-gmv)).
 
-> **Not a GMV:** `SHOW multigres_version` (and `SELECT multigres.version()`) is
+> **Not a GMV:** `SHOW multigres.server_version` (and `SELECT multigres.version()`) is
 > also answered by the gateway, but it is a read-only pseudo-variable, not a
 > GMV — it has no `SET`/`RESET`/`set_config`/transaction behavior and is not in
 > this registry. See [`multigres_version.md`](./multigres_version.md). Don't add

--- a/docs/query_serving/multigres_version.md
+++ b/docs/query_serving/multigres_version.md
@@ -5,15 +5,15 @@ its own — a short GUC and a full-string function. This lets an operator check
 which multigateway build is serving them without shell access to a binary, and
 makes the version easy to include in a bug report.
 
-| Surface                      | Analogous to     | Returns               |
-| ---------------------------- | ---------------- | --------------------- |
-| `SHOW multigres_version`     | `server_version` | Short release version |
-| `SELECT multigres.version()` | `version()`      | Full build string     |
+| Surface                         | Analogous to     | Returns               |
+| ------------------------------- | ---------------- | --------------------- |
+| `SHOW multigres.server_version` | `server_version` | Short release version |
+| `SELECT multigres.version()`    | `version()`      | Full build string     |
 
 ```console
-psql> SHOW multigres_version;
- multigres_version
--------------------
+psql> SHOW multigres.server_version;
+ multigres.server_version
+--------------------------
  0.1.0-SNAPSHOT
 (1 row)
 
@@ -25,7 +25,7 @@ psql> SELECT multigres.version();
 ```
 
 Both work in the simple and extended (prepared-statement) query protocols.
-`SHOW multigres_version` is answered entirely by the gateway;
+`SHOW multigres.server_version` is answered entirely by the gateway;
 `SELECT multigres.version()` is folded to a literal and then runs on PostgreSQL
 (see below), so it composes into any query.
 
@@ -64,15 +64,22 @@ backend. `multigres.version()` lives in its own `multigres` schema and does not
 shadow it. A `SELECT version()` still reports PostgreSQL; `SELECT
 multigres.version()` reports multigres.
 
-## `multigres_version` is not a gateway-managed variable
+The variable is namespaced for the same reason: `multigres.server_version` sits
+in the `multigres.` prefix that PostgreSQL reserves for custom (extension) GUCs,
+so it reads as a multigres setting rather than a core one and can never collide
+with a PostgreSQL GUC. The parser accepts dotted names in `SHOW` (`var_name` is
+`ColId ('.' ColId)*`), so no grammar change was needed.
 
-Despite the `SHOW <name>` surface, `multigres_version` is **not** a
+## `multigres.server_version` is not a gateway-managed variable
+
+Despite the `SHOW <name>` surface, `multigres.server_version` is **not** a
 [gateway-managed variable](./gateway_managed_variables.md). It is a read-only
 pseudo-variable: not in the `gatewayManagedVariables` registry, and with no
-`SET` / `RESET` / `set_config` / transaction behavior. A `SET multigres_version
-= ...` falls through to PostgreSQL, which rejects it as an unrecognized
-configuration parameter — matching how PostgreSQL treats its own read-only
-`server_version`.
+`SET` / `RESET` / `set_config` / transaction behavior. The gateway only
+intercepts `SHOW`; a `SET multigres.server_version = ...` falls through to
+PostgreSQL, which accepts any dotted name as a custom-GUC placeholder and stores
+it on the session. That stored value is inert — `SHOW multigres.server_version`
+is still answered by the gateway and still reports the running build.
 
 ## Where the version comes from
 
@@ -100,16 +107,16 @@ and CI stamp them.
 | -------------------------------- | ---------------------------------------------------------------- |
 | `common/servenv/version.go`      | `versionName` — the committed release version constant           |
 | `common/servenv/buildinfo.go`    | `Version()` (short) and `AppVersion()` (full) version strings    |
-| `common/constants/gateway.go`    | `MultigresVersionVariable`, `MultigresSchema`                    |
+| `common/constants/gateway.go`    | `MultigresServerVersionVariable`, `MultigresSchema`              |
 | `handler/gateway_functions.go`   | Folds `multigres.version()` into a literal                       |
-| `planner/variable_show_stmt.go`  | Intercepts `SHOW multigres_version`                              |
+| `planner/variable_show_stmt.go`  | Intercepts `SHOW multigres.server_version`                       |
 | `engine/gateway_show_version.go` | `GatewayShowVersion` primitive; SHOW matcher and Describe helper |
 | `executor/executor.go`           | Serves the extended-protocol `Describe` for SHOW locally         |
 
 ## Extended protocol notes
 
-`SHOW multigres_version` is served by the gateway, so it needs two things over
-the extended protocol that a backend-routed query gets for free:
+`SHOW multigres.server_version` is served by the gateway, so it needs two things
+over the extended protocol that a backend-routed query gets for free:
 
 - **Describe** is normally forwarded straight to the backend, which has no such
   GUC. The executor intercepts it and returns a synthetic `StatementDescription`

--- a/go/common/constants/gateway.go
+++ b/go/common/constants/gateway.go
@@ -15,11 +15,11 @@
 package constants
 
 const (
-	// MultigresVersionVariable is the pseudo-variable name that, via
-	// `SHOW multigres_version`, reports the running multigateway's short release
+	// MultigresServerVersionVariable is the pseudo-variable name that, via
+	// `SHOW multigres.server_version`, reports the running multigateway's short release
 	// version. It is not a real PostgreSQL GUC: the gateway answers it locally
 	// and never forwards it to a backend.
-	MultigresVersionVariable = "multigres_version"
+	MultigresServerVersionVariable = "multigres.server_version"
 
 	// MultigresSchema is the schema used to namespace gateway-provided functions
 	// (e.g. `multigres.version()`) so they do not shadow PostgreSQL's own

--- a/go/common/servenv/buildinfo.go
+++ b/go/common/servenv/buildinfo.go
@@ -79,7 +79,7 @@ func loadBuildSnapshot() {
 }
 
 // Version returns the short release version (versionName, e.g. "0.1.0-SNAPSHOT").
-// It is the value reported by `SHOW multigres_version`, mirroring PostgreSQL's
+// It is the value reported by `SHOW multigres.server_version`, mirroring PostgreSQL's
 // server_version. The full build string — release version plus VCS revision,
 // commit date, and Go toolchain — is AppVersion, reported by
 // `SELECT multigres.version()`.
@@ -89,7 +89,7 @@ func Version() string {
 
 // AppVersion returns a one-line, human-readable description of the running
 // binary's Multigres version, suitable for display to operators (e.g. via
-// `SHOW multigres_version` or a future --version flag) and for pasting into bug
+// `SHOW multigres.server_version` or a future --version flag) and for pasting into bug
 // reports. It is the release version plus the VCS identity the Go toolchain
 // embeds; VCS fields are omitted so it degrades gracefully on builds without VCS
 // stamping (e.g. inside a linked git worktree).

--- a/go/common/servenv/buildinfo_test.go
+++ b/go/common/servenv/buildinfo_test.go
@@ -39,7 +39,7 @@ func TestReadBuildSnapshot(t *testing.T) {
 }
 
 // TestFormatAppVersion pins the string layout of the version reported by
-// `SHOW multigres_version` across the combinations of build fields that may be
+// `SHOW multigres.server_version` across the combinations of build fields that may be
 // present or absent.
 func TestFormatAppVersion(t *testing.T) {
 	commit := time.Date(2026, 7, 10, 15, 4, 5, 0, time.UTC)

--- a/go/services/multigateway/engine/gateway_show_version.go
+++ b/go/services/multigateway/engine/gateway_show_version.go
@@ -31,7 +31,7 @@ import (
 
 // The gateway exposes its version two ways, mirroring PostgreSQL:
 //
-//   - `SHOW multigres_version` returns the short release version (like
+//   - `SHOW multigres.server_version` returns the short release version (like
 //     `server_version`), served locally by the GatewayShowVersion primitive
 //     below because postgres has no such GUC.
 //   - `SELECT multigres.version()` returns the full build string (like
@@ -48,14 +48,14 @@ func textField(name string) *query.Field {
 	}
 }
 
-// GatewayShowVersion handles `SHOW multigres_version`, returning the gateway's
+// GatewayShowVersion handles `SHOW multigres.server_version`, returning the gateway's
 // short release version as a single-row result. The value is a process-wide
 // constant, so it answers without a PostgreSQL round trip.
 type GatewayShowVersion struct {
 	sql string // Original SQL for debugging
 }
 
-// NewGatewayShowVersion creates the primitive for `SHOW multigres_version`.
+// NewGatewayShowVersion creates the primitive for `SHOW multigres.server_version`.
 func NewGatewayShowVersion(sql string) *GatewayShowVersion {
 	return &GatewayShowVersion{sql: sql}
 }
@@ -72,7 +72,7 @@ func (g *GatewayShowVersion) result(withFields bool) *sqltypes.Result {
 		CommandTag: "SHOW",
 	}
 	if withFields {
-		result.Fields = []*query.Field{textField(constants.MultigresVersionVariable)}
+		result.Fields = []*query.Field{textField(constants.MultigresServerVersionVariable)}
 	}
 	return result
 }
@@ -127,22 +127,22 @@ func (g *GatewayShowVersion) String() string {
 // Ensure GatewayShowVersion implements Primitive interface.
 var _ Primitive = (*GatewayShowVersion)(nil)
 
-// IsMultigresVersionShow reports whether stmt is `SHOW multigres_version`, the
+// IsMultigresServerVersionShow reports whether stmt is `SHOW multigres.server_version`, the
 // gateway-only pseudo-variable served locally. The name compares
 // case-insensitively, matching PostgreSQL's handling of unquoted (lowercased)
 // and quoted (case-preserving) identifiers.
-func IsMultigresVersionShow(stmt ast.Stmt) bool {
+func IsMultigresServerVersionShow(stmt ast.Stmt) bool {
 	show, ok := stmt.(*ast.VariableShowStmt)
-	return ok && strings.ToLower(show.Name) == constants.MultigresVersionVariable
+	return ok && strings.ToLower(show.Name) == constants.MultigresServerVersionVariable
 }
 
-// MultigresVersionShowDescription is the extended-protocol Describe response for
-// `SHOW multigres_version`: no bind parameters, one text column. It lets the
+// MultigresServerVersionShowDescription is the extended-protocol Describe response for
+// `SHOW multigres.server_version`: no bind parameters, one text column. It lets the
 // gateway answer Describe locally, since postgres has no such GUC to describe.
-func MultigresVersionShowDescription() *query.StatementDescription {
+func MultigresServerVersionShowDescription() *query.StatementDescription {
 	return &query.StatementDescription{
 		Parameters: []*query.ParameterDescription{},
-		Fields:     []*query.Field{textField(constants.MultigresVersionVariable)},
+		Fields:     []*query.Field{textField(constants.MultigresServerVersionVariable)},
 		HasFields:  true,
 	}
 }

--- a/go/services/multigateway/engine/gateway_show_version_test.go
+++ b/go/services/multigateway/engine/gateway_show_version_test.go
@@ -38,9 +38,9 @@ func collectResults(t *testing.T, run func(func(context.Context, *sqltypes.Resul
 }
 
 // TestGatewayShowVersion_StreamExecute checks the GUC surface: a single text
-// column named multigres_version carrying the short release version.
+// column named multigres.server_version carrying the short release version.
 func TestGatewayShowVersion_StreamExecute(t *testing.T) {
-	prim := NewGatewayShowVersion("SHOW multigres_version")
+	prim := NewGatewayShowVersion("SHOW multigres.server_version")
 
 	results := collectResults(t, func(cb func(context.Context, *sqltypes.Result) error) error {
 		return prim.StreamExecute(context.Background(), nil, nil, nil, nil, PlanExecInfo{}, cb)
@@ -48,7 +48,7 @@ func TestGatewayShowVersion_StreamExecute(t *testing.T) {
 
 	require.Len(t, results, 1)
 	require.Len(t, results[0].Fields, 1)
-	assert.Equal(t, "multigres_version", results[0].Fields[0].Name)
+	assert.Equal(t, "multigres.server_version", results[0].Fields[0].Name)
 	assert.Equal(t, uint32(ast.TEXTOID), results[0].Fields[0].DataTypeOid)
 	assert.Equal(t, "SHOW", results[0].CommandTag)
 	require.Len(t, results[0].Rows, 1)
@@ -61,7 +61,7 @@ func TestGatewayShowVersion_StreamExecute(t *testing.T) {
 // when a Describe('P') was folded into it (includeDescribe). Attaching Fields
 // otherwise would emit an illegal second RowDescription mid-Execute.
 func TestGatewayShowVersion_PortalStreamExecute(t *testing.T) {
-	prim := NewGatewayShowVersion("SHOW multigres_version")
+	prim := NewGatewayShowVersion("SHOW multigres.server_version")
 
 	run := func(includeDescribe bool) *sqltypes.Result {
 		results := collectResults(t, func(cb func(context.Context, *sqltypes.Result) error) error {
@@ -80,29 +80,29 @@ func TestGatewayShowVersion_PortalStreamExecute(t *testing.T) {
 	t.Run("with folded describe carries fields", func(t *testing.T) {
 		res := run(true)
 		require.Len(t, res.Fields, 1)
-		assert.Equal(t, "multigres_version", res.Fields[0].Name)
+		assert.Equal(t, "multigres.server_version", res.Fields[0].Name)
 		require.Len(t, res.Rows, 1)
 	})
 }
 
-// TestIsMultigresVersionShow covers the SHOW matcher.
-func TestIsMultigresVersionShow(t *testing.T) {
-	assert.True(t, IsMultigresVersionShow(&ast.VariableShowStmt{Name: "multigres_version"}))
-	assert.True(t, IsMultigresVersionShow(&ast.VariableShowStmt{Name: "Multigres_Version"}))
-	assert.False(t, IsMultigresVersionShow(&ast.VariableShowStmt{Name: "statement_timeout"}))
-	assert.False(t, IsMultigresVersionShow(&ast.SelectStmt{}))
-	assert.False(t, IsMultigresVersionShow(nil))
+// TestIsMultigresServerVersionShow covers the SHOW matcher.
+func TestIsMultigresServerVersionShow(t *testing.T) {
+	assert.True(t, IsMultigresServerVersionShow(&ast.VariableShowStmt{Name: "multigres.server_version"}))
+	assert.True(t, IsMultigresServerVersionShow(&ast.VariableShowStmt{Name: "Multigres.Server_Version"}))
+	assert.False(t, IsMultigresServerVersionShow(&ast.VariableShowStmt{Name: "statement_timeout"}))
+	assert.False(t, IsMultigresServerVersionShow(&ast.SelectStmt{}))
+	assert.False(t, IsMultigresServerVersionShow(nil))
 }
 
-// TestMultigresVersionShowDescription verifies the synthetic Describe response:
+// TestMultigresServerVersionShowDescription verifies the synthetic Describe response:
 // no bind parameters and a single text column, so the extended-protocol Describe
 // can be answered without a backend round-trip.
-func TestMultigresVersionShowDescription(t *testing.T) {
-	desc := MultigresVersionShowDescription()
+func TestMultigresServerVersionShowDescription(t *testing.T) {
+	desc := MultigresServerVersionShowDescription()
 	require.NotNil(t, desc.Parameters)
 	assert.Empty(t, desc.Parameters, "SHOW takes no bind parameters")
 	require.Len(t, desc.Fields, 1)
-	assert.Equal(t, "multigres_version", desc.Fields[0].Name)
+	assert.Equal(t, "multigres.server_version", desc.Fields[0].Name)
 	assert.Equal(t, uint32(ast.TEXTOID), desc.Fields[0].DataTypeOid)
 	assert.True(t, desc.HasFields)
 }

--- a/go/services/multigateway/executor/executor.go
+++ b/go/services/multigateway/executor/executor.go
@@ -336,12 +336,12 @@ func (e *Executor) Describe(
 		"database", conn.Database(),
 		"connection_id", conn.ConnectionID())
 
-	// SHOW multigres_version is a gateway-only pseudo-variable with no backing
+	// SHOW multigres.server_version is a gateway-only pseudo-variable with no backing
 	// postgres GUC. Answer Describe locally rather than forwarding it, which the
 	// backend would reject as an unrecognized configuration parameter. Execute
 	// is already served locally via the planner (planVariableShowStmt).
-	if stmt := describeAST(portalInfo, preparedStatementInfo); stmt != nil && engine.IsMultigresVersionShow(stmt) {
-		return engine.MultigresVersionShowDescription(), nil
+	if stmt := describeAST(portalInfo, preparedStatementInfo); stmt != nil && engine.IsMultigresServerVersionShow(stmt) {
+		return engine.MultigresServerVersionShowDescription(), nil
 	}
 
 	// TODO: We will need to plan the query to find whether it can

--- a/go/services/multigateway/planner/variable_show_stmt.go
+++ b/go/services/multigateway/planner/variable_show_stmt.go
@@ -39,12 +39,12 @@ func (p *Planner) planVariableShowStmt(
 	// and matches the column label PostgreSQL returns.
 	name := strings.ToLower(stmt.Name)
 
-	// multigres_version is a gateway-only pseudo-variable that reports the
+	// multigres.server_version is a gateway-only pseudo-variable that reports the
 	// multigateway build identity. It has no backing PostgreSQL GUC, so answer
 	// it here rather than falling through to planDefault (which postgres would
 	// reject as an unrecognized configuration parameter).
-	if name == constants.MultigresVersionVariable {
-		p.logger.Debug("planning SHOW multigres_version")
+	if name == constants.MultigresServerVersionVariable {
+		p.logger.Debug("planning SHOW multigres.server_version")
 		return engine.NewPlan(sql, engine.NewGatewayShowVersion(sql)), nil
 	}
 

--- a/go/services/multigateway/planner/variable_show_stmt_test.go
+++ b/go/services/multigateway/planner/variable_show_stmt_test.go
@@ -71,17 +71,18 @@ func TestPlanVariableShowStmt_QuotedGatewayManagedName(t *testing.T) {
 	require.Len(t, results[0].Rows, 1)
 }
 
-// TestPlanVariableShowStmt_MultigresVersion verifies that SHOW multigres_version
-// is handled locally by the gateway (never routed to a backend) and produces a
-// single-row result whose column is labelled multigres_version.
-func TestPlanVariableShowStmt_MultigresVersion(t *testing.T) {
+// TestPlanVariableShowStmt_MultigresServerVersion verifies that SHOW
+// multigres.server_version is handled locally by the gateway (never routed to a
+// backend) and produces a single-row result whose column is labelled
+// multigres.server_version.
+func TestPlanVariableShowStmt_MultigresServerVersion(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
 	p := NewPlanner("default", logger, nil)
 	testConn := server.NewTestConn(&bytes.Buffer{})
 
 	// The parser lowercases unquoted identifiers; assert the executor also
 	// matches a case-preserving quoted spelling.
-	for _, name := range []string{"multigres_version", "Multigres_Version"} {
+	for _, name := range []string{"multigres.server_version", "Multigres.Server_Version"} {
 		t.Run(name, func(t *testing.T) {
 			stmt := &ast.VariableShowStmt{Name: name}
 
@@ -101,7 +102,7 @@ func TestPlanVariableShowStmt_MultigresVersion(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, results, 1)
 			require.Len(t, results[0].Fields, 1)
-			assert.Equal(t, "multigres_version", results[0].Fields[0].Name)
+			assert.Equal(t, "multigres.server_version", results[0].Fields[0].Name)
 			require.Len(t, results[0].Rows, 1)
 			require.Len(t, results[0].Rows[0].Values, 1)
 			// The GUC returns the short release version.

--- a/go/test/endtoend/queryserving/multigres_version_test.go
+++ b/go/test/endtoend/queryserving/multigres_version_test.go
@@ -30,17 +30,17 @@ import (
 
 // TestMultigateway_MultigresVersion verifies both version surfaces:
 //
-//   - SHOW multigres_version   → short release version (like server_version),
+//   - SHOW multigres.server_version   → short release version (like server_version),
 //     answered locally by the gateway.
 //   - SELECT multigres.version() → full build string (like version()), folded to
 //     a literal before it reaches PostgreSQL, so it works in any expression
 //     position and in both the simple and extended query protocols.
 func TestMultigateway_MultigresVersion(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping multigres_version test in short mode")
+		t.Skip("skipping multigres.server_version test in short mode")
 	}
 	if utils.ShouldSkipRealPostgres() {
-		t.Skip("PostgreSQL binaries not found, skipping multigres_version test")
+		t.Skip("PostgreSQL binaries not found, skipping multigres.server_version test")
 	}
 
 	setup := getSharedSetup(t)
@@ -73,9 +73,9 @@ func TestMultigateway_MultigresVersion(t *testing.T) {
 	}
 	bothProtocols := map[string]func(*testing.T, string) string{"simple": simpleQuery, "extended": preparedQuery}
 
-	t.Run("SHOW multigres_version returns the short version", func(t *testing.T) {
+	t.Run("SHOW multigres.server_version returns the short version", func(t *testing.T) {
 		for _, run := range bothProtocols {
-			version := run(t, "SHOW multigres_version")
+			version := run(t, "SHOW multigres.server_version")
 			assert.NotEmpty(t, version, "version should not be empty")
 			assert.NotContains(t, version, "built with", "SHOW should return the short version, got %q", version)
 		}


### PR DESCRIPTION
## Summary

- Renames the gateway pseudo-variable from `multigres_version` to `multigres.server_version`. Follow-up to #1255, which landed it under the unqualified name.
- `SELECT multigres.version()` is unchanged.

## Description

`multigres.` is the prefix PostgreSQL reserves for custom (extension) GUCs, so the qualified name reads as a multigres setting rather than a core one and can never collide with a PostgreSQL GUC. No grammar change was needed — `var_name` is already `ColId ('.' ColId)*`, so the dotted name parses into a single `VariableShowStmt`.

The constant and its helpers are renamed to match (`MultigresServerVersionVariable`, `IsMultigresServerVersionShow`, `MultigresServerVersionShowDescription`).

One behavior note the rename introduces, now corrected in the docs: `SET multigres_version = ...` used to be rejected by PostgreSQL as an unrecognized parameter, but PostgreSQL accepts any dotted name as a custom-GUC placeholder. So `SET multigres.server_version = ...` now succeeds silently. The stored value is inert — the gateway intercepts `SHOW` and still reports the running build.

Unit tests pass; the version e2e test passes over both the simple and extended protocols.