### PR TITLE
fix(multipooler): preserve backend vpid table during promotion

### DIFF
--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -1401,18 +1401,15 @@ func (pm *MultipoolerManager) promoteStandbyToPrimary(ctx context.Context, state
 	}
 
 	go func() {
-		// After a failover PostgreSQL resets unlogged tables to empty. Best-effort drop
-		// them so clients hit a clear "relation does not exist" error and rebuild from
-		// scratch, rather than silently reading an empty table. Runs here, after the node
-		// is a writable primary but before the topology flips to PRIMARY/SERVING, so clients
-		// never observe the empty intermediate state. See dropUnloggedTablesAfterPromotion.
+		// After a failover PostgreSQL resets user-created unlogged tables to empty.
+		// Best-effort drop them asynchronously so clients get a clear "relation does
+		// not exist" error and rebuild instead of silently reading an empty table.
 		pm.dropUnloggedTablesAfterPromotion(ctx)
 	}()
 
-	// backend_vpid is an unlogged Multigres sidecar table, so the sweep above drops
-	// it too. Recreate the empty relation before the pooler is marked serving; the
-	// rows are intentionally ephemeral, but lock-wait probes need the relation to
-	// exist whenever backend VPID tracking is enabled.
+	// Ensure the unlogged backend_vpid sidecar table exists before the pooler is
+	// marked serving. The asynchronous sweep preserves it because VPID tracking
+	// and lock-wait probes require the relation to remain present.
 	if err := pm.createBackendVpidTable(ctx); err != nil {
 		pm.logger.WarnContext(ctx, "Failed to recreate backend_vpid table after promotion", "error", err)
 	}
@@ -1420,8 +1417,8 @@ func (pm *MultipoolerManager) promoteStandbyToPrimary(ctx context.Context, state
 	return nil
 }
 
-// dropUnloggedTablesAfterPromotion best-effort drops every unlogged table on the
-// freshly promoted primary.
+// dropUnloggedTablesAfterPromotion best-effort drops user-created unlogged tables
+// on the freshly promoted primary.
 //
 // Unlogged table data is never replicated to standbys, so on promotion PostgreSQL
 // resets these tables to empty. Leaving them in place would silently present an empty
@@ -1457,6 +1454,11 @@ func (pm *MultipoolerManager) dropUnloggedTablesAfterPromotion(ctx context.Conte
 		name, err := executor.GetString(row, 0)
 		if err != nil {
 			pm.logger.WarnContext(ctx, "Failed to parse unlogged table name after promotion; skipping", "error", err)
+			continue
+		}
+		// PostgreSQL already resets this unlogged table on promotion; keep it for
+		// VPID tracking and isolation lock-wait probes.
+		if name == "multigres.backend_vpid" {
 			continue
 		}
 		if err := pm.exec(ctx, "DROP TABLE "+name); err != nil {

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -594,8 +594,8 @@ func expectLeaderPromoteMocks(m *mock.QueryService) {
 
 // expectLeaderPromoteMocksWithUnlogged is expectLeaderPromoteMocks plus the
 // dropUnloggedTablesAfterPromotion catalog query, which returns the given fully
-// qualified unlogged table names (none when nil). Callers that pass a non-empty
-// list must also register the matching DROP TABLE patterns.
+// qualified unlogged table names (none when nil). Callers that pass user tables
+// must also register the matching DROP TABLE patterns.
 func expectLeaderPromoteMocksWithUnlogged(m *mock.QueryService, unloggedTables []string) {
 	expectStandbyReadyMocks(m)
 	// checkPromotionState: postgres is still in recovery (standby before promotion)
@@ -609,13 +609,13 @@ func expectLeaderPromoteMocksWithUnlogged(m *mock.QueryService, unloggedTables [
 	// resetPrimaryConnInfo: clear conninfo + reload
 	m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
 	expectReloadConfig(m)
-	// dropUnloggedTablesAfterPromotion: list unlogged tables to drop.
+	// dropUnloggedTablesAfterPromotion: list unlogged tables to inspect.
 	rows := make([][]any, len(unloggedTables))
 	for i, tbl := range unloggedTables {
 		rows[i] = []any{tbl}
 	}
 	m.AddQueryPatternOnce("relpersistence = 'u'", mock.MakeQueryResult([]string{"format"}, rows))
-	// Recreate the unlogged backend_vpid sidecar table after the sweep.
+	// Ensure the unlogged backend_vpid sidecar table exists while the sweep runs.
 	m.AddQueryPatternOnce("CREATE UNLOGGED TABLE IF NOT EXISTS multigres.backend_vpid", mock.MakeQueryResult(nil, nil))
 }
 
@@ -1062,8 +1062,8 @@ func TestPromote(t *testing.T) {
 }
 
 // TestPromoteDropsUnloggedTables verifies the post-promotion unlogged-table
-// sweep: every unlogged table is dropped, and a drop blocked by a dependency is
-// logged without failing the promotion.
+// sweep: user tables are dropped, backend_vpid is preserved, and a drop blocked
+// by a dependency is logged without failing the promotion.
 func TestPromoteDropsUnloggedTables(t *testing.T) {
 	selfID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "test-pooler"}
 	coordinatorA := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "coordinator-a"}
@@ -1099,7 +1099,7 @@ func TestPromoteDropsUnloggedTables(t *testing.T) {
 		return m, err
 	}
 
-	t.Run("drops every unlogged table", func(t *testing.T) {
+	t.Run("drops user tables and preserves backend vpid", func(t *testing.T) {
 		var mu sync.Mutex
 		var dropped []string
 		m, err := runPromote(t, func(m *mock.QueryService) {
@@ -1114,10 +1114,11 @@ func TestPromoteDropsUnloggedTables(t *testing.T) {
 		require.Eventually(t, func() bool {
 			mu.Lock()
 			defer mu.Unlock()
-			return len(dropped) == 3
-		}, time.Second, 10*time.Millisecond, "expected all unlogged tables to be dropped")
+			return len(dropped) == 2
+		}, time.Second, 10*time.Millisecond, "expected user-created unlogged tables to be dropped")
 		mu.Lock()
-		assert.ElementsMatch(t, []string{"public.foo", "public.bar", "multigres.backend_vpid"}, dropped)
+		assert.ElementsMatch(t, []string{"public.foo", "public.bar"}, dropped)
+		assert.NotContains(t, dropped, "multigres.backend_vpid")
 		mu.Unlock()
 		assert.NoError(t, m.ExpectationsWereMet())
 	})


### PR DESCRIPTION
## Summary

- preserve `multigres.backend_vpid` during the asynchronous post-promotion unlogged-table sweep
- continue dropping user-created unlogged tables asynchronously
- verify the sidecar table is not dropped while preserving dependency-blocked drop coverage

## Testing

- `/mt-dev unit ./go/services/multipooler/internal/manager TestPromoteDropsUnloggedTables`
- `/mt-dev unit ./go/services/multipooler/internal/manager/...`