### PR TITLE
feat(multipooler): detect recruit LSN drift before promotion

### DIFF
--- a/go/common/consensus/compare.go
+++ b/go/common/consensus/compare.go
@@ -163,7 +163,7 @@ func MostAdvancedPosition(statuses []*clustermetadatapb.ConsensusStatus) *cluste
 	var best *clustermetadatapb.PoolerPosition
 	for _, cs := range statuses {
 		pos := cs.GetCurrentPosition()
-		if _, err := pgutil.ParseLSN(pos.GetLsn()); err != nil {
+		if _, err := pgutil.ParseLSN(pos.GetFlushedLsn()); err != nil {
 			continue
 		}
 		if best == nil || ComparePoolerPosition(pos, best) > 0 {
@@ -294,8 +294,8 @@ func ComparePoolerPosition(a, b *clustermetadatapb.PoolerPosition) int {
 	if cmp := CompareRulePosition(a.GetPosition(), b.GetPosition()); cmp != 0 {
 		return cmp
 	}
-	lsnA, errA := pgutil.ParseLSN(a.GetLsn())
-	lsnB, errB := pgutil.ParseLSN(b.GetLsn())
+	lsnA, errA := pgutil.ParseLSN(a.GetFlushedLsn())
+	lsnB, errB := pgutil.ParseLSN(b.GetFlushedLsn())
 	okA := errA == nil
 	okB := errB == nil
 	switch {

--- a/go/common/consensus/compare_test.go
+++ b/go/common/consensus/compare_test.go
@@ -55,8 +55,8 @@ func TestRuleNamesLeader(t *testing.T) {
 
 func pos(term int64, lsn string) *clustermetadatapb.PoolerPosition {
 	return &clustermetadatapb.PoolerPosition{
-		Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: rn(term, 0)}},
-		Lsn:      lsn,
+		Position:   &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: rn(term, 0)}},
+		FlushedLsn: lsn,
 	}
 }
 
@@ -115,7 +115,7 @@ func TestMostAdvancedPosition(t *testing.T) {
 			status("c", pos(3, "0/500000")),
 		})
 		assert.Equal(t, int64(4), got.GetPosition().GetDecision().GetRuleNumber().GetCoordinatorTerm())
-		assert.Equal(t, "0/100", got.GetLsn())
+		assert.Equal(t, "0/100", got.GetFlushedLsn())
 	})
 
 	t.Run("same rule highest LSN wins", func(t *testing.T) {
@@ -124,7 +124,7 @@ func TestMostAdvancedPosition(t *testing.T) {
 			status("b", pos(3, "0/300")),
 			status("c", pos(3, "0/200")),
 		})
-		assert.Equal(t, "0/300", got.GetLsn())
+		assert.Equal(t, "0/300", got.GetFlushedLsn())
 	})
 
 	t.Run("skips statuses with unparsable LSN", func(t *testing.T) {
@@ -135,7 +135,7 @@ func TestMostAdvancedPosition(t *testing.T) {
 		// pooler-a's rule is higher (5) but its LSN is unparsable, so it's
 		// filtered out and pooler-b wins despite the lower rule.
 		assert.Equal(t, int64(3), got.GetPosition().GetDecision().GetRuleNumber().GetCoordinatorTerm())
-		assert.Equal(t, "0/100", got.GetLsn())
+		assert.Equal(t, "0/100", got.GetFlushedLsn())
 	})
 }
 

--- a/go/common/consensus/proposals.go
+++ b/go/common/consensus/proposals.go
@@ -429,6 +429,12 @@ func discoverMostAdvancedRulePositions(
 // it still counted toward the position check above, since that check must
 // catch a stale/unfrozen view regardless of LSN, but it can't itself be
 // selected as leader here.
+//
+// GetFlushedLsn() reports the durably-flushed WAL position deliberately, not
+// applied/replayed — this ranking feeds leader selection, which cares which
+// candidate has retained the most durable WAL, not which has replayed the
+// most of it. See PoolerPosition's proto doc and PoolerLsn for the paired
+// flushed+applied view used for diagnostic purposes instead.
 func narrowByLSN(
 	mostAdvanced []*clustermetadatapb.ConsensusStatus,
 	minLSN pgutil.LSN,
@@ -436,7 +442,7 @@ func narrowByLSN(
 	var bestLSN pgutil.LSN
 	var eligibleLeaders []*clustermetadatapb.ConsensusStatus
 	for _, cs := range mostAdvanced {
-		lsn, err := pgutil.ParseLSN(cs.GetCurrentPosition().GetLsn())
+		lsn, err := pgutil.ParseLSN(cs.GetCurrentPosition().GetFlushedLsn())
 		if err != nil || lsn < minLSN {
 			// The caller's filterByValidPosition guarantees all surviving statuses
 			// have parseable LSNs, so a parse failure here is unreachable in practice.
@@ -573,7 +579,7 @@ func filterByValidPosition(statuses []*clustermetadatapb.ConsensusStatus) []*clu
 		if ruleNumberIsUnset(cs.GetCurrentPosition().GetPosition().GetDecision().GetRuleNumber()) {
 			continue
 		}
-		if _, err := pgutil.ParseLSN(cs.GetCurrentPosition().GetLsn()); err == nil {
+		if _, err := pgutil.ParseLSN(cs.GetCurrentPosition().GetFlushedLsn()); err == nil {
 			result = append(result, cs)
 		}
 	}

--- a/go/common/consensus/proposals_test.go
+++ b/go/common/consensus/proposals_test.go
@@ -90,8 +90,8 @@ func makeStatusWithLSN(id *clustermetadatapb.ID, rule *clustermetadatapb.ShardRu
 		Id:             id,
 		TermRevocation: revocation,
 		CurrentPosition: &clustermetadatapb.PoolerPosition{
-			Position: &clustermetadatapb.RulePosition{Decision: rule},
-			Lsn:      lsn,
+			Position:   &clustermetadatapb.RulePosition{Decision: rule},
+			FlushedLsn: lsn,
 		},
 	}
 }
@@ -110,8 +110,8 @@ func makeStatusWithProposal(id *clustermetadatapb.ID, position *clustermetadatap
 		Id:             id,
 		TermRevocation: revocation,
 		CurrentPosition: &clustermetadatapb.PoolerPosition{
-			Position: position,
-			Lsn:      lsn,
+			Position:   position,
+			FlushedLsn: lsn,
 		},
 	}
 }
@@ -166,8 +166,8 @@ func makeUnrecruitedStatus(id *clustermetadatapb.ID, rule *clustermetadatapb.Sha
 	return &clustermetadatapb.ConsensusStatus{
 		Id: id,
 		CurrentPosition: &clustermetadatapb.PoolerPosition{
-			Position: &clustermetadatapb.RulePosition{Decision: rule},
-			Lsn:      "0/1000000",
+			Position:   &clustermetadatapb.RulePosition{Decision: rule},
+			FlushedLsn: "0/1000000",
 		},
 	}
 }

--- a/go/common/consensus/revocation.go
+++ b/go/common/consensus/revocation.go
@@ -208,7 +208,7 @@ func ValidateRevocation(status *clustermetadatapb.ConsensusStatus, revocation *c
 	if pos == nil {
 		return errors.New("cannot accept revocation: unknown WAL position")
 	}
-	if _, err := pgutil.ParseLSN(pos.Lsn); err != nil {
+	if _, err := pgutil.ParseLSN(pos.FlushedLsn); err != nil {
 		return mterrors.Wrap(err, "cannot accept revocation")
 	}
 	if !IsRuleRevoked(pos.GetPosition(), revocation) {

--- a/go/common/consensus/revocation_test.go
+++ b/go/common/consensus/revocation_test.go
@@ -129,7 +129,7 @@ func TestValidateRevocation(t *testing.T) {
 							CoordinatorTerm: 4,
 						},
 					}},
-					Lsn: "abc",
+					FlushedLsn: "abc",
 				},
 			},
 			revocation: revocationAt5,
@@ -299,7 +299,7 @@ func positionAtCoordTerm(coordTerm int64) *clustermetadatapb.PoolerPosition {
 				CoordinatorTerm: coordTerm,
 			},
 		}},
-		Lsn: "16/B374D848",
+		FlushedLsn: "16/B374D848",
 	}
 }
 
@@ -313,7 +313,7 @@ func positionWithUndecidedProposal(decisionTerm, proposalTerm int64) *clustermet
 			Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: decisionTerm}},
 			Proposal: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: proposalTerm}},
 		},
-		Lsn: "16/B374D848",
+		FlushedLsn: "16/B374D848",
 	}
 }
 
@@ -442,19 +442,19 @@ func TestNewTermRevocation(t *testing.T) {
 				Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
 					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4, LeaderSubterm: 2},
 				}},
-				Lsn: "16/B374D848",
+				FlushedLsn: "16/B374D848",
 			}},
 			{CurrentPosition: &clustermetadatapb.PoolerPosition{
 				Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
 					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4, LeaderSubterm: 5},
 				}},
-				Lsn: "16/B374D900",
+				FlushedLsn: "16/B374D900",
 			}},
 			{CurrentPosition: &clustermetadatapb.PoolerPosition{
 				Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
 					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 3, LeaderSubterm: 9},
 				}},
-				Lsn: "16/B374D700",
+				FlushedLsn: "16/B374D700",
 			}},
 		}
 		rev, err := NewTermRevocation(statuses, coord, ts1)

--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -2124,8 +2124,14 @@ type ConsensusPromises struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
 	TermRevocation      *TermRevocation        `protobuf:"bytes,1,opt,name=term_revocation,json=termRevocation,proto3" json:"term_revocation,omitempty"`
 	RecruitBlockedUntil *LsnPosition           `protobuf:"bytes,2,opt,name=recruit_blocked_until,json=recruitBlockedUntil,proto3" json:"recruit_blocked_until,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// The WAL LSN observed immediately after accepting term_revocation, once
+	// waitForReplayStabilize declared replay stable. Used to detect whether
+	// that stabilize heuristic under-waited: if the current LSN has advanced
+	// past this by the time Promote()/SetPrimary() acts on the same
+	// revocation, replay kept moving after we called it stable.
+	RecruitObservedLsn string `protobuf:"bytes,3,opt,name=recruit_observed_lsn,json=recruitObservedLsn,proto3" json:"recruit_observed_lsn,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *ConsensusPromises) Reset() {
@@ -2170,6 +2176,13 @@ func (x *ConsensusPromises) GetRecruitBlockedUntil() *LsnPosition {
 		return x.RecruitBlockedUntil
 	}
 	return nil
+}
+
+func (x *ConsensusPromises) GetRecruitObservedLsn() string {
+	if x != nil {
+		return x.RecruitObservedLsn
+	}
+	return ""
 }
 
 // RoutingState is a pooler's self-reported routing/HA state: its writability
@@ -2948,10 +2961,11 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\bproposal\x18\x02 \x01(\v2\x1b.clustermetadata.RuleNumberR\bproposal\"`\n" +
 	"\vLsnPosition\x12?\n" +
 	"\bposition\x18\x01 \x01(\v2#.clustermetadata.RuleNumberPositionR\bposition\x12\x10\n" +
-	"\x03lsn\x18\x02 \x01(\tR\x03lsn\"\xaf\x01\n" +
+	"\x03lsn\x18\x02 \x01(\tR\x03lsn\"\xe1\x01\n" +
 	"\x11ConsensusPromises\x12H\n" +
 	"\x0fterm_revocation\x18\x01 \x01(\v2\x1f.clustermetadata.TermRevocationR\x0etermRevocation\x12P\n" +
-	"\x15recruit_blocked_until\x18\x02 \x01(\v2\x1c.clustermetadata.LsnPositionR\x13recruitBlockedUntil\"q\n" +
+	"\x15recruit_blocked_until\x18\x02 \x01(\v2\x1c.clustermetadata.LsnPositionR\x13recruitBlockedUntil\x120\n" +
+	"\x14recruit_observed_lsn\x18\x03 \x01(\tR\x12recruitObservedLsn\"q\n" +
 	"\fRoutingState\x120\n" +
 	"\x04role\x18\x01 \x01(\x0e2\x1c.clustermetadata.RoutingRoleR\x04role\x12/\n" +
 	"\x04rule\x18\x02 \x01(\v2\x1b.clustermetadata.RuleNumberR\x04rule\"\xac\x01\n" +

--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -1949,10 +1949,17 @@ type PoolerPosition struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The highest rule position this pooler has committed to local WAL.
 	Position *RulePosition `protobuf:"bytes,1,opt,name=position,proto3" json:"position,omitempty"`
-	// The current real-time WAL head at the time of reading. Note that this is likely
-	// beyond the LSN at which the rule was committed. For a primary: pg_current_wal_lsn().
-	// For a standby: pg_last_wal_receive_lsn() (or pg_last_wal_replay_lsn() if receive is null).
-	Lsn           string `protobuf:"bytes,2,opt,name=lsn,proto3" json:"lsn,omitempty"`
+	// The WAL position this pooler has durably flushed to disk at the time of
+	// reading — not the applied/visible position. Note that this is likely
+	// beyond the LSN at which the rule was committed. For a primary:
+	// pg_current_wal_flush_lsn(). For a standby: pg_last_wal_receive_lsn(),
+	// which Postgres itself defines as "received and synced to disk" (i.e.
+	// already flush-durable, not merely written). Deliberately not applied_lsn:
+	// go/common/consensus's comparison/ranking algorithms need durability
+	// ("who has retained the most data"), not visibility — see PoolerLsn for
+	// the paired flushed+applied view used for diagnostic/defense-in-depth
+	// purposes instead.
+	FlushedLsn    string `protobuf:"bytes,2,opt,name=flushed_lsn,json=flushedLsn,proto3" json:"flushed_lsn,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1994,9 +2001,72 @@ func (x *PoolerPosition) GetPosition() *RulePosition {
 	return nil
 }
 
-func (x *PoolerPosition) GetLsn() string {
+func (x *PoolerPosition) GetFlushedLsn() string {
 	if x != nil {
-		return x.Lsn
+		return x.FlushedLsn
+	}
+	return ""
+}
+
+// PoolerLsn reports both WAL positions for a pooler, read together in a
+// single query so they reflect the same instant. Kept outside
+// PoolerPosition/ConsensusStatus deliberately: go/common/consensus's
+// comparison algorithms are pure and only need the durable position
+// (PoolerPosition.flushed_lsn); applied_lsn is diagnostic context for
+// detecting a stuck-replay bug, not a consensus-algorithm input.
+type PoolerLsn struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Durably flushed to disk. Same source as PoolerPosition.flushed_lsn.
+	FlushedLsn string `protobuf:"bytes,1,opt,name=flushed_lsn,json=flushedLsn,proto3" json:"flushed_lsn,omitempty"`
+	// Applied to (visible in) this pooler's own database state. For a primary:
+	// pg_current_wal_lsn() (a primary's writes are visible immediately; there
+	// is no separate replay step, though flush can still lag write slightly).
+	// For a standby: pg_last_wal_replay_lsn().
+	AppliedLsn    string `protobuf:"bytes,2,opt,name=applied_lsn,json=appliedLsn,proto3" json:"applied_lsn,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PoolerLsn) Reset() {
+	*x = PoolerLsn{}
+	mi := &file_clustermetadata_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PoolerLsn) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PoolerLsn) ProtoMessage() {}
+
+func (x *PoolerLsn) ProtoReflect() protoreflect.Message {
+	mi := &file_clustermetadata_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PoolerLsn.ProtoReflect.Descriptor instead.
+func (*PoolerLsn) Descriptor() ([]byte, []int) {
+	return file_clustermetadata_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *PoolerLsn) GetFlushedLsn() string {
+	if x != nil {
+		return x.FlushedLsn
+	}
+	return ""
+}
+
+func (x *PoolerLsn) GetAppliedLsn() string {
+	if x != nil {
+		return x.AppliedLsn
 	}
 	return ""
 }
@@ -2021,7 +2091,7 @@ type RuleNumberPosition struct {
 
 func (x *RuleNumberPosition) Reset() {
 	*x = RuleNumberPosition{}
-	mi := &file_clustermetadata_proto_msgTypes[20]
+	mi := &file_clustermetadata_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2033,7 +2103,7 @@ func (x *RuleNumberPosition) String() string {
 func (*RuleNumberPosition) ProtoMessage() {}
 
 func (x *RuleNumberPosition) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[20]
+	mi := &file_clustermetadata_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2046,7 +2116,7 @@ func (x *RuleNumberPosition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuleNumberPosition.ProtoReflect.Descriptor instead.
 func (*RuleNumberPosition) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{20}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *RuleNumberPosition) GetDecision() *RuleNumber {
@@ -2075,7 +2145,7 @@ type LsnPosition struct {
 
 func (x *LsnPosition) Reset() {
 	*x = LsnPosition{}
-	mi := &file_clustermetadata_proto_msgTypes[21]
+	mi := &file_clustermetadata_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2087,7 +2157,7 @@ func (x *LsnPosition) String() string {
 func (*LsnPosition) ProtoMessage() {}
 
 func (x *LsnPosition) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[21]
+	mi := &file_clustermetadata_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2100,7 +2170,7 @@ func (x *LsnPosition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsnPosition.ProtoReflect.Descriptor instead.
 func (*LsnPosition) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{21}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *LsnPosition) GetPosition() *RuleNumberPosition {
@@ -2136,7 +2206,7 @@ type ConsensusPromises struct {
 
 func (x *ConsensusPromises) Reset() {
 	*x = ConsensusPromises{}
-	mi := &file_clustermetadata_proto_msgTypes[22]
+	mi := &file_clustermetadata_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2148,7 +2218,7 @@ func (x *ConsensusPromises) String() string {
 func (*ConsensusPromises) ProtoMessage() {}
 
 func (x *ConsensusPromises) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[22]
+	mi := &file_clustermetadata_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2161,7 +2231,7 @@ func (x *ConsensusPromises) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConsensusPromises.ProtoReflect.Descriptor instead.
 func (*ConsensusPromises) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{22}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ConsensusPromises) GetTermRevocation() *TermRevocation {
@@ -2213,7 +2283,7 @@ type RoutingState struct {
 
 func (x *RoutingState) Reset() {
 	*x = RoutingState{}
-	mi := &file_clustermetadata_proto_msgTypes[23]
+	mi := &file_clustermetadata_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2225,7 +2295,7 @@ func (x *RoutingState) String() string {
 func (*RoutingState) ProtoMessage() {}
 
 func (x *RoutingState) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[23]
+	mi := &file_clustermetadata_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2238,7 +2308,7 @@ func (x *RoutingState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoutingState.ProtoReflect.Descriptor instead.
 func (*RoutingState) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{23}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *RoutingState) GetRole() RoutingRole {
@@ -2303,7 +2373,7 @@ type ReplicationPrimary struct {
 
 func (x *ReplicationPrimary) Reset() {
 	*x = ReplicationPrimary{}
-	mi := &file_clustermetadata_proto_msgTypes[24]
+	mi := &file_clustermetadata_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2315,7 +2385,7 @@ func (x *ReplicationPrimary) String() string {
 func (*ReplicationPrimary) ProtoMessage() {}
 
 func (x *ReplicationPrimary) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[24]
+	mi := &file_clustermetadata_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2328,7 +2398,7 @@ func (x *ReplicationPrimary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplicationPrimary.ProtoReflect.Descriptor instead.
 func (*ReplicationPrimary) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{24}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ReplicationPrimary) GetPosition() *RulePosition {
@@ -2396,7 +2466,7 @@ type TermRevocation struct {
 
 func (x *TermRevocation) Reset() {
 	*x = TermRevocation{}
-	mi := &file_clustermetadata_proto_msgTypes[25]
+	mi := &file_clustermetadata_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2408,7 +2478,7 @@ func (x *TermRevocation) String() string {
 func (*TermRevocation) ProtoMessage() {}
 
 func (x *TermRevocation) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[25]
+	mi := &file_clustermetadata_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2421,7 +2491,7 @@ func (x *TermRevocation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TermRevocation.ProtoReflect.Descriptor instead.
 func (*TermRevocation) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{25}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *TermRevocation) GetRevokedBelowTerm() int64 {
@@ -2484,7 +2554,7 @@ type ExternallyCertifiedRevocation struct {
 
 func (x *ExternallyCertifiedRevocation) Reset() {
 	*x = ExternallyCertifiedRevocation{}
-	mi := &file_clustermetadata_proto_msgTypes[26]
+	mi := &file_clustermetadata_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2496,7 +2566,7 @@ func (x *ExternallyCertifiedRevocation) String() string {
 func (*ExternallyCertifiedRevocation) ProtoMessage() {}
 
 func (x *ExternallyCertifiedRevocation) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[26]
+	mi := &file_clustermetadata_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2509,7 +2579,7 @@ func (x *ExternallyCertifiedRevocation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExternallyCertifiedRevocation.ProtoReflect.Descriptor instead.
 func (*ExternallyCertifiedRevocation) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{26}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ExternallyCertifiedRevocation) GetTermRevocation() *TermRevocation {
@@ -2579,7 +2649,7 @@ type ConsensusStatus struct {
 
 func (x *ConsensusStatus) Reset() {
 	*x = ConsensusStatus{}
-	mi := &file_clustermetadata_proto_msgTypes[27]
+	mi := &file_clustermetadata_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2591,7 +2661,7 @@ func (x *ConsensusStatus) String() string {
 func (*ConsensusStatus) ProtoMessage() {}
 
 func (x *ConsensusStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[27]
+	mi := &file_clustermetadata_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2604,7 +2674,7 @@ func (x *ConsensusStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConsensusStatus.ProtoReflect.Descriptor instead.
 func (*ConsensusStatus) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{27}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ConsensusStatus) GetTermRevocation() *TermRevocation {
@@ -2657,7 +2727,7 @@ type LeadershipStatus struct {
 
 func (x *LeadershipStatus) Reset() {
 	*x = LeadershipStatus{}
-	mi := &file_clustermetadata_proto_msgTypes[28]
+	mi := &file_clustermetadata_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2669,7 +2739,7 @@ func (x *LeadershipStatus) String() string {
 func (*LeadershipStatus) ProtoMessage() {}
 
 func (x *LeadershipStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[28]
+	mi := &file_clustermetadata_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2682,7 +2752,7 @@ func (x *LeadershipStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeadershipStatus.ProtoReflect.Descriptor instead.
 func (*LeadershipStatus) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{28}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *LeadershipStatus) GetLeaderTerm() int64 {
@@ -2737,7 +2807,7 @@ type AvailabilityStatus struct {
 
 func (x *AvailabilityStatus) Reset() {
 	*x = AvailabilityStatus{}
-	mi := &file_clustermetadata_proto_msgTypes[29]
+	mi := &file_clustermetadata_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2749,7 +2819,7 @@ func (x *AvailabilityStatus) String() string {
 func (*AvailabilityStatus) ProtoMessage() {}
 
 func (x *AvailabilityStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[29]
+	mi := &file_clustermetadata_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2762,7 +2832,7 @@ func (x *AvailabilityStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AvailabilityStatus.ProtoReflect.Descriptor instead.
 func (*AvailabilityStatus) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{29}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *AvailabilityStatus) GetLeadershipStatus() *LeadershipStatus {
@@ -2799,7 +2869,7 @@ type CohortEligibilityStatus struct {
 
 func (x *CohortEligibilityStatus) Reset() {
 	*x = CohortEligibilityStatus{}
-	mi := &file_clustermetadata_proto_msgTypes[30]
+	mi := &file_clustermetadata_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2811,7 +2881,7 @@ func (x *CohortEligibilityStatus) String() string {
 func (*CohortEligibilityStatus) ProtoMessage() {}
 
 func (x *CohortEligibilityStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[30]
+	mi := &file_clustermetadata_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2824,7 +2894,7 @@ func (x *CohortEligibilityStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CohortEligibilityStatus.ProtoReflect.Descriptor instead.
 func (*CohortEligibilityStatus) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{30}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *CohortEligibilityStatus) GetSignal() CohortEligibilitySignal {
@@ -2952,10 +3022,16 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\rcreation_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\fcreationTime\"~\n" +
 	"\fRulePosition\x126\n" +
 	"\bdecision\x18\x01 \x01(\v2\x1a.clustermetadata.ShardRuleR\bdecision\x126\n" +
-	"\bproposal\x18\x02 \x01(\v2\x1a.clustermetadata.ShardRuleR\bproposal\"]\n" +
+	"\bproposal\x18\x02 \x01(\v2\x1a.clustermetadata.ShardRuleR\bproposal\"l\n" +
 	"\x0ePoolerPosition\x129\n" +
-	"\bposition\x18\x01 \x01(\v2\x1d.clustermetadata.RulePositionR\bposition\x12\x10\n" +
-	"\x03lsn\x18\x02 \x01(\tR\x03lsn\"\x86\x01\n" +
+	"\bposition\x18\x01 \x01(\v2\x1d.clustermetadata.RulePositionR\bposition\x12\x1f\n" +
+	"\vflushed_lsn\x18\x02 \x01(\tR\n" +
+	"flushedLsn\"M\n" +
+	"\tPoolerLsn\x12\x1f\n" +
+	"\vflushed_lsn\x18\x01 \x01(\tR\n" +
+	"flushedLsn\x12\x1f\n" +
+	"\vapplied_lsn\x18\x02 \x01(\tR\n" +
+	"appliedLsn\"\x86\x01\n" +
 	"\x12RuleNumberPosition\x127\n" +
 	"\bdecision\x18\x01 \x01(\v2\x1b.clustermetadata.RuleNumberR\bdecision\x127\n" +
 	"\bproposal\x18\x02 \x01(\v2\x1b.clustermetadata.RuleNumberR\bproposal\"`\n" +
@@ -3045,7 +3121,7 @@ func file_clustermetadata_proto_rawDescGZIP() []byte {
 }
 
 var file_clustermetadata_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_clustermetadata_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
+var file_clustermetadata_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_clustermetadata_proto_goTypes = []any{
 	(PoolerType)(0),                       // 0: clustermetadata.PoolerType
 	(PoolerLifecycleStatus)(0),            // 1: clustermetadata.PoolerLifecycleStatus
@@ -3075,21 +3151,22 @@ var file_clustermetadata_proto_goTypes = []any{
 	(*ShardRule)(nil),                     // 25: clustermetadata.ShardRule
 	(*RulePosition)(nil),                  // 26: clustermetadata.RulePosition
 	(*PoolerPosition)(nil),                // 27: clustermetadata.PoolerPosition
-	(*RuleNumberPosition)(nil),            // 28: clustermetadata.RuleNumberPosition
-	(*LsnPosition)(nil),                   // 29: clustermetadata.LsnPosition
-	(*ConsensusPromises)(nil),             // 30: clustermetadata.ConsensusPromises
-	(*RoutingState)(nil),                  // 31: clustermetadata.RoutingState
-	(*ReplicationPrimary)(nil),            // 32: clustermetadata.ReplicationPrimary
-	(*TermRevocation)(nil),                // 33: clustermetadata.TermRevocation
-	(*ExternallyCertifiedRevocation)(nil), // 34: clustermetadata.ExternallyCertifiedRevocation
-	(*ConsensusStatus)(nil),               // 35: clustermetadata.ConsensusStatus
-	(*LeadershipStatus)(nil),              // 36: clustermetadata.LeadershipStatus
-	(*AvailabilityStatus)(nil),            // 37: clustermetadata.AvailabilityStatus
-	(*CohortEligibilityStatus)(nil),       // 38: clustermetadata.CohortEligibilityStatus
-	nil,                                   // 39: clustermetadata.Multipooler.PortMapEntry
-	nil,                                   // 40: clustermetadata.Multigateway.PortMapEntry
-	nil,                                   // 41: clustermetadata.Multiorch.PortMapEntry
-	(*timestamppb.Timestamp)(nil),         // 42: google.protobuf.Timestamp
+	(*PoolerLsn)(nil),                     // 28: clustermetadata.PoolerLsn
+	(*RuleNumberPosition)(nil),            // 29: clustermetadata.RuleNumberPosition
+	(*LsnPosition)(nil),                   // 30: clustermetadata.LsnPosition
+	(*ConsensusPromises)(nil),             // 31: clustermetadata.ConsensusPromises
+	(*RoutingState)(nil),                  // 32: clustermetadata.RoutingState
+	(*ReplicationPrimary)(nil),            // 33: clustermetadata.ReplicationPrimary
+	(*TermRevocation)(nil),                // 34: clustermetadata.TermRevocation
+	(*ExternallyCertifiedRevocation)(nil), // 35: clustermetadata.ExternallyCertifiedRevocation
+	(*ConsensusStatus)(nil),               // 36: clustermetadata.ConsensusStatus
+	(*LeadershipStatus)(nil),              // 37: clustermetadata.LeadershipStatus
+	(*AvailabilityStatus)(nil),            // 38: clustermetadata.AvailabilityStatus
+	(*CohortEligibilityStatus)(nil),       // 39: clustermetadata.CohortEligibilityStatus
+	nil,                                   // 40: clustermetadata.Multipooler.PortMapEntry
+	nil,                                   // 41: clustermetadata.Multigateway.PortMapEntry
+	nil,                                   // 42: clustermetadata.Multiorch.PortMapEntry
+	(*timestamppb.Timestamp)(nil),         // 43: google.protobuf.Timestamp
 }
 var file_clustermetadata_proto_depIdxs = []int32{
 	12, // 0: clustermetadata.Database.backup_location:type_name -> clustermetadata.BackupLocation
@@ -3104,47 +3181,47 @@ var file_clustermetadata_proto_depIdxs = []int32{
 	21, // 9: clustermetadata.Multipooler.key_range:type_name -> clustermetadata.KeyRange
 	0,  // 10: clustermetadata.Multipooler.type:type_name -> clustermetadata.PoolerType
 	2,  // 11: clustermetadata.Multipooler.serving_status:type_name -> clustermetadata.PoolerServingStatus
-	39, // 12: clustermetadata.Multipooler.port_map:type_name -> clustermetadata.Multipooler.PortMapEntry
+	40, // 12: clustermetadata.Multipooler.port_map:type_name -> clustermetadata.Multipooler.PortMapEntry
 	22, // 13: clustermetadata.Multipooler.lifecycle_status:type_name -> clustermetadata.PoolerLifecycle
-	31, // 14: clustermetadata.Multipooler.routing_state:type_name -> clustermetadata.RoutingState
+	32, // 14: clustermetadata.Multipooler.routing_state:type_name -> clustermetadata.RoutingState
 	20, // 15: clustermetadata.Multigateway.id:type_name -> clustermetadata.ID
-	40, // 16: clustermetadata.Multigateway.port_map:type_name -> clustermetadata.Multigateway.PortMapEntry
+	41, // 16: clustermetadata.Multigateway.port_map:type_name -> clustermetadata.Multigateway.PortMapEntry
 	20, // 17: clustermetadata.Multiorch.id:type_name -> clustermetadata.ID
-	41, // 18: clustermetadata.Multiorch.port_map:type_name -> clustermetadata.Multiorch.PortMapEntry
+	42, // 18: clustermetadata.Multiorch.port_map:type_name -> clustermetadata.Multiorch.PortMapEntry
 	7,  // 19: clustermetadata.ID.component:type_name -> clustermetadata.ID.ComponentType
 	1,  // 20: clustermetadata.PoolerLifecycle.status:type_name -> clustermetadata.PoolerLifecycleStatus
-	42, // 21: clustermetadata.PoolerLifecycle.updated:type_name -> google.protobuf.Timestamp
+	43, // 21: clustermetadata.PoolerLifecycle.updated:type_name -> google.protobuf.Timestamp
 	3,  // 22: clustermetadata.DurabilityPolicy.quorum_type:type_name -> clustermetadata.QuorumType
 	24, // 23: clustermetadata.ShardRule.rule_number:type_name -> clustermetadata.RuleNumber
 	20, // 24: clustermetadata.ShardRule.leader_id:type_name -> clustermetadata.ID
 	20, // 25: clustermetadata.ShardRule.cohort_members:type_name -> clustermetadata.ID
 	23, // 26: clustermetadata.ShardRule.durability_policy:type_name -> clustermetadata.DurabilityPolicy
 	20, // 27: clustermetadata.ShardRule.coordinator_id:type_name -> clustermetadata.ID
-	42, // 28: clustermetadata.ShardRule.creation_time:type_name -> google.protobuf.Timestamp
+	43, // 28: clustermetadata.ShardRule.creation_time:type_name -> google.protobuf.Timestamp
 	25, // 29: clustermetadata.RulePosition.decision:type_name -> clustermetadata.ShardRule
 	25, // 30: clustermetadata.RulePosition.proposal:type_name -> clustermetadata.ShardRule
 	26, // 31: clustermetadata.PoolerPosition.position:type_name -> clustermetadata.RulePosition
 	24, // 32: clustermetadata.RuleNumberPosition.decision:type_name -> clustermetadata.RuleNumber
 	24, // 33: clustermetadata.RuleNumberPosition.proposal:type_name -> clustermetadata.RuleNumber
-	28, // 34: clustermetadata.LsnPosition.position:type_name -> clustermetadata.RuleNumberPosition
-	33, // 35: clustermetadata.ConsensusPromises.term_revocation:type_name -> clustermetadata.TermRevocation
-	29, // 36: clustermetadata.ConsensusPromises.recruit_blocked_until:type_name -> clustermetadata.LsnPosition
+	29, // 34: clustermetadata.LsnPosition.position:type_name -> clustermetadata.RuleNumberPosition
+	34, // 35: clustermetadata.ConsensusPromises.term_revocation:type_name -> clustermetadata.TermRevocation
+	30, // 36: clustermetadata.ConsensusPromises.recruit_blocked_until:type_name -> clustermetadata.LsnPosition
 	4,  // 37: clustermetadata.RoutingState.role:type_name -> clustermetadata.RoutingRole
 	24, // 38: clustermetadata.RoutingState.rule:type_name -> clustermetadata.RuleNumber
 	26, // 39: clustermetadata.ReplicationPrimary.position:type_name -> clustermetadata.RulePosition
 	15, // 40: clustermetadata.ReplicationPrimary.primary:type_name -> clustermetadata.PoolerAddress
 	20, // 41: clustermetadata.TermRevocation.accepted_coordinator_id:type_name -> clustermetadata.ID
-	42, // 42: clustermetadata.TermRevocation.coordinator_initiated_at:type_name -> google.protobuf.Timestamp
+	43, // 42: clustermetadata.TermRevocation.coordinator_initiated_at:type_name -> google.protobuf.Timestamp
 	24, // 43: clustermetadata.TermRevocation.outgoing_rule:type_name -> clustermetadata.RuleNumber
-	33, // 44: clustermetadata.ExternallyCertifiedRevocation.term_revocation:type_name -> clustermetadata.TermRevocation
-	33, // 45: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
+	34, // 44: clustermetadata.ExternallyCertifiedRevocation.term_revocation:type_name -> clustermetadata.TermRevocation
+	34, // 45: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
 	27, // 46: clustermetadata.ConsensusStatus.current_position:type_name -> clustermetadata.PoolerPosition
-	32, // 47: clustermetadata.ConsensusStatus.replication_primary:type_name -> clustermetadata.ReplicationPrimary
+	33, // 47: clustermetadata.ConsensusStatus.replication_primary:type_name -> clustermetadata.ReplicationPrimary
 	20, // 48: clustermetadata.ConsensusStatus.id:type_name -> clustermetadata.ID
-	29, // 49: clustermetadata.ConsensusStatus.recruit_blocked_until:type_name -> clustermetadata.LsnPosition
+	30, // 49: clustermetadata.ConsensusStatus.recruit_blocked_until:type_name -> clustermetadata.LsnPosition
 	5,  // 50: clustermetadata.LeadershipStatus.signal:type_name -> clustermetadata.LeadershipSignal
-	36, // 51: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
-	38, // 52: clustermetadata.AvailabilityStatus.cohort_eligibility_status:type_name -> clustermetadata.CohortEligibilityStatus
+	37, // 51: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
+	39, // 52: clustermetadata.AvailabilityStatus.cohort_eligibility_status:type_name -> clustermetadata.CohortEligibilityStatus
 	6,  // 53: clustermetadata.CohortEligibilityStatus.signal:type_name -> clustermetadata.CohortEligibilitySignal
 	54, // [54:54] is the sub-list for method output_type
 	54, // [54:54] is the sub-list for method input_type
@@ -3168,7 +3245,7 @@ func file_clustermetadata_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_clustermetadata_proto_rawDesc), len(file_clustermetadata_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   34,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/pb/consensusdata/consensusdata.pb.go
+++ b/go/pb/consensusdata/consensusdata.pb.go
@@ -182,8 +182,13 @@ func (x *RecruitRequest) GetTermRevocation() *clustermetadata.TermRevocation {
 type RecruitResponse struct {
 	state           protoimpl.MessageState           `protogen:"open.v1"`
 	ConsensusStatus *clustermetadata.ConsensusStatus `protobuf:"bytes,1,opt,name=consensus_status,json=consensusStatus,proto3" json:"consensus_status,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// Flushed and applied WAL position at the same instant this pooler
+	// accepted the revocation, for the coordinator to use as diagnostic
+	// context (e.g. detecting a stuck-replay bug) — not a consensus-algorithm
+	// input; see PoolerLsn's proto doc.
+	Lsn           *clustermetadata.PoolerLsn `protobuf:"bytes,2,opt,name=lsn,proto3" json:"lsn,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *RecruitResponse) Reset() {
@@ -219,6 +224,13 @@ func (*RecruitResponse) Descriptor() ([]byte, []int) {
 func (x *RecruitResponse) GetConsensusStatus() *clustermetadata.ConsensusStatus {
 	if x != nil {
 		return x.ConsensusStatus
+	}
+	return nil
+}
+
+func (x *RecruitResponse) GetLsn() *clustermetadata.PoolerLsn {
+	if x != nil {
+		return x.Lsn
 	}
 	return nil
 }
@@ -454,9 +466,10 @@ const file_consensusdata_proto_rawDesc = "" +
 	"\x13proposed_transition\x18\x03 \x01(\v2\x1d.clustermetadata.RulePositionR\x12proposedTransition\x120\n" +
 	"\x14skip_outgoing_quorum\x18\x04 \x01(\bR\x12skipOutgoingQuorum\"Z\n" +
 	"\x0eRecruitRequest\x12H\n" +
-	"\x0fterm_revocation\x18\x01 \x01(\v2\x1f.clustermetadata.TermRevocationR\x0etermRevocation\"^\n" +
+	"\x0fterm_revocation\x18\x01 \x01(\v2\x1f.clustermetadata.TermRevocationR\x0etermRevocation\"\x8c\x01\n" +
 	"\x0fRecruitResponse\x12K\n" +
-	"\x10consensus_status\x18\x01 \x01(\v2 .clustermetadata.ConsensusStatusR\x0fconsensusStatus\"\xa9\x01\n" +
+	"\x10consensus_status\x18\x01 \x01(\v2 .clustermetadata.ConsensusStatusR\x0fconsensusStatus\x12,\n" +
+	"\x03lsn\x18\x02 \x01(\v2\x1a.clustermetadata.PoolerLsnR\x03lsn\"\xa9\x01\n" +
 	"\x0ePromoteRequest\x12>\n" +
 	"\bproposal\x18\x01 \x01(\v2\".consensusdata.CoordinatorProposalR\bproposal\x12\x16\n" +
 	"\x06reason\x18\x02 \x01(\tR\x06reason\x12?\n" +
@@ -493,8 +506,9 @@ var file_consensusdata_proto_goTypes = []any{
 	(*clustermetadata.PoolerAddress)(nil),      // 8: clustermetadata.PoolerAddress
 	(*clustermetadata.RulePosition)(nil),       // 9: clustermetadata.RulePosition
 	(*clustermetadata.ConsensusStatus)(nil),    // 10: clustermetadata.ConsensusStatus
-	(*clustermetadata.ID)(nil),                 // 11: clustermetadata.ID
-	(*clustermetadata.ReplicationPrimary)(nil), // 12: clustermetadata.ReplicationPrimary
+	(*clustermetadata.PoolerLsn)(nil),          // 11: clustermetadata.PoolerLsn
+	(*clustermetadata.ID)(nil),                 // 12: clustermetadata.ID
+	(*clustermetadata.ReplicationPrimary)(nil), // 13: clustermetadata.ReplicationPrimary
 }
 var file_consensusdata_proto_depIdxs = []int32{
 	7,  // 0: consensusdata.CoordinatorProposal.term_revocation:type_name -> clustermetadata.TermRevocation
@@ -502,16 +516,17 @@ var file_consensusdata_proto_depIdxs = []int32{
 	9,  // 2: consensusdata.CoordinatorProposal.proposed_transition:type_name -> clustermetadata.RulePosition
 	7,  // 3: consensusdata.RecruitRequest.term_revocation:type_name -> clustermetadata.TermRevocation
 	10, // 4: consensusdata.RecruitResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
-	0,  // 5: consensusdata.PromoteRequest.proposal:type_name -> consensusdata.CoordinatorProposal
-	11, // 6: consensusdata.PromoteRequest.accepted_node_ids:type_name -> clustermetadata.ID
-	10, // 7: consensusdata.PromoteResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
-	12, // 8: consensusdata.SetPrimaryRequest.replication_primary:type_name -> clustermetadata.ReplicationPrimary
-	10, // 9: consensusdata.SetPrimaryResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
-	10, // [10:10] is the sub-list for method output_type
-	10, // [10:10] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	11, // 5: consensusdata.RecruitResponse.lsn:type_name -> clustermetadata.PoolerLsn
+	0,  // 6: consensusdata.PromoteRequest.proposal:type_name -> consensusdata.CoordinatorProposal
+	12, // 7: consensusdata.PromoteRequest.accepted_node_ids:type_name -> clustermetadata.ID
+	10, // 8: consensusdata.PromoteResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	13, // 9: consensusdata.SetPrimaryRequest.replication_primary:type_name -> clustermetadata.ReplicationPrimary
+	10, // 10: consensusdata.SetPrimaryResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	11, // [11:11] is the sub-list for method output_type
+	11, // [11:11] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_consensusdata_proto_init() }

--- a/go/services/multiadmin/rule_change.go
+++ b/go/services/multiadmin/rule_change.go
@@ -206,7 +206,7 @@ func (s *MultiadminServer) buildCert(
 			TermRevocation: &clustermetadatapb.TermRevocation{
 				OutgoingRule: decision.GetRuleNumber(),
 			},
-			FrozenLsn: pos.GetLsn(),
+			FrozenLsn: pos.GetFlushedLsn(),
 		}, nil
 
 	default:
@@ -327,7 +327,7 @@ func (s *MultiadminServer) probeMostAdvanced(
 	s.logger.InfoContext(ctx, "derived cert from reachable cohort",
 		"reachable", len(reachable), "total", total)
 
-	frozenLSN := best.GetLsn()
+	frozenLSN := best.GetFlushedLsn()
 	if frozenLSN == "" {
 		return nil, status.Error(codes.Unavailable, "most-advanced cohort member reported an empty LSN")
 	}

--- a/go/services/multiadmin/rule_change_test.go
+++ b/go/services/multiadmin/rule_change_test.go
@@ -257,8 +257,8 @@ func TestProbeMostAdvanced_PicksMostAdvanced(t *testing.T) {
 			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
 				Id: p.pooler.Id,
 				CurrentPosition: &clustermetadatapb.PoolerPosition{
-					Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: p.term}}},
-					Lsn:      p.lsn,
+					Position:   &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: p.term}}},
+					FlushedLsn: p.lsn,
 				},
 			},
 		})
@@ -271,7 +271,7 @@ func TestProbeMostAdvanced_PicksMostAdvanced(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, int64(5), best.GetPosition().GetDecision().GetRuleNumber().GetCoordinatorTerm())
-	assert.Equal(t, "0/200", best.GetLsn())
+	assert.Equal(t, "0/200", best.GetFlushedLsn())
 }
 
 func TestProbeMostAdvanced_InsufficientCohortRecruitment(t *testing.T) {
@@ -292,8 +292,8 @@ func TestProbeMostAdvanced_InsufficientCohortRecruitment(t *testing.T) {
 		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
 			Id: mp1.Id,
 			CurrentPosition: &clustermetadatapb.PoolerPosition{
-				Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}}},
-				Lsn:      "0/100",
+				Position:   &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}}},
+				FlushedLsn: "0/100",
 			},
 		},
 	})
@@ -333,7 +333,7 @@ func TestFindRuleByNumber_Found(t *testing.T) {
 					RuleNumber:    &clustermetadatapb.RuleNumber{CoordinatorTerm: 2},
 					CohortMembers: []*clustermetadatapb.ID{mp1.Id},
 				}},
-				Lsn: "0/100",
+				FlushedLsn: "0/100",
 			},
 		},
 	})
@@ -348,7 +348,7 @@ func TestFindRuleByNumber_Found(t *testing.T) {
 						CohortMembers: []*clustermetadatapb.ID{mp1.Id, mp2.Id},
 					},
 				},
-				Lsn: "0/200",
+				FlushedLsn: "0/200",
 			},
 		},
 	})
@@ -372,8 +372,8 @@ func TestFindRuleByNumber_NotFound(t *testing.T) {
 		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
 			Id: mp1.Id,
 			CurrentPosition: &clustermetadatapb.PoolerPosition{
-				Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}}},
-				Lsn:      "0/100",
+				Position:   &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}}},
+				FlushedLsn: "0/100",
 			},
 		},
 	})
@@ -439,8 +439,8 @@ func TestBuildCert_ExplicitCert_Cloned(t *testing.T) {
 		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
 			Id: mp1.Id,
 			CurrentPosition: &clustermetadatapb.PoolerPosition{
-				Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 3}}},
-				Lsn:      "0/100",
+				Position:   &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 3}}},
+				FlushedLsn: "0/100",
 			},
 		},
 	})
@@ -491,8 +491,8 @@ func TestBuildCert_UnsafeDerive_UsesProbe(t *testing.T) {
 		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
 			Id: mp1.Id,
 			CurrentPosition: &clustermetadatapb.PoolerPosition{
-				Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4}}},
-				Lsn:      "0/200",
+				Position:   &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4}}},
+				FlushedLsn: "0/200",
 			},
 		},
 	})
@@ -500,8 +500,8 @@ func TestBuildCert_UnsafeDerive_UsesProbe(t *testing.T) {
 		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
 			Id: mp2.Id,
 			CurrentPosition: &clustermetadatapb.PoolerPosition{
-				Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4}}},
-				Lsn:      "0/300",
+				Position:   &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4}}},
+				FlushedLsn: "0/300",
 			},
 		},
 	})
@@ -643,8 +643,8 @@ func TestApplyCertifiedRuleChange_ForwardsToOrch(t *testing.T) {
 			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
 				Id: id,
 				CurrentPosition: &clustermetadatapb.PoolerPosition{
-					Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}}},
-					Lsn:      "0/100",
+					Position:   &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}}},
+					FlushedLsn: "0/100",
 				},
 			},
 		})
@@ -696,8 +696,8 @@ func TestApplyCertifiedRuleChange_PropagatesOrchError(t *testing.T) {
 		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
 			Id: mp1.Id,
 			CurrentPosition: &clustermetadatapb.PoolerPosition{
-				Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}}},
-				Lsn:      "0/100",
+				Position:   &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}}},
+				FlushedLsn: "0/100",
 			},
 		},
 	})

--- a/go/services/multiorch/consensus/coordinator.go
+++ b/go/services/multiorch/consensus/coordinator.go
@@ -167,7 +167,7 @@ func (c *Coordinator) AppointInitialLeader(ctx context.Context, shardKey *cluste
 
 	cert := &clustermetadatapb.ExternallyCertifiedRevocation{
 		TermRevocation: revocation,
-		FrozenLsn:      mostAdvanced.GetLsn(),
+		FrozenLsn:      mostAdvanced.GetFlushedLsn(),
 	}
 
 	poolerByID, _ := buildCohortMaps(cohort)

--- a/go/services/multiorch/consensus/leader_appointment_test.go
+++ b/go/services/multiorch/consensus/leader_appointment_test.go
@@ -59,8 +59,8 @@ func createMockNode(fakeClient *rpcclient.FakeClient, name string, term int64, w
 				RevokedBelowTerm: term,
 			},
 			CurrentPosition: &clustermetadatapb.PoolerPosition{
-				Lsn:      walPosition,
-				Position: &clustermetadatapb.RulePosition{Decision: rule},
+				FlushedLsn: walPosition,
+				Position:   &clustermetadatapb.RulePosition{Decision: rule},
 			},
 		},
 	})
@@ -129,16 +129,16 @@ func TestAppointLeader(t *testing.T) {
 		// here too. createMockNode leaves these fields zero on the cached status.
 		mp.ConsensusStatus.Id = id
 		mp.ConsensusStatus.CurrentPosition = &clustermetadatapb.PoolerPosition{
-			Lsn:      walPositions[i],
-			Position: &clustermetadatapb.RulePosition{Decision: outgoingRule},
+			FlushedLsn: walPositions[i],
+			Position:   &clustermetadatapb.RulePosition{Decision: outgoingRule},
 		}
 		key := topoclient.ComponentIDString(id)
 		fakeClient.RecruitResponses[key] = &consensusdatapb.RecruitResponse{
 			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
 				Id: id,
 				CurrentPosition: &clustermetadatapb.PoolerPosition{
-					Lsn:      walPositions[i],
-					Position: &clustermetadatapb.RulePosition{Decision: outgoingRule},
+					FlushedLsn: walPositions[i],
+					Position:   &clustermetadatapb.RulePosition{Decision: outgoingRule},
 				},
 			},
 		}
@@ -216,8 +216,8 @@ func TestAppointLeader_PropagatesUndecidedMostAdvancedPosition(t *testing.T) {
 	mp := createMockNode(fakeClient, "mp1", 3, "0/1000000", true, oldRule)
 	mp.ConsensusStatus.Id = mpID
 	mp.ConsensusStatus.CurrentPosition = &clustermetadatapb.PoolerPosition{
-		Lsn:      "0/1000000",
-		Position: &clustermetadatapb.RulePosition{Decision: oldRule, Proposal: undecidedProposal},
+		FlushedLsn: "0/1000000",
+		Position:   &clustermetadatapb.RulePosition{Decision: oldRule, Proposal: undecidedProposal},
 	}
 	require.NoError(t, ts.CreateMultipooler(ctx, mp.Multipooler))
 
@@ -225,8 +225,8 @@ func TestAppointLeader_PropagatesUndecidedMostAdvancedPosition(t *testing.T) {
 		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
 			Id: mpID,
 			CurrentPosition: &clustermetadatapb.PoolerPosition{
-				Lsn:      "0/1000000",
-				Position: &clustermetadatapb.RulePosition{Decision: oldRule, Proposal: undecidedProposal},
+				FlushedLsn: "0/1000000",
+				Position:   &clustermetadatapb.RulePosition{Decision: oldRule, Proposal: undecidedProposal},
 			},
 		},
 	}
@@ -299,8 +299,8 @@ func TestAppointInitialLeader(t *testing.T) {
 		mp.ConsensusStatus = &clustermetadatapb.ConsensusStatus{
 			Id: id,
 			CurrentPosition: &clustermetadatapb.PoolerPosition{
-				Lsn:      walPositions[i],
-				Position: &clustermetadatapb.RulePosition{Decision: sentinelRule},
+				FlushedLsn: walPositions[i],
+				Position:   &clustermetadatapb.RulePosition{Decision: sentinelRule},
 			},
 		}
 		key := topoclient.ComponentIDString(id)
@@ -308,8 +308,8 @@ func TestAppointInitialLeader(t *testing.T) {
 			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
 				Id: id,
 				CurrentPosition: &clustermetadatapb.PoolerPosition{
-					Lsn:      walPositions[i],
-					Position: &clustermetadatapb.RulePosition{Decision: sentinelRule},
+					FlushedLsn: walPositions[i],
+					Position:   &clustermetadatapb.RulePosition{Decision: sentinelRule},
 				},
 			},
 		}

--- a/go/services/multiorch/consensus/rule_change.go
+++ b/go/services/multiorch/consensus/rule_change.go
@@ -340,7 +340,7 @@ func (r *coordinatorLedRuleChange) recruit(
 		cs := resp.GetConsensusStatus()
 		r.coordinator.logger.InfoContext(ctx, "Recruited pooler",
 			"pooler", p.Multipooler.Id.Name,
-			"lsn", cs.GetCurrentPosition().GetLsn())
+			"lsn", cs.GetCurrentPosition().GetFlushedLsn())
 		return cs
 	}
 }

--- a/go/services/multiorch/consensus/rule_change_certified_test.go
+++ b/go/services/multiorch/consensus/rule_change_certified_test.go
@@ -183,7 +183,7 @@ func TestApplyCertifiedRuleChange_UndecidedOutgoingProposal(t *testing.T) {
 			Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 3}},
 			Proposal: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4}},
 		},
-		Lsn: "0/1000",
+		FlushedLsn: "0/1000",
 	}
 	fc.SetStatusResponse(topoclient.ComponentIDString(mp1.Id), &multipoolermanagerdatapb.StatusResponse{
 		ConsensusStatus: &clustermetadatapb.ConsensusStatus{Id: mp1.Id, CurrentPosition: position},
@@ -424,8 +424,8 @@ func TestRefreshShardConsensusStatuses(t *testing.T) {
 		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
 			Id: mp1.Id,
 			CurrentPosition: &clustermetadatapb.PoolerPosition{
-				Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4}}},
-				Lsn:      "0/100",
+				Position:   &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4}}},
+				FlushedLsn: "0/100",
 			},
 		},
 	})
@@ -433,8 +433,8 @@ func TestRefreshShardConsensusStatuses(t *testing.T) {
 		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
 			Id: mp2.Id,
 			CurrentPosition: &clustermetadatapb.PoolerPosition{
-				Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4}}},
-				Lsn:      "0/200",
+				Position:   &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4}}},
+				FlushedLsn: "0/200",
 			},
 		},
 	})
@@ -447,8 +447,8 @@ func TestRefreshShardConsensusStatuses(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, statuses, 2, "non-matching shard pooler should be filtered out")
-		assert.Equal(t, "0/100", statuses[topoclient.ClusterIDString(mp1.Id)].GetCurrentPosition().GetLsn())
-		assert.Equal(t, "0/200", statuses[topoclient.ClusterIDString(mp2.Id)].GetCurrentPosition().GetLsn())
+		assert.Equal(t, "0/100", statuses[topoclient.ClusterIDString(mp1.Id)].GetCurrentPosition().GetFlushedLsn())
+		assert.Equal(t, "0/200", statuses[topoclient.ClusterIDString(mp2.Id)].GetCurrentPosition().GetFlushedLsn())
 		assert.NotContains(t, statuses, topoclient.ClusterIDString(mp3OtherShard.Id))
 	})
 

--- a/go/services/multiorch/recovery/actions/demote_stale_leader_test.go
+++ b/go/services/multiorch/recovery/actions/demote_stale_leader_test.go
@@ -76,7 +76,7 @@ func makeDemoteScenarioPoolers(t *testing.T, poolerStore *store.PoolerCache) (st
 			RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
 			LeaderId:   correctLeaderID,
 		}},
-		Lsn: "0/1000",
+		FlushedLsn: "0/1000",
 	}
 	store.SeedCache(t, poolerStore, store.NewPooler(&multiorchdatapb.PoolerHealthState{
 		Multipooler: &clustermetadatapb.Multipooler{

--- a/go/services/multiorch/recovery/actions/fix_replication_test.go
+++ b/go/services/multiorch/recovery/actions/fix_replication_test.go
@@ -267,7 +267,7 @@ func TestFixReplicationAction_ExecuteSuccessNotReplicating(t *testing.T) {
 			RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
 			LeaderId:   fixReplPrimaryID,
 		}},
-		Lsn: "0/1234",
+		FlushedLsn: "0/1234",
 	}
 	store.SeedCache(t, poolerStore, store.NewPooler(&multiorchdatapb.PoolerHealthState{
 		Multipooler: &clustermetadatapb.Multipooler{

--- a/go/services/multipooler/internal/manager/consensus/cohort_membership_test.go
+++ b/go/services/multipooler/internal/manager/consensus/cohort_membership_test.go
@@ -30,8 +30,8 @@ type fakeCohortRuleStore struct {
 	pos *clustermetadatapb.PoolerPosition
 }
 
-func (f *fakeCohortRuleStore) ObservePosition(context.Context) (*clustermetadatapb.PoolerPosition, error) {
-	return f.pos, nil
+func (f *fakeCohortRuleStore) ObservePosition(context.Context) (*clustermetadatapb.PoolerPosition, *clustermetadatapb.PoolerLsn, error) {
+	return f.pos, nil, nil
 }
 
 func (f *fakeCohortRuleStore) UpdateRule(context.Context, *RuleUpdateBuilder) (*clustermetadatapb.PoolerPosition, error) {

--- a/go/services/multipooler/internal/manager/consensus/consensus_promises.go
+++ b/go/services/multipooler/internal/manager/consensus/consensus_promises.go
@@ -35,24 +35,21 @@ type ConsensusPromises struct {
 	serviceID *clustermetadatapb.ID
 
 	mu sync.Mutex
-	// revocation is persisted to disk; see promise_storage.go.
-	revocation *clustermetadatapb.TermRevocation
-	// recruitBlockedUntil, if non-nil, is the minimum position this pooler
-	// must reach before Recruit() may succeed — set before an operation
-	// (restore-from-backup, pg_rewind) that can silently break WAL
-	// continuity. Persisted alongside revocation; see promise_storage.go. See
-	// ConsensusManager.recruitPositionFloorIfOutstanding for enforcement; no
-	// explicit clearing here.
-	recruitBlockedUntil *clustermetadatapb.LsnPosition
+	// promises is the full on-disk state, held in memory; see
+	// promise_storage.go. Never nil after construction. Every mutator clones
+	// it, updates only the field it owns, persists the clone, then swaps it
+	// in — so a field's zero value is never mistaken for "leave unchanged."
+	promises *clustermetadatapb.ConsensusPromises
 }
 
 // NewConsensusPromises creates a new ConsensusPromises manager.
-// It does not load state from disk - call Load() to initialize.
+// It does not load state from disk - call Load() to initialize; promises is
+// nil until then (proto3 getters are nil-safe, so reads before Load() behave
+// like an all-default message).
 func NewConsensusPromises(poolerDir string, serviceID *clustermetadatapb.ID) *ConsensusPromises {
 	return &ConsensusPromises{
-		poolerDir:  poolerDir,
-		serviceID:  serviceID,
-		revocation: nil,
+		poolerDir: poolerDir,
+		serviceID: serviceID,
 	}
 }
 
@@ -64,27 +61,12 @@ func (cs *ConsensusPromises) Load() (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("failed to load consensus promises: %w", err)
 	}
-	revocation := file.GetTermRevocation()
-	if revocation == nil {
-		revocation = &clustermetadatapb.TermRevocation{}
-	}
 
 	cs.mu.Lock()
-	cs.revocation = revocation
-	cs.recruitBlockedUntil = file.GetRecruitBlockedUntil()
+	cs.promises = file
 	cs.mu.Unlock()
 
-	return revocation.RevokedBelowTerm, nil
-}
-
-// GetRecruitBlockedUntil returns the minimum position this pooler must reach
-// before Recruit() may succeed, or nil if no floor is set. No action lock
-// required: a plain mu-guarded read, safe from lock-free paths (e.g.
-// building a cached ConsensusStatus), mirroring GetReplicationPrimary.
-func (cs *ConsensusPromises) GetRecruitBlockedUntil() *clustermetadatapb.LsnPosition {
-	cs.mu.Lock()
-	defer cs.mu.Unlock()
-	return cloneRecruitBlockedUntil(cs.recruitBlockedUntil)
+	return file.GetTermRevocation().GetRevokedBelowTerm(), nil
 }
 
 // SetRecruitBlockedUntil records the minimum position this pooler must reach
@@ -96,78 +78,60 @@ func (cs *ConsensusPromises) SetRecruitBlockedUntil(ctx context.Context, pos *cl
 	}
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
-	if err := cs.persistLocked(nil, pos); err != nil {
+
+	updated := cloneConsensusPromises(cs.promises)
+	updated.RecruitBlockedUntil = pos
+	if err := cs.writePromisesToDisk(updated); err != nil {
 		return fmt.Errorf("failed to save recruit position floor: %w", err)
 	}
-	cs.recruitBlockedUntil = cloneRecruitBlockedUntil(pos)
+	cs.promises = updated
 	return nil
 }
 
-// persistLocked writes both promises to disk in one file. Pass nil for
-// whichever field isn't changing to preserve its current in-memory value —
-// safe because neither promise is ever meant to be explicitly cleared back
-// to nil (revocation only grows; recruitBlockedUntil's "no explicit
-// clearing" is documented on the struct field). Must be called with cs.mu
-// held; does not itself update in-memory state.
-func (cs *ConsensusPromises) persistLocked(revocation *clustermetadatapb.TermRevocation, floor *clustermetadatapb.LsnPosition) error {
-	if revocation == nil {
-		revocation = cs.revocation
+// cloneConsensusPromises creates a deep copy of a ConsensusPromises message,
+// or an empty one if p is nil — so a caller that clones-then-mutates (the
+// Set*/Accept* methods below) never dereferences a nil result. Reads may
+// safely pass a nil-valued clone straight back out: proto3 getters are
+// nil-safe, so a nil-vs-not-yet-loaded message behaves like an all-default
+// one to callers.
+func cloneConsensusPromises(p *clustermetadatapb.ConsensusPromises) *clustermetadatapb.ConsensusPromises {
+	if p == nil {
+		return &clustermetadatapb.ConsensusPromises{}
 	}
-	if floor == nil {
-		floor = cs.recruitBlockedUntil
-	}
-	return cs.writePromisesToDisk(&clustermetadatapb.ConsensusPromises{
-		TermRevocation:      revocation,
-		RecruitBlockedUntil: floor,
-	})
+	return proto.Clone(p).(*clustermetadatapb.ConsensusPromises)
 }
 
-// cloneRecruitBlockedUntil creates a deep copy of an LsnPosition.
-func cloneRecruitBlockedUntil(pos *clustermetadatapb.LsnPosition) *clustermetadatapb.LsnPosition {
-	if pos == nil {
-		return nil
-	}
-	return proto.Clone(pos).(*clustermetadatapb.LsnPosition)
-}
-
-// GetInconsistentRevocation returns a copy of the current term revocation for monitoring.
-// It doesn't require the action lock to be held, so the value returned may
-// be outdated by the time it's used. Use GetRevocation() as part of any action
-// workflow to protect against race conditions.
-// Returns nil if state has not been loaded.
-func (cs *ConsensusPromises) GetInconsistentRevocation() *clustermetadatapb.TermRevocation {
+// GetInconsistent returns a copy of the current promises (term revocation,
+// recruit-blocked floor, recruit-observed LSN) without requiring the action
+// lock, so the result may be stale by the time it's used. For status
+// snapshots and monitoring only (e.g. ConsensusStatus, the recruit-position
+// floor check) — never for gating a consensus decision; use GetConsistent
+// for that.
+func (cs *ConsensusPromises) GetInconsistent() *clustermetadatapb.ConsensusPromises {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
-
-	if cs.revocation == nil {
-		return nil
-	}
-
-	// Return a copy to prevent external modifications
-	return cloneRevocation(cs.revocation)
+	return cloneConsensusPromises(cs.promises)
 }
 
-// GetRevocation returns a copy of the current term revocation.
-// Returns nil if state has not been loaded.
-func (cs *ConsensusPromises) GetRevocation(ctx context.Context) (*clustermetadatapb.TermRevocation, error) {
+// GetConsistent returns a copy of the current promises. Requires the action
+// lock: callers gating a consensus decision (Promote, SetPrimary, Recruit)
+// must read this under the same lock they'll act within, so the check
+// reflects the actual locked state rather than a potentially stale snapshot.
+func (cs *ConsensusPromises) GetConsistent(ctx context.Context) (*clustermetadatapb.ConsensusPromises, error) {
 	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
 		return nil, err
 	}
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
-
-	if cs.revocation == nil {
-		return nil, nil
-	}
-
-	// Return a copy to prevent external modifications
-	return cloneRevocation(cs.revocation), nil
+	return cloneConsensusPromises(cs.promises), nil
 }
 
-// AcceptRevocation validates and persists a TermRevocation in one atomic step.
-// It builds the validation status from the observed position in status combined
-// with the current in-memory revocation (read under the mutex), so the check
-// reflects the actual locked state rather than a potentially stale snapshot.
+// AcceptRevocation validates and persists a TermRevocation in one atomic step,
+// snapshotting the LSN observed in status (the freshly re-read, post-stabilize
+// position) as the new recruit-observed baseline. It builds the validation
+// status from the observed position in status combined with the current
+// in-memory revocation (read under the mutex), so the check reflects the
+// actual locked state rather than a potentially stale snapshot.
 func (cs *ConsensusPromises) AcceptRevocation(ctx context.Context, status *clustermetadatapb.ConsensusStatus, revocation *clustermetadatapb.TermRevocation) error {
 	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
 		return err
@@ -175,7 +139,7 @@ func (cs *ConsensusPromises) AcceptRevocation(ctx context.Context, status *clust
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 
-	if !proto.Equal(status.TermRevocation, cs.revocation) {
+	if !proto.Equal(status.TermRevocation, cs.promises.GetTermRevocation()) {
 		return errors.New("status parameter is out of date")
 	}
 
@@ -183,29 +147,12 @@ func (cs *ConsensusPromises) AcceptRevocation(ctx context.Context, status *clust
 		return err
 	}
 
-	return cs.saveAndUpdateLocked(cloneRevocation(revocation))
-}
-
-// saveAndUpdateLocked saves the revocation to disk and updates memory.
-// MUST be called with cs.mu held.
-// This is the key method that ensures memory never diverges from disk.
-// If the save fails, memory remains unchanged and the error is returned.
-func (cs *ConsensusPromises) saveAndUpdateLocked(newRevocation *clustermetadatapb.TermRevocation) error {
-	// Save to disk (lock still held)
-	if err := cs.persistLocked(newRevocation, nil); err != nil {
-		// Save failed - don't update memory, propagate error
+	updated := cloneConsensusPromises(cs.promises)
+	updated.TermRevocation = proto.Clone(revocation).(*clustermetadatapb.TermRevocation)
+	updated.RecruitObservedLsn = status.GetCurrentPosition().GetLsn()
+	if err := cs.writePromisesToDisk(updated); err != nil {
 		return fmt.Errorf("failed to save consensus term: %w", err)
 	}
-
-	// Save succeeded - NOW update memory
-	cs.revocation = cloneRevocation(newRevocation)
+	cs.promises = updated
 	return nil
-}
-
-// cloneRevocation creates a deep copy of a TermRevocation.
-func cloneRevocation(revocation *clustermetadatapb.TermRevocation) *clustermetadatapb.TermRevocation {
-	if revocation == nil {
-		return nil
-	}
-	return proto.Clone(revocation).(*clustermetadatapb.TermRevocation)
 }

--- a/go/services/multipooler/internal/manager/consensus/consensus_promises.go
+++ b/go/services/multipooler/internal/manager/consensus/consensus_promises.go
@@ -127,12 +127,13 @@ func (cs *ConsensusPromises) GetConsistent(ctx context.Context) (*clustermetadat
 }
 
 // AcceptRevocation validates and persists a TermRevocation in one atomic step,
-// snapshotting the LSN observed in status (the freshly re-read, post-stabilize
-// position) as the new recruit-observed baseline. It builds the validation
-// status from the observed position in status combined with the current
-// in-memory revocation (read under the mutex), so the check reflects the
-// actual locked state rather than a potentially stale snapshot.
-func (cs *ConsensusPromises) AcceptRevocation(ctx context.Context, status *clustermetadatapb.ConsensusStatus, revocation *clustermetadatapb.TermRevocation) error {
+// snapshotting appliedLsn (the freshly re-read, post-stabilize applied/replay
+// position, read alongside status via ObservePosition) as the new
+// recruit-observed baseline. It builds the validation status from the
+// observed position in status combined with the current in-memory revocation
+// (read under the mutex), so the check reflects the actual locked state
+// rather than a potentially stale snapshot.
+func (cs *ConsensusPromises) AcceptRevocation(ctx context.Context, status *clustermetadatapb.ConsensusStatus, revocation *clustermetadatapb.TermRevocation, appliedLsn string) error {
 	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
 		return err
 	}
@@ -149,7 +150,7 @@ func (cs *ConsensusPromises) AcceptRevocation(ctx context.Context, status *clust
 
 	updated := cloneConsensusPromises(cs.promises)
 	updated.TermRevocation = proto.Clone(revocation).(*clustermetadatapb.TermRevocation)
-	updated.RecruitObservedLsn = status.GetCurrentPosition().GetLsn()
+	updated.RecruitObservedLsn = appliedLsn
 	if err := cs.writePromisesToDisk(updated); err != nil {
 		return fmt.Errorf("failed to save consensus term: %w", err)
 	}

--- a/go/services/multipooler/internal/manager/consensus/consensus_promises_test.go
+++ b/go/services/multipooler/internal/manager/consensus/consensus_promises_test.go
@@ -59,7 +59,7 @@ func TestConsensusPromises_PersistsAcrossReload(t *testing.T) {
 		OutgoingRule:           &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
 	}
 	status := &clustermetadatapb.ConsensusStatus{
-		TermRevocation:  first.GetInconsistentRevocation(),
+		TermRevocation:  first.GetInconsistent().GetTermRevocation(),
 		CurrentPosition: promisesTestPosition(0, "0/3000"),
 	}
 	require.NoError(t, first.AcceptRevocation(ctx, status, revocation))
@@ -70,11 +70,53 @@ func TestConsensusPromises_PersistsAcrossReload(t *testing.T) {
 	term, err := second.Load()
 	require.NoError(t, err)
 	assert.Equal(t, int64(5), term)
-	assert.Equal(t, "0/2000", second.GetRecruitBlockedUntil().GetLsn())
+	assert.Equal(t, "0/2000", second.GetInconsistent().GetRecruitBlockedUntil().GetLsn())
 
-	reloaded, err := second.GetRevocation(ctx)
+	reloadedPromises, err := second.GetConsistent(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, int64(5), reloaded.GetRevokedBelowTerm())
+	assert.Equal(t, int64(5), reloadedPromises.GetTermRevocation().GetRevokedBelowTerm())
+	assert.Equal(t, "0/3000", reloadedPromises.GetRecruitObservedLsn(),
+		"AcceptRevocation must snapshot status.CurrentPosition.Lsn as the recruit-observed baseline")
+}
+
+// TestConsensusPromises_AcceptRevocationOverwritesObservedLsnOnRetry verifies
+// that a retried Recruit (idempotent re-accept of the same revocation)
+// re-snapshots the latest observed LSN rather than keeping the first one —
+// the invariant checked by Promote/SetPrimary is "since the last accept, has
+// the position moved further," not "since the very first accept."
+func TestConsensusPromises_AcceptRevocationOverwritesObservedLsnOnRetry(t *testing.T) {
+	dir := t.TempDir()
+	ctx := withTestActionLock(t)
+
+	promises := NewConsensusPromises(dir, nil)
+	_, err := promises.Load()
+	require.NoError(t, err)
+
+	revocation := &clustermetadatapb.TermRevocation{
+		RevokedBelowTerm:       5,
+		AcceptedCoordinatorId:  &clustermetadatapb.ID{Cell: "zone1", Name: "coordinator"},
+		CoordinatorInitiatedAt: promisesTestInitiatedAt,
+		OutgoingRule:           &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
+	}
+	firstStatus := &clustermetadatapb.ConsensusStatus{
+		TermRevocation:  promises.GetInconsistent().GetTermRevocation(),
+		CurrentPosition: promisesTestPosition(0, "0/1000"),
+	}
+	require.NoError(t, promises.AcceptRevocation(ctx, firstStatus, revocation))
+	got, err := promises.GetConsistent(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "0/1000", got.GetRecruitObservedLsn())
+
+	// Idempotent retry: same revocation, but replay had progressed further
+	// before this attempt's pause.
+	retryStatus := &clustermetadatapb.ConsensusStatus{
+		TermRevocation:  promises.GetInconsistent().GetTermRevocation(),
+		CurrentPosition: promisesTestPosition(0, "0/2000"),
+	}
+	require.NoError(t, promises.AcceptRevocation(ctx, retryStatus, revocation))
+	got, err = promises.GetConsistent(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "0/2000", got.GetRecruitObservedLsn(), "retry must re-snapshot the latest observed LSN")
 }
 
 func TestConsensusPromises_SetRecruitBlockedUntilDoesNotClobberRevocation(t *testing.T) {
@@ -92,7 +134,7 @@ func TestConsensusPromises_SetRecruitBlockedUntilDoesNotClobberRevocation(t *tes
 		OutgoingRule:           &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
 	}
 	status := &clustermetadatapb.ConsensusStatus{
-		TermRevocation:  promises.GetInconsistentRevocation(),
+		TermRevocation:  promises.GetInconsistent().GetTermRevocation(),
 		CurrentPosition: promisesTestPosition(0, "0/3000"),
 	}
 	require.NoError(t, promises.AcceptRevocation(ctx, status, revocation))
@@ -103,7 +145,7 @@ func TestConsensusPromises_SetRecruitBlockedUntilDoesNotClobberRevocation(t *tes
 	term, err := reloaded.Load()
 	require.NoError(t, err)
 	assert.Equal(t, int64(3), term, "recording the floor must not clobber the already-persisted revocation")
-	assert.Equal(t, "0/1000", reloaded.GetRecruitBlockedUntil().GetLsn())
+	assert.Equal(t, "0/1000", reloaded.GetInconsistent().GetRecruitBlockedUntil().GetLsn())
 }
 
 func TestConsensusPromises_LoadWithCorruptFile(t *testing.T) {
@@ -130,12 +172,12 @@ func TestConsensusPromises_SetRecruitBlockedUntilFilesystemReadOnly(t *testing.T
 	err = promises.SetRecruitBlockedUntil(ctx, &clustermetadatapb.LsnPosition{Lsn: "0/1000"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to save recruit position floor")
-	assert.Nil(t, promises.GetRecruitBlockedUntil(), "a failed save must not update in-memory state")
+	assert.Nil(t, promises.GetInconsistent().GetRecruitBlockedUntil(), "a failed save must not update in-memory state")
 }
 
 func TestConsensusPromises_SetRecruitBlockedUntilRequiresActionLock(t *testing.T) {
 	promises := NewConsensusPromises(t.TempDir(), nil)
 	err := promises.SetRecruitBlockedUntil(t.Context(), &clustermetadatapb.LsnPosition{Lsn: "0/1000"})
 	require.Error(t, err)
-	assert.Nil(t, promises.GetRecruitBlockedUntil())
+	assert.Nil(t, promises.GetInconsistent().GetRecruitBlockedUntil())
 }

--- a/go/services/multipooler/internal/manager/consensus/consensus_promises_test.go
+++ b/go/services/multipooler/internal/manager/consensus/consensus_promises_test.go
@@ -31,13 +31,15 @@ import (
 var promisesTestInitiatedAt = timestamppb.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 
 // promisesTestPosition returns a PoolerPosition whose decision rule is at
-// the given coordinator term, with no outstanding proposal.
-func promisesTestPosition(coordinatorTerm int64, lsn string) *clustermetadatapb.PoolerPosition {
+// the given coordinator term, with no outstanding proposal. FlushedLsn is a
+// fixed placeholder: ValidateRevocation requires a parseable LSN, but these
+// tests exercise AcceptRevocation's appliedLsn parameter, not flushed ranking.
+func promisesTestPosition(coordinatorTerm int64) *clustermetadatapb.PoolerPosition {
 	return &clustermetadatapb.PoolerPosition{
 		Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
 			RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: coordinatorTerm},
 		}},
-		Lsn: lsn,
+		FlushedLsn: "0/0",
 	}
 }
 
@@ -60,9 +62,9 @@ func TestConsensusPromises_PersistsAcrossReload(t *testing.T) {
 	}
 	status := &clustermetadatapb.ConsensusStatus{
 		TermRevocation:  first.GetInconsistent().GetTermRevocation(),
-		CurrentPosition: promisesTestPosition(0, "0/3000"),
+		CurrentPosition: promisesTestPosition(0),
 	}
-	require.NoError(t, first.AcceptRevocation(ctx, status, revocation))
+	require.NoError(t, first.AcceptRevocation(ctx, status, revocation, "0/3000"))
 
 	// Simulate a process restart: a fresh ConsensusPromises rooted at the
 	// same directory must recover both promises from disk.
@@ -76,7 +78,7 @@ func TestConsensusPromises_PersistsAcrossReload(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(5), reloadedPromises.GetTermRevocation().GetRevokedBelowTerm())
 	assert.Equal(t, "0/3000", reloadedPromises.GetRecruitObservedLsn(),
-		"AcceptRevocation must snapshot status.CurrentPosition.Lsn as the recruit-observed baseline")
+		"AcceptRevocation must snapshot the passed appliedLsn as the recruit-observed baseline")
 }
 
 // TestConsensusPromises_AcceptRevocationOverwritesObservedLsnOnRetry verifies
@@ -100,9 +102,9 @@ func TestConsensusPromises_AcceptRevocationOverwritesObservedLsnOnRetry(t *testi
 	}
 	firstStatus := &clustermetadatapb.ConsensusStatus{
 		TermRevocation:  promises.GetInconsistent().GetTermRevocation(),
-		CurrentPosition: promisesTestPosition(0, "0/1000"),
+		CurrentPosition: promisesTestPosition(0),
 	}
-	require.NoError(t, promises.AcceptRevocation(ctx, firstStatus, revocation))
+	require.NoError(t, promises.AcceptRevocation(ctx, firstStatus, revocation, "0/1000"))
 	got, err := promises.GetConsistent(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "0/1000", got.GetRecruitObservedLsn())
@@ -111,9 +113,9 @@ func TestConsensusPromises_AcceptRevocationOverwritesObservedLsnOnRetry(t *testi
 	// before this attempt's pause.
 	retryStatus := &clustermetadatapb.ConsensusStatus{
 		TermRevocation:  promises.GetInconsistent().GetTermRevocation(),
-		CurrentPosition: promisesTestPosition(0, "0/2000"),
+		CurrentPosition: promisesTestPosition(0),
 	}
-	require.NoError(t, promises.AcceptRevocation(ctx, retryStatus, revocation))
+	require.NoError(t, promises.AcceptRevocation(ctx, retryStatus, revocation, "0/2000"))
 	got, err = promises.GetConsistent(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "0/2000", got.GetRecruitObservedLsn(), "retry must re-snapshot the latest observed LSN")
@@ -135,9 +137,9 @@ func TestConsensusPromises_SetRecruitBlockedUntilDoesNotClobberRevocation(t *tes
 	}
 	status := &clustermetadatapb.ConsensusStatus{
 		TermRevocation:  promises.GetInconsistent().GetTermRevocation(),
-		CurrentPosition: promisesTestPosition(0, "0/3000"),
+		CurrentPosition: promisesTestPosition(0),
 	}
-	require.NoError(t, promises.AcceptRevocation(ctx, status, revocation))
+	require.NoError(t, promises.AcceptRevocation(ctx, status, revocation, "0/3000"))
 
 	require.NoError(t, promises.SetRecruitBlockedUntil(ctx, &clustermetadatapb.LsnPosition{Lsn: "0/1000"}))
 

--- a/go/services/multipooler/internal/manager/consensus/consensustest/consensustest.go
+++ b/go/services/multipooler/internal/manager/consensus/consensustest/consensustest.go
@@ -28,6 +28,14 @@ import (
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
 
+// maxLSN is the highest representable PostgreSQL LSN. Used as SeedTerm's
+// default recruit-observed baseline so tests seeding a revocation without
+// caring about the LSN-drift check (Promote/SetPrimary's
+// checkRecruitLsnDrift) never trip it regardless of what current position
+// they simulate. Tests exercising the drift check itself should use
+// SeedTermWithObservedLsn instead.
+const maxLSN = "FFFFFFFF/FFFFFFFF"
+
 // SeedTerm writes the consensus promises file into poolerDir so a
 // ConsensusPromises rooted at that directory will load the given revocation.
 // It writes the file directly, bypassing any in-memory cache, so tests can
@@ -35,7 +43,17 @@ import (
 // it.
 func SeedTerm(t testing.TB, poolerDir string, revocation *clustermetadatapb.TermRevocation) {
 	t.Helper()
-	data, err := protojson.Marshal(&clustermetadatapb.ConsensusPromises{TermRevocation: revocation})
+	SeedTermWithObservedLsn(t, poolerDir, revocation, maxLSN)
+}
+
+// SeedTermWithObservedLsn is SeedTerm plus an explicit recruit-observed LSN
+// baseline, for tests exercising checkRecruitLsnDrift.
+func SeedTermWithObservedLsn(t testing.TB, poolerDir string, revocation *clustermetadatapb.TermRevocation, observedLsn string) {
+	t.Helper()
+	data, err := protojson.Marshal(&clustermetadatapb.ConsensusPromises{
+		TermRevocation:     revocation,
+		RecruitObservedLsn: observedLsn,
+	})
 	require.NoError(t, err)
 	path := filepath.Join(poolerDir, constants.ConsensusPromisesFile)
 	require.NoError(t, os.WriteFile(path, data, 0o644))

--- a/go/services/multipooler/internal/manager/consensus/manager.go
+++ b/go/services/multipooler/internal/manager/consensus/manager.go
@@ -192,7 +192,7 @@ func (cm *ConsensusManager) Rules() RuleStorer { return cm.rules }
 // postgres is unreachable, since a partial status (term without position) could
 // mislead callers about this pooler's rule position.
 func (cm *ConsensusManager) ConsensusStatus(ctx context.Context) (*clustermetadatapb.ConsensusStatus, error) {
-	revocation, err := cm.promises.GetRevocation(ctx)
+	promises, err := cm.promises.GetConsistent(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read consensus term: %w", err)
 	}
@@ -200,7 +200,7 @@ func (cm *ConsensusManager) ConsensusStatus(ctx context.Context) (*clustermetada
 	if err != nil {
 		return nil, fmt.Errorf("failed to read current rule position: %w", err)
 	}
-	return cm.buildStatus(revocation, pos), nil
+	return cm.buildStatus(promises, pos), nil
 }
 
 // CachedConsensusStatus builds a ConsensusStatus from the in-memory term cache and
@@ -212,7 +212,7 @@ func (cm *ConsensusManager) CachedConsensusStatus() *clustermetadatapb.Consensus
 	if pos == nil {
 		return nil
 	}
-	return cm.buildStatus(cm.promises.GetInconsistentRevocation(), pos)
+	return cm.buildStatus(cm.promises.GetInconsistent(), pos)
 }
 
 // InconsistentConsensusStatus builds a ConsensusStatus from a fresh postgres
@@ -224,20 +224,22 @@ func (cm *ConsensusManager) InconsistentConsensusStatus(ctx context.Context) (*c
 	if err != nil {
 		return nil, err
 	}
-	return cm.buildStatus(cm.promises.GetInconsistentRevocation(), pos), nil
+	return cm.buildStatus(cm.promises.GetInconsistent(), pos), nil
 }
 
-// buildStatus assembles a ConsensusStatus from a pre-resolved revocation and
-// position plus the recorded replication primary. Any input may be nil; the
-// corresponding field is left unset. Never performs I/O.
+// buildStatus assembles a ConsensusStatus from a single promises snapshot
+// (term revocation and recruit-blocked floor read together, so they can never
+// disagree about which point in time they reflect) plus a position and the
+// recorded replication primary. pos may be nil; the corresponding fields are
+// then left unset. Never performs I/O.
 //
 // The published HighestKnownRule reflects best knowledge from any source: the
 // rule is the max of the observed position's rule and the rule from the most
 // recent SetPrimary/Promote RPC, and the primary is the contact info from that
 // RPC (ObservePosition cannot carry it).
-func (cm *ConsensusManager) buildStatus(revocation *clustermetadatapb.TermRevocation, pos *clustermetadatapb.PoolerPosition) *clustermetadatapb.ConsensusStatus {
+func (cm *ConsensusManager) buildStatus(promises *clustermetadatapb.ConsensusPromises, pos *clustermetadatapb.PoolerPosition) *clustermetadatapb.ConsensusStatus {
 	status := &clustermetadatapb.ConsensusStatus{Id: cm.id}
-	if revocation != nil {
+	if revocation := promises.GetTermRevocation(); revocation != nil {
 		status.TermRevocation = revocation
 	}
 	if pos != nil {
@@ -246,7 +248,7 @@ func (cm *ConsensusManager) buildStatus(revocation *clustermetadatapb.TermRevoca
 	if highest := statusReplicationPrimary(pos, cm.GetReplicationPrimary()); highest != nil {
 		status.ReplicationPrimary = highest
 	}
-	if floor := cm.recruitPositionFloorIfOutstanding(pos); floor != nil {
+	if floor := recruitPositionFloorIfOutstanding(promises.GetRecruitBlockedUntil(), pos); floor != nil {
 		status.RecruitBlockedUntil = floor
 	}
 	return status
@@ -546,14 +548,12 @@ func ruleNamesCohortMember(rule *clustermetadatapb.ShardRule, selfID *clustermet
 	return false
 }
 
-// recruitPositionFloorIfOutstanding returns the recorded recruit-position
-// floor (see ConsensusPromises.GetRecruitBlockedUntil) if pos hasn't caught
-// up to it yet, or nil if there's no floor or it's satisfied. Rule position
-// takes precedence over LSN (mirroring consensus.ComparePoolerPosition); LSN
-// only breaks a tie between equal rule positions. Fails closed on a parse
-// error. No explicit clearing — omitted from ConsensusStatus once satisfied.
-func (cm *ConsensusManager) recruitPositionFloorIfOutstanding(pos *clustermetadatapb.PoolerPosition) *clustermetadatapb.LsnPosition {
-	floor := cm.promises.GetRecruitBlockedUntil()
+// recruitPositionFloorIfOutstanding returns floor if pos hasn't caught up to
+// it yet, or nil if there's no floor or it's satisfied. Rule position takes
+// precedence over LSN (mirroring consensus.ComparePoolerPosition); LSN only
+// breaks a tie between equal rule positions. Fails closed on a parse error.
+// No explicit clearing — omitted from ConsensusStatus once satisfied.
+func recruitPositionFloorIfOutstanding(floor *clustermetadatapb.LsnPosition, pos *clustermetadatapb.PoolerPosition) *clustermetadatapb.LsnPosition {
 	if floor == nil {
 		return nil
 	}

--- a/go/services/multipooler/internal/manager/consensus/manager.go
+++ b/go/services/multipooler/internal/manager/consensus/manager.go
@@ -196,7 +196,7 @@ func (cm *ConsensusManager) ConsensusStatus(ctx context.Context) (*clustermetada
 	if err != nil {
 		return nil, fmt.Errorf("failed to read consensus term: %w", err)
 	}
-	pos, err := cm.rules.ObservePosition(ctx)
+	pos, _, err := cm.rules.ObservePosition(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read current rule position: %w", err)
 	}
@@ -220,7 +220,7 @@ func (cm *ConsensusManager) CachedConsensusStatus() *clustermetadatapb.Consensus
 // state during a concurrent Recruit, so it is suitable for observability only.
 // Returns an error if postgres is unreachable.
 func (cm *ConsensusManager) InconsistentConsensusStatus(ctx context.Context) (*clustermetadatapb.ConsensusStatus, error) {
-	pos, err := cm.rules.ObservePosition(ctx)
+	pos, _, err := cm.rules.ObservePosition(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -553,6 +553,11 @@ func ruleNamesCohortMember(rule *clustermetadatapb.ShardRule, selfID *clustermet
 // precedence over LSN (mirroring consensus.ComparePoolerPosition); LSN only
 // breaks a tie between equal rule positions. Fails closed on a parse error.
 // No explicit clearing — omitted from ConsensusStatus once satisfied.
+//
+// pos.FlushedLsn (durably retained, not applied/visible) is intentional here:
+// this floor exists to guard against recruiting a node before it has durably
+// caught back up post-rewind, which is a durability concern, not a
+// visibility one.
 func recruitPositionFloorIfOutstanding(floor *clustermetadatapb.LsnPosition, pos *clustermetadatapb.PoolerPosition) *clustermetadatapb.LsnPosition {
 	if floor == nil {
 		return nil
@@ -568,7 +573,7 @@ func recruitPositionFloorIfOutstanding(floor *clustermetadatapb.LsnPosition, pos
 		}
 		return floor
 	}
-	currentLSN, errA := pgutil.ParseLSN(pos.GetLsn())
+	currentLSN, errA := pgutil.ParseLSN(pos.GetFlushedLsn())
 	floorLSN, errB := pgutil.ParseLSN(floor.GetLsn())
 	if errA != nil || errB != nil || currentLSN < floorLSN {
 		return floor

--- a/go/services/multipooler/internal/manager/consensus/manager_test.go
+++ b/go/services/multipooler/internal/manager/consensus/manager_test.go
@@ -303,15 +303,7 @@ func TestRecruitPositionFloorIfOutstanding(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			promises := NewConsensusPromises(t.TempDir(), nil)
-			_, err := promises.Load()
-			require.NoError(t, err)
-			if tt.floor != nil {
-				require.NoError(t, promises.SetRecruitBlockedUntil(actionLockCtx(t), tt.floor))
-			}
-			cm := NewManagerForTesting(t, nil, promises, nil, nil)
-
-			got := cm.recruitPositionFloorIfOutstanding(tt.pos)
+			got := recruitPositionFloorIfOutstanding(tt.floor, tt.pos)
 			if tt.wantOutstanding {
 				require.NotNil(t, got, "expected the floor to still be outstanding")
 				assert.True(t, proto.Equal(tt.floor, got), "returned floor should match the recorded one")

--- a/go/services/multipooler/internal/manager/consensus/manager_test.go
+++ b/go/services/multipooler/internal/manager/consensus/manager_test.go
@@ -207,8 +207,8 @@ func TestRecordTermPrimary_ReturnsCopies(t *testing.T) {
 // numbers and LSN, for exercising recruitPositionFloorIfOutstanding directly.
 func poolerPosAt(decisionTerm, proposalTerm int64, lsn string) *clustermetadatapb.PoolerPosition {
 	pos := &clustermetadatapb.PoolerPosition{
-		Position: &clustermetadatapb.RulePosition{Decision: ruleAt(decisionTerm, 0)},
-		Lsn:      lsn,
+		Position:   &clustermetadatapb.RulePosition{Decision: ruleAt(decisionTerm, 0)},
+		FlushedLsn: lsn,
 	}
 	if proposalTerm != 0 {
 		pos.Position.Proposal = ruleAt(proposalTerm, 0)

--- a/go/services/multipooler/internal/manager/consensus/rule_store.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store.go
@@ -42,9 +42,13 @@ import (
 // RuleStorer is the interface for reading and writing the current shard rule.
 // *ruleStore implements this; tests use fakeRuleStore.
 type RuleStorer interface {
-	// ObservePosition reads the current rule and WAL LSN from postgres.
-	// Always returns a non-nil position when err is nil (the initial row guarantees a row exists).
-	ObservePosition(ctx context.Context) (*clustermetadatapb.PoolerPosition, error)
+	// ObservePosition reads the current rule and both WAL positions from
+	// postgres, in one round trip so they reflect the same instant. Always
+	// returns a non-nil position when err is nil (the initial row guarantees a
+	// row exists). The returned PoolerLsn is diagnostic context (flushed +
+	// applied together) — not part of PoolerPosition itself (see PoolerLsn's
+	// proto doc); most callers only need the position and discard it.
+	ObservePosition(ctx context.Context) (*clustermetadatapb.PoolerPosition, *clustermetadatapb.PoolerLsn, error)
 	UpdateRule(ctx context.Context, update *RuleUpdateBuilder) (*clustermetadatapb.PoolerPosition, error)
 	// CreateRuleTables creates multigres.current_rule and multigres.rule_history
 	// if they do not already exist, and inserts the initial row for the default
@@ -453,7 +457,13 @@ var errRuleConflict = errors.New("rule conflict: current rule version changed si
 // (tables not initialized) or when postgres is unreachable.
 //
 // The caller is responsible for adding an appropriate context timeout.
-func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clustermetadatapb.PoolerPosition, error) {
+// readCurrentRule reads the current rule row and both WAL positions — flushed
+// (durable) and applied (visible) — in one round trip, so the two reflect the
+// same instant. Only this plain-SELECT variant needs the applied column;
+// readCurrentRule is the one path callers use to build a PoolerLsn (see
+// ObservePosition), unlike the two RETURNING-clause variants elsewhere in this
+// file, which only ever need the flushed position for PoolerPosition.
+func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (pos *clustermetadatapb.PoolerPosition, appliedLsn string, err error) {
 	suffix := ""
 	if forUpdate {
 		suffix = " FOR UPDATE NOWAIT"
@@ -468,21 +478,32 @@ func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clus
 		       proposal_created_at,
 		       CASE
 		         WHEN pg_is_in_recovery()
-		           THEN COALESCE(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn(), '0/0'::pg_lsn)
+		           THEN COALESCE(pg_last_wal_receive_lsn(), '0/0'::pg_lsn)
+		         ELSE pg_current_wal_flush_lsn()
+		       END::text AS flushed_lsn,
+		       CASE
+		         WHEN pg_is_in_recovery()
+		           THEN COALESCE(pg_last_wal_replay_lsn(), '0/0'::pg_lsn)
 		         ELSE pg_current_wal_lsn()
-		       END::text AS current_lsn
+		       END::text AS applied_lsn
+		-- TODO: '0/0' undersells a node freshly restored from a pgbackrest backup
+		-- (restoreFromBackupLocked in rpc_backup.go) but not yet streaming — it has
+		-- durably replayed WAL from the backup, just none received via streaming
+		-- yet. list.go already parses the backup's StopLsn; nothing currently
+		-- persists it here as a floor to use in place of '0/0' until real
+		-- receive/replay data supersedes it.
 		FROM multigres.current_rule
 		WHERE shard_id = $1`+suffix, []byte("0"))
 	if err != nil {
-		return nil, mterrors.Wrap(err, "failed to read current_rule")
+		return nil, "", mterrors.Wrap(err, "failed to read current_rule")
 	}
 	if len(result.Rows) == 0 {
-		return nil, mterrors.Errorf(mtrpcpb.Code_INTERNAL, "current_rule initial row missing for shard 0: tables may not be initialized")
+		return nil, "", mterrors.Errorf(mtrpcpb.Code_INTERNAL, "current_rule initial row missing for shard 0: tables may not be initialized")
 	}
 
 	var decision, proposal unvalidatedRuleRow
 	var coordinatorIDStr *string
-	var lsn string
+	var flushedLsn string
 	if err := executor.ScanRow(result.Rows[0],
 		&decision.coordinatorTerm,
 		&decision.leaderSubterm,
@@ -501,20 +522,21 @@ func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clus
 		&proposal.durabilityQuorumType,
 		&proposal.durabilityRequiredCount,
 		&proposal.createdAt,
-		&lsn,
+		&flushedLsn,
+		&appliedLsn,
 	); err != nil {
-		return nil, mterrors.Wrap(err, "failed to scan current_rule")
+		return nil, "", mterrors.Wrap(err, "failed to scan current_rule")
 	}
 
 	var coordinatorIDStrVal string
 	if coordinatorIDStr != nil {
 		coordinatorIDStrVal = *coordinatorIDStr
 	}
-	pos, err := buildPoolerPosition(decision, coordinatorIDStrVal, proposal, lsn)
+	pos, err = buildPoolerPosition(decision, coordinatorIDStrVal, proposal, flushedLsn)
 	if err != nil {
-		return nil, mterrors.Wrap(err, "failed to parse current_rule")
+		return nil, "", mterrors.Wrap(err, "failed to parse current_rule")
 	}
-	return pos, nil
+	return pos, appliedLsn, nil
 }
 
 // ObservePosition reads the current rule and WAL LSN from postgres and returns
@@ -533,15 +555,15 @@ func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clus
 // cannot call Recalc directly. Figure out if/how to surface "the observed rule
 // moved" to the StateManager (a lock-free recalc, or an observer the manager
 // wires up) without coupling this layer to serving state.
-func (rs *ruleStore) ObservePosition(ctx context.Context) (*clustermetadatapb.PoolerPosition, error) {
+func (rs *ruleStore) ObservePosition(ctx context.Context) (*clustermetadatapb.PoolerPosition, *clustermetadatapb.PoolerLsn, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, timeouts.RuleReadTimeout)
 	defer cancel()
-	pos, err := rs.readCurrentRule(queryCtx, false)
+	pos, appliedLsn, err := rs.readCurrentRule(queryCtx, false)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	rs.cacheRuleObservation(pos)
-	return pos, nil
+	return pos, &clustermetadatapb.PoolerLsn{FlushedLsn: pos.GetFlushedLsn(), AppliedLsn: appliedLsn}, nil
 }
 
 // readCurrentRuleLocked reads the current_rule row and returns a lockedCtx that
@@ -558,7 +580,7 @@ func (rs *ruleStore) ObservePosition(ctx context.Context) (*clustermetadatapb.Po
 func (rs *ruleStore) readCurrentRuleLocked(ctx context.Context, inRecovery bool) (*clustermetadatapb.PoolerPosition, context.Context, error) {
 	readCtx, readCancel := context.WithTimeout(ctx, timeouts.RuleReadTimeout)
 	defer readCancel()
-	pos, err := rs.readCurrentRule(readCtx, !inRecovery)
+	pos, _, err := rs.readCurrentRule(readCtx, !inRecovery)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1060,8 +1082,8 @@ func (rs *ruleStore) markProposalAsDecision(
 		       updated.created_at,
 		       CASE
 		         WHEN pg_is_in_recovery()
-		           THEN COALESCE(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn(), '0/0'::pg_lsn)
-		         ELSE pg_current_wal_lsn()
+		           THEN COALESCE(pg_last_wal_receive_lsn(), '0/0'::pg_lsn)
+		         ELSE pg_current_wal_flush_lsn()
 		       END::text AS current_lsn
 		FROM updated, history_updated`,
 		[]byte("0"), // shard_id
@@ -1247,8 +1269,8 @@ func (rs *ruleStore) writeRuleProposal(ctx context.Context, p ruleProposalWriteP
 		       updated.proposal_durability_required_count, updated.proposal_created_at,
 		       CASE
 		         WHEN pg_is_in_recovery()
-		           THEN COALESCE(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn(), '0/0'::pg_lsn)
-		         ELSE pg_current_wal_lsn()
+		           THEN COALESCE(pg_last_wal_receive_lsn(), '0/0'::pg_lsn)
+		         ELSE pg_current_wal_flush_lsn()
 		       END::text AS current_lsn
 		FROM updated, inserted`,
 		[]byte("0"), // shard_id
@@ -1566,8 +1588,8 @@ func buildPoolerPosition(
 	}
 
 	return &clustermetadatapb.PoolerPosition{
-		Position: &clustermetadatapb.RulePosition{Decision: decisionRule, Proposal: proposalRule},
-		Lsn:      lsn,
+		Position:   &clustermetadatapb.RulePosition{Decision: decisionRule, Proposal: proposalRule},
+		FlushedLsn: lsn,
 	}, nil
 }
 

--- a/go/services/multipooler/internal/manager/consensus/rule_store_pg_test.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store_pg_test.go
@@ -361,11 +361,14 @@ func TestRuleStorePG_ObservePosition_FreshState(t *testing.T) {
 	rs, conn := newTestRuleStore(ctx, t)
 	defer conn.Close()
 
-	pos, err := rs.ObservePosition(ctx)
+	pos, lsn, err := rs.ObservePosition(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, pos, "fresh state should still return a position with the current LSN")
 	assert.Equal(t, int64(0), pos.GetPosition().GetDecision().GetRuleNumber().GetCoordinatorTerm(), "fresh initial row has coordinator_term=0")
-	assert.NotEmpty(t, pos.GetLsn(), "fresh state should include the current WAL LSN")
+	assert.NotEmpty(t, pos.GetFlushedLsn(), "fresh state should include the current WAL LSN")
+	require.NotNil(t, lsn, "fresh state should also return the paired flushed/applied PoolerLsn")
+	assert.Equal(t, pos.GetFlushedLsn(), lsn.GetFlushedLsn(), "PoolerLsn.FlushedLsn must match PoolerPosition.FlushedLsn (same read)")
+	assert.NotEmpty(t, lsn.GetAppliedLsn(), "fresh state should include the current applied WAL LSN")
 
 	// The initial row written by CreateRuleTables must carry the bootstrap durability policy.
 	dp := pos.GetPosition().GetDecision().GetDurabilityPolicy()
@@ -388,7 +391,7 @@ func TestRuleStorePG_ObservePosition_InitialRowMissing(t *testing.T) {
 	_, err := conn.Query(ctx, "DELETE FROM multigres.current_rule")
 	require.NoError(t, err)
 
-	_, err = rs.ObservePosition(ctx)
+	_, _, err = rs.ObservePosition(ctx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "current_rule initial row missing for shard 0")
 }
@@ -407,7 +410,7 @@ func TestRuleStorePG_ObservePosition_InitialPolicyCarriedThroughUpdate(t *testin
 	_, err := rs.UpdateRule(ctx, NewRuleUpdate(1, coordinatorID, "promotion", "initial", time.Now()))
 	require.NoError(t, err)
 
-	pos, err := rs.ObservePosition(ctx)
+	pos, _, err := rs.ObservePosition(ctx)
 	require.NoError(t, err)
 
 	dp := pos.GetPosition().GetDecision().GetDurabilityPolicy()
@@ -470,7 +473,7 @@ func TestRuleStorePG_ObservePosition_SurfacesStuckProposal(t *testing.T) {
 		proposalCreatedAt.UTC().Format("2006-01-02 15:04:05.999999-07")))
 	require.NoError(t, err)
 
-	pos, err := rs.ObservePosition(ctx)
+	pos, _, err := rs.ObservePosition(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, pos)
 
@@ -584,7 +587,7 @@ func TestRuleStorePG_UpdateRule_RejectsWhenProposalStuck(t *testing.T) {
 
 	// The rejected write must not have partially applied — decision and
 	// proposal are exactly as seeded.
-	pos, err := rs.ObservePosition(ctx)
+	pos, _, err := rs.ObservePosition(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(3), pos.GetPosition().GetDecision().GetRuleNumber().GetCoordinatorTerm())
 	require.NotNil(t, pos.GetPosition().GetProposal())
@@ -810,7 +813,7 @@ func TestRuleStorePG_UpdateRule_ObserveAfterWrite(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	pos, err := rs.ObservePosition(ctx)
+	pos, _, err := rs.ObservePosition(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, pos)
 	assert.Equal(t, int64(3), pos.Position.Decision.RuleNumber.CoordinatorTerm)
@@ -828,7 +831,7 @@ func TestRuleStorePG_UpdateRule_ObserveAfterWrite(t *testing.T) {
 	assert.Equal(t, "member-1", pos.Position.Decision.CohortMembers[0].Name)
 	assert.Equal(t, "member-2", pos.Position.Decision.CohortMembers[1].Name)
 
-	assert.NotEmpty(t, pos.Lsn, "LSN should be populated after a write")
+	assert.NotEmpty(t, pos.FlushedLsn, "LSN should be populated after a write")
 }
 
 func TestRuleStorePG_UpdateRule_HistoryFields(t *testing.T) {
@@ -1022,7 +1025,7 @@ func TestRuleStorePG_UpdateRule_Concurrent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, records, goroutines, "every concurrent write must produce a history row")
 
-	pos, err := rs.ObservePosition(ctx)
+	pos, _, err := rs.ObservePosition(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, pos)
 	assert.Equal(t, int64(1), pos.Position.Decision.RuleNumber.CoordinatorTerm)
@@ -1059,7 +1062,7 @@ func TestRuleStorePG_UpdateRule_DurabilityPolicyRoundTrip(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	pos, err := rs.ObservePosition(ctx)
+	pos, _, err := rs.ObservePosition(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, pos)
 
@@ -1105,7 +1108,7 @@ func TestRuleStorePG_UpdateRule_DurabilityPolicyPreservedOnUpdate(t *testing.T) 
 	)
 	require.NoError(t, err)
 
-	pos, err := rs.ObservePosition(ctx)
+	pos, _, err := rs.ObservePosition(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, pos)
 
@@ -1292,7 +1295,7 @@ func TestRuleStorePG_GUCReconciliation(t *testing.T) {
 	rs, ssm := newTestRuleStoreWithRealSSM(t, localID)
 
 	// Warm the rule cache via ObservePosition without touching GUC.
-	_, err := rs.ObservePosition(ctx)
+	_, _, err := rs.ObservePosition(ctx)
 	require.NoError(t, err)
 
 	// Cold SSM cache: postgres has the correct values but cache is empty, so
@@ -1344,7 +1347,7 @@ func TestRuleStorePG_GUCDriftDetectedAndHealed(t *testing.T) {
 	bootstrapRuleState(ctx, t, bootstrapRS, policy, cohort)
 
 	rs, _ := newTestRuleStoreWithRealSSM(t, localID)
-	_, err := rs.ObservePosition(ctx)
+	_, _, err := rs.ObservePosition(ctx)
 	require.NoError(t, err)
 	require.NoError(t, rs.ReconcileGUC(ctx, false))
 	require.False(t, rs.HasInconsistentGUC(ctx), "precondition: GUC should be consistent after initial reconcile")
@@ -1600,7 +1603,7 @@ func TestRuleStorePG_UpdateRule_RejectsLeaderChangeOutsidePromotion(t *testing.T
 	assert.Contains(t, err.Error(), "UpdateRule cannot change leader outside of a promotion")
 
 	// The decision must be untouched.
-	pos, err := rs.ObservePosition(ctx)
+	pos, _, err := rs.ObservePosition(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "leader-1", pos.GetPosition().GetDecision().GetLeaderId().GetName())
 }
@@ -1686,7 +1689,7 @@ func TestRuleStorePG_ReadCurrentRule_ParseFailureFromBogusQuorumType(t *testing.
 		[]byte("0"))
 	require.NoError(t, err)
 
-	_, err = rs.ObservePosition(ctx)
+	_, _, err = rs.ObservePosition(ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse current_rule")
 }

--- a/go/services/multipooler/internal/manager/consensus/rule_store_test.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store_test.go
@@ -467,14 +467,14 @@ func mockDecidedReadResult() *sqltypes.Result {
 			"durability_policy_name", "durability_quorum_type", "durability_required_count", "created_at",
 			"proposal_coordinator_term", "proposal_leader_subterm", "proposal_leader_id", "proposal_cohort_members",
 			"proposal_durability_policy_name", "proposal_durability_quorum_type", "proposal_durability_required_count",
-			"proposal_created_at", "current_lsn",
+			"proposal_created_at", "flushed_lsn", "applied_lsn",
 		},
 		[][]any{
 			{
 				int64(1), int64(0), "zone1_leader-1", "zone1_coordinator-1", "{zone1_member-1,zone1_member-2}",
 				"AT_LEAST_2", "QUORUM_TYPE_AT_LEAST_N", int64(2), "2026-01-01 00:00:00+00",
 				nil, nil, nil, nil, nil, nil, nil, nil,
-				"0/100",
+				"0/100", "0/100",
 			},
 		},
 	)

--- a/go/services/multipooler/internal/manager/fake_rule_store_test.go
+++ b/go/services/multipooler/internal/manager/fake_rule_store_test.go
@@ -62,11 +62,17 @@ func (noopSyncStandbyManager) NeedsApply(_ context.Context, _ commonconsensus.Po
 // the sequence is exhausted. This is useful for simulating a position that
 // changes between calls (e.g., Recruit's sanity check vs. post-stop check).
 type fakeRuleStore struct {
-	mu                 sync.Mutex
-	pos                *clustermetadatapb.PoolerPosition
-	posSequence        []*clustermetadatapb.PoolerPosition
-	observeCalls       int
-	observeErr         error
+	mu           sync.Mutex
+	pos          *clustermetadatapb.PoolerPosition
+	posSequence  []*clustermetadatapb.PoolerPosition
+	lsn          *clustermetadatapb.PoolerLsn
+	observeCalls int
+	observeErr   error
+	// observeErrAtCall, if non-zero, makes ObservePosition return observeErr
+	// only on the call whose 1-indexed number matches it, succeeding on every
+	// other call — for exercising a failure at one specific ObservePosition
+	// call site among several in the same code path.
+	observeErrAtCall   int
 	updateErr          error
 	updateErrAfterHook error
 	updates            []*consensus.RuleUpdateBuilder
@@ -83,22 +89,56 @@ func (f *fakeRuleStore) observePositionCallCount() int {
 	return f.observeCalls
 }
 
-func (f *fakeRuleStore) ObservePosition(_ context.Context) (*clustermetadatapb.PoolerPosition, error) {
+// armObserveErrAfterCalls resets the ObservePosition call counter and arms
+// observeErr to fire on the nth ObservePosition call from this point on —
+// use right before invoking the operation under test, so unrelated
+// ObservePosition calls made during test/manager setup don't throw off the
+// count.
+func (f *fakeRuleStore) armObserveErrAfterCalls(n int, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.observeCalls = 0
+	f.observeErrAtCall = n
+	f.observeErr = err
+}
+
+func (f *fakeRuleStore) ObservePosition(_ context.Context) (*clustermetadatapb.PoolerPosition, *clustermetadatapb.PoolerLsn, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.observeCalls++
+	// observeErrAtCall, when armed, fully overrides the usual observeErr
+	// semantics: only the targeted call fails; every other call succeeds
+	// regardless of observeErr (which armObserveErrAfterCalls also sets, for
+	// the targeted call to return).
+	if f.observeErrAtCall != 0 {
+		if f.observeCalls == f.observeErrAtCall {
+			return nil, nil, f.observeErr
+		}
+		return f.pos, f.lsnOrDefault(f.pos), nil
+	}
 	if len(f.posSequence) > 0 {
 		pos := f.posSequence[0]
 		f.posSequence = f.posSequence[1:]
 		if pos == nil && f.observeErr == nil {
-			return nil, errors.New("fakeRuleStore: no position set")
+			return nil, nil, errors.New("fakeRuleStore: no position set")
 		}
-		return pos, f.observeErr
+		return pos, f.lsnOrDefault(pos), f.observeErr
 	}
 	if f.pos == nil && f.observeErr == nil {
-		return nil, errors.New("fakeRuleStore: no position set")
+		return nil, nil, errors.New("fakeRuleStore: no position set")
 	}
-	return f.pos, f.observeErr
+	return f.pos, f.lsnOrDefault(f.pos), f.observeErr
+}
+
+// lsnOrDefault returns f.lsn when the test explicitly set it (for exercising
+// checkRecruitLsnDrift), or otherwise a PoolerLsn synthesized from pos's
+// FlushedLsn — most tests don't care about the flushed/applied distinction
+// and just want a consistent, parseable "current LSN".
+func (f *fakeRuleStore) lsnOrDefault(pos *clustermetadatapb.PoolerPosition) *clustermetadatapb.PoolerLsn {
+	if f.lsn != nil {
+		return f.lsn
+	}
+	return &clustermetadatapb.PoolerLsn{FlushedLsn: pos.GetFlushedLsn(), AppliedLsn: pos.GetFlushedLsn()}
 }
 
 func (f *fakeRuleStore) CreateRuleTables(_ context.Context, _ *clustermetadatapb.DurabilityPolicy, _ *clustermetadatapb.ID) error {
@@ -153,7 +193,7 @@ func (f *fakeRuleStore) UpdateRule(ctx context.Context, update *consensus.RuleUp
 		}},
 	}
 	if pos != nil {
-		newPos.Lsn = pos.GetLsn()
+		newPos.FlushedLsn = pos.GetFlushedLsn()
 	}
 	f.mu.Lock()
 	f.pos = newPos

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -98,7 +98,7 @@ func (pm *MultipoolerManager) staleStandbyDemoteTarget() *clustermetadatapb.Pool
 		return nil
 	}
 	// Don't race a mid-flight Recruit/Propose: skip a revoked rule.
-	if commonconsensus.IsRuleRevoked(rp.GetPosition(), pm.consensusMgr.Promises().GetInconsistentRevocation()) {
+	if commonconsensus.IsRuleRevoked(rp.GetPosition(), pm.consensusMgr.Promises().GetInconsistent().GetTermRevocation()) {
 		return nil
 	}
 	return target
@@ -398,7 +398,7 @@ func (pm *MultipoolerManager) primaryConnInfoDiffersFromRecorded(ctx context.Con
 	// Skip if the recorded rule is revoked. The cached primary is from before
 	// the current revocation took effect; restoring conninfo to it would race
 	// the Recruit/Promote flow that's mid-flight (see function doc).
-	if commonconsensus.IsRuleRevoked(rp.GetPosition(), pm.consensusMgr.Promises().GetInconsistentRevocation()) {
+	if commonconsensus.IsRuleRevoked(rp.GetPosition(), pm.consensusMgr.Promises().GetInconsistent().GetTermRevocation()) {
 		return false
 	}
 	targetHost := target.GetHost()

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -326,7 +326,7 @@ func (pm *MultipoolerManager) discoverPostgresState(ctx context.Context) (postgr
 		// missing) — the role would rest on stale/absent consensus state, so surface
 		// the error and let the monitor skip remediation this tick, matching the
 		// isPrimary probe above.
-		if _, err := pm.consensusMgr.Rules().ObservePosition(ctx); err != nil {
+		if _, _, err := pm.consensusMgr.Rules().ObservePosition(ctx); err != nil {
 			return state, fmt.Errorf("refresh consensus position: %w", err)
 		}
 	}

--- a/go/services/multipooler/internal/manager/rpc_backup.go
+++ b/go/services/multipooler/internal/manager/rpc_backup.go
@@ -353,7 +353,7 @@ func (pm *MultipoolerManager) restoreFromBackupLocked(ctx context.Context, backu
 	// re-established the query-service connection, so observe the position now
 	// rather than leaving the cache stale until the next monitor tick. A failure
 	// here is non-fatal — the next ObservePosition will refresh it.
-	if _, err := pm.consensusMgr.Rules().ObservePosition(ctx); err != nil {
+	if _, _, err := pm.consensusMgr.Rules().ObservePosition(ctx); err != nil {
 		pm.logger.WarnContext(ctx, "Could not refresh rule observation after restore", "error", err)
 	}
 

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -30,6 +30,7 @@ import (
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pgmode"
+	"github.com/multigres/multigres/go/tools/pgutil"
 	"github.com/multigres/multigres/go/tools/telemetry"
 )
 
@@ -368,6 +369,31 @@ func (pm *MultipoolerManager) Promote(ctx context.Context, req *consensusdatapb.
 	return resp, err
 }
 
+// checkRecruitLsnDrift reports an error if current has advanced past observed
+// — evidence that waitForReplayStabilize (run during Recruit) declared replay
+// stable too early, and it kept moving after this node promised observed as
+// its position. Fails closed (treats a parse error as drift). callSite names
+// the calling RPC ("promote" or "set_primary"), logged as a distinct field
+// (not just embedded in the error text) so it's queryable without parsing
+// the message. This is a rare, failover-blocking condition: the returned
+// error already fails the RPC loudly (visible via the generic per-method
+// RPC status-code metrics from otelgrpc, mirroring how Vitess's ERS/PRS
+// treat reparent safety violations — a loud error plus a shared
+// success/failure signal, not a dedicated metric per condition), so this
+// logs explicitly rather than also mint a bespoke counter.
+func (pm *MultipoolerManager) checkRecruitLsnDrift(ctx context.Context, observed, current, callSite string) error {
+	observedParsed, observedErr := pgutil.ParseLSN(observed)
+	currentParsed, currentErr := pgutil.ParseLSN(current)
+	if observedErr == nil && currentErr == nil && currentParsed <= observedParsed {
+		return nil
+	}
+	pm.logger.ErrorContext(ctx, "consensus: recruited position drifted before this RPC could proceed",
+		"call_site", callSite, "observed_lsn", observed, "current_lsn", current)
+	return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
+		"recruited position drifted %s: observed %q at Recruit, now %q — "+
+			"waitForReplayStabilize likely under-waited", callSite, observed, current)
+}
+
 func (pm *MultipoolerManager) promoteLocked(ctx context.Context, req *consensusdatapb.PromoteRequest) (*consensusdatapb.PromoteResponse, error) {
 	proposal := req.GetProposal()
 	revocation := proposal.GetTermRevocation()
@@ -441,6 +467,20 @@ func (pm *MultipoolerManager) promoteLocked(ctx context.Context, req *consensusd
 	if connInfo != "" {
 		return nil, mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
 			"primary_conninfo is set (%q); call Recruit before Promote to stop replication", connInfo)
+	}
+
+	// Detect whether waitForReplayStabilize (run during Recruit) under-waited:
+	// if replay kept advancing after we told the coordinator "this is my
+	// stable position," current LSN will have moved past the one we recorded
+	// when accepting this same revocation. Checked only once we know we're
+	// still in standby mode with no primary_conninfo above — a node that's
+	// already out of recovery has a more fundamental problem to report first.
+	promises, err := pm.consensusMgr.Promises().GetConsistent(ctx)
+	if err != nil {
+		return nil, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION, err.Error())
+	}
+	if err := pm.checkRecruitLsnDrift(ctx, promises.GetRecruitObservedLsn(), beforeStatus.GetCurrentPosition().GetLsn(), "promote"); err != nil {
+		return nil, err
 	}
 
 	// Leader path: promote postgres, write rule, enable query service.
@@ -602,10 +642,11 @@ func (pm *MultipoolerManager) SetPrimary(ctx context.Context, req *consensusdata
 	// the cohort will reconverge as it makes progress. Returning the cached
 	// status keeps the response shape consistent with the "incoming rule
 	// not higher" no-op below.
-	revocation, err := pm.consensusMgr.Promises().GetRevocation(ctx)
+	promises, err := pm.consensusMgr.Promises().GetConsistent(ctx)
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to read revocation while validating SetPrimary")
 	}
+	revocation := promises.GetTermRevocation()
 	if commonconsensus.IsRuleRevoked(rp.GetPosition(), revocation) {
 		pm.logger.InfoContext(ctx, "SetPrimary: rule revoked, ignoring",
 			"incoming_rule", undecidedRule.GetRuleNumber(),
@@ -656,6 +697,23 @@ func (pm *MultipoolerManager) SetPrimary(ctx context.Context, req *consensusdata
 			pm.reconcilePrimaryConnInfoToRecorded(ctx, "SetPrimary")
 		}
 		return &consensusdatapb.SetPrimaryResponse{ConsensusStatus: pm.consensusMgr.CachedConsensusStatus()}, nil
+	}
+
+	// Detect whether our own waitForReplayStabilize (run during our own
+	// Recruit) under-waited. Only applies when the incoming rule is the very
+	// one this revocation authorized — coordinator term equal to
+	// revoked_below_term with a fresh leader_subterm (0), the signature
+	// rule_store.go assigns a freshly-established rule under a new
+	// coordinator term. A later leader_subterm bump under the same term is a
+	// different recruit round; our stored baseline doesn't apply to it, so
+	// skip the check rather than false-positive. Checked against our own
+	// state, not the new leader's — every cohort member independently ran
+	// Recruit/stabilize/accept for this same revocation.
+	incomingRuleNumber := undecidedRule.GetRuleNumber()
+	if incomingRuleNumber.GetCoordinatorTerm() == revocation.GetRevokedBelowTerm() && incomingRuleNumber.GetLeaderSubterm() == 0 {
+		if err := pm.checkRecruitLsnDrift(ctx, promises.GetRecruitObservedLsn(), selfPos.GetLsn(), "set_primary"); err != nil {
+			return nil, err
+		}
 	}
 
 	// Both no-op gates passed — this call will actually reconfigure replication.

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -180,13 +180,22 @@ func (pm *MultipoolerManager) Recruit(ctx context.Context, req *consensusdatapb.
 	// Re-check against the stable position and persist atomically.
 	// AcceptRevocation combines the observed WAL position with the locked stored
 	// revocation so ValidateRevocation sees authoritative state for both checks.
+	// stableStatus.CurrentPosition.FlushedLsn is the durable position used for
+	// consensus ranking; poolerLsn.AppliedLsn (read moments later, in the same
+	// settled state) is what gets snapshotted as the recruit-observed baseline
+	// for checkRecruitLsnDrift, which cares about replay progress specifically.
 	stableStatus, err := pm.consensusMgr.ConsensusStatus(ctx)
 	if err != nil {
 		eventlog.Emit(ctx, pm.logger, eventlog.Failed, termEvent, "error", err)
 		return nil, mterrors.Wrap(err, "failed to read stable status after stopping replication")
 	}
+	_, poolerLsn, err := pm.consensusMgr.Rules().ObservePosition(ctx)
+	if err != nil {
+		eventlog.Emit(ctx, pm.logger, eventlog.Failed, termEvent, "error", err)
+		return nil, mterrors.Wrap(err, "failed to read applied LSN after stopping replication")
+	}
 
-	if err := pm.consensusMgr.Promises().AcceptRevocation(ctx, stableStatus, revocation); err != nil {
+	if err := pm.consensusMgr.Promises().AcceptRevocation(ctx, stableStatus, revocation, poolerLsn.GetAppliedLsn()); err != nil {
 		raceErr := mterrors.Wrap(err, "failed to persist term revocation")
 		eventlog.Emit(ctx, pm.logger, eventlog.Failed, termEvent, "error", raceErr)
 		pm.restoreReplicationAfterRecruitRace(ctx, pgMode, savedConnInfo)
@@ -208,9 +217,13 @@ func (pm *MultipoolerManager) Recruit(ctx context.Context, req *consensusdatapb.
 		pm.logger.WarnContext(ctx, "Recruit: failed to recalc serving state after revocation", "error", err)
 	}
 
-	// Step 5: Return ConsensusStatus with the stable post-revoke position.
+	// Step 5: Return ConsensusStatus with the stable post-revoke position, plus
+	// the paired flushed/applied LSN as diagnostic context for the coordinator.
 	// Uses the cached position warmed by the getConsensusStatus call in step 3.
-	return &consensusdatapb.RecruitResponse{ConsensusStatus: pm.consensusMgr.CachedConsensusStatus()}, nil
+	return &consensusdatapb.RecruitResponse{
+		ConsensusStatus: pm.consensusMgr.CachedConsensusStatus(),
+		Lsn:             poolerLsn,
+	}, nil
 }
 
 // recruitDrainTimeout is the drain window when recruiting a primary.
@@ -475,11 +488,25 @@ func (pm *MultipoolerManager) promoteLocked(ctx context.Context, req *consensusd
 	// when accepting this same revocation. Checked only once we know we're
 	// still in standby mode with no primary_conninfo above — a node that's
 	// already out of recovery has a more fundamental problem to report first.
+	//
+	// TODO: this compares against our own self-tracked RecruitObservedLsn
+	// (this pooler's memory of what it told the coordinator at Recruit time),
+	// not what the coordinator actually built its decision from. A
+	// coordinator-supplied expected_applied_lsn on PromoteRequest — sourced
+	// from the PoolerLsn this same pooler already returned in RecruitResponse
+	// — would validate against the coordinator's real view instead and let
+	// RecruitObservedLsn be dropped entirely. Deferred: needs a version-skew
+	// answer for what an old coordinator's request (field unset) should do —
+	// skip the check or reject.
 	promises, err := pm.consensusMgr.Promises().GetConsistent(ctx)
 	if err != nil {
 		return nil, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION, err.Error())
 	}
-	if err := pm.checkRecruitLsnDrift(ctx, promises.GetRecruitObservedLsn(), beforeStatus.GetCurrentPosition().GetLsn(), "promote"); err != nil {
+	_, currentLsn, err := pm.consensusMgr.Rules().ObservePosition(ctx)
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to observe local position before promote")
+	}
+	if err := pm.checkRecruitLsnDrift(ctx, promises.GetRecruitObservedLsn(), currentLsn.GetAppliedLsn(), "promote"); err != nil {
 		return nil, err
 	}
 
@@ -505,7 +532,7 @@ func (pm *MultipoolerManager) promoteLocked(ctx context.Context, req *consensusd
 		WithCohort(proposedRule.GetCohortMembers()).
 		WithDurabilityPolicy(proposedRule.GetDurabilityPolicy()).
 		WithAcceptedMembers(req.GetAcceptedNodeIds()).
-		WithWALPosition(beforeStatus.GetCurrentPosition().GetLsn()).
+		WithWALPosition(beforeStatus.GetCurrentPosition().GetFlushedLsn()).
 		WithPromotionHook(func(hookCtx context.Context) error {
 			if err := pm.consensusMgr.ClearResignedLeaderAtTerm(ctx); err != nil {
 				return mterrors.Wrap(err, "failed to clear resigned primary term")
@@ -669,7 +696,7 @@ func (pm *MultipoolerManager) SetPrimary(ctx context.Context, req *consensusdata
 
 	// Observe the freshest view of our rule. SetPrimary is the staleness gate,
 	// so we want authoritative state — not the cached snapshot.
-	selfPos, err := pm.consensusMgr.Rules().ObservePosition(ctx)
+	selfPos, selfLsn, err := pm.consensusMgr.Rules().ObservePosition(ctx)
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to observe local position")
 	}
@@ -709,9 +736,13 @@ func (pm *MultipoolerManager) SetPrimary(ctx context.Context, req *consensusdata
 	// skip the check rather than false-positive. Checked against our own
 	// state, not the new leader's — every cohort member independently ran
 	// Recruit/stabilize/accept for this same revocation.
+	//
+	// TODO: same self-tracked-baseline limitation as promoteLocked's drift
+	// check — see the TODO there re: a coordinator-supplied
+	// expected_applied_lsn on SetPrimaryRequest instead.
 	incomingRuleNumber := undecidedRule.GetRuleNumber()
 	if incomingRuleNumber.GetCoordinatorTerm() == revocation.GetRevokedBelowTerm() && incomingRuleNumber.GetLeaderSubterm() == 0 {
-		if err := pm.checkRecruitLsnDrift(ctx, promises.GetRecruitObservedLsn(), selfPos.GetLsn(), "set_primary"); err != nil {
+		if err := pm.checkRecruitLsnDrift(ctx, promises.GetRecruitObservedLsn(), selfLsn.GetAppliedLsn(), "set_primary"); err != nil {
 			return nil, err
 		}
 	}

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -418,7 +418,7 @@ func TestRecruit(t *testing.T) {
 			}
 
 			// Verify persisted state matches expectations regardless of success/failure.
-			persisted := pm.consensusMgr.Promises().GetInconsistentRevocation()
+			persisted := pm.consensusMgr.Promises().GetInconsistent().GetTermRevocation()
 			assert.Equal(t, tt.expectPersistedTerm, persisted.GetRevokedBelowTerm())
 			assert.Equal(t, tt.expectPersistedCoordinator, persisted.GetAcceptedCoordinatorId().GetName())
 
@@ -1059,6 +1059,68 @@ func TestPromote(t *testing.T) {
 			}, time.Second, time.Millisecond, "mock expectations not met after promotion")
 		})
 	}
+}
+
+// TestPromote_RecruitLsnDrift verifies that Promote rejects a request when the
+// WAL replay position has advanced past what Recruit recorded as stable for
+// this same revocation — evidence that waitForReplayStabilize declared
+// replay stable too early. makeRulePosition(0) (the fake rule store's
+// current position, used as beforeStatus.GetCurrentPosition()) reports LSN
+// "16/B374D848".
+func TestPromote_RecruitLsnDrift(t *testing.T) {
+	selfID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "test-pooler"}
+	coordinatorA := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "coordinator-a"}
+	otherPooler := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "other-pooler"}
+
+	recruitedTerm := &clustermetadatapb.TermRevocation{
+		RevokedBelowTerm:       7,
+		AcceptedCoordinatorId:  coordinatorA,
+		CoordinatorInitiatedAt: recruitTS,
+		OutgoingRule:           &clustermetadatapb.RuleNumber{CoordinatorTerm: 0, LeaderSubterm: 1},
+	}
+	req := &consensusdatapb.PromoteRequest{
+		Proposal: &consensusdatapb.CoordinatorProposal{
+			TermRevocation: recruitedTerm,
+			ProposalLeader: &clustermetadatapb.PoolerAddress{Id: selfID, Host: "pg-primary.internal", PostgresPort: 5432},
+			ProposedTransition: &clustermetadatapb.RulePosition{Proposal: &clustermetadatapb.ShardRule{
+				RuleNumber:    &clustermetadatapb.RuleNumber{CoordinatorTerm: 7},
+				CohortMembers: []*clustermetadatapb.ID{selfID, otherPooler},
+				CoordinatorId: coordinatorA,
+				CreationTime:  ruleCreatedTS,
+			}},
+		},
+	}
+
+	runPromote := func(t *testing.T, observedLsn string, setupMocks func(*mock.QueryService)) error {
+		m := mock.NewQueryService()
+		setupMocks(m)
+		pm, tmpDir := setupManagerWithMockDB(t, m, &fakeRuleStore{pos: makeRulePosition(0)})
+		consensustest.SeedTermWithObservedLsn(t, tmpDir, recruitedTerm, observedLsn)
+		_, err := pm.consensusMgr.Promises().Load()
+		require.NoError(t, err)
+		_, err = pm.Promote(t.Context(), req)
+		return err
+	}
+
+	t.Run("rejects when current LSN has advanced past the recruited baseline", func(t *testing.T) {
+		// No mocks registered beyond the standby-state check: the drift check
+		// must reject before reaching any promotion query.
+		err := runPromote(t, "10/00000000", expectStandbyReadyMocks)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "recruited position drifted")
+		assert.Contains(t, err.Error(), "promote")
+	})
+
+	t.Run("rejects on an unparseable recruit-observed LSN (fails closed)", func(t *testing.T) {
+		err := runPromote(t, "not-an-lsn", expectStandbyReadyMocks)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "recruited position drifted")
+	})
+
+	t.Run("succeeds when current LSN has not advanced past the baseline", func(t *testing.T) {
+		err := runPromote(t, "16/B374D848", expectLeaderPromoteMocks)
+		require.NoError(t, err)
+	})
 }
 
 // TestPromoteDropsUnloggedTables verifies the post-promotion unlogged-table

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -1149,7 +1149,7 @@ func TestPromote_RecruitLsnDrift(t *testing.T) {
 		assert.Contains(t, err.Error(), "promote")
 	})
 
-	t.Run("rejects on an unparseable recruit-observed LSN (fails closed)", func(t *testing.T) {
+	t.Run("rejects on an unparsable recruit-observed LSN (fails closed)", func(t *testing.T) {
 		err := runPromote(t, "not-an-lsn", expectStandbyReadyMocks)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "recruited position drifted")

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -172,7 +172,7 @@ func makeRulePosition(coordinatorTerm int64) *clustermetadatapb.PoolerPosition {
 				CoordinatorTerm: coordinatorTerm,
 			},
 		}},
-		Lsn: "16/B374D848",
+		FlushedLsn: "16/B374D848",
 	}
 }
 
@@ -415,6 +415,10 @@ func TestRecruit(t *testing.T) {
 				require.NotNil(t, resp.ConsensusStatus)
 				require.NotNil(t, resp.ConsensusStatus.TermRevocation)
 				assert.Equal(t, tt.expectPersistedTerm, resp.ConsensusStatus.TermRevocation.GetRevokedBelowTerm())
+				// The response carries the paired flushed/applied LSN read after
+				// stopping replication, for the coordinator's diagnostic use.
+				require.NotNil(t, resp.GetLsn())
+				assert.NotEmpty(t, resp.GetLsn().GetAppliedLsn())
 			}
 
 			// Verify persisted state matches expectations regardless of success/failure.
@@ -456,6 +460,40 @@ func TestRecruit(t *testing.T) {
 		}
 	})
 
+	t.Run("AppliedLsnReadFails", func(t *testing.T) {
+		// The post-stabilize ObservePosition call added specifically to read
+		// the applied LSN for AcceptRevocation/RecruitResponse.Lsn is the 3rd
+		// ObservePosition call in this path (preStatus, stableStatus, then
+		// this one) — arm the fake to fail only that one, exercising its own
+		// error wrap without disturbing the earlier reads Recruit also needs.
+		mockQueryService := mock.NewQueryService()
+		expectStandbyRecruitMocks(mockQueryService, "0/2000000", "")
+		ruleStore := &fakeRuleStore{pos: makeRulePosition(0)}
+		pm, tmpDir := setupManagerWithMockDB(t, mockQueryService, ruleStore)
+		consensustest.SeedTerm(t, tmpDir, &clustermetadatapb.TermRevocation{RevokedBelowTerm: 3})
+		_, err := pm.consensusMgr.Promises().Load()
+		require.NoError(t, err)
+
+		// Stop the background postgres monitor poller before arming: it also
+		// calls ObservePosition on its own tick, which would otherwise race
+		// with this test's exact call-count targeting.
+		pm.pgMonitor.Stop()
+		ruleStore.armObserveErrAfterCalls(3, errors.New("connection reset"))
+
+		req := &consensusdatapb.RecruitRequest{
+			TermRevocation: &clustermetadatapb.TermRevocation{
+				RevokedBelowTerm:       7,
+				AcceptedCoordinatorId:  coordinatorA,
+				CoordinatorInitiatedAt: recruitTS,
+				OutgoingRule:           &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
+			},
+		}
+		resp, err := pm.Recruit(t.Context(), req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read applied LSN after stopping replication")
+		assert.Nil(t, resp)
+	})
+
 	seedFloor := func(t *testing.T, pm *MultipoolerManager, floor *clustermetadatapb.LsnPosition) {
 		t.Helper()
 		lockCtx, err := pm.actionLock.Acquire(t.Context(), "test-seed-floor")
@@ -468,7 +506,7 @@ func TestRecruit(t *testing.T) {
 	// tests that need to control the LSN relative to a seeded floor.
 	rulePositionWithLSN := func(coordinatorTerm int64, lsn string) *clustermetadatapb.PoolerPosition {
 		pos := makeRulePosition(coordinatorTerm)
-		pos.Lsn = lsn
+		pos.FlushedLsn = lsn
 		return pos
 	}
 
@@ -587,7 +625,7 @@ func expectStandbyReadyMocks(m *mock.QueryService) {
 // expectLeaderPromoteMocks sets up the postgres query expectations for the leader
 // Promote path: check recovery state, pg_promote, wait for promotion, reset conninfo,
 // reload config. The WAL position is read from the rule store's cached LSN
-// (via beforeStatus.GetCurrentPosition().GetLsn()), not from a separate pg_current_wal_lsn query.
+// (via beforeStatus.GetCurrentPosition().GetFlushedLsn()), not from a separate pg_current_wal_lsn query.
 func expectLeaderPromoteMocks(m *mock.QueryService) {
 	expectLeaderPromoteMocksWithUnlogged(m, nil)
 }
@@ -876,9 +914,9 @@ func TestPromote(t *testing.T) {
 				assert.True(t, proto.Equal(coordinatorA, update.GetCoordinatorID()))
 				assert.True(t, proto.Equal(selfID, update.GetLeaderID()))
 				assert.Len(t, update.GetCohortMembers(), 2)
-				// walPosition comes from beforeStatus.GetCurrentPosition().GetLsn(),
+				// walPosition comes from beforeStatus.GetCurrentPosition().GetFlushedLsn(),
 				// which is the rule store's cached LSN at the time of the Promote call.
-				assert.Equal(t, makeRulePosition(0).Lsn, update.GetWALPosition())
+				assert.Equal(t, makeRulePosition(0).FlushedLsn, update.GetWALPosition())
 				assert.Nil(t, update.GetDurabilityPolicy())
 				assert.Empty(t, update.GetAcceptedMembers())
 

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -436,7 +436,7 @@ func (pm *MultipoolerManager) UpdateConsensusRule(ctx context.Context, operation
 	// === Parse Current Configuration ===
 
 	// Read current cohort from the rule store (authoritative source of truth).
-	pos, err := pm.consensusMgr.Rules().ObservePosition(ctx)
+	pos, _, err := pm.consensusMgr.Rules().ObservePosition(ctx)
 	if err != nil {
 		return err
 	}
@@ -999,7 +999,7 @@ func (pm *MultipoolerManager) restartAsStandbyLocked(
 				Decision: status.GetCurrentPosition().GetPosition().GetDecision().GetRuleNumber(),
 				Proposal: status.GetCurrentPosition().GetPosition().GetProposal().GetRuleNumber(),
 			},
-			Lsn: status.GetCurrentPosition().GetLsn(),
+			Lsn: status.GetCurrentPosition().GetFlushedLsn(),
 		}
 		if err := pm.consensusMgr.Promises().SetRecruitBlockedUntil(ctx, floor); err != nil {
 			return false, mterrors.Wrap(err, "failed to record recruit position floor")

--- a/go/services/multipooler/internal/manager/rpc_manager_test.go
+++ b/go/services/multipooler/internal/manager/rpc_manager_test.go
@@ -92,14 +92,14 @@ func expectRewindPositionFloorMocks(m *mock.QueryService) {
 				"durability_policy_name", "durability_quorum_type", "durability_required_count", "created_at",
 				"proposal_coordinator_term", "proposal_leader_subterm", "proposal_leader_id", "proposal_cohort_members",
 				"proposal_durability_policy_name", "proposal_durability_quorum_type", "proposal_durability_required_count",
-				"proposal_created_at", "current_lsn",
+				"proposal_created_at", "flushed_lsn", "applied_lsn",
 			},
 			[][]any{
 				{
 					int64(1), int64(0), "zone1_leader-1", "zone1_coordinator-1", "{zone1_member-1,zone1_member-2}",
 					"AT_LEAST_2", "QUORUM_TYPE_AT_LEAST_N", int64(2), "2026-01-01 00:00:00+00",
 					nil, nil, nil, nil, nil, nil, nil, nil,
-					"0/100",
+					"0/100", "0/100",
 				},
 			},
 		))
@@ -708,7 +708,7 @@ func TestReplicationStatus(t *testing.T) {
 							{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler-b"},
 						},
 					}},
-					Lsn: "0/1000000",
+					FlushedLsn: "0/1000000",
 				},
 			}))
 		require.NoError(t, err)

--- a/go/services/multipooler/internal/manager/rpc_set_primary_test.go
+++ b/go/services/multipooler/internal/manager/rpc_set_primary_test.go
@@ -371,6 +371,97 @@ func TestSetPrimary_StandbyAppliesNewPrimary(t *testing.T) {
 	assert.Equal(t, "primary-host", recorded.GetHost())
 }
 
+// standbyApplyMocks registers the postgres query expectations for the
+// standby-update apply path (mirrors TestSetPrimary_StandbyAppliesNewPrimary):
+// isPrimary checks, pause replication, set primary_conninfo, resume
+// replication. Used by TestSetPrimary_RecruitLsnDrift's cases that are
+// expected to reach the actual apply.
+func standbyApplyMocks(m *mock.QueryService) {
+	m.AddQueryPatternOnce("SELECT pg_is_in_recovery",
+		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
+	m.AddQueryPatternOnce("SELECT pg_is_in_recovery",
+		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
+	m.AddQueryPatternOnce("SELECT pg_wal_replay_pause", mock.MakeQueryResult(nil, nil))
+	m.AddQueryPattern("^SELECT pg_last_wal_replay_lsn",
+		mock.MakeQueryResult([]string{"replay_lsn", "is_paused"}, [][]any{{"0/100", true}}))
+	m.AddQueryPatternWithCallback("ALTER SYSTEM SET primary_conninfo", mock.MakeQueryResult(nil, nil), func(string) {})
+	expectReloadConfig(m)
+	m.AddQueryPattern("^SELECT 1$", mock.MakeQueryResult(nil, nil))
+	m.AddQueryPatternOnce("SELECT pg_wal_replay_resume", mock.MakeQueryResult(nil, nil))
+}
+
+// TestSetPrimary_RecruitLsnDrift verifies that SetPrimary rejects a request
+// when this follower's own WAL replay position has advanced past what its
+// own Recruit recorded as stable for this same revocation — evidence that
+// waitForReplayStabilize declared replay stable too early. Only applies when
+// the incoming rule is the very one the revocation authorized (coordinator
+// term == revoked_below_term, leader_subterm == 0); a later leader_subterm
+// bump under the same term must skip the check.
+func TestSetPrimary_RecruitLsnDrift(t *testing.T) {
+	coordinatorA := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "coordinator-a"}
+	leader := newLeaderAddress("new-primary", "primary-host", 5432)
+
+	// recruitedTerm simulates this follower having independently run its own
+	// Recruit for term 10 — the same term newLeader's SetPrimary establishes.
+	recruitedTerm := &clustermetadatapb.TermRevocation{
+		RevokedBelowTerm:       10,
+		AcceptedCoordinatorId:  coordinatorA,
+		CoordinatorInitiatedAt: recruitTS,
+		OutgoingRule:           &clustermetadatapb.RuleNumber{CoordinatorTerm: 3},
+	}
+
+	// makeRulePosition(3) (the fake rule store's initial cached position,
+	// also what ObservePosition reports as "current") reports LSN "16/B374D848".
+	runSetPrimary := func(t *testing.T, ruleNumber *clustermetadatapb.RuleNumber, observedLsn string, setupMocks func(*mock.QueryService)) error {
+		m := mock.NewQueryService()
+		setupMocks(m)
+		pm, tmpDir := setupManagerWithMockDB(t, m, &fakeRuleStore{pos: makeRulePosition(3)})
+		consensustest.SeedTermWithObservedLsn(t, tmpDir, recruitedTerm, observedLsn)
+		_, err := pm.consensusMgr.Promises().Load()
+		require.NoError(t, err)
+
+		req := &consensusdatapb.SetPrimaryRequest{
+			ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
+				Position:    &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: ruleNumber, LeaderId: leader.GetId()}},
+				Primary:     leader,
+				RewindReady: true,
+			},
+		}
+		_, err = pm.SetPrimary(t.Context(), req)
+		return err
+	}
+
+	freshRule := &clustermetadatapb.RuleNumber{CoordinatorTerm: 10} // leader_subterm 0: the rule this revocation authorized
+
+	t.Run("rejects when current LSN has advanced past the recruited baseline", func(t *testing.T) {
+		// No mocks registered: the drift check must reject before any query.
+		err := runSetPrimary(t, freshRule, "10/00000000", func(*mock.QueryService) {})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "recruited position drifted")
+		assert.Contains(t, err.Error(), "set_primary")
+	})
+
+	t.Run("rejects on an unparseable recruit-observed LSN (fails closed)", func(t *testing.T) {
+		err := runSetPrimary(t, freshRule, "not-an-lsn", func(*mock.QueryService) {})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "recruited position drifted")
+	})
+
+	t.Run("succeeds when current LSN has not advanced past the baseline", func(t *testing.T) {
+		err := runSetPrimary(t, freshRule, "16/B374D848", standbyApplyMocks)
+		require.NoError(t, err)
+	})
+
+	t.Run("skips the check when leader_subterm is not fresh (different recruit round)", func(t *testing.T) {
+		// Same coordinator term but leader_subterm=1: not the rule this
+		// revocation authorized. Baseline "10/00000000" would otherwise
+		// drift against current "16/B374D848" — the check must not fire.
+		staleSubtermRule := &clustermetadatapb.RuleNumber{CoordinatorTerm: 10, LeaderSubterm: 1}
+		err := runSetPrimary(t, staleSubtermRule, "10/00000000", standbyApplyMocks)
+		require.NoError(t, err)
+	})
+}
+
 // TestSetPrimary_StalePrimaryDemotes verifies the stale-primary branch end to end:
 // when the receiver is acting as primary (pg_is_in_recovery=false) and the
 // supplied position is higher, SetPrimary must drive a full demote — pg_rewind,
@@ -451,7 +542,7 @@ func TestSetPrimary_StalePrimaryDemotes(t *testing.T) {
 	// SetPrimary must NOT touch term_revocation. The revocation seeded above
 	// (revoked_below_term=3) is preserved verbatim. Revocations are authored
 	// by coordinators via Recruit, not by side effects of SetPrimary.
-	rev := pm.consensusMgr.Promises().GetInconsistentRevocation()
+	rev := pm.consensusMgr.Promises().GetInconsistent().GetTermRevocation()
 	assert.Equal(t, int64(3), rev.GetRevokedBelowTerm(),
 		"SetPrimary must not bump revoked_below_term — that's a coordinator responsibility")
 

--- a/go/services/multipooler/internal/manager/rpc_set_primary_test.go
+++ b/go/services/multipooler/internal/manager/rpc_set_primary_test.go
@@ -441,7 +441,7 @@ func TestSetPrimary_RecruitLsnDrift(t *testing.T) {
 		assert.Contains(t, err.Error(), "set_primary")
 	})
 
-	t.Run("rejects on an unparseable recruit-observed LSN (fails closed)", func(t *testing.T) {
+	t.Run("rejects on an unparsable recruit-observed LSN (fails closed)", func(t *testing.T) {
 		err := runSetPrimary(t, freshRule, "not-an-lsn", func(*mock.QueryService) {})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "recruited position drifted")

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -512,7 +512,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		// Get the final primary's LSN position
 		statusResp, err := finalPrimaryClient.Manager.Status(utils.WithShortDeadline(t), &multipoolermanagerdatapb.StatusRequest{})
 		require.NoError(t, err, "Should be able to get final primary position")
-		primaryLSN := statusResp.GetConsensusStatus().GetCurrentPosition().GetLsn()
+		primaryLSN := statusResp.GetConsensusStatus().GetCurrentPosition().GetFlushedLsn()
 
 		// Collect multipooler test clients for all multipoolers (primary + standbys) and wait for replicas to catch up
 		var poolerClients []*shardsetup.MultipoolerTestClient
@@ -568,7 +568,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		defer primaryMgrClient.Close()
 		primaryStatusResp, err := primaryMgrClient.Manager.Status(utils.WithShortDeadline(t), &multipoolermanagerdatapb.StatusRequest{})
 		require.NoError(t, err)
-		primaryLSN := primaryStatusResp.GetConsensusStatus().GetCurrentPosition().GetLsn()
+		primaryLSN := primaryStatusResp.GetConsensusStatus().GetCurrentPosition().GetFlushedLsn()
 
 		// Connect to primary and get row count and checksum
 		primarySocketDir := filepath.Join(finalPrimaryInst.Pgctld.PoolerDir, "pg_sockets")

--- a/go/test/endtoend/multiorch/demote_stale_primary_test.go
+++ b/go/test/endtoend/multiorch/demote_stale_primary_test.go
@@ -371,7 +371,7 @@ func verifyDataReplication(t *testing.T, setup *shardsetup.ShardSetup, replicaNa
 	// Get primary's current LSN
 	statusResp, err := primaryClient.Manager.Status(utils.WithShortDeadline(t), &multipoolermanagerdatapb.StatusRequest{})
 	require.NoError(t, err, "should get primary LSN position")
-	primaryLSN := statusResp.GetConsensusStatus().GetCurrentPosition().GetLsn()
+	primaryLSN := statusResp.GetConsensusStatus().GetCurrentPosition().GetFlushedLsn()
 	t.Logf("Primary LSN after insert: %s", primaryLSN)
 
 	// Wait for replica PostgreSQL to be ready after pg_rewind and restart

--- a/go/test/endtoend/multiorch/recruit_promote_lsn_drift_test.go
+++ b/go/test/endtoend/multiorch/recruit_promote_lsn_drift_test.go
@@ -1,0 +1,218 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiorch
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+)
+
+// TestRecruitPromoteLsnDrift is a direct, consensus-doesn't-need-to-be-correct
+// experiment: it drives Recruit() and Promote() by hand against a single
+// standby (bypassing multiorch's own failover decisions entirely) to verify
+// Recruit() genuinely stopped WAL replay from advancing.
+//
+// Durability/quorum policy is irrelevant here: checkRecruitLsnDrift runs in
+// promoteLocked before the rule write that needs quorum ack, so a Promote()
+// call that hangs on writing the rule (because the real pooler-1 will never
+// ack a fake cohort) already tells us the drift check passed silently — we
+// use a short client-side timeout on Promote() and only care whether it
+// returns the specific "recruited position drifted" error quickly, not
+// whether the whole call succeeds.
+//
+// recovery_min_apply_delay creates a real, growing gap between received and
+// applied WAL while writes flow to the primary; a real wall-clock gap between
+// Recruit() and Promote() gives the standby's background replay process time
+// to drain that gap in the background (recovery_min_apply_delay expiry is
+// time-based, not tied to promotion) — if Recruit()'s waitForReplayStabilize
+// call correctly waited out replay before returning, Promote() should see the
+// same position; if it returned prematurely, checkRecruitLsnDrift should
+// reject it.
+func TestRecruitPromoteLsnDrift(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping TestRecruitPromoteLsnDrift test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("Skipping end-to-end recruit/promote LSN drift test (no postgres binaries)")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2),
+		shardsetup.WithMultiorchCount(1),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+	)
+	defer cleanup()
+
+	setup.StartMultiorchs(t.Context(), t)
+
+	pName := waitForShardReady(t, setup, 1, 30*time.Second)
+	t.Logf("Shard ready: primary=%s", pName)
+
+	var standbyName string
+	for name := range setup.Multipoolers {
+		if name != pName {
+			standbyName = name
+			break
+		}
+	}
+	require.NotEmpty(t, standbyName, "should have a standby")
+	t.Logf("Standby to recruit/promote directly: %s", standbyName)
+
+	primaryInst := setup.GetMultipoolerInstance(pName)
+	require.NotNil(t, primaryInst, "primary instance should exist")
+	primarySocketDir := filepath.Join(primaryInst.Pgctld.PoolerDir, "pg_sockets")
+	primaryDB := connectToPostgres(t, primarySocketDir, primaryInst.Pgctld.PgPort)
+	defer primaryDB.Close()
+
+	standbyInst := setup.GetMultipoolerInstance(standbyName)
+	require.NotNil(t, standbyInst, "standby instance should exist")
+	standbySocketDir := filepath.Join(standbyInst.Pgctld.PoolerDir, "pg_sockets")
+	standbyDB := connectToPostgres(t, standbySocketDir, standbyInst.Pgctld.PgPort)
+	defer standbyDB.Close()
+
+	// Make sure orch is settled, then keep it out of the way: we drive
+	// Recruit/Promote by hand, so multiorch must not race with us.
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioInitialSettle)
+	setup.DisableRecovery(t, "multiorch")
+
+	// Force a real, growing gap between received and applied WAL on the
+	// standby: recovery_min_apply_delay delays application by a fixed amount
+	// past each record's commit timestamp, independent of promotion.
+	_, err := standbyDB.Exec("ALTER SYSTEM SET recovery_min_apply_delay = '3000ms'")
+	require.NoError(t, err, "should set recovery_min_apply_delay on standby")
+	_, err = standbyDB.Exec("SELECT pg_reload_conf()")
+	require.NoError(t, err, "should reload standby config")
+
+	_, err = primaryDB.Exec("CREATE TABLE IF NOT EXISTS recruit_drift_test (id SERIAL PRIMARY KEY, data TEXT)")
+	require.NoError(t, err, "should create test table on primary")
+
+	// Generate sustained write traffic so there's a continuous backlog
+	// building up behind the standby's apply delay.
+	stopWrites := make(chan struct{})
+	writesDone := make(chan struct{})
+	go func() {
+		defer close(writesDone)
+		for {
+			select {
+			case <-stopWrites:
+				return
+			default:
+				_, _ = primaryDB.Exec("INSERT INTO recruit_drift_test (data) VALUES ('x')")
+				time.Sleep(20 * time.Millisecond)
+			}
+		}
+	}()
+	time.Sleep(2 * time.Second) // let backlog build up behind the delay
+	close(stopWrites)
+	<-writesDone
+
+	standbyClient, err := shardsetup.NewMultipoolerClient(standbyInst.Multipooler.GrpcPort)
+	require.NoError(t, err)
+	defer standbyClient.Close()
+
+	statusResp, err := standbyClient.Manager.Status(utils.WithTimeout(t, 5*time.Second), &multipoolermanagerdatapb.StatusRequest{})
+	require.NoError(t, err, "should get standby status")
+	standbyID := statusResp.ConsensusStatus.GetId()
+	require.NotNil(t, standbyID, "standby status should carry its own id")
+	previousRule := statusResp.ConsensusStatus.GetCurrentPosition().GetPosition().GetDecision()
+	require.NotNil(t, previousRule, "standby should have a recorded rule before recruit")
+	outgoingRule := previousRule.GetRuleNumber()
+
+	term := outgoingRule.GetCoordinatorTerm() + 1
+	coordinatorID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIORCH,
+		Cell:      setup.CellName,
+		Name:      "test-coordinator",
+	}
+	revocation := &clustermetadatapb.TermRevocation{
+		RevokedBelowTerm:       term,
+		AcceptedCoordinatorId:  coordinatorID,
+		CoordinatorInitiatedAt: timestamppb.Now(),
+		OutgoingRule:           outgoingRule,
+	}
+
+	t.Logf("Calling Recruit on standby %s with term %d", standbyName, term)
+	recruitResp, err := standbyClient.Consensus.Recruit(utils.WithTimeout(t, 15*time.Second), &consensusdatapb.RecruitRequest{
+		TermRevocation: revocation,
+	})
+	require.NoError(t, err, "Recruit should succeed")
+	observedLsn := recruitResp.GetLsn().GetAppliedLsn()
+	t.Logf("Recruit succeeded; observed (recorded-as-stable) LSN: %s", observedLsn)
+
+	// Give the standby's background replay process real wall-clock time to
+	// drain the recovery_min_apply_delay backlog — independent of promotion.
+	// This is the gap checkRecruitLsnDrift exists to catch if
+	// waitForReplayStabilize under-waited.
+	t.Log("Sleeping to let delayed WAL apply in the background before Promote...")
+	time.Sleep(5 * time.Second)
+
+	// Cohort/durability policy is irrelevant to what we're testing —
+	// checkRecruitLsnDrift runs before the rule write that needs quorum ack.
+	// A short client-side timeout below means we only observe whether
+	// Promote() rejects quickly with the drift error, not whether the whole
+	// call (including the write pooler-1 will never ack) completes.
+	proposedRule := &clustermetadatapb.ShardRule{
+		RuleNumber:    &clustermetadatapb.RuleNumber{CoordinatorTerm: term},
+		LeaderId:      standbyID,
+		CohortMembers: previousRule.GetCohortMembers(),
+		DurabilityPolicy: &clustermetadatapb.DurabilityPolicy{
+			QuorumType:    clustermetadatapb.QuorumType_QUORUM_TYPE_AT_LEAST_N,
+			RequiredCount: 1,
+		},
+		CoordinatorId: coordinatorID,
+		CreationTime:  timestamppb.Now(),
+	}
+	promoteResp, err := standbyClient.Consensus.Promote(utils.WithTimeout(t, 5*time.Second), &consensusdatapb.PromoteRequest{
+		Proposal: &consensusdatapb.CoordinatorProposal{
+			TermRevocation: revocation,
+			ProposalLeader: &clustermetadatapb.PoolerAddress{
+				Id:           standbyID,
+				Host:         "localhost",
+				PostgresPort: int32(standbyInst.Pgctld.PgPort),
+			},
+			ProposedTransition: &clustermetadatapb.RulePosition{Proposal: proposedRule},
+		},
+	})
+
+	switch {
+	case err == nil:
+		require.NotNil(t, promoteResp)
+		t.Log("Promote succeeded — no drift detected between Recruit and Promote")
+	case strings.Contains(err.Error(), "recruited position drifted"):
+		t.Log("Drift correctly detected: Promote rejected before ever reaching the rule write")
+	case strings.Contains(err.Error(), "context deadline exceeded"):
+		// The call hung on the later rule-write step (pooler-1 will never ack
+		// a fake cohort). checkRecruitLsnDrift runs before that write, so
+		// reaching this hang means the drift check already passed silently —
+		// a valid negative result, not a broken test.
+		t.Logf("Promote did not return within 5s (hung on the unrelated quorum write, as expected): %v", err)
+		t.Log("No drift detected: checkRecruitLsnDrift must have passed silently before the hang")
+	default:
+		t.Fatalf("Promote failed with an unexpected error (not drift, not the expected quorum-write timeout): %v", err)
+	}
+}

--- a/go/test/endtoend/multipooler/rpc_manager_api_test.go
+++ b/go/test/endtoend/multipooler/rpc_manager_api_test.go
@@ -90,6 +90,6 @@ func TestMultipoolerPrimaryLSN(t *testing.T) {
 	ctx := utils.WithTimeout(t, 5*time.Second)
 	statusResp, err := primaryClient.Manager.Status(ctx, &multipoolermanagerdatapb.StatusRequest{})
 	require.NoError(t, err)
-	assert.NotEmpty(t, statusResp.GetConsensusStatus().GetCurrentPosition().GetLsn(), "Primary LSN should not be empty")
-	assert.Contains(t, statusResp.GetConsensusStatus().GetCurrentPosition().GetLsn(), "/", "LSN should be in PostgreSQL format (e.g., 0/1234ABCD)")
+	assert.NotEmpty(t, statusResp.GetConsensusStatus().GetCurrentPosition().GetFlushedLsn(), "Primary LSN should not be empty")
+	assert.Contains(t, statusResp.GetConsensusStatus().GetCurrentPosition().GetFlushedLsn(), "/", "LSN should be in PostgreSQL format (e.g., 0/1234ABCD)")
 }

--- a/go/test/endtoend/multipooler/rpc_manager_replication_api_test.go
+++ b/go/test/endtoend/multipooler/rpc_manager_replication_api_test.go
@@ -75,7 +75,7 @@ func TestReplicationAPIs(t *testing.T) {
 
 		primaryPosResp, err := primaryClient.Manager.Status(ctx, &multipoolermanagerdatapb.StatusRequest{})
 		require.NoError(t, err)
-		targetLSN := primaryPosResp.GetConsensusStatus().GetCurrentPosition().GetLsn()
+		targetLSN := primaryPosResp.GetConsensusStatus().GetCurrentPosition().GetFlushedLsn()
 		t.Logf("Target LSN from primary: %s", targetLSN)
 
 		// Wait for standby to reach the target LSN

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -485,10 +485,34 @@ message PoolerPosition {
   // The highest rule position this pooler has committed to local WAL.
   RulePosition position = 1;
 
-  // The current real-time WAL head at the time of reading. Note that this is likely
-  // beyond the LSN at which the rule was committed. For a primary: pg_current_wal_lsn().
-  // For a standby: pg_last_wal_receive_lsn() (or pg_last_wal_replay_lsn() if receive is null).
-  string lsn = 2;
+  // The WAL position this pooler has durably flushed to disk at the time of
+  // reading — not the applied/visible position. Note that this is likely
+  // beyond the LSN at which the rule was committed. For a primary:
+  // pg_current_wal_flush_lsn(). For a standby: pg_last_wal_receive_lsn(),
+  // which Postgres itself defines as "received and synced to disk" (i.e.
+  // already flush-durable, not merely written). Deliberately not applied_lsn:
+  // go/common/consensus's comparison/ranking algorithms need durability
+  // ("who has retained the most data"), not visibility — see PoolerLsn for
+  // the paired flushed+applied view used for diagnostic/defense-in-depth
+  // purposes instead.
+  string flushed_lsn = 2;
+}
+
+// PoolerLsn reports both WAL positions for a pooler, read together in a
+// single query so they reflect the same instant. Kept outside
+// PoolerPosition/ConsensusStatus deliberately: go/common/consensus's
+// comparison algorithms are pure and only need the durable position
+// (PoolerPosition.flushed_lsn); applied_lsn is diagnostic context for
+// detecting a stuck-replay bug, not a consensus-algorithm input.
+message PoolerLsn {
+  // Durably flushed to disk. Same source as PoolerPosition.flushed_lsn.
+  string flushed_lsn = 1;
+
+  // Applied to (visible in) this pooler's own database state. For a primary:
+  // pg_current_wal_lsn() (a primary's writes are visible immediately; there
+  // is no separate replay step, though flush can still lag write slightly).
+  // For a standby: pg_last_wal_replay_lsn().
+  string applied_lsn = 2;
 }
 
 // RuleNumberPosition mirrors RulePosition but carries only rule numbers, not

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -519,6 +519,13 @@ message LsnPosition {
 message ConsensusPromises {
   TermRevocation term_revocation = 1;
   LsnPosition recruit_blocked_until = 2;
+
+  // The WAL LSN observed immediately after accepting term_revocation, once
+  // waitForReplayStabilize declared replay stable. Used to detect whether
+  // that stabilize heuristic under-waited: if the current LSN has advanced
+  // past this by the time Promote()/SetPrimary() acts on the same
+  // revocation, replay kept moving after we called it stable.
+  string recruit_observed_lsn = 3;
 }
 
 // RoutingRole is a pooler's role for query ROUTING and HA purposes. It is about

--- a/proto/consensusdata.proto
+++ b/proto/consensusdata.proto
@@ -67,6 +67,12 @@ message RecruitRequest {
 // promotion candidate.
 message RecruitResponse {
   clustermetadata.ConsensusStatus consensus_status = 1;
+
+  // Flushed and applied WAL position at the same instant this pooler
+  // accepted the revocation, for the coordinator to use as diagnostic
+  // context (e.g. detecting a stuck-replay bug) — not a consensus-algorithm
+  // input; see PoolerLsn's proto doc.
+  clustermetadata.PoolerLsn lsn = 2;
 }
 
 // PromoteRequest carries the coordinator's complete proposal for a new shard

--- a/web/multiadmin/lib/api/generated/clustermetadata_pb.ts
+++ b/web/multiadmin/lib/api/generated/clustermetadata_pb.ts
@@ -1632,13 +1632,20 @@ export class PoolerPosition extends Message<PoolerPosition> {
   position?: RulePosition;
 
   /**
-   * The current real-time WAL head at the time of reading. Note that this is likely
-   * beyond the LSN at which the rule was committed. For a primary: pg_current_wal_lsn().
-   * For a standby: pg_last_wal_receive_lsn() (or pg_last_wal_replay_lsn() if receive is null).
+   * The WAL position this pooler has durably flushed to disk at the time of
+   * reading — not the applied/visible position. Note that this is likely
+   * beyond the LSN at which the rule was committed. For a primary:
+   * pg_current_wal_flush_lsn(). For a standby: pg_last_wal_receive_lsn(),
+   * which Postgres itself defines as "received and synced to disk" (i.e.
+   * already flush-durable, not merely written). Deliberately not applied_lsn:
+   * go/common/consensus's comparison/ranking algorithms need durability
+   * ("who has retained the most data"), not visibility — see PoolerLsn for
+   * the paired flushed+applied view used for diagnostic/defense-in-depth
+   * purposes instead.
    *
-   * @generated from field: string lsn = 2;
+   * @generated from field: string flushed_lsn = 2;
    */
-  lsn = "";
+  flushedLsn = "";
 
   constructor(data?: PartialMessage<PoolerPosition>) {
     super();
@@ -1649,7 +1656,7 @@ export class PoolerPosition extends Message<PoolerPosition> {
   static readonly typeName = "clustermetadata.PoolerPosition";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "position", kind: "message", T: RulePosition },
-    { no: 2, name: "lsn", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "flushed_lsn", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): PoolerPosition {
@@ -1666,6 +1673,63 @@ export class PoolerPosition extends Message<PoolerPosition> {
 
   static equals(a: PoolerPosition | PlainMessage<PoolerPosition> | undefined, b: PoolerPosition | PlainMessage<PoolerPosition> | undefined): boolean {
     return proto3.util.equals(PoolerPosition, a, b);
+  }
+}
+
+/**
+ * PoolerLsn reports both WAL positions for a pooler, read together in a
+ * single query so they reflect the same instant. Kept outside
+ * PoolerPosition/ConsensusStatus deliberately: go/common/consensus's
+ * comparison algorithms are pure and only need the durable position
+ * (PoolerPosition.flushed_lsn); applied_lsn is diagnostic context for
+ * detecting a stuck-replay bug, not a consensus-algorithm input.
+ *
+ * @generated from message clustermetadata.PoolerLsn
+ */
+export class PoolerLsn extends Message<PoolerLsn> {
+  /**
+   * Durably flushed to disk. Same source as PoolerPosition.flushed_lsn.
+   *
+   * @generated from field: string flushed_lsn = 1;
+   */
+  flushedLsn = "";
+
+  /**
+   * Applied to (visible in) this pooler's own database state. For a primary:
+   * pg_current_wal_lsn() (a primary's writes are visible immediately; there
+   * is no separate replay step, though flush can still lag write slightly).
+   * For a standby: pg_last_wal_replay_lsn().
+   *
+   * @generated from field: string applied_lsn = 2;
+   */
+  appliedLsn = "";
+
+  constructor(data?: PartialMessage<PoolerLsn>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "clustermetadata.PoolerLsn";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "flushed_lsn", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "applied_lsn", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): PoolerLsn {
+    return new PoolerLsn().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): PoolerLsn {
+    return new PoolerLsn().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): PoolerLsn {
+    return new PoolerLsn().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: PoolerLsn | PlainMessage<PoolerLsn> | undefined, b: PoolerLsn | PlainMessage<PoolerLsn> | undefined): boolean {
+    return proto3.util.equals(PoolerLsn, a, b);
   }
 }
 

--- a/web/multiadmin/lib/api/generated/clustermetadata_pb.ts
+++ b/web/multiadmin/lib/api/generated/clustermetadata_pb.ts
@@ -1787,6 +1787,17 @@ export class ConsensusPromises extends Message<ConsensusPromises> {
    */
   recruitBlockedUntil?: LsnPosition;
 
+  /**
+   * The WAL LSN observed immediately after accepting term_revocation, once
+   * waitForReplayStabilize declared replay stable. Used to detect whether
+   * that stabilize heuristic under-waited: if the current LSN has advanced
+   * past this by the time Promote()/SetPrimary() acts on the same
+   * revocation, replay kept moving after we called it stable.
+   *
+   * @generated from field: string recruit_observed_lsn = 3;
+   */
+  recruitObservedLsn = "";
+
   constructor(data?: PartialMessage<ConsensusPromises>) {
     super();
     proto3.util.initPartial(data, this);
@@ -1797,6 +1808,7 @@ export class ConsensusPromises extends Message<ConsensusPromises> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "term_revocation", kind: "message", T: TermRevocation },
     { no: 2, name: "recruit_blocked_until", kind: "message", T: LsnPosition },
+    { no: 3, name: "recruit_observed_lsn", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ConsensusPromises {


### PR DESCRIPTION
- `Recruit()`'s `waitForReplayStabilize` heuristic can declare replay stable before it truly is. `Promote()` and `SetPrimary()` now compare the current WAL position against what `Recruit()` recorded as stable for that same revocation, rejecting the RPC if it moved.
- `Promote()` checks its own position (after the standby/`primary_conninfo` preconditions, since those are more fundamental failures to report first); `SetPrimary()` checks its own position only when the incoming rule is the fresh one (`leader_subterm == 0`) that revocation authorized — every cohort member independently ran its own Recruit/stabilize/accept for the same revocation.
- `PoolerPosition`'s single LSN field reverts to reporting the durable/flushed WAL position (what consensus ranking and the rewind durability floor actually need), rather than applied/replayed — a mid-review correction after the initial version silently made those other consumers more conservative than intended. A new `PoolerLsn` message carries both flushed and applied, read atomically and surfaced via `RecruitResponse` as diagnostic context; the drift check above now sources its applied-LSN comparisons from `PoolerLsn` instead.
- Refactored `ConsensusPromises` to hold a single on-disk proto message instead of parallel Go fields (`GetConsistent`/`GetInconsistent` replace the old per-field getters), since a third field would have made the old "nil means unchanged" persistence pattern unwieldy.
- This is a best-effort assertion, not a guaranteed backstop — it only catches drift the recruiting node's own state can see, not every path to promoting an out-of-date primary. The goal is to surface `waitForReplayStabilize` bugs quickly via CI e2e runs, staging, and chaos testing rather than let them fail silently.