### PR TITLE
test(pgregress): make compatibility results deterministic

### DIFF
--- a/go/test/endtoend/pgregresstest/patch_verify_test.go
+++ b/go/test/endtoend/pgregresstest/patch_verify_test.go
@@ -390,7 +390,7 @@ func TestMarkdownSummaryClassifiesCompatibilityResults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"✅ upstream-compatible", "⚠️ accepted divergence", "❌ residual failure"} {
+	for _, want := range []string{"✅ compatible", "✅ accepted divergence", "❌ residual failure"} {
 		if !contains(summary, want) {
 			t.Fatalf("summary does not contain %q:\n%s", want, summary)
 		}

--- a/go/test/endtoend/pgregresstest/patch_verify_test.go
+++ b/go/test/endtoend/pgregresstest/patch_verify_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/multigres/multigres/go/test/endtoend/pgbuilder"
 	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
 )
 
@@ -238,6 +239,179 @@ func TestGenerate_RemovesRedundantPatch(t *testing.T) {
 	patchFile := filepath.Join(in.PatchDir, in.Name+".patch")
 	if _, err := os.Stat(patchFile); !os.IsNotExist(err) {
 		t.Errorf("expected stale patch to be removed; stat err=%v", err)
+	}
+}
+
+func TestExpectedVariantsIncludesZeroThroughNine(t *testing.T) {
+	regressDir := t.TempDir()
+	expectedDir := filepath.Join(regressDir, "expected")
+	if err := os.Mkdir(expectedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"variant.out", "variant_0.out", "variant_1.out", "variant_9.out", "variant_10.out"} {
+		if err := os.WriteFile(filepath.Join(expectedDir, name), []byte(name), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := expectedVariants(regressDir, "variant")
+	want := []string{
+		filepath.Join(expectedDir, "variant.out"),
+		filepath.Join(expectedDir, "variant_0.out"),
+		filepath.Join(expectedDir, "variant_1.out"),
+		filepath.Join(expectedDir, "variant_9.out"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expectedVariants() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expectedVariants()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestPreferExpectedVariant(t *testing.T) {
+	variants := []string{"/expected/xml.out", "/expected/xml_1.out", "/expected/xml_2.out"}
+	got, err := preferExpectedVariant(variants, "xml_1.out")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"/expected/xml_1.out", "/expected/xml.out", "/expected/xml_2.out"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("preferExpectedVariant()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if _, err := preferExpectedVariant(variants, "xml_9.out"); err == nil {
+		t.Fatal("missing preferred variant should fail")
+	}
+}
+
+func TestExpectedFileForPatchUsesExplicitVariant(t *testing.T) {
+	regressDir := t.TempDir()
+	expectedDir := filepath.Join(regressDir, "expected")
+	patchDir := filepath.Join(regressDir, "patches")
+	for _, dir := range []string{expectedDir, patchDir} {
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	canonical := filepath.Join(expectedDir, "xmlmap.out")
+	alternate := filepath.Join(expectedDir, "xmlmap_1.out")
+	for _, path := range []string{canonical, alternate} {
+		if err := os.WriteFile(path, []byte("expected\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	patch := "# no-libxml baseline\n# pgregress-expected-file: xmlmap_1.out\n--- a\n+++ b\n"
+	if err := os.WriteFile(filepath.Join(patchDir, "xmlmap.patch"), []byte(patch), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := expectedFileForPatch(regressDir, "xmlmap", patchDir, []string{canonical, alternate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != alternate {
+		t.Fatalf("expectedFileForPatch() = %q, want %q", got, alternate)
+	}
+}
+
+func TestExpectedFileForPatchRejectsInvalidMetadata(t *testing.T) {
+	regressDir := t.TempDir()
+	expectedDir := filepath.Join(regressDir, "expected")
+	patchDir := filepath.Join(regressDir, "patches")
+	for _, dir := range []string{expectedDir, patchDir} {
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	canonical := filepath.Join(expectedDir, "xml.out")
+	if err := os.WriteFile(canonical, []byte("expected\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	patch := "# pgregress-expected-file: ../xml_1.out\n--- a\n+++ b\n"
+	if err := os.WriteFile(filepath.Join(patchDir, "xml.patch"), []byte(patch), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := expectedFileForPatch(regressDir, "xml", patchDir, []string{canonical}); err == nil {
+		t.Fatal("expected invalid expected-file metadata to fail")
+	}
+}
+
+func TestVerifyWithPatchesAcceptsCoreAlternateExpected(t *testing.T) {
+	sourceDir := filepath.Join(t.TempDir(), "source")
+	regressDir := filepath.Join(sourceDir, "src", "test", "regress")
+	buildRegressDir := filepath.Join(t.TempDir(), "regress")
+	for _, dir := range []string{filepath.Join(regressDir, "expected"), filepath.Join(buildRegressDir, "results")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	const testName = "core_variant_unit"
+	if err := os.WriteFile(filepath.Join(regressDir, "expected", testName+".out"), []byte("canonical\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(regressDir, "expected", testName+"_1.out"), []byte("alternate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(buildRegressDir, "results", testName+".out"), []byte("alternate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(PatchModeEnv, string(PatchModeVerify))
+	pb := &PostgresBuilder{Builder: &pgbuilder.Builder{SourceDir: sourceDir}}
+	results := &TestResults{
+		TotalTests:  1,
+		FailedTests: 1,
+		Tests:       []IndividualTestResult{{Name: testName, Status: "fail"}},
+	}
+	if err := pb.VerifyWithPatches(t, t.Context(), results, buildRegressDir, t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	if results.PassedTests != 1 || results.FailedTests != 0 || results.Tests[0].PatchApplied {
+		t.Fatalf("alternate core output not accepted cleanly: %+v", results)
+	}
+}
+
+func TestMarkdownSummaryClassifiesCompatibilityResults(t *testing.T) {
+	pb := &PostgresBuilder{Builder: &pgbuilder.Builder{OutputDir: t.TempDir()}}
+	results := &TestResults{
+		TotalTests: 3,
+		Tests: []IndividualTestResult{
+			{Name: "stock", Status: "pass"},
+			{Name: "accepted", Status: "pass", PatchApplied: true, PatchPath: "accepted.patch"},
+			{Name: "residual", Status: "fail"},
+		},
+	}
+	summary, err := pb.WriteMarkdownSummary(t, []SuiteResult{{Name: "Regression Tests", Results: results}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"✅ upstream-compatible", "⚠️ accepted divergence", "❌ residual failure"} {
+		if !contains(summary, want) {
+			t.Fatalf("summary does not contain %q:\n%s", want, summary)
+		}
+	}
+}
+
+func TestMarkUpstreamCompatibleRemovesStalePatchInGenerateMode(t *testing.T) {
+	patchDir := t.TempDir()
+	patchPath := filepath.Join(patchDir, "variant.patch")
+	if err := os.WriteFile(patchPath, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	test := &IndividualTestResult{Name: "variant", Status: "fail", PatchApplied: true, PatchPath: patchPath, FailReason: "old"}
+
+	markUpstreamCompatible(test, patchDir, PatchModeGenerate)
+
+	if test.Status != "pass" || test.PatchApplied || test.PatchPath != "" || test.FailReason != "" {
+		t.Fatalf("markUpstreamCompatible() left stale state: %+v", test)
+	}
+	if _, err := os.Stat(patchPath); !os.IsNotExist(err) {
+		t.Fatalf("stale patch was not removed: %v", err)
 	}
 }
 

--- a/go/test/endtoend/pgregresstest/pg_regress.go
+++ b/go/test/endtoend/pgregresstest/pg_regress.go
@@ -448,23 +448,27 @@ func (pb *PostgresBuilder) verifyModuleResults(ctx context.Context, expectedDir,
 			continue
 		}
 
-		if actualMatchesAnyVariant(actPath, variants) {
-			test.Status = "pass"
-			test.PatchApplied = false
-			test.PatchPath = ""
-			test.FailReason = ""
-			// A patch is unnecessary once a stock variant matches; drop a stale one.
-			if mode == PatchModeGenerate {
-				_ = os.Remove(filepath.Join(patchDir, test.Name+".patch"))
-			}
+		// A TAP pass is pg_regress's authoritative verdict and may come from a
+		// resultmap entry that is not named like a numbered variant. Otherwise,
+		// repeat the comparison after the patch pipeline's whitespace
+		// normalization so harmless caret-position shifts still pass unpatched.
+		if test.Status == "pass" || actualMatchesAnyVariant(actPath, variants) {
+			markUpstreamCompatible(test, patchDir, mode)
 			continue
 		}
 
-		// No variant matches: apply (verify) or write (generate) a patch against
-		// the canonical expected file for genuine multigres-specific differences.
+		// No stock output matches: apply the reviewed Multigres patch against its
+		// declared upstream base (canonical unless the patch preamble says
+		// otherwise).
+		expPath, err := expectedFileForPatch(expectedDir, test.Name, patchDir, variants)
+		if err != nil {
+			test.Status = "fail"
+			test.FailReason = err.Error()
+			continue
+		}
 		outcome, err := VerifyTest(ctx, VerifyInput{
 			Name:         test.Name,
-			ExpectedPath: variants[0],
+			ExpectedPath: expPath,
 			ActualPath:   actPath,
 			PatchDir:     patchDir,
 			RepoRoot:     repoRoot,
@@ -482,23 +486,117 @@ func (pb *PostgresBuilder) verifyModuleResults(ctx context.Context, expectedDir,
 	}
 }
 
-// expectedVariants returns the expected-output files pg_regress would accept for
-// a test: the canonical <name>.out first, then numbered variants
-// <name>_1.out … <name>_9.out that exist. Mirrors findExpectedFile's search but
-// returns every match rather than only the first.
+// expectedVariants returns the canonical expected output followed by numbered
+// alternatives. PostgreSQL's results_differ() checks suffixes _0 through _9.
+// Non-numbered resultmap selections are covered by preserving pg_regress's TAP
+// pass verdict before this helper is consulted.
 func expectedVariants(regressDir, name string) []string {
 	var out []string
 	canonical := filepath.Join(regressDir, "expected", name+".out")
 	if suiteutil.FileExists(canonical) {
 		out = append(out, canonical)
 	}
-	for i := 1; i < 10; i++ {
+	for i := range 10 {
 		p := filepath.Join(regressDir, "expected", fmt.Sprintf("%s_%d.out", name, i))
 		if suiteutil.FileExists(p) {
 			out = append(out, p)
 		}
 	}
 	return out
+}
+
+const expectedFileDirective = "# pgregress-expected-file:"
+
+// corePreferredExpectedFiles records build-specific bases for residual diffs.
+// The pinned core build intentionally omits --with-libxml, so PostgreSQL's
+// no-libxml alternatives are the correct comparison files. Exact matching still
+// checks every variant before this preference matters.
+var corePreferredExpectedFiles = map[string]string{
+	"xml":    "xml_1.out",
+	"xmlmap": "xmlmap_1.out",
+}
+
+func preferExpectedVariant(variants []string, filename string) ([]string, error) {
+	if filename == "" {
+		return variants, nil
+	}
+	for i, variant := range variants {
+		if filepath.Base(variant) != filename {
+			continue
+		}
+		if i == 0 {
+			return variants, nil
+		}
+		out := make([]string, 0, len(variants))
+		out = append(out, variant)
+		out = append(out, variants[:i]...)
+		out = append(out, variants[i+1:]...)
+		return out, nil
+	}
+	return nil, fmt.Errorf("preferred expected file %q does not exist", filename)
+}
+
+// expectedFileForPatch returns the upstream file a reviewed patch is based on.
+// Most patches use canonical output. Platform/build-specific patches can name a
+// different file in their comment preamble, for example:
+//
+//	# pgregress-expected-file: xml_1.out
+//
+// Keeping this choice explicit avoids picking a patch base from whichever
+// candidate happens to produce the shortest diff on a particular run.
+func expectedFileForPatch(regressDir, name, patchDir string, variants []string) (string, error) {
+	if len(variants) == 0 {
+		return "", fmt.Errorf("no expected output found for %s", name)
+	}
+
+	patchPath := filepath.Join(patchDir, name+".patch")
+	raw, err := os.ReadFile(patchPath)
+	if os.IsNotExist(err) {
+		return variants[0], nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read patch metadata %q: %w", patchPath, err)
+	}
+
+	comment, _ := suiteutil.SplitPatchComment(raw)
+	var selected string
+	foundDirective := false
+	for line := range strings.SplitSeq(string(comment), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, expectedFileDirective) {
+			continue
+		}
+		if foundDirective {
+			return "", fmt.Errorf("patch %q has multiple %s directives", patchPath, expectedFileDirective)
+		}
+		foundDirective = true
+		selected = strings.TrimSpace(strings.TrimPrefix(line, expectedFileDirective))
+	}
+	if !foundDirective {
+		return variants[0], nil
+	}
+	if selected == "" {
+		return "", fmt.Errorf("patch %q has an empty %s directive", patchPath, expectedFileDirective)
+	}
+	if filepath.Base(selected) != selected || filepath.Ext(selected) != ".out" {
+		return "", fmt.Errorf("patch %q has invalid expected file %q", patchPath, selected)
+	}
+
+	expectedPath := filepath.Join(regressDir, "expected", selected)
+	if !suiteutil.FileExists(expectedPath) {
+		return "", fmt.Errorf("patch %q selects missing expected file %q", patchPath, selected)
+	}
+	return expectedPath, nil
+}
+
+func markUpstreamCompatible(test *IndividualTestResult, patchDir string, mode PatchMode) {
+	test.Status = "pass"
+	test.PatchApplied = false
+	test.PatchPath = ""
+	test.FailReason = ""
+	if mode == PatchModeGenerate {
+		_ = os.Remove(filepath.Join(patchDir, test.Name+".patch"))
+	}
 }
 
 // actualMatchesAnyVariant reports whether the actual output equals any expected
@@ -522,29 +620,12 @@ func actualMatchesAnyVariant(actPath string, variants []string) bool {
 	return false
 }
 
-// findExpectedFile locates the expected-output file pg_regress would use for
-// the given test name. PostgreSQL ships variant files (name_1.out, name_2.out,
-// …) for platform-dependent output. We try the canonical name first, then
-// numbered variants in order. Returns the empty string if none exist.
-func findExpectedFile(regressDir, name string) string {
-	canonical := filepath.Join(regressDir, "expected", name+".out")
-	if suiteutil.FileExists(canonical) {
-		return canonical
-	}
-	for i := 1; i < 10; i++ {
-		p := filepath.Join(regressDir, "expected", fmt.Sprintf("%s_%d.out", name, i))
-		if suiteutil.FileExists(p) {
-			return p
-		}
-	}
-	return ""
-}
-
 // VerifyWithPatches re-evaluates each test's pass/fail status using the
-// patch-based pipeline (see patch_verify.go). After pg_regress runs, this
-// ignores pg_regress's own pass/fail verdict (which is a strict text diff)
-// and replaces it with: does the actual output match the (patched) expected
-// output? Results are updated in-place, including aggregate counters.
+// patch-based pipeline (see patch_verify.go). A pg_regress pass remains
+// authoritative because it may have matched resultmap or a numbered upstream
+// variant. Raw failures are replaced with: does the actual output match any
+// normalized stock variant, or the reviewed patched expected output? Results
+// are updated in-place, including aggregate counters.
 //
 // In generate mode, any residual diffs are absorbed by (re)writing patches.
 //
@@ -590,9 +671,14 @@ func (pb *PostgresBuilder) VerifyWithPatches(t *testing.T, ctx context.Context, 
 			continue
 		}
 
-		expPath := findExpectedFile(sourceRegressDir, test.Name)
+		variants := expectedVariants(sourceRegressDir, test.Name)
+		var err error
+		variants, err = preferExpectedVariant(variants, corePreferredExpectedFiles[test.Name])
+		if err != nil {
+			return fmt.Errorf("select preferred expected output for %s: %w", test.Name, err)
+		}
 		actPath := filepath.Join(buildRegressDir, "results", test.Name+".out")
-		if expPath == "" || !suiteutil.FileExists(actPath) {
+		if len(variants) == 0 || !suiteutil.FileExists(actPath) {
 			// Infrastructure problem (test didn't run, expected missing).
 			// Preserve TAP verdict, count accordingly.
 			test.FailReason = "expected or actual output missing; kept TAP verdict"
@@ -608,6 +694,19 @@ func (pb *PostgresBuilder) VerifyWithPatches(t *testing.T, ctx context.Context, 
 			continue
 		}
 
+		// pg_regress already accepts resultmap and numbered alternatives. Keep a
+		// raw TAP pass authoritative, and also allow the patch pipeline's
+		// whitespace-normalized comparison against every numbered variant.
+		if test.Status == "pass" || actualMatchesAnyVariant(actPath, variants) {
+			markUpstreamCompatible(test, patchDir, mode)
+			passed++
+			continue
+		}
+
+		expPath, err := expectedFileForPatch(sourceRegressDir, test.Name, patchDir, variants)
+		if err != nil {
+			return fmt.Errorf("select expected output for %s: %w", test.Name, err)
+		}
 		outcome, err := VerifyTest(ctx, VerifyInput{
 			Name:         test.Name,
 			ExpectedPath: expPath,

--- a/go/test/endtoend/pgregresstest/report.go
+++ b/go/test/endtoend/pgregresstest/report.go
@@ -107,12 +107,16 @@ func (pb *PostgresBuilder) WriteMarkdownSummary(t *testing.T, suites []SuiteResu
 		sb.WriteString("|---|------|--------|-------|----------|\n")
 
 		for i, test := range s.Results.Tests {
-			status := "✅ ok"
+			status := "✅ upstream-compatible"
 			switch test.Status {
 			case "fail":
-				status = "❌ FAIL"
+				status = "❌ residual failure"
 			case "skip":
 				status = "⏭️ skip"
+			default:
+				if test.PatchApplied {
+					status = "⚠️ accepted divergence"
+				}
 			}
 			duration := test.Duration
 			if duration == "" {

--- a/go/test/endtoend/pgregresstest/report.go
+++ b/go/test/endtoend/pgregresstest/report.go
@@ -107,7 +107,7 @@ func (pb *PostgresBuilder) WriteMarkdownSummary(t *testing.T, suites []SuiteResu
 		sb.WriteString("|---|------|--------|-------|----------|\n")
 
 		for i, test := range s.Results.Tests {
-			status := "✅ upstream-compatible"
+			status := "✅ compatible"
 			switch test.Status {
 			case "fail":
 				status = "❌ residual failure"
@@ -115,7 +115,7 @@ func (pb *PostgresBuilder) WriteMarkdownSummary(t *testing.T, suites []SuiteResu
 				status = "⏭️ skip"
 			default:
 				if test.PatchApplied {
-					status = "⚠️ accepted divergence"
+					status = "✅ accepted divergence"
 				}
 			}
 			duration := test.Duration

--- a/go/test/endtoend/pgregresstest/testdata/pg17/README.md
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/README.md
@@ -4,7 +4,9 @@ This directory holds **per-test patches** that describe known-acceptable
 differences between PostgreSQL 17's upstream expected output and multigres's
 actual output. The regress and isolation runners apply these patches to the
 upstream `expected/<name>.out` before comparing against the actual
-`results/<name>.out`.
+`results/<name>.out`. PostgreSQL's stock numbered alternatives are checked
+first, so a matching `_0.out` through `_9.out` is an upstream-compatible pass
+and needs no patch.
 
 ## Layout
 
@@ -23,6 +25,20 @@ produces a differently-worded error message, or emits fewer error-context
 lines than Postgres. Patches must not absorb real regressions (wrong result
 rows, flipped success/error, changed column types). The reviewer's job is to
 inspect each patch like any other diff.
+
+Every intentional security/safety divergence must have a comment preamble that
+names the blocked capability and explains any directly dependent output. When
+a patch is based on a non-canonical upstream file, declare it explicitly:
+
+```text
+# pgregress-expected-file: xml_1.out
+```
+
+Verification fails if that file is missing or the directive is malformed. This
+keeps patch generation deterministic instead of choosing whichever expected
+file happens to produce the shortest diff. Core `xml` and `xmlmap` also have
+explicit no-libxml preferences in the verifier so residual diffs use `_1.out`
+even when no patch exists.
 
 ## Workflow
 
@@ -55,6 +71,12 @@ Each test gets three columns in `results.json`:
 | `status`        | `pass` or `fail`                                  |
 | `patch_applied` | `true` if a patch was used to make expected match |
 | `patch_path`    | relative path to the patch file (empty if none)   |
+
+Together these fields classify every result:
+
+- `pass` without a patch: upstream-compatible.
+- `pass` with a patch: accepted Multigres divergence.
+- `fail`: genuine residual failure (possibly after an accepted narrow patch).
 
 ## When to delete a patch
 

--- a/go/test/endtoend/pgregresstest/testdata/pg17/README.md
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/README.md
@@ -5,7 +5,7 @@ differences between PostgreSQL 17's upstream expected output and multigres's
 actual output. The regress and isolation runners apply these patches to the
 upstream `expected/<name>.out` before comparing against the actual
 `results/<name>.out`. PostgreSQL's stock numbered alternatives are checked
-first, so a matching `_0.out` through `_9.out` is an upstream-compatible pass
+first, so a matching `_0.out` through `_9.out` is a compatible pass
 and needs no patch.
 
 ## Layout
@@ -74,8 +74,8 @@ Each test gets three columns in `results.json`:
 
 Together these fields classify every result:
 
-- `pass` without a patch: upstream-compatible.
-- `pass` with a patch: accepted Multigres divergence.
+- `pass` without a patch: compatible.
+- `pass` with a patch: accepted Multigres divergence (also shown as passed).
 - `fail`: genuine residual failure (possibly after an accepted narrow patch).
 
 ## When to delete a patch

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/database.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/database.patch
@@ -1,3 +1,8 @@
+# Accepted safety divergence: Multigres exposes one topology-managed database
+# per multipooler and rejects CREATE/DROP DATABASE through pooled client
+# connections. The following missing-database errors are direct fallout from
+# the blocked CREATE. Database lifecycle remains an administrative operation.
+# See go/services/multigateway/planner/unsafe_stmt.go.
 --- a
 +++ b
 @@ -1,9 +1,14 @@

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/foreign_data.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/foreign_data.patch
@@ -1,0 +1,2377 @@
+# Accepted security divergence: Multigres blocks CREATE FOREIGN DATA WRAPPER
+# and CREATE SERVER so pooled clients cannot establish arbitrary outbound server
+# connections. The missing wrappers/servers/tables and their catalog/cleanup
+# output are direct consequences. Missing regression roles are excluded and
+# remain residual database-setup failures.
+# See go/services/multigateway/planner/unsafe_stmt.go.
+--- a
++++ b
+@@ -22,15 +22,16 @@
+ CREATE ROLE regress_test_indirect;
+ CREATE ROLE regress_unprivileged_role;
+ CREATE FOREIGN DATA WRAPPER dummy;
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+ COMMENT ON FOREIGN DATA WRAPPER dummy IS 'useless';
++ERROR: foreign-data wrapper "dummy" does not exist
+ CREATE FOREIGN DATA WRAPPER postgresql VALIDATOR postgresql_fdw_validator;
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+ -- At this point we should have 2 built-in wrappers and no servers.
+ SELECT fdwname, fdwhandler::regproc, fdwvalidator::regproc, fdwoptions FROM pg_foreign_data_wrapper ORDER BY 1, 2, 3;
+ fdwname | fdwhandler | fdwvalidator | fdwoptions
+-------------+------------+--------------------------+------------
+-dummy | - | - |
+-postgresql | - | postgresql_fdw_validator |
+-(2 rows)
++---------+------------+--------------+------------
++(0 rows)
+ 
+ SELECT srvname, srvoptions FROM pg_foreign_server;
+ srvname | srvoptions
+@@ -44,125 +45,111 @@
+ 
+ -- CREATE FOREIGN DATA WRAPPER
+ CREATE FOREIGN DATA WRAPPER foo VALIDATOR bar; -- ERROR
+-ERROR: function bar(text[], oid) does not exist
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+ CREATE FOREIGN DATA WRAPPER foo;
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+ \dew
+ List of foreign-data wrappers
+ Name | Owner | Handler | Validator
+-------------+---------------------------+---------+--------------------------
+-dummy | regress_foreign_data_user | - | -
+-foo | regress_foreign_data_user | - | -
+-postgresql | regress_foreign_data_user | - | postgresql_fdw_validator
+-(3 rows)
++------+-------+---------+-----------
++(0 rows)
+ 
+ CREATE FOREIGN DATA WRAPPER foo; -- duplicate
+-ERROR: foreign-data wrapper "foo" already exists
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+ DROP FOREIGN DATA WRAPPER foo;
++ERROR: foreign-data wrapper "foo" does not exist
+ CREATE FOREIGN DATA WRAPPER foo OPTIONS (testing '1');
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+ \dew+
+ List of foreign-data wrappers
+ Name | Owner | Handler | Validator | Access privileges | FDW options | Description
+-------------+---------------------------+---------+--------------------------+-------------------+---------------+-------------
+-dummy | regress_foreign_data_user | - | - | | | useless
+-foo | regress_foreign_data_user | - | - | | (testing '1') |
+-postgresql | regress_foreign_data_user | - | postgresql_fdw_validator | | |
+-(3 rows)
++------+-------+---------+-----------+-------------------+-------------+-------------
++(0 rows)
+ 
+ DROP FOREIGN DATA WRAPPER foo;
++ERROR: foreign-data wrapper "foo" does not exist
+ CREATE FOREIGN DATA WRAPPER foo OPTIONS (testing '1', testing '2'); -- ERROR
+-ERROR: option "testing" provided more than once
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+ CREATE FOREIGN DATA WRAPPER foo OPTIONS (testing '1', another '2');
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+ \dew+
+ List of foreign-data wrappers
+ Name | Owner | Handler | Validator | Access privileges | FDW options | Description
+-------------+---------------------------+---------+--------------------------+-------------------+----------------------------+-------------
+-dummy | regress_foreign_data_user | - | - | | | useless
+-foo | regress_foreign_data_user | - | - | | (testing '1', another '2') |
+-postgresql | regress_foreign_data_user | - | postgresql_fdw_validator | | |
+-(3 rows)
++------+-------+---------+-----------+-------------------+-------------+-------------
++(0 rows)
+ 
+ DROP FOREIGN DATA WRAPPER foo;
++ERROR: foreign-data wrapper "foo" does not exist
+ SET ROLE regress_test_role;
+ CREATE FOREIGN DATA WRAPPER foo; -- ERROR
+-ERROR: permission denied to create foreign-data wrapper "foo"
+-HINT: Must be superuser to create a foreign-data wrapper.
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+ RESET ROLE;
+ CREATE FOREIGN DATA WRAPPER foo VALIDATOR postgresql_fdw_validator;
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+ \dew+
+ List of foreign-data wrappers
+ Name | Owner | Handler | Validator | Access privileges | FDW options | Description
+-------------+---------------------------+---------+--------------------------+-------------------+-------------+-------------
+-dummy | regress_foreign_data_user | - | - | | | useless
+-foo | regress_foreign_data_user | - | postgresql_fdw_validator | | |
+-postgresql | regress_foreign_data_user | - | postgresql_fdw_validator | | |
+-(3 rows)
++------+-------+---------+-----------+-------------------+-------------+-------------
++(0 rows)
+ 
+ -- HANDLER related checks
+ CREATE FUNCTION invalid_fdw_handler() RETURNS int LANGUAGE SQL AS 'SELECT 1;';
+ CREATE FOREIGN DATA WRAPPER test_fdw HANDLER invalid_fdw_handler; -- ERROR
+-ERROR: function invalid_fdw_handler must return type fdw_handler
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+ CREATE FOREIGN DATA WRAPPER test_fdw HANDLER test_fdw_handler HANDLER invalid_fdw_handler; -- ERROR
+-ERROR: conflicting or redundant options
+-LINE 1: ...GN DATA WRAPPER test_fdw HANDLER test_fdw_handler HANDLER in...
+-^
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+ CREATE FOREIGN DATA WRAPPER test_fdw HANDLER test_fdw_handler;
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+ DROP FOREIGN DATA WRAPPER test_fdw;
++ERROR: foreign-data wrapper "test_fdw" does not exist
+ -- ALTER FOREIGN DATA WRAPPER
+ ALTER FOREIGN DATA WRAPPER foo OPTIONS (nonexistent 'fdw'); -- ERROR
+-ERROR: invalid option "nonexistent"
+-HINT: There are no valid options in this context.
++ERROR: foreign-data wrapper "foo" does not exist
+ ALTER FOREIGN DATA WRAPPER foo; -- ERROR
+ ERROR: syntax error at or near ";"
+ LINE 1: ALTER FOREIGN DATA WRAPPER foo;
+ ^
+ ALTER FOREIGN DATA WRAPPER foo VALIDATOR bar; -- ERROR
+-ERROR: function bar(text[], oid) does not exist
++ERROR: foreign-data wrapper "foo" does not exist
+ ALTER FOREIGN DATA WRAPPER foo NO VALIDATOR;
++ERROR: foreign-data wrapper "foo" does not exist
+ \dew+
+ List of foreign-data wrappers
+ Name | Owner | Handler | Validator | Access privileges | FDW options | Description
+-------------+---------------------------+---------+--------------------------+-------------------+-------------+-------------
+-dummy | regress_foreign_data_user | - | - | | | useless
+-foo | regress_foreign_data_user | - | - | | |
+-postgresql | regress_foreign_data_user | - | postgresql_fdw_validator | | |
+-(3 rows)
++------+-------+---------+-----------+-------------------+-------------+-------------
++(0 rows)
+ 
+ ALTER FOREIGN DATA WRAPPER foo OPTIONS (a '1', b '2');
++ERROR: foreign-data wrapper "foo" does not exist
+ ALTER FOREIGN DATA WRAPPER foo OPTIONS (SET c '4'); -- ERROR
+-ERROR: option "c" not found
++ERROR: foreign-data wrapper "foo" does not exist
+ ALTER FOREIGN DATA WRAPPER foo OPTIONS (DROP c); -- ERROR
+-ERROR: option "c" not found
++ERROR: foreign-data wrapper "foo" does not exist
+ ALTER FOREIGN DATA WRAPPER foo OPTIONS (ADD x '1', DROP x);
++ERROR: foreign-data wrapper "foo" does not exist
+ \dew+
+ List of foreign-data wrappers
+ Name | Owner | Handler | Validator | Access privileges | FDW options | Description
+-------------+---------------------------+---------+--------------------------+-------------------+----------------+-------------
+-dummy | regress_foreign_data_user | - | - | | | useless
+-foo | regress_foreign_data_user | - | - | | (a '1', b '2') |
+-postgresql | regress_foreign_data_user | - | postgresql_fdw_validator | | |
+-(3 rows)
++------+-------+---------+-----------+-------------------+-------------+-------------
++(0 rows)
+ 
+ ALTER FOREIGN DATA WRAPPER foo OPTIONS (DROP a, SET b '3', ADD c '4');
++ERROR: foreign-data wrapper "foo" does not exist
+ \dew+
+ List of foreign-data wrappers
+ Name | Owner | Handler | Validator | Access privileges | FDW options | Description
+-------------+---------------------------+---------+--------------------------+-------------------+----------------+-------------
+-dummy | regress_foreign_data_user | - | - | | | useless
+-foo | regress_foreign_data_user | - | - | | (b '3', c '4') |
+-postgresql | regress_foreign_data_user | - | postgresql_fdw_validator | | |
+-(3 rows)
++------+-------+---------+-----------+-------------------+-------------+-------------
++(0 rows)
+ 
+ ALTER FOREIGN DATA WRAPPER foo OPTIONS (a '2');
++ERROR: foreign-data wrapper "foo" does not exist
+ ALTER FOREIGN DATA WRAPPER foo OPTIONS (b '4'); -- ERROR
+-ERROR: option "b" provided more than once
++ERROR: foreign-data wrapper "foo" does not exist
+ \dew+
+ List of foreign-data wrappers
+ Name | Owner | Handler | Validator | Access privileges | FDW options | Description
+-------------+---------------------------+---------+--------------------------+-------------------+-----------------------+-------------
+-dummy | regress_foreign_data_user | - | - | | | useless
+-foo | regress_foreign_data_user | - | - | | (b '3', c '4', a '2') |
+-postgresql | regress_foreign_data_user | - | postgresql_fdw_validator | | |
+-(3 rows)
++------+-------+---------+-----------+-------------------+-------------+-------------
++(0 rows)
+ 
+ SET ROLE regress_test_role;
+ ALTER FOREIGN DATA WRAPPER foo OPTIONS (ADD d '5'); -- ERROR
+@@ -170,19 +157,17 @@
+ HINT: Must be superuser to alter a foreign-data wrapper.
+ SET ROLE regress_test_role_super;
+ ALTER FOREIGN DATA WRAPPER foo OPTIONS (ADD d '5');
++ERROR: foreign-data wrapper "foo" does not exist
+ \dew+
+ List of foreign-data wrappers
+ Name | Owner | Handler | Validator | Access privileges | FDW options | Description
+-------------+---------------------------+---------+--------------------------+-------------------+------------------------------+-------------
+-dummy | regress_foreign_data_user | - | - | | | useless
+-foo | regress_foreign_data_user | - | - | | (b '3', c '4', a '2', d '5') |
+-postgresql | regress_foreign_data_user | - | postgresql_fdw_validator | | |
+-(3 rows)
++------+-------+---------+-----------+-------------------+-------------+-------------
++(0 rows)
+ 
+ ALTER FOREIGN DATA WRAPPER foo OWNER TO regress_test_role; -- ERROR
+-ERROR: permission denied to change owner of foreign-data wrapper "foo"
+-HINT: The owner of a foreign-data wrapper must be a superuser.
++ERROR: foreign-data wrapper "foo" does not exist
+ ALTER FOREIGN DATA WRAPPER foo OWNER TO regress_test_role_super;
++ERROR: foreign-data wrapper "foo" does not exist
+ ALTER ROLE regress_test_role_super NOSUPERUSER;
+ SET ROLE regress_test_role_super;
+ ALTER FOREIGN DATA WRAPPER foo OPTIONS (ADD e '6'); -- ERROR
+@@ -192,32 +177,26 @@
+ \dew+
+ List of foreign-data wrappers
+ Name | Owner | Handler | Validator | Access privileges | FDW options | Description
+-------------+---------------------------+---------+--------------------------+-------------------+------------------------------+-------------
+-dummy | regress_foreign_data_user | - | - | | | useless
+-foo | regress_test_role_super | - | - | | (b '3', c '4', a '2', d '5') |
+-postgresql | regress_foreign_data_user | - | postgresql_fdw_validator | | |
+-(3 rows)
++------+-------+---------+-----------+-------------------+-------------+-------------
++(0 rows)
+ 
+ ALTER FOREIGN DATA WRAPPER foo RENAME TO foo1;
++ERROR: foreign-data wrapper "foo" does not exist
+ \dew+
+ List of foreign-data wrappers
+ Name | Owner | Handler | Validator | Access privileges | FDW options | Description
+-------------+---------------------------+---------+--------------------------+-------------------+------------------------------+-------------
+-dummy | regress_foreign_data_user | - | - | | | useless
+-foo1 | regress_test_role_super | - | - | | (b '3', c '4', a '2', d '5') |
+-postgresql | regress_foreign_data_user | - | postgresql_fdw_validator | | |
+-(3 rows)
++------+-------+---------+-----------+-------------------+-------------+-------------
++(0 rows)
+ 
+ ALTER FOREIGN DATA WRAPPER foo1 RENAME TO foo;
++ERROR: foreign-data wrapper "foo1" does not exist
+ -- HANDLER related checks
+ ALTER FOREIGN DATA WRAPPER foo HANDLER invalid_fdw_handler; -- ERROR
+-ERROR: function invalid_fdw_handler must return type fdw_handler
++ERROR: foreign-data wrapper "foo" does not exist
+ ALTER FOREIGN DATA WRAPPER foo HANDLER test_fdw_handler HANDLER anything; -- ERROR
+-ERROR: conflicting or redundant options
+-LINE 1: ...FOREIGN DATA WRAPPER foo HANDLER test_fdw_handler HANDLER an...
+-^
++ERROR: foreign-data wrapper "foo" does not exist
+ ALTER FOREIGN DATA WRAPPER foo HANDLER test_fdw_handler;
+-WARNING: changing the foreign-data wrapper handler can change behavior of existing foreign tables
++ERROR: foreign-data wrapper "foo" does not exist
+ DROP FUNCTION invalid_fdw_handler();
+ -- DROP FOREIGN DATA WRAPPER
+ DROP FOREIGN DATA WRAPPER nonexistent; -- ERROR
+@@ -227,78 +206,38 @@
+ \dew+
+ List of foreign-data wrappers
+ Name | Owner | Handler | Validator | Access privileges | FDW options | Description
+-------------+---------------------------+------------------+--------------------------+-------------------+------------------------------+-------------
+-dummy | regress_foreign_data_user | - | - | | | useless
+-foo | regress_test_role_super | test_fdw_handler | - | | (b '3', c '4', a '2', d '5') |
+-postgresql | regress_foreign_data_user | - | postgresql_fdw_validator | | |
+-(3 rows)
++------+-------+---------+-----------+-------------------+-------------+-------------
++(0 rows)
+ 
+ DROP ROLE regress_test_role_super; -- ERROR
+-ERROR: role "regress_test_role_super" cannot be dropped because some objects depend on it
+-DETAIL: owner of foreign-data wrapper foo
+ SET ROLE regress_test_role_super;
+ DROP FOREIGN DATA WRAPPER foo;
++ERROR: foreign-data wrapper "foo" does not exist
+ RESET ROLE;
+ DROP ROLE regress_test_role_super;
+ \dew+
+ List of foreign-data wrappers
+ Name | Owner | Handler | Validator | Access privileges | FDW options | Description
+-------------+---------------------------+---------+--------------------------+-------------------+-------------+-------------
+-dummy | regress_foreign_data_user | - | - | | | useless
+-postgresql | regress_foreign_data_user | - | postgresql_fdw_validator | | |
+-(2 rows)
++------+-------+---------+-----------+-------------------+-------------+-------------
++(0 rows)
+ 
+ CREATE FOREIGN DATA WRAPPER foo;
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+ CREATE SERVER s1 FOREIGN DATA WRAPPER foo;
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
+ COMMENT ON SERVER s1 IS 'foreign server';
++ERROR: server "s1" does not exist
+ CREATE USER MAPPING FOR current_user SERVER s1;
++ERROR: server "s1" does not exist
+ CREATE USER MAPPING FOR current_user SERVER s1; -- ERROR
+-ERROR: user mapping for "regress_foreign_data_user" already exists for server "s1"
++ERROR: server "s1" does not exist
+ CREATE USER MAPPING IF NOT EXISTS FOR current_user SERVER s1; -- NOTICE
+-NOTICE: user mapping for "regress_foreign_data_user" already exists for server "s1", skipping
++ERROR: server "s1" does not exist
+ \dew+
+ List of foreign-data wrappers
+ Name | Owner | Handler | Validator | Access privileges | FDW options | Description
+-------------+---------------------------+---------+--------------------------+-------------------+-------------+-------------
+-dummy | regress_foreign_data_user | - | - | | | useless
+-foo | regress_foreign_data_user | - | - | | |
+-postgresql | regress_foreign_data_user | - | postgresql_fdw_validator | | |
+-(3 rows)
+-
+-\des+
+-List of foreign servers
+-Name | Owner | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description
+-------+---------------------------+----------------------+-------------------+------+---------+-------------+----------------
+-s1 | regress_foreign_data_user | foo | | | | | foreign server
+-(1 row)
+-
+-\deu+
+-List of user mappings
+-Server | User name | FDW options
+---------+---------------------------+-------------
+-s1 | regress_foreign_data_user |
+-(1 row)
+-
+-DROP FOREIGN DATA WRAPPER foo; -- ERROR
+-ERROR: cannot drop foreign-data wrapper foo because other objects depend on it
+-DETAIL: server s1 depends on foreign-data wrapper foo
+-user mapping for regress_foreign_data_user on server s1 depends on server s1
+-HINT: Use DROP ... CASCADE to drop the dependent objects too.
+-SET ROLE regress_test_role;
+-DROP FOREIGN DATA WRAPPER foo CASCADE; -- ERROR
+-ERROR: must be owner of foreign-data wrapper foo
+-RESET ROLE;
+-DROP FOREIGN DATA WRAPPER foo CASCADE;
+-NOTICE: drop cascades to 2 other objects
+-DETAIL: drop cascades to server s1
+-drop cascades to user mapping for regress_foreign_data_user on server s1
+-\dew+
+-List of foreign-data wrappers
+-Name | Owner | Handler | Validator | Access privileges | FDW options | Description
+-------------+---------------------------+---------+--------------------------+-------------------+-------------+-------------
+-dummy | regress_foreign_data_user | - | - | | | useless
+-postgresql | regress_foreign_data_user | - | postgresql_fdw_validator | | |
+-(2 rows)
++------+-------+---------+-----------+-------------------+-------------+-------------
++(0 rows)
+ 
+ \des+
+ List of foreign servers
+@@ -312,85 +251,98 @@
+ --------+-----------+-------------
+ (0 rows)
+ 
+--- exercise CREATE SERVER
+-CREATE SERVER s1 FOREIGN DATA WRAPPER foo; -- ERROR
+-ERROR: foreign-data wrapper "foo" does not exist
+-CREATE FOREIGN DATA WRAPPER foo OPTIONS ("test wrapper" 'true');
+-CREATE SERVER s1 FOREIGN DATA WRAPPER foo;
+-CREATE SERVER s1 FOREIGN DATA WRAPPER foo; -- ERROR
+-ERROR: server "s1" already exists
+-CREATE SERVER IF NOT EXISTS s1 FOREIGN DATA WRAPPER foo; -- No ERROR, just NOTICE
+-NOTICE: server "s1" already exists, skipping
+-CREATE SERVER s2 FOREIGN DATA WRAPPER foo OPTIONS (host 'a', dbname 'b');
+-CREATE SERVER s3 TYPE 'oracle' FOREIGN DATA WRAPPER foo;
+-CREATE SERVER s4 TYPE 'oracle' FOREIGN DATA WRAPPER foo OPTIONS (host 'a', dbname 'b');
+-CREATE SERVER s5 VERSION '15.0' FOREIGN DATA WRAPPER foo;
+-CREATE SERVER s6 VERSION '16.0' FOREIGN DATA WRAPPER foo OPTIONS (host 'a', dbname 'b');
+-CREATE SERVER s7 TYPE 'oracle' VERSION '17.0' FOREIGN DATA WRAPPER foo OPTIONS (host 'a', dbname 'b');
+-CREATE SERVER s8 FOREIGN DATA WRAPPER postgresql OPTIONS (foo '1'); -- ERROR
+-ERROR: invalid option "foo"
+-CREATE SERVER s8 FOREIGN DATA WRAPPER postgresql OPTIONS (host 'localhost', dbname 's8db');
++DROP FOREIGN DATA WRAPPER foo; -- ERROR
++ERROR: foreign-data wrapper "foo" does not exist
++SET ROLE regress_test_role;
++DROP FOREIGN DATA WRAPPER foo CASCADE; -- ERROR
++ERROR: foreign-data wrapper "foo" does not exist
++RESET ROLE;
++DROP FOREIGN DATA WRAPPER foo CASCADE;
++ERROR: foreign-data wrapper "foo" does not exist
++\dew+
++List of foreign-data wrappers
++Name | Owner | Handler | Validator | Access privileges | FDW options | Description
++------+-------+---------+-----------+-------------------+-------------+-------------
++(0 rows)
++
+ \des+
+ List of foreign servers
+ Name | Owner | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description
+-------+---------------------------+----------------------+-------------------+--------+---------+-----------------------------------+-------------
+-s1 | regress_foreign_data_user | foo | | | | |
+-s2 | regress_foreign_data_user | foo | | | | (host 'a', dbname 'b') |
+-s3 | regress_foreign_data_user | foo | | oracle | | |
+-s4 | regress_foreign_data_user | foo | | oracle | | (host 'a', dbname 'b') |
+-s5 | regress_foreign_data_user | foo | | | 15.0 | |
+-s6 | regress_foreign_data_user | foo | | | 16.0 | (host 'a', dbname 'b') |
+-s7 | regress_foreign_data_user | foo | | oracle | 17.0 | (host 'a', dbname 'b') |
+-s8 | regress_foreign_data_user | postgresql | | | | (host 'localhost', dbname 's8db') |
+-(8 rows)
+-
+-SET ROLE regress_test_role;
+-CREATE SERVER t1 FOREIGN DATA WRAPPER foo; -- ERROR: no usage on FDW
+-ERROR: permission denied for foreign-data wrapper foo
+-RESET ROLE;
+-GRANT USAGE ON FOREIGN DATA WRAPPER foo TO regress_test_role;
+-SET ROLE regress_test_role;
+-CREATE SERVER t1 FOREIGN DATA WRAPPER foo;
+-RESET ROLE;
++------+-------+----------------------+-------------------+------+---------+-------------+-------------
++(0 rows)
++
++\deu+
++List of user mappings
++Server | User name | FDW options
++--------+-----------+-------------
++(0 rows)
++
++-- exercise CREATE SERVER
++CREATE SERVER s1 FOREIGN DATA WRAPPER foo; -- ERROR
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++CREATE FOREIGN DATA WRAPPER foo OPTIONS ("test wrapper" 'true');
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
++CREATE SERVER s1 FOREIGN DATA WRAPPER foo;
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++CREATE SERVER s1 FOREIGN DATA WRAPPER foo; -- ERROR
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++CREATE SERVER IF NOT EXISTS s1 FOREIGN DATA WRAPPER foo; -- No ERROR, just NOTICE
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++CREATE SERVER s2 FOREIGN DATA WRAPPER foo OPTIONS (host 'a', dbname 'b');
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++CREATE SERVER s3 TYPE 'oracle' FOREIGN DATA WRAPPER foo;
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++CREATE SERVER s4 TYPE 'oracle' FOREIGN DATA WRAPPER foo OPTIONS (host 'a', dbname 'b');
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++CREATE SERVER s5 VERSION '15.0' FOREIGN DATA WRAPPER foo;
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++CREATE SERVER s6 VERSION '16.0' FOREIGN DATA WRAPPER foo OPTIONS (host 'a', dbname 'b');
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++CREATE SERVER s7 TYPE 'oracle' VERSION '17.0' FOREIGN DATA WRAPPER foo OPTIONS (host 'a', dbname 'b');
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++CREATE SERVER s8 FOREIGN DATA WRAPPER postgresql OPTIONS (foo '1'); -- ERROR
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++CREATE SERVER s8 FOREIGN DATA WRAPPER postgresql OPTIONS (host 'localhost', dbname 's8db');
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
+ \des+
+ List of foreign servers
+ Name | Owner | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description
+-------+---------------------------+----------------------+-------------------+--------+---------+-----------------------------------+-------------
+-s1 | regress_foreign_data_user | foo | | | | |
+-s2 | regress_foreign_data_user | foo | | | | (host 'a', dbname 'b') |
+-s3 | regress_foreign_data_user | foo | | oracle | | |
+-s4 | regress_foreign_data_user | foo | | oracle | | (host 'a', dbname 'b') |
+-s5 | regress_foreign_data_user | foo | | | 15.0 | |
+-s6 | regress_foreign_data_user | foo | | | 16.0 | (host 'a', dbname 'b') |
+-s7 | regress_foreign_data_user | foo | | oracle | 17.0 | (host 'a', dbname 'b') |
+-s8 | regress_foreign_data_user | postgresql | | | | (host 'localhost', dbname 's8db') |
+-t1 | regress_test_role | foo | | | | |
+-(9 rows)
+-
+-REVOKE USAGE ON FOREIGN DATA WRAPPER foo FROM regress_test_role;
+-GRANT USAGE ON FOREIGN DATA WRAPPER foo TO regress_test_indirect;
+-SET ROLE regress_test_role;
+-CREATE SERVER t2 FOREIGN DATA WRAPPER foo; -- ERROR
+-ERROR: permission denied for foreign-data wrapper foo
+-RESET ROLE;
+-GRANT regress_test_indirect TO regress_test_role;
+-SET ROLE regress_test_role;
+-CREATE SERVER t2 FOREIGN DATA WRAPPER foo;
++------+-------+----------------------+-------------------+------+---------+-------------+-------------
++(0 rows)
++
++SET ROLE regress_test_role;
++CREATE SERVER t1 FOREIGN DATA WRAPPER foo; -- ERROR: no usage on FDW
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++RESET ROLE;
++GRANT USAGE ON FOREIGN DATA WRAPPER foo TO regress_test_role;
++ERROR: foreign-data wrapper "foo" does not exist
++SET ROLE regress_test_role;
++CREATE SERVER t1 FOREIGN DATA WRAPPER foo;
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++RESET ROLE;
+ \des+
+ List of foreign servers
+ Name | Owner | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description
+-------+---------------------------+----------------------+-------------------+--------+---------+-----------------------------------+-------------
+-s1 | regress_foreign_data_user | foo | | | | |
+-s2 | regress_foreign_data_user | foo | | | | (host 'a', dbname 'b') |
+-s3 | regress_foreign_data_user | foo | | oracle | | |
+-s4 | regress_foreign_data_user | foo | | oracle | | (host 'a', dbname 'b') |
+-s5 | regress_foreign_data_user | foo | | | 15.0 | |
+-s6 | regress_foreign_data_user | foo | | | 16.0 | (host 'a', dbname 'b') |
+-s7 | regress_foreign_data_user | foo | | oracle | 17.0 | (host 'a', dbname 'b') |
+-s8 | regress_foreign_data_user | postgresql | | | | (host 'localhost', dbname 's8db') |
+-t1 | regress_test_role | foo | | | | |
+-t2 | regress_test_role | foo | | | | |
+-(10 rows)
++------+-------+----------------------+-------------------+------+---------+-------------+-------------
++(0 rows)
++
++REVOKE USAGE ON FOREIGN DATA WRAPPER foo FROM regress_test_role;
++ERROR: foreign-data wrapper "foo" does not exist
++GRANT USAGE ON FOREIGN DATA WRAPPER foo TO regress_test_indirect;
++ERROR: foreign-data wrapper "foo" does not exist
++SET ROLE regress_test_role;
++CREATE SERVER t2 FOREIGN DATA WRAPPER foo; -- ERROR
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++RESET ROLE;
++GRANT regress_test_indirect TO regress_test_role;
++SET ROLE regress_test_role;
++CREATE SERVER t2 FOREIGN DATA WRAPPER foo;
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++\des+
++List of foreign servers
++Name | Owner | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description
++------+-------+----------------------+-------------------+------+---------+-------------+-------------
++(0 rows)
+ 
+ RESET ROLE;
+ REVOKE regress_test_indirect FROM regress_test_role;
+@@ -402,96 +354,72 @@
+ ALTER SERVER s0 OPTIONS (a '1'); -- ERROR
+ ERROR: server "s0" does not exist
+ ALTER SERVER s1 VERSION '1.0' OPTIONS (servername 's1');
++ERROR: server "s1" does not exist
+ ALTER SERVER s2 VERSION '1.1';
++ERROR: server "s2" does not exist
+ ALTER SERVER s3 OPTIONS ("tns name" 'orcl', port '1521');
++ERROR: server "s3" does not exist
+ GRANT USAGE ON FOREIGN SERVER s1 TO regress_test_role;
++ERROR: server "s1" does not exist
+ GRANT USAGE ON FOREIGN SERVER s6 TO regress_test_role2 WITH GRANT OPTION;
++ERROR: server "s6" does not exist
+ \des+
+ List of foreign servers
+ Name | Owner | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description
+-------+---------------------------+----------------------+-------------------------------------------------------+--------+---------+-----------------------------------+-------------
+-s1 | regress_foreign_data_user | foo | regress_foreign_data_user=U/regress_foreign_data_user+| | 1.0 | (servername 's1') |
+-| | | regress_test_role=U/regress_foreign_data_user | | | |
+-s2 | regress_foreign_data_user | foo | | | 1.1 | (host 'a', dbname 'b') |
+-s3 | regress_foreign_data_user | foo | | oracle | | ("tns name" 'orcl', port '1521') |
+-s4 | regress_foreign_data_user | foo | | oracle | | (host 'a', dbname 'b') |
+-s5 | regress_foreign_data_user | foo | | | 15.0 | |
+-s6 | regress_foreign_data_user | foo | regress_foreign_data_user=U/regress_foreign_data_user+| | 16.0 | (host 'a', dbname 'b') |
+-| | | regress_test_role2=U*/regress_foreign_data_user | | | |
+-s7 | regress_foreign_data_user | foo | | oracle | 17.0 | (host 'a', dbname 'b') |
+-s8 | regress_foreign_data_user | postgresql | | | | (host 'localhost', dbname 's8db') |
+-t1 | regress_test_role | foo | | | | |
+-t2 | regress_test_role | foo | | | | |
+-(10 rows)
++------+-------+----------------------+-------------------+------+---------+-------------+-------------
++(0 rows)
+ 
+ SET ROLE regress_test_role;
+ ALTER SERVER s1 VERSION '1.1'; -- ERROR
+-ERROR: must be owner of foreign server s1
++ERROR: server "s1" does not exist
+ ALTER SERVER s1 OWNER TO regress_test_role; -- ERROR
+-ERROR: must be owner of foreign server s1
++ERROR: server "s1" does not exist
+ RESET ROLE;
+ ALTER SERVER s1 OWNER TO regress_test_role;
++ERROR: server "s1" does not exist
+ GRANT regress_test_role2 TO regress_test_role;
+ SET ROLE regress_test_role;
+ ALTER SERVER s1 VERSION '1.1';
++ERROR: server "s1" does not exist
+ ALTER SERVER s1 OWNER TO regress_test_role2; -- ERROR
+-ERROR: permission denied for foreign-data wrapper foo
++ERROR: server "s1" does not exist
+ RESET ROLE;
+ ALTER SERVER s8 OPTIONS (foo '1'); -- ERROR option validation
+-ERROR: invalid option "foo"
++ERROR: server "s8" does not exist
+ ALTER SERVER s8 OPTIONS (connect_timeout '30', SET dbname 'db1', DROP host);
++ERROR: server "s8" does not exist
+ SET ROLE regress_test_role;
+ ALTER SERVER s1 OWNER TO regress_test_indirect; -- ERROR
+-ERROR: must be able to SET ROLE "regress_test_indirect"
++ERROR: server "s1" does not exist
+ RESET ROLE;
+ GRANT regress_test_indirect TO regress_test_role;
+ SET ROLE regress_test_role;
+ ALTER SERVER s1 OWNER TO regress_test_indirect;
++ERROR: server "s1" does not exist
+ RESET ROLE;
+ GRANT USAGE ON FOREIGN DATA WRAPPER foo TO regress_test_indirect;
++ERROR: foreign-data wrapper "foo" does not exist
+ SET ROLE regress_test_role;
+ ALTER SERVER s1 OWNER TO regress_test_indirect;
++ERROR: server "s1" does not exist
+ RESET ROLE;
+ DROP ROLE regress_test_indirect; -- ERROR
+-ERROR: role "regress_test_indirect" cannot be dropped because some objects depend on it
+-DETAIL: privileges for foreign-data wrapper foo
+-owner of server s1
+ \des+
+ List of foreign servers
+ Name | Owner | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description
+-------+---------------------------+----------------------+-------------------------------------------------------+--------+---------+--------------------------------------+-------------
+-s1 | regress_test_indirect | foo | regress_test_indirect=U/regress_test_indirect | | 1.1 | (servername 's1') |
+-s2 | regress_foreign_data_user | foo | | | 1.1 | (host 'a', dbname 'b') |
+-s3 | regress_foreign_data_user | foo | | oracle | | ("tns name" 'orcl', port '1521') |
+-s4 | regress_foreign_data_user | foo | | oracle | | (host 'a', dbname 'b') |
+-s5 | regress_foreign_data_user | foo | | | 15.0 | |
+-s6 | regress_foreign_data_user | foo | regress_foreign_data_user=U/regress_foreign_data_user+| | 16.0 | (host 'a', dbname 'b') |
+-| | | regress_test_role2=U*/regress_foreign_data_user | | | |
+-s7 | regress_foreign_data_user | foo | | oracle | 17.0 | (host 'a', dbname 'b') |
+-s8 | regress_foreign_data_user | postgresql | | | | (dbname 'db1', connect_timeout '30') |
+-t1 | regress_test_role | foo | | | | |
+-t2 | regress_test_role | foo | | | | |
+-(10 rows)
++------+-------+----------------------+-------------------+------+---------+-------------+-------------
++(0 rows)
+ 
+ ALTER SERVER s8 RENAME to s8new;
++ERROR: server "s8" does not exist
+ \des+
+ List of foreign servers
+ Name | Owner | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description
+--------+---------------------------+----------------------+-------------------------------------------------------+--------+---------+--------------------------------------+-------------
+-s1 | regress_test_indirect | foo | regress_test_indirect=U/regress_test_indirect | | 1.1 | (servername 's1') |
+-s2 | regress_foreign_data_user | foo | | | 1.1 | (host 'a', dbname 'b') |
+-s3 | regress_foreign_data_user | foo | | oracle | | ("tns name" 'orcl', port '1521') |
+-s4 | regress_foreign_data_user | foo | | oracle | | (host 'a', dbname 'b') |
+-s5 | regress_foreign_data_user | foo | | | 15.0 | |
+-s6 | regress_foreign_data_user | foo | regress_foreign_data_user=U/regress_foreign_data_user+| | 16.0 | (host 'a', dbname 'b') |
+-| | | regress_test_role2=U*/regress_foreign_data_user | | | |
+-s7 | regress_foreign_data_user | foo | | oracle | 17.0 | (host 'a', dbname 'b') |
+-s8new | regress_foreign_data_user | postgresql | | | | (dbname 'db1', connect_timeout '30') |
+-t1 | regress_test_role | foo | | | | |
+-t2 | regress_test_role | foo | | | | |
+-(10 rows)
++------+-------+----------------------+-------------------+------+---------+-------------+-------------
++(0 rows)
+ 
+ ALTER SERVER s8new RENAME to s8;
++ERROR: server "s8new" does not exist
+ -- DROP SERVER
+ DROP SERVER nonexistent; -- ERROR
+ ERROR: server "nonexistent" does not exist
+@@ -500,83 +428,50 @@
+ \des
+ List of foreign servers
+ Name | Owner | Foreign-data wrapper
+-------+---------------------------+----------------------
+-s1 | regress_test_indirect | foo
+-s2 | regress_foreign_data_user | foo
+-s3 | regress_foreign_data_user | foo
+-s4 | regress_foreign_data_user | foo
+-s5 | regress_foreign_data_user | foo
+-s6 | regress_foreign_data_user | foo
+-s7 | regress_foreign_data_user | foo
+-s8 | regress_foreign_data_user | postgresql
+-t1 | regress_test_role | foo
+-t2 | regress_test_role | foo
+-(10 rows)
++------+-------+----------------------
++(0 rows)
+ 
+ SET ROLE regress_test_role;
+ DROP SERVER s2; -- ERROR
+-ERROR: must be owner of foreign server s2
++ERROR: server "s2" does not exist
+ DROP SERVER s1;
++ERROR: server "s1" does not exist
+ RESET ROLE;
+ \des
+ List of foreign servers
+ Name | Owner | Foreign-data wrapper
+-------+---------------------------+----------------------
+-s2 | regress_foreign_data_user | foo
+-s3 | regress_foreign_data_user | foo
+-s4 | regress_foreign_data_user | foo
+-s5 | regress_foreign_data_user | foo
+-s6 | regress_foreign_data_user | foo
+-s7 | regress_foreign_data_user | foo
+-s8 | regress_foreign_data_user | postgresql
+-t1 | regress_test_role | foo
+-t2 | regress_test_role | foo
+-(9 rows)
++------+-------+----------------------
++(0 rows)
+ 
+ ALTER SERVER s2 OWNER TO regress_test_role;
++ERROR: server "s2" does not exist
+ SET ROLE regress_test_role;
+ DROP SERVER s2;
++ERROR: server "s2" does not exist
+ RESET ROLE;
+ \des
+ List of foreign servers
+ Name | Owner | Foreign-data wrapper
+-------+---------------------------+----------------------
+-s3 | regress_foreign_data_user | foo
+-s4 | regress_foreign_data_user | foo
+-s5 | regress_foreign_data_user | foo
+-s6 | regress_foreign_data_user | foo
+-s7 | regress_foreign_data_user | foo
+-s8 | regress_foreign_data_user | postgresql
+-t1 | regress_test_role | foo
+-t2 | regress_test_role | foo
+-(8 rows)
++------+-------+----------------------
++(0 rows)
+ 
+ CREATE USER MAPPING FOR current_user SERVER s3;
++ERROR: server "s3" does not exist
+ \deu
+ List of user mappings
+ Server | User name
+---------+---------------------------
+-s3 | regress_foreign_data_user
+-(1 row)
++--------+-----------
++(0 rows)
+ 
+ DROP SERVER s3; -- ERROR
+-ERROR: cannot drop server s3 because other objects depend on it
+-DETAIL: user mapping for regress_foreign_data_user on server s3 depends on server s3
+-HINT: Use DROP ... CASCADE to drop the dependent objects too.
++ERROR: server "s3" does not exist
+ DROP SERVER s3 CASCADE;
+-NOTICE: drop cascades to user mapping for regress_foreign_data_user on server s3
++ERROR: server "s3" does not exist
+ \des
+ List of foreign servers
+ Name | Owner | Foreign-data wrapper
+-------+---------------------------+----------------------
+-s4 | regress_foreign_data_user | foo
+-s5 | regress_foreign_data_user | foo
+-s6 | regress_foreign_data_user | foo
+-s7 | regress_foreign_data_user | foo
+-s8 | regress_foreign_data_user | postgresql
+-t1 | regress_test_role | foo
+-t2 | regress_test_role | foo
+-(7 rows)
++------+-------+----------------------
++(0 rows)
+ 
+ \deu
+ List of user mappings
+@@ -590,40 +485,40 @@
+ CREATE USER MAPPING FOR current_user SERVER s1; -- ERROR
+ ERROR: server "s1" does not exist
+ CREATE USER MAPPING FOR current_user SERVER s4;
++ERROR: server "s4" does not exist
+ CREATE USER MAPPING FOR user SERVER s4; -- ERROR duplicate
+-ERROR: user mapping for "regress_foreign_data_user" already exists for server "s4"
++ERROR: server "s4" does not exist
+ CREATE USER MAPPING FOR public SERVER s4 OPTIONS ("this mapping" 'is public');
++ERROR: server "s4" does not exist
+ CREATE USER MAPPING FOR user SERVER s8 OPTIONS (username 'test', password 'secret'); -- ERROR
+-ERROR: invalid option "username"
+-HINT: Perhaps you meant the option "user".
++ERROR: server "s8" does not exist
+ CREATE USER MAPPING FOR user SERVER s8 OPTIONS (user 'test', password 'secret');
++ERROR: server "s8" does not exist
+ ALTER SERVER s5 OWNER TO regress_test_role;
++ERROR: server "s5" does not exist
+ ALTER SERVER s6 OWNER TO regress_test_indirect;
+ SET ROLE regress_test_role;
+ CREATE USER MAPPING FOR current_user SERVER s5;
++ERROR: server "s5" does not exist
+ CREATE USER MAPPING FOR current_user SERVER s6 OPTIONS (username 'test');
++ERROR: server "s6" does not exist
+ CREATE USER MAPPING FOR current_user SERVER s7; -- ERROR
+-ERROR: permission denied for foreign server s7
++ERROR: server "s7" does not exist
+ CREATE USER MAPPING FOR public SERVER s8; -- ERROR
+-ERROR: must be owner of foreign server s8
++ERROR: server "s8" does not exist
+ RESET ROLE;
+ ALTER SERVER t1 OWNER TO regress_test_indirect;
+ SET ROLE regress_test_role;
+ CREATE USER MAPPING FOR current_user SERVER t1 OPTIONS (username 'bob', password 'boo');
++ERROR: server "t1" does not exist
+ CREATE USER MAPPING FOR public SERVER t1;
++ERROR: server "t1" does not exist
+ RESET ROLE;
+ \deu
+ List of user mappings
+ Server | User name
+---------+---------------------------
+-s4 | public
+-s4 | regress_foreign_data_user
+-s5 | regress_test_role
+-s6 | regress_test_role
+-s8 | regress_foreign_data_user
+-t1 | public
+-t1 | regress_test_role
+-(7 rows)
++--------+-----------
++(0 rows)
+ 
+ -- ALTER USER MAPPING
+ ALTER USER MAPPING FOR regress_test_missing_role SERVER s4 OPTIONS (gotcha 'true'); -- ERROR
+@@ -631,29 +526,24 @@
+ ALTER USER MAPPING FOR user SERVER ss4 OPTIONS (gotcha 'true'); -- ERROR
+ ERROR: server "ss4" does not exist
+ ALTER USER MAPPING FOR public SERVER s5 OPTIONS (gotcha 'true'); -- ERROR
+-ERROR: user mapping for "public" does not exist for server "s5"
++ERROR: server "s5" does not exist
+ ALTER USER MAPPING FOR current_user SERVER s8 OPTIONS (username 'test'); -- ERROR
+-ERROR: invalid option "username"
+-HINT: Perhaps you meant the option "user".
++ERROR: server "s8" does not exist
+ ALTER USER MAPPING FOR current_user SERVER s8 OPTIONS (DROP user, SET password 'public');
++ERROR: server "s8" does not exist
+ SET ROLE regress_test_role;
+ ALTER USER MAPPING FOR current_user SERVER s5 OPTIONS (ADD modified '1');
++ERROR: server "s5" does not exist
+ ALTER USER MAPPING FOR public SERVER s4 OPTIONS (ADD modified '1'); -- ERROR
+-ERROR: must be owner of foreign server s4
++ERROR: server "s4" does not exist
+ ALTER USER MAPPING FOR public SERVER t1 OPTIONS (ADD modified '1');
++ERROR: server "t1" does not exist
+ RESET ROLE;
+ \deu+
+ List of user mappings
+ Server | User name | FDW options
+---------+---------------------------+----------------------------------
+-s4 | public | ("this mapping" 'is public')
+-s4 | regress_foreign_data_user |
+-s5 | regress_test_role | (modified '1')
+-s6 | regress_test_role | (username 'test')
+-s8 | regress_foreign_data_user | (password 'public')
+-t1 | public | (modified '1')
+-t1 | regress_test_role | (username 'bob', password 'boo')
+-(7 rows)
++--------+-----------+-------------
++(0 rows)
+ 
+ -- DROP USER MAPPING
+ DROP USER MAPPING FOR regress_test_missing_role SERVER s4; -- ERROR
+@@ -661,36 +551,31 @@
+ DROP USER MAPPING FOR user SERVER ss4;
+ ERROR: server "ss4" does not exist
+ DROP USER MAPPING FOR public SERVER s7; -- ERROR
+-ERROR: user mapping for "public" does not exist for server "s7"
++ERROR: server "s7" does not exist
+ DROP USER MAPPING IF EXISTS FOR regress_test_missing_role SERVER s4;
+ NOTICE: role "regress_test_missing_role" does not exist, skipping
+ DROP USER MAPPING IF EXISTS FOR user SERVER ss4;
+ NOTICE: server "ss4" does not exist, skipping
+ DROP USER MAPPING IF EXISTS FOR public SERVER s7;
+-NOTICE: user mapping for "public" does not exist for server "s7", skipping
++NOTICE: server "s7" does not exist, skipping
+ CREATE USER MAPPING FOR public SERVER s8;
++ERROR: server "s8" does not exist
+ SET ROLE regress_test_role;
+ DROP USER MAPPING FOR public SERVER s8; -- ERROR
+-ERROR: must be owner of foreign server s8
++ERROR: server "s8" does not exist
+ RESET ROLE;
+ DROP SERVER s7;
++ERROR: server "s7" does not exist
+ \deu
+ List of user mappings
+ Server | User name
+---------+---------------------------
+-s4 | public
+-s4 | regress_foreign_data_user
+-s5 | regress_test_role
+-s6 | regress_test_role
+-s8 | public
+-s8 | regress_foreign_data_user
+-t1 | public
+-t1 | regress_test_role
+-(8 rows)
++--------+-----------
++(0 rows)
+ 
+ -- CREATE FOREIGN TABLE
+ CREATE SCHEMA foreign_schema;
+ CREATE SERVER s0 FOREIGN DATA WRAPPER dummy;
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
+ CREATE FOREIGN TABLE ft1 (); -- ERROR
+ ERROR: syntax error at or near ";"
+ LINE 1: CREATE FOREIGN TABLE ft1 ();
+@@ -730,53 +615,47 @@
+ c3 date,
+ CHECK (c3 BETWEEN '1994-01-01'::date AND '1994-01-31'::date)
+ ) SERVER s0 OPTIONS (delimiter ',', quote '"', "be quoted" 'value');
++ERROR: server "s0" does not exist
+ COMMENT ON FOREIGN TABLE ft1 IS 'ft1';
++ERROR: relation "ft1" does not exist
+ COMMENT ON COLUMN ft1.c1 IS 'ft1.c1';
++ERROR: relation "ft1" does not exist
+ \d+ ft1
+-Foreign table "public.ft1"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+--------------------------------+----------+--------------+-------------
+-c1 | integer | | not null | | ("param 1" 'val1') | plain | | ft1.c1
+-c2 | text | | | | (param2 'val2', param3 'val3') | extended | |
+-c3 | date | | | | | plain | |
+-Check constraints:
+-"ft1_c2_check" CHECK (c2 <> ''::text)
+-"ft1_c3_check" CHECK (c3 >= '01-01-1994'::date AND c3 <= '01-31-1994'::date)
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-
+ \det+
+ List of foreign tables
+ Schema | Table | Server | FDW options | Description
+---------+-------+--------+-------------------------------------------------+-------------
+-public | ft1 | s0 | (delimiter ',', quote '"', "be quoted" 'value') | ft1
+-(1 row)
++--------+-------+--------+-------------+-------------
++(0 rows)
+ 
+ CREATE INDEX id_ft1_c2 ON ft1 (c2); -- ERROR
+-ERROR: cannot create index on relation "ft1"
+-DETAIL: This operation is not supported for foreign tables.
++ERROR: relation "ft1" does not exist
+ SELECT * FROM ft1; -- ERROR
+-ERROR: foreign-data wrapper "dummy" has no handler
++ERROR: relation "ft1" does not exist
++LINE 1: SELECT * FROM ft1;
++^
+ EXPLAIN SELECT * FROM ft1; -- ERROR
+-ERROR: foreign-data wrapper "dummy" has no handler
++ERROR: relation "ft1" does not exist
++LINE 1: EXPLAIN SELECT * FROM ft1;
++^
+ CREATE TABLE lt1 (a INT) PARTITION BY RANGE (a);
+ CREATE FOREIGN TABLE ft_part1
+ PARTITION OF lt1 FOR VALUES FROM (0) TO (1000) SERVER s0;
++ERROR: server "s0" does not exist
+ CREATE INDEX ON lt1 (a); -- skips partition
+ CREATE UNIQUE INDEX ON lt1 (a); -- ERROR
+-ERROR: cannot create unique index on partitioned table "lt1"
+-DETAIL: Table "lt1" contains partitions that are foreign tables.
+ ALTER TABLE lt1 ADD PRIMARY KEY (a); -- ERROR
+-ERROR: cannot create unique index on partitioned table "lt1"
+-DETAIL: Table "lt1" contains partitions that are foreign tables.
+ DROP TABLE lt1;
+ CREATE TABLE lt1 (a INT) PARTITION BY RANGE (a);
+ CREATE INDEX ON lt1 (a);
+ CREATE FOREIGN TABLE ft_part1
+ PARTITION OF lt1 FOR VALUES FROM (0) TO (1000) SERVER s0;
++ERROR: server "s0" does not exist
+ CREATE FOREIGN TABLE ft_part2 (a INT) SERVER s0;
++ERROR: server "s0" does not exist
+ ALTER TABLE lt1 ATTACH PARTITION ft_part2 FOR VALUES FROM (1000) TO (2000);
++ERROR: relation "ft_part2" does not exist
+ DROP FOREIGN TABLE ft_part1, ft_part2;
++ERROR: foreign table "ft_part1" does not exist
+ CREATE UNIQUE INDEX ON lt1 (a);
+ ALTER TABLE lt1 ADD PRIMARY KEY (a);
+ CREATE FOREIGN TABLE ft_part1
+@@ -784,12 +663,13 @@
+ ERROR: cannot create foreign partition of partitioned table "lt1"
+ DETAIL: Table "lt1" contains indexes that are unique.
+ CREATE FOREIGN TABLE ft_part2 (a INT NOT NULL) SERVER s0;
++ERROR: server "s0" does not exist
+ ALTER TABLE lt1 ATTACH PARTITION ft_part2
+ FOR VALUES FROM (1000) TO (2000); -- ERROR
+-ERROR: cannot attach foreign table "ft_part2" as partition of partitioned table "lt1"
+-DETAIL: Partitioned table "lt1" contains unique indexes.
++ERROR: relation "ft_part2" does not exist
+ DROP TABLE lt1;
+ DROP FOREIGN TABLE ft_part2;
++ERROR: foreign table "ft_part2" does not exist
+ CREATE TABLE lt1 (a INT) PARTITION BY RANGE (a);
+ CREATE INDEX ON lt1 (a);
+ CREATE TABLE lt1_part1
+@@ -797,130 +677,126 @@
+ PARTITION BY RANGE (a);
+ CREATE FOREIGN TABLE ft_part_1_1
+ PARTITION OF lt1_part1 FOR VALUES FROM (0) TO (100) SERVER s0;
++ERROR: server "s0" does not exist
+ CREATE FOREIGN TABLE ft_part_1_2 (a INT) SERVER s0;
++ERROR: server "s0" does not exist
+ ALTER TABLE lt1_part1 ATTACH PARTITION ft_part_1_2 FOR VALUES FROM (100) TO (200);
+-CREATE UNIQUE INDEX ON lt1 (a);
+-ERROR: cannot create unique index on partitioned table "lt1"
+-DETAIL: Table "lt1" contains partitions that are foreign tables.
+-ALTER TABLE lt1 ADD PRIMARY KEY (a);
+-ERROR: cannot create unique index on partitioned table "lt1_part1"
+-DETAIL: Table "lt1_part1" contains partitions that are foreign tables.
+-DROP FOREIGN TABLE ft_part_1_1, ft_part_1_2;
++ERROR: relation "ft_part_1_2" does not exist
+ CREATE UNIQUE INDEX ON lt1 (a);
+ ALTER TABLE lt1 ADD PRIMARY KEY (a);
++DROP FOREIGN TABLE ft_part_1_1, ft_part_1_2;
++ERROR: foreign table "ft_part_1_1" does not exist
++CREATE UNIQUE INDEX ON lt1 (a);
++ALTER TABLE lt1 ADD PRIMARY KEY (a);
++ERROR: multiple primary keys for table "lt1" are not allowed
+ CREATE FOREIGN TABLE ft_part_1_1
+ PARTITION OF lt1_part1 FOR VALUES FROM (0) TO (100) SERVER s0;
+ ERROR: cannot create foreign partition of partitioned table "lt1_part1"
+ DETAIL: Table "lt1_part1" contains indexes that are unique.
+ CREATE FOREIGN TABLE ft_part_1_2 (a INT NOT NULL) SERVER s0;
++ERROR: server "s0" does not exist
+ ALTER TABLE lt1_part1 ATTACH PARTITION ft_part_1_2 FOR VALUES FROM (100) TO (200);
+-ERROR: cannot attach foreign table "ft_part_1_2" as partition of partitioned table "lt1_part1"
+-DETAIL: Partitioned table "lt1_part1" contains unique indexes.
++ERROR: relation "ft_part_1_2" does not exist
+ DROP TABLE lt1;
+ DROP FOREIGN TABLE ft_part_1_2;
++ERROR: foreign table "ft_part_1_2" does not exist
+ -- ALTER FOREIGN TABLE
+ COMMENT ON FOREIGN TABLE ft1 IS 'foreign table';
++ERROR: relation "ft1" does not exist
+ COMMENT ON FOREIGN TABLE ft1 IS NULL;
++ERROR: relation "ft1" does not exist
+ COMMENT ON COLUMN ft1.c1 IS 'foreign column';
++ERROR: relation "ft1" does not exist
+ COMMENT ON COLUMN ft1.c1 IS NULL;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ADD COLUMN c4 integer;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ADD COLUMN c5 integer DEFAULT 0;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ADD COLUMN c6 integer;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ADD COLUMN c7 integer NOT NULL;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ADD COLUMN c8 integer;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ADD COLUMN c9 integer;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ADD COLUMN c10 integer OPTIONS (p1 'v1');
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ALTER COLUMN c4 SET DEFAULT 0;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ALTER COLUMN c5 DROP DEFAULT;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ALTER COLUMN c6 SET NOT NULL;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ALTER COLUMN c7 DROP NOT NULL;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ALTER COLUMN c8 TYPE char(10) USING '0'; -- ERROR
+-ERROR: "ft1" is not a table
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ALTER COLUMN c8 TYPE char(10);
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ALTER COLUMN c8 SET DATA TYPE text;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ALTER COLUMN xmin OPTIONS (ADD p1 'v1'); -- ERROR
+-ERROR: cannot alter system column "xmin"
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ALTER COLUMN c7 OPTIONS (ADD p1 'v1', ADD p2 'v2'),
+ ALTER COLUMN c8 OPTIONS (ADD p1 'v1', ADD p2 'v2');
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ALTER COLUMN c8 OPTIONS (SET p2 'V2', DROP p1);
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ALTER COLUMN c1 SET STATISTICS 10000;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ALTER COLUMN c1 SET (n_distinct = 100);
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ALTER COLUMN c8 SET STATISTICS -1;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ALTER COLUMN c8 SET STORAGE PLAIN;
++ERROR: relation "ft1" does not exist
+ \d+ ft1
+-Foreign table "public.ft1"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+--------------------------------+----------+--------------+-------------
+-c1 | integer | | not null | | ("param 1" 'val1') | plain | 10000 |
+-c2 | text | | | | (param2 'val2', param3 'val3') | extended | |
+-c3 | date | | | | | plain | |
+-c4 | integer | | | 0 | | plain | |
+-c5 | integer | | | | | plain | |
+-c6 | integer | | not null | | | plain | |
+-c7 | integer | | | | (p1 'v1', p2 'v2') | plain | |
+-c8 | text | | | | (p2 'V2') | plain | |
+-c9 | integer | | | | | plain | |
+-c10 | integer | | | | (p1 'v1') | plain | |
+-Check constraints:
+-"ft1_c2_check" CHECK (c2 <> ''::text)
+-"ft1_c3_check" CHECK (c3 >= '01-01-1994'::date AND c3 <= '01-31-1994'::date)
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-
+ -- can't change the column type if it's used elsewhere
+ CREATE TABLE use_ft1_column_type (x ft1);
++ERROR: type "ft1" does not exist
++LINE 1: CREATE TABLE use_ft1_column_type (x ft1);
++^
+ ALTER FOREIGN TABLE ft1 ALTER COLUMN c8 SET DATA TYPE integer; -- ERROR
+-ERROR: cannot alter foreign table "ft1" because column "use_ft1_column_type.x" uses its row type
++ERROR: relation "ft1" does not exist
+ DROP TABLE use_ft1_column_type;
++ERROR: table "use_ft1_column_type" does not exist
+ ALTER FOREIGN TABLE ft1 ADD PRIMARY KEY (c7); -- ERROR
+-ERROR: primary key constraints are not supported on foreign tables
+-LINE 1: ALTER FOREIGN TABLE ft1 ADD PRIMARY KEY (c7);
+-^
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ADD CONSTRAINT ft1_c9_check CHECK (c9 < 0) NOT VALID;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ALTER CONSTRAINT ft1_c9_check DEFERRABLE; -- ERROR
+-ERROR: ALTER action ALTER CONSTRAINT cannot be performed on relation "ft1"
+-DETAIL: This operation is not supported for foreign tables.
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 DROP CONSTRAINT ft1_c9_check;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 DROP CONSTRAINT no_const; -- ERROR
+-ERROR: constraint "no_const" of relation "ft1" does not exist
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 DROP CONSTRAINT IF EXISTS no_const;
+-NOTICE: constraint "no_const" of relation "ft1" does not exist, skipping
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 OWNER TO regress_test_role;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 OPTIONS (DROP delimiter, SET quote '~', ADD escape '@');
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 DROP COLUMN no_column; -- ERROR
+-ERROR: column "no_column" of relation "ft1" does not exist
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 DROP COLUMN IF EXISTS no_column;
+-NOTICE: column "no_column" of relation "ft1" does not exist, skipping
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 DROP COLUMN c9;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 ADD COLUMN c11 serial;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 SET SCHEMA foreign_schema;
++ERROR: relation "ft1" does not exist
+ ALTER FOREIGN TABLE ft1 SET TABLESPACE ts; -- ERROR
+ ERROR: relation "ft1" does not exist
+ ALTER SEQUENCE foreign_schema.ft1_c11_seq SET SCHEMA public; -- ERROR
+-ERROR: cannot move an owned sequence into another schema
+-DETAIL: Sequence "ft1_c11_seq" is linked to table "ft1".
++ERROR: relation "foreign_schema.ft1_c11_seq" does not exist
+ ALTER FOREIGN TABLE foreign_schema.ft1 RENAME c1 TO foreign_column_1;
++ERROR: relation "foreign_schema.ft1" does not exist
+ ALTER FOREIGN TABLE foreign_schema.ft1 RENAME TO foreign_table_1;
++ERROR: relation "foreign_schema.ft1" does not exist
+ \d foreign_schema.foreign_table_1
+-Foreign table "foreign_schema.foreign_table_1"
+-Column | Type | Collation | Nullable | Default | FDW options
+-------------------+---------+-----------+----------+-------------------------------------------------+--------------------------------
+-foreign_column_1 | integer | | not null | | ("param 1" 'val1')
+-c2 | text | | | | (param2 'val2', param3 'val3')
+-c3 | date | | | |
+-c4 | integer | | | 0 |
+-c5 | integer | | | |
+-c6 | integer | | not null | |
+-c7 | integer | | | | (p1 'v1', p2 'v2')
+-c8 | text | | | | (p2 'V2')
+-c10 | integer | | | | (p1 'v1')
+-c11 | integer | | not null | nextval('foreign_schema.ft1_c11_seq'::regclass) |
+-Check constraints:
+-"ft1_c2_check" CHECK (c2 <> ''::text)
+-"ft1_c3_check" CHECK (c3 >= '01-01-1994'::date AND c3 <= '01-31-1994'::date)
+-Server: s0
+-FDW options: (quote '~', "be quoted" 'value', escape '@')
+-
+ -- alter noexisting table
+ ALTER FOREIGN TABLE IF EXISTS doesnt_exist_ft1 ADD COLUMN c4 integer;
+ NOTICE: relation "doesnt_exist_ft1" does not exist, skipping
+@@ -968,132 +844,77 @@
+ -- Information schema
+ SELECT * FROM information_schema.foreign_data_wrappers ORDER BY 1, 2;
+ foreign_data_wrapper_catalog | foreign_data_wrapper_name | authorization_identifier | library_name | foreign_data_wrapper_language
+-------------------------------+---------------------------+---------------------------+--------------+-------------------------------
+-regression | dummy | regress_foreign_data_user | | c
+-regression | foo | regress_foreign_data_user | | c
+-regression | postgresql | regress_foreign_data_user | | c
+-(3 rows)
++------------------------------+---------------------------+--------------------------+--------------+-------------------------------
++(0 rows)
+ 
+ SELECT * FROM information_schema.foreign_data_wrapper_options ORDER BY 1, 2, 3;
+ foreign_data_wrapper_catalog | foreign_data_wrapper_name | option_name | option_value
+-------------------------------+---------------------------+--------------+--------------
+-regression | foo | test wrapper | true
+-(1 row)
++------------------------------+---------------------------+-------------+--------------
++(0 rows)
+ 
+ SELECT * FROM information_schema.foreign_servers ORDER BY 1, 2;
+ foreign_server_catalog | foreign_server_name | foreign_data_wrapper_catalog | foreign_data_wrapper_name | foreign_server_type | foreign_server_version | authorization_identifier
+-------------------------+---------------------+------------------------------+---------------------------+---------------------+------------------------+---------------------------
+-regression | s0 | regression | dummy | | | regress_foreign_data_user
+-regression | s4 | regression | foo | oracle | | regress_foreign_data_user
+-regression | s5 | regression | foo | | 15.0 | regress_test_role
+-regression | s6 | regression | foo | | 16.0 | regress_test_indirect
+-regression | s8 | regression | postgresql | | | regress_foreign_data_user
+-regression | t1 | regression | foo | | | regress_test_indirect
+-regression | t2 | regression | foo | | | regress_test_role
+-(7 rows)
++------------------------+---------------------+------------------------------+---------------------------+---------------------+------------------------+--------------------------
++(0 rows)
+ 
+ SELECT * FROM information_schema.foreign_server_options ORDER BY 1, 2, 3;
+ foreign_server_catalog | foreign_server_name | option_name | option_value
+-------------------------+---------------------+-----------------+--------------
+-regression | s4 | dbname | b
+-regression | s4 | host | a
+-regression | s6 | dbname | b
+-regression | s6 | host | a
+-regression | s8 | connect_timeout | 30
+-regression | s8 | dbname | db1
+-(6 rows)
++------------------------+---------------------+-------------+--------------
++(0 rows)
+ 
+ SELECT * FROM information_schema.user_mappings ORDER BY lower(authorization_identifier), 2, 3;
+ authorization_identifier | foreign_server_catalog | foreign_server_name
+----------------------------+------------------------+---------------------
+-PUBLIC | regression | s4
+-PUBLIC | regression | s8
+-PUBLIC | regression | t1
+-regress_foreign_data_user | regression | s4
+-regress_foreign_data_user | regression | s8
+-regress_test_role | regression | s5
+-regress_test_role | regression | s6
+-regress_test_role | regression | t1
+-(8 rows)
++--------------------------+------------------------+---------------------
++(0 rows)
+ 
+ SELECT * FROM information_schema.user_mapping_options ORDER BY lower(authorization_identifier), 2, 3, 4;
+ authorization_identifier | foreign_server_catalog | foreign_server_name | option_name | option_value
+----------------------------+------------------------+---------------------+--------------+--------------
+-PUBLIC | regression | s4 | this mapping | is public
+-PUBLIC | regression | t1 | modified | 1
+-regress_foreign_data_user | regression | s8 | password | public
+-regress_test_role | regression | s5 | modified | 1
+-regress_test_role | regression | s6 | username | test
+-regress_test_role | regression | t1 | password | boo
+-regress_test_role | regression | t1 | username | bob
+-(7 rows)
++--------------------------+------------------------+---------------------+-------------+--------------
++(0 rows)
+ 
+ SELECT * FROM information_schema.usage_privileges WHERE object_type LIKE 'FOREIGN%' AND object_name IN ('s6', 'foo') ORDER BY 1, 2, 3, 4, 5;
+ grantor | grantee | object_catalog | object_schema | object_name | object_type | privilege_type | is_grantable
+----------------------------+---------------------------+----------------+---------------+-------------+----------------------+----------------+--------------
+-regress_foreign_data_user | regress_foreign_data_user | regression | | foo | FOREIGN DATA WRAPPER | USAGE | YES
+-regress_foreign_data_user | regress_test_indirect | regression | | foo | FOREIGN DATA WRAPPER | USAGE | NO
+-regress_test_indirect | regress_test_indirect | regression | | s6 | FOREIGN SERVER | USAGE | YES
+-regress_test_indirect | regress_test_role2 | regression | | s6 | FOREIGN SERVER | USAGE | YES
+-(4 rows)
++---------+---------+----------------+---------------+-------------+-------------+----------------+--------------
++(0 rows)
+ 
+ SELECT * FROM information_schema.role_usage_grants WHERE object_type LIKE 'FOREIGN%' AND object_name IN ('s6', 'foo') ORDER BY 1, 2, 3, 4, 5;
+ grantor | grantee | object_catalog | object_schema | object_name | object_type | privilege_type | is_grantable
+----------------------------+---------------------------+----------------+---------------+-------------+----------------------+----------------+--------------
+-regress_foreign_data_user | regress_foreign_data_user | regression | | foo | FOREIGN DATA WRAPPER | USAGE | YES
+-regress_foreign_data_user | regress_test_indirect | regression | | foo | FOREIGN DATA WRAPPER | USAGE | NO
+-regress_test_indirect | regress_test_indirect | regression | | s6 | FOREIGN SERVER | USAGE | YES
+-regress_test_indirect | regress_test_role2 | regression | | s6 | FOREIGN SERVER | USAGE | YES
+-(4 rows)
++---------+---------+----------------+---------------+-------------+-------------+----------------+--------------
++(0 rows)
+ 
+ SELECT * FROM information_schema.foreign_tables ORDER BY 1, 2, 3;
+ foreign_table_catalog | foreign_table_schema | foreign_table_name | foreign_server_catalog | foreign_server_name
+ -----------------------+----------------------+--------------------+------------------------+---------------------
+-regression | foreign_schema | foreign_table_1 | regression | s0
+-(1 row)
++(0 rows)
+ 
+ SELECT * FROM information_schema.foreign_table_options ORDER BY 1, 2, 3, 4;
+ foreign_table_catalog | foreign_table_schema | foreign_table_name | option_name | option_value
+ -----------------------+----------------------+--------------------+-------------+--------------
+-regression | foreign_schema | foreign_table_1 | be quoted | value
+-regression | foreign_schema | foreign_table_1 | escape | @
+-regression | foreign_schema | foreign_table_1 | quote | ~
+-(3 rows)
++(0 rows)
+ 
+ SET ROLE regress_test_role;
+ SELECT * FROM information_schema.user_mapping_options ORDER BY 1, 2, 3, 4;
+ authorization_identifier | foreign_server_catalog | foreign_server_name | option_name | option_value
+ --------------------------+------------------------+---------------------+-------------+--------------
+-PUBLIC | regression | t1 | modified | 1
+-regress_test_role | regression | s5 | modified | 1
+-regress_test_role | regression | s6 | username | test
+-regress_test_role | regression | t1 | password | boo
+-regress_test_role | regression | t1 | username | bob
+-(5 rows)
++(0 rows)
+ 
+ SELECT * FROM information_schema.usage_privileges WHERE object_type LIKE 'FOREIGN%' AND object_name IN ('s6', 'foo') ORDER BY 1, 2, 3, 4, 5;
+ grantor | grantee | object_catalog | object_schema | object_name | object_type | privilege_type | is_grantable
+----------------------------+-----------------------+----------------+---------------+-------------+----------------------+----------------+--------------
+-regress_foreign_data_user | regress_test_indirect | regression | | foo | FOREIGN DATA WRAPPER | USAGE | NO
+-regress_test_indirect | regress_test_indirect | regression | | s6 | FOREIGN SERVER | USAGE | YES
+-regress_test_indirect | regress_test_role2 | regression | | s6 | FOREIGN SERVER | USAGE | YES
+-(3 rows)
++---------+---------+----------------+---------------+-------------+-------------+----------------+--------------
++(0 rows)
+ 
+ SELECT * FROM information_schema.role_usage_grants WHERE object_type LIKE 'FOREIGN%' AND object_name IN ('s6', 'foo') ORDER BY 1, 2, 3, 4, 5;
+ grantor | grantee | object_catalog | object_schema | object_name | object_type | privilege_type | is_grantable
+----------------------------+-----------------------+----------------+---------------+-------------+----------------------+----------------+--------------
+-regress_foreign_data_user | regress_test_indirect | regression | | foo | FOREIGN DATA WRAPPER | USAGE | NO
+-regress_test_indirect | regress_test_indirect | regression | | s6 | FOREIGN SERVER | USAGE | YES
+-regress_test_indirect | regress_test_role2 | regression | | s6 | FOREIGN SERVER | USAGE | YES
+-(3 rows)
++---------+---------+----------------+---------------+-------------+-------------+----------------+--------------
++(0 rows)
+ 
+ DROP USER MAPPING FOR current_user SERVER t1;
++ERROR: server "t1" does not exist
+ SET ROLE regress_test_role2;
+ SELECT * FROM information_schema.user_mapping_options ORDER BY 1, 2, 3, 4;
+ authorization_identifier | foreign_server_catalog | foreign_server_name | option_name | option_value
+ --------------------------+------------------------+---------------------+-------------+--------------
+-regress_test_role | regression | s6 | username |
+-(1 row)
++(0 rows)
+ 
+ RESET ROLE;
+ -- has_foreign_data_wrapper_privilege
+@@ -1101,255 +922,211 @@
+ (SELECT oid FROM pg_foreign_data_wrapper WHERE fdwname='foo'), 'USAGE');
+ has_foreign_data_wrapper_privilege
+ ------------------------------------
+-t
++
+ (1 row)
+ 
+ SELECT has_foreign_data_wrapper_privilege('regress_test_role', 'foo', 'USAGE');
+-has_foreign_data_wrapper_privilege
+-------------------------------------
+-t
+-(1 row)
+-
++ERROR: foreign-data wrapper "foo" does not exist
+ SELECT has_foreign_data_wrapper_privilege(
+ (SELECT oid FROM pg_roles WHERE rolname='regress_test_role'),
+ (SELECT oid FROM pg_foreign_data_wrapper WHERE fdwname='foo'), 'USAGE');
+ has_foreign_data_wrapper_privilege
+ ------------------------------------
+-t
++
+ (1 row)
+ 
+ SELECT has_foreign_data_wrapper_privilege(
+ (SELECT oid FROM pg_foreign_data_wrapper WHERE fdwname='foo'), 'USAGE');
+ has_foreign_data_wrapper_privilege
+ ------------------------------------
+-t
++
+ (1 row)
+ 
+ SELECT has_foreign_data_wrapper_privilege(
+ (SELECT oid FROM pg_roles WHERE rolname='regress_test_role'), 'foo', 'USAGE');
+-has_foreign_data_wrapper_privilege
+-------------------------------------
+-t
+-(1 row)
+-
++ERROR: foreign-data wrapper "foo" does not exist
+ SELECT has_foreign_data_wrapper_privilege('foo', 'USAGE');
+-has_foreign_data_wrapper_privilege
+-------------------------------------
+-t
+-(1 row)
+-
++ERROR: foreign-data wrapper "foo" does not exist
+ GRANT USAGE ON FOREIGN DATA WRAPPER foo TO regress_test_role;
++ERROR: foreign-data wrapper "foo" does not exist
+ SELECT has_foreign_data_wrapper_privilege('regress_test_role', 'foo', 'USAGE');
+-has_foreign_data_wrapper_privilege
+-------------------------------------
+-t
+-(1 row)
+-
++ERROR: foreign-data wrapper "foo" does not exist
+ -- has_server_privilege
+ SELECT has_server_privilege('regress_test_role',
+ (SELECT oid FROM pg_foreign_server WHERE srvname='s8'), 'USAGE');
+ has_server_privilege
+ ----------------------
+-f
++
+ (1 row)
+ 
+ SELECT has_server_privilege('regress_test_role', 's8', 'USAGE');
+-has_server_privilege
+-----------------------
+-f
+-(1 row)
+-
++ERROR: server "s8" does not exist
+ SELECT has_server_privilege(
+ (SELECT oid FROM pg_roles WHERE rolname='regress_test_role'),
+ (SELECT oid FROM pg_foreign_server WHERE srvname='s8'), 'USAGE');
+ has_server_privilege
+ ----------------------
+-f
++
+ (1 row)
+ 
+ SELECT has_server_privilege(
+ (SELECT oid FROM pg_foreign_server WHERE srvname='s8'), 'USAGE');
+ has_server_privilege
+ ----------------------
+-t
++
+ (1 row)
+ 
+ SELECT has_server_privilege(
+ (SELECT oid FROM pg_roles WHERE rolname='regress_test_role'), 's8', 'USAGE');
+-has_server_privilege
+-----------------------
+-f
+-(1 row)
+-
++ERROR: server "s8" does not exist
+ SELECT has_server_privilege('s8', 'USAGE');
+-has_server_privilege
+-----------------------
+-t
+-(1 row)
+-
++ERROR: server "s8" does not exist
+ GRANT USAGE ON FOREIGN SERVER s8 TO regress_test_role;
++ERROR: server "s8" does not exist
+ SELECT has_server_privilege('regress_test_role', 's8', 'USAGE');
+-has_server_privilege
+-----------------------
+-t
+-(1 row)
+-
++ERROR: server "s8" does not exist
+ REVOKE USAGE ON FOREIGN SERVER s8 FROM regress_test_role;
++ERROR: server "s8" does not exist
+ GRANT USAGE ON FOREIGN SERVER s4 TO regress_test_role;
++ERROR: server "s4" does not exist
+ DROP USER MAPPING FOR public SERVER s4;
++ERROR: server "s4" does not exist
+ ALTER SERVER s6 OPTIONS (DROP host, DROP dbname);
++ERROR: server "s6" does not exist
+ ALTER USER MAPPING FOR regress_test_role SERVER s6 OPTIONS (DROP username);
++ERROR: server "s6" does not exist
+ ALTER FOREIGN DATA WRAPPER foo VALIDATOR postgresql_fdw_validator;
+-WARNING: changing the foreign-data wrapper validator can cause the options for dependent objects to become invalid
++ERROR: foreign-data wrapper "foo" does not exist
+ -- Privileges
+ SET ROLE regress_unprivileged_role;
+ CREATE FOREIGN DATA WRAPPER foobar; -- ERROR
+-ERROR: permission denied to create foreign-data wrapper "foobar"
+-HINT: Must be superuser to create a foreign-data wrapper.
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+ ALTER FOREIGN DATA WRAPPER foo OPTIONS (gotcha 'true'); -- ERROR
+ ERROR: permission denied to alter foreign-data wrapper "foo"
+ HINT: Must be superuser to alter a foreign-data wrapper.
+ ALTER FOREIGN DATA WRAPPER foo OWNER TO regress_unprivileged_role; -- ERROR
+-ERROR: permission denied to change owner of foreign-data wrapper "foo"
+-HINT: Must be superuser to change owner of a foreign-data wrapper.
++ERROR: foreign-data wrapper "foo" does not exist
+ DROP FOREIGN DATA WRAPPER foo; -- ERROR
+-ERROR: must be owner of foreign-data wrapper foo
++ERROR: foreign-data wrapper "foo" does not exist
+ GRANT USAGE ON FOREIGN DATA WRAPPER foo TO regress_test_role; -- ERROR
+-ERROR: permission denied for foreign-data wrapper foo
++ERROR: foreign-data wrapper "foo" does not exist
+ CREATE SERVER s9 FOREIGN DATA WRAPPER foo; -- ERROR
+-ERROR: permission denied for foreign-data wrapper foo
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
+ ALTER SERVER s4 VERSION '0.5'; -- ERROR
+-ERROR: must be owner of foreign server s4
++ERROR: server "s4" does not exist
+ ALTER SERVER s4 OWNER TO regress_unprivileged_role; -- ERROR
+-ERROR: must be owner of foreign server s4
++ERROR: server "s4" does not exist
+ DROP SERVER s4; -- ERROR
+-ERROR: must be owner of foreign server s4
++ERROR: server "s4" does not exist
+ GRANT USAGE ON FOREIGN SERVER s4 TO regress_test_role; -- ERROR
+-ERROR: permission denied for foreign server s4
++ERROR: server "s4" does not exist
+ CREATE USER MAPPING FOR public SERVER s4; -- ERROR
+-ERROR: must be owner of foreign server s4
++ERROR: server "s4" does not exist
+ ALTER USER MAPPING FOR regress_test_role SERVER s6 OPTIONS (gotcha 'true'); -- ERROR
+-ERROR: must be owner of foreign server s6
++ERROR: server "s6" does not exist
+ DROP USER MAPPING FOR regress_test_role SERVER s6; -- ERROR
+-ERROR: must be owner of foreign server s6
++ERROR: server "s6" does not exist
+ RESET ROLE;
+ GRANT USAGE ON FOREIGN DATA WRAPPER postgresql TO regress_unprivileged_role;
++ERROR: foreign-data wrapper "postgresql" does not exist
+ GRANT USAGE ON FOREIGN DATA WRAPPER foo TO regress_unprivileged_role WITH GRANT OPTION;
++ERROR: foreign-data wrapper "foo" does not exist
+ SET ROLE regress_unprivileged_role;
+ CREATE FOREIGN DATA WRAPPER foobar; -- ERROR
+-ERROR: permission denied to create foreign-data wrapper "foobar"
+-HINT: Must be superuser to create a foreign-data wrapper.
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+ ALTER FOREIGN DATA WRAPPER foo OPTIONS (gotcha 'true'); -- ERROR
+ ERROR: permission denied to alter foreign-data wrapper "foo"
+ HINT: Must be superuser to alter a foreign-data wrapper.
+ DROP FOREIGN DATA WRAPPER foo; -- ERROR
+-ERROR: must be owner of foreign-data wrapper foo
++ERROR: foreign-data wrapper "foo" does not exist
+ GRANT USAGE ON FOREIGN DATA WRAPPER postgresql TO regress_test_role; -- WARNING
+-WARNING: no privileges were granted for "postgresql"
++ERROR: foreign-data wrapper "postgresql" does not exist
+ GRANT USAGE ON FOREIGN DATA WRAPPER foo TO regress_test_role;
++ERROR: foreign-data wrapper "foo" does not exist
+ CREATE SERVER s9 FOREIGN DATA WRAPPER postgresql;
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
+ ALTER SERVER s6 VERSION '0.5'; -- ERROR
+-ERROR: must be owner of foreign server s6
++ERROR: server "s6" does not exist
+ DROP SERVER s6; -- ERROR
+-ERROR: must be owner of foreign server s6
++ERROR: server "s6" does not exist
+ GRANT USAGE ON FOREIGN SERVER s6 TO regress_test_role; -- ERROR
+-ERROR: permission denied for foreign server s6
++ERROR: server "s6" does not exist
+ GRANT USAGE ON FOREIGN SERVER s9 TO regress_test_role;
++ERROR: server "s9" does not exist
+ CREATE USER MAPPING FOR public SERVER s6; -- ERROR
+-ERROR: must be owner of foreign server s6
++ERROR: server "s6" does not exist
+ CREATE USER MAPPING FOR public SERVER s9;
++ERROR: server "s9" does not exist
+ ALTER USER MAPPING FOR regress_test_role SERVER s6 OPTIONS (gotcha 'true'); -- ERROR
+-ERROR: must be owner of foreign server s6
++ERROR: server "s6" does not exist
+ DROP USER MAPPING FOR regress_test_role SERVER s6; -- ERROR
+-ERROR: must be owner of foreign server s6
++ERROR: server "s6" does not exist
+ RESET ROLE;
+ REVOKE USAGE ON FOREIGN DATA WRAPPER foo FROM regress_unprivileged_role; -- ERROR
+-ERROR: dependent privileges exist
+-HINT: Use CASCADE to revoke them too.
++ERROR: foreign-data wrapper "foo" does not exist
+ REVOKE USAGE ON FOREIGN DATA WRAPPER foo FROM regress_unprivileged_role CASCADE;
++ERROR: foreign-data wrapper "foo" does not exist
+ SET ROLE regress_unprivileged_role;
+ GRANT USAGE ON FOREIGN DATA WRAPPER foo TO regress_test_role; -- ERROR
+-ERROR: permission denied for foreign-data wrapper foo
++ERROR: foreign-data wrapper "foo" does not exist
+ CREATE SERVER s10 FOREIGN DATA WRAPPER foo; -- ERROR
+-ERROR: permission denied for foreign-data wrapper foo
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
+ ALTER SERVER s9 VERSION '1.1';
++ERROR: server "s9" does not exist
+ GRANT USAGE ON FOREIGN SERVER s9 TO regress_test_role;
++ERROR: server "s9" does not exist
+ CREATE USER MAPPING FOR current_user SERVER s9;
++ERROR: server "s9" does not exist
+ DROP SERVER s9 CASCADE;
+-NOTICE: drop cascades to 2 other objects
+-DETAIL: drop cascades to user mapping for public on server s9
+-drop cascades to user mapping for regress_unprivileged_role on server s9
++ERROR: server "s9" does not exist
+ RESET ROLE;
+ CREATE SERVER s9 FOREIGN DATA WRAPPER foo;
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
+ GRANT USAGE ON FOREIGN SERVER s9 TO regress_unprivileged_role;
++ERROR: server "s9" does not exist
+ SET ROLE regress_unprivileged_role;
+ ALTER SERVER s9 VERSION '1.2'; -- ERROR
+-ERROR: must be owner of foreign server s9
++ERROR: server "s9" does not exist
+ GRANT USAGE ON FOREIGN SERVER s9 TO regress_test_role; -- WARNING
+-WARNING: no privileges were granted for "s9"
++ERROR: server "s9" does not exist
+ CREATE USER MAPPING FOR current_user SERVER s9;
++ERROR: server "s9" does not exist
+ DROP SERVER s9 CASCADE; -- ERROR
+-ERROR: must be owner of foreign server s9
++ERROR: server "s9" does not exist
+ -- Check visibility of user mapping data
+ SET ROLE regress_test_role;
+ CREATE SERVER s10 FOREIGN DATA WRAPPER foo;
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
+ CREATE USER MAPPING FOR public SERVER s10 OPTIONS (user 'secret');
++ERROR: server "s10" does not exist
+ CREATE USER MAPPING FOR regress_unprivileged_role SERVER s10 OPTIONS (user 'secret');
++ERROR: server "s10" does not exist
+ -- owner of server can see some option fields
+ \deu+
+ List of user mappings
+ Server | User name | FDW options
+---------+---------------------------+-------------------
+-s10 | public | ("user" 'secret')
+-s10 | regress_unprivileged_role |
+-s4 | regress_foreign_data_user |
+-s5 | regress_test_role | (modified '1')
+-s6 | regress_test_role |
+-s8 | public |
+-s8 | regress_foreign_data_user |
+-s9 | regress_unprivileged_role |
+-t1 | public | (modified '1')
+-(9 rows)
++--------+-----------+-------------
++(0 rows)
+ 
+ RESET ROLE;
+ -- superuser can see all option fields
+ \deu+
+ List of user mappings
+ Server | User name | FDW options
+---------+---------------------------+---------------------
+-s10 | public | ("user" 'secret')
+-s10 | regress_unprivileged_role | ("user" 'secret')
+-s4 | regress_foreign_data_user |
+-s5 | regress_test_role | (modified '1')
+-s6 | regress_test_role |
+-s8 | public |
+-s8 | regress_foreign_data_user | (password 'public')
+-s9 | regress_unprivileged_role |
+-t1 | public | (modified '1')
+-(9 rows)
++--------+-----------+-------------
++(0 rows)
+ 
+ -- unprivileged user cannot see any option field
+ SET ROLE regress_unprivileged_role;
+ \deu+
+ List of user mappings
+ Server | User name | FDW options
+---------+---------------------------+-------------
+-s10 | public |
+-s10 | regress_unprivileged_role |
+-s4 | regress_foreign_data_user |
+-s5 | regress_test_role |
+-s6 | regress_test_role |
+-s8 | public |
+-s8 | regress_foreign_data_user |
+-s9 | regress_unprivileged_role |
+-t1 | public |
+-(9 rows)
++--------+-----------+-------------
++(0 rows)
+ 
+ RESET ROLE;
+ DROP SERVER s10 CASCADE;
+-NOTICE: drop cascades to 2 other objects
+-DETAIL: drop cascades to user mapping for public on server s10
+-drop cascades to user mapping for regress_unprivileged_role on server s10
++ERROR: server "s10" does not exist
+ -- Triggers
+ CREATE FUNCTION dummy_trigger() RETURNS TRIGGER AS $$
+ BEGIN
+@@ -1360,39 +1137,47 @@
+ ON foreign_schema.foreign_table_1
+ FOR EACH STATEMENT
+ EXECUTE PROCEDURE dummy_trigger();
++ERROR: relation "foreign_schema.foreign_table_1" does not exist
+ CREATE TRIGGER trigtest_after_stmt AFTER INSERT OR UPDATE OR DELETE
+ ON foreign_schema.foreign_table_1
+ FOR EACH STATEMENT
+ EXECUTE PROCEDURE dummy_trigger();
++ERROR: relation "foreign_schema.foreign_table_1" does not exist
+ CREATE TRIGGER trigtest_after_stmt_tt AFTER INSERT OR UPDATE OR DELETE -- ERROR
+ ON foreign_schema.foreign_table_1
+ REFERENCING NEW TABLE AS new_table
+ FOR EACH STATEMENT
+ EXECUTE PROCEDURE dummy_trigger();
+-ERROR: "foreign_table_1" is a foreign table
+-DETAIL: Triggers on foreign tables cannot have transition tables.
++ERROR: relation "foreign_schema.foreign_table_1" does not exist
+ CREATE TRIGGER trigtest_before_row BEFORE INSERT OR UPDATE OR DELETE
+ ON foreign_schema.foreign_table_1
+ FOR EACH ROW
+ EXECUTE PROCEDURE dummy_trigger();
++ERROR: relation "foreign_schema.foreign_table_1" does not exist
+ CREATE TRIGGER trigtest_after_row AFTER INSERT OR UPDATE OR DELETE
+ ON foreign_schema.foreign_table_1
+ FOR EACH ROW
+ EXECUTE PROCEDURE dummy_trigger();
++ERROR: relation "foreign_schema.foreign_table_1" does not exist
+ CREATE CONSTRAINT TRIGGER trigtest_constraint AFTER INSERT OR UPDATE OR DELETE
+ ON foreign_schema.foreign_table_1
+ FOR EACH ROW
+ EXECUTE PROCEDURE dummy_trigger();
+-ERROR: "foreign_table_1" is a foreign table
+-DETAIL: Foreign tables cannot have constraint triggers.
++ERROR: relation "foreign_schema.foreign_table_1" does not exist
+ ALTER FOREIGN TABLE foreign_schema.foreign_table_1
+ DISABLE TRIGGER trigtest_before_stmt;
++ERROR: relation "foreign_schema.foreign_table_1" does not exist
+ ALTER FOREIGN TABLE foreign_schema.foreign_table_1
+ ENABLE TRIGGER trigtest_before_stmt;
++ERROR: relation "foreign_schema.foreign_table_1" does not exist
+ DROP TRIGGER trigtest_before_stmt ON foreign_schema.foreign_table_1;
++ERROR: relation "foreign_schema.foreign_table_1" does not exist
+ DROP TRIGGER trigtest_before_row ON foreign_schema.foreign_table_1;
++ERROR: relation "foreign_schema.foreign_table_1" does not exist
+ DROP TRIGGER trigtest_after_stmt ON foreign_schema.foreign_table_1;
++ERROR: relation "foreign_schema.foreign_table_1" does not exist
+ DROP TRIGGER trigtest_after_row ON foreign_schema.foreign_table_1;
++ERROR: relation "foreign_schema.foreign_table_1" does not exist
+ DROP FUNCTION dummy_trigger();
+ -- Table inheritance
+ CREATE TABLE fd_pt1 (
+@@ -1402,6 +1187,7 @@
+ );
+ CREATE FOREIGN TABLE ft2 () INHERITS (fd_pt1)
+ SERVER s0 OPTIONS (delimiter ',', quote '"', "be quoted" 'value');
++ERROR: server "s0" does not exist
+ \d+ fd_pt1
+ Table "public.fd_pt1"
+ Column | Type | Collation | Nullable | Default | Storage | Stats target | Description
+@@ -1409,20 +1195,10 @@
+ c1 | integer | | not null | | plain | |
+ c2 | text | | | | extended | |
+ c3 | date | | | | plain | |
+-Child tables: ft2, FOREIGN
+ 
+ \d+ ft2
+-Foreign table "public.ft2"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | |
+-c2 | text | | | | | extended | |
+-c3 | date | | | | | plain | |
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-Inherits: fd_pt1
+-
+ DROP FOREIGN TABLE ft2;
++ERROR: foreign table "ft2" does not exist
+ \d+ fd_pt1
+ Table "public.fd_pt1"
+ Column | Type | Collation | Nullable | Default | Storage | Stats target | Description
+@@ -1436,17 +1212,10 @@
+ c2 text,
+ c3 date
+ ) SERVER s0 OPTIONS (delimiter ',', quote '"', "be quoted" 'value');
++ERROR: server "s0" does not exist
+ \d+ ft2
+-Foreign table "public.ft2"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | |
+-c2 | text | | | | | extended | |
+-c3 | date | | | | | plain | |
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-
+ ALTER FOREIGN TABLE ft2 INHERIT fd_pt1;
++ERROR: relation "ft2" does not exist
+ \d+ fd_pt1
+ Table "public.fd_pt1"
+ Column | Type | Collation | Nullable | Default | Storage | Stats target | Description
+@@ -1454,61 +1223,20 @@
+ c1 | integer | | not null | | plain | |
+ c2 | text | | | | extended | |
+ c3 | date | | | | plain | |
+-Child tables: ft2, FOREIGN
+ 
+ \d+ ft2
+-Foreign table "public.ft2"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | |
+-c2 | text | | | | | extended | |
+-c3 | date | | | | | plain | |
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-Inherits: fd_pt1
+-
+ CREATE TABLE ct3() INHERITS(ft2);
++ERROR: relation "ft2" does not exist
+ CREATE FOREIGN TABLE ft3 (
+ c1 integer NOT NULL,
+ c2 text,
+ c3 date
+ ) INHERITS(ft2)
+ SERVER s0;
+-NOTICE: merging column "c1" with inherited definition
+-NOTICE: merging column "c2" with inherited definition
+-NOTICE: merging column "c3" with inherited definition
++ERROR: relation "ft2" does not exist
+ \d+ ft2
+-Foreign table "public.ft2"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | |
+-c2 | text | | | | | extended | |
+-c3 | date | | | | | plain | |
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-Inherits: fd_pt1
+-Child tables: ct3,
+-ft3, FOREIGN
+-
+ \d+ ct3
+-Table "public.ct3"
+-Column | Type | Collation | Nullable | Default | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+----------+--------------+-------------
+-c1 | integer | | not null | | plain | |
+-c2 | text | | | | extended | |
+-c3 | date | | | | plain | |
+-Inherits: ft2
+-
+ \d+ ft3
+-Foreign table "public.ft3"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | |
+-c2 | text | | | | | extended | |
+-c3 | date | | | | | plain | |
+-Server: s0
+-Inherits: ft2
+-
+ -- add attributes recursively
+ ALTER TABLE fd_pt1 ADD COLUMN c4 integer;
+ ALTER TABLE fd_pt1 ADD COLUMN c5 integer DEFAULT 0;
+@@ -1527,62 +1255,16 @@
+ c6 | integer | | | | plain | |
+ c7 | integer | | not null | | plain | |
+ c8 | integer | | | | plain | |
+-Child tables: ft2, FOREIGN
+ 
+ \d+ ft2
+-Foreign table "public.ft2"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | |
+-c2 | text | | | | | extended | |
+-c3 | date | | | | | plain | |
+-c4 | integer | | | | | plain | |
+-c5 | integer | | | 0 | | plain | |
+-c6 | integer | | | | | plain | |
+-c7 | integer | | not null | | | plain | |
+-c8 | integer | | | | | plain | |
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-Inherits: fd_pt1
+-Child tables: ct3,
+-ft3, FOREIGN
+-
+ \d+ ct3
+-Table "public.ct3"
+-Column | Type | Collation | Nullable | Default | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+----------+--------------+-------------
+-c1 | integer | | not null | | plain | |
+-c2 | text | | | | extended | |
+-c3 | date | | | | plain | |
+-c4 | integer | | | | plain | |
+-c5 | integer | | | 0 | plain | |
+-c6 | integer | | | | plain | |
+-c7 | integer | | not null | | plain | |
+-c8 | integer | | | | plain | |
+-Inherits: ft2
+-
+ \d+ ft3
+-Foreign table "public.ft3"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | |
+-c2 | text | | | | | extended | |
+-c3 | date | | | | | plain | |
+-c4 | integer | | | | | plain | |
+-c5 | integer | | | 0 | | plain | |
+-c6 | integer | | | | | plain | |
+-c7 | integer | | not null | | | plain | |
+-c8 | integer | | | | | plain | |
+-Server: s0
+-Inherits: ft2
+-
+ -- alter attributes recursively
+ ALTER TABLE fd_pt1 ALTER COLUMN c4 SET DEFAULT 0;
+ ALTER TABLE fd_pt1 ALTER COLUMN c5 DROP DEFAULT;
+ ALTER TABLE fd_pt1 ALTER COLUMN c6 SET NOT NULL;
+ ALTER TABLE fd_pt1 ALTER COLUMN c7 DROP NOT NULL;
+ ALTER TABLE fd_pt1 ALTER COLUMN c8 TYPE char(10) USING '0'; -- ERROR
+-ERROR: "ft2" is not a table
+ ALTER TABLE fd_pt1 ALTER COLUMN c8 TYPE char(10);
+ ALTER TABLE fd_pt1 ALTER COLUMN c8 SET DATA TYPE text;
+ ALTER TABLE fd_pt1 ALTER COLUMN c1 SET STATISTICS 10000;
+@@ -1601,26 +1283,8 @@
+ c6 | integer | | not null | | plain | |
+ c7 | integer | | | | plain | |
+ c8 | text | | | | external | |
+-Child tables: ft2, FOREIGN
+ 
+ \d+ ft2
+-Foreign table "public.ft2"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | 10000 |
+-c2 | text | | | | | extended | |
+-c3 | date | | | | | plain | |
+-c4 | integer | | | 0 | | plain | |
+-c5 | integer | | | | | plain | |
+-c6 | integer | | not null | | | plain | |
+-c7 | integer | | | | | plain | |
+-c8 | text | | | | | external | |
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-Inherits: fd_pt1
+-Child tables: ct3,
+-ft3, FOREIGN
+-
+ -- drop attributes recursively
+ ALTER TABLE fd_pt1 DROP COLUMN c4;
+ ALTER TABLE fd_pt1 DROP COLUMN c5;
+@@ -1634,21 +1298,8 @@
+ c1 | integer | | not null | | plain | 10000 |
+ c2 | text | | | | extended | |
+ c3 | date | | | | plain | |
+-Child tables: ft2, FOREIGN
+ 
+ \d+ ft2
+-Foreign table "public.ft2"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | 10000 |
+-c2 | text | | | | | extended | |
+-c3 | date | | | | | plain | |
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-Inherits: fd_pt1
+-Child tables: ct3,
+-ft3, FOREIGN
+-
+ -- add constraints recursively
+ ALTER TABLE fd_pt1 ADD CONSTRAINT fd_pt1chk1 CHECK (c1 > 0) NO INHERIT;
+ ALTER TABLE fd_pt1 ADD CONSTRAINT fd_pt1chk2 CHECK (c2 <> '');
+@@ -1674,42 +1325,25 @@
+ Check constraints:
+ "fd_pt1chk1" CHECK (c1 > 0) NO INHERIT
+ "fd_pt1chk2" CHECK (c2 <> ''::text)
+-Child tables: ft2, FOREIGN
+ 
+ \d+ ft2
+-Foreign table "public.ft2"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | 10000 |
+-c2 | text | | | | | extended | |
+-c3 | date | | | | | plain | |
+-Check constraints:
+-"fd_pt1chk2" CHECK (c2 <> ''::text)
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-Inherits: fd_pt1
+-Child tables: ct3,
+-ft3, FOREIGN
+-
+ DROP FOREIGN TABLE ft2; -- ERROR
+-ERROR: cannot drop foreign table ft2 because other objects depend on it
+-DETAIL: table ct3 depends on foreign table ft2
+-foreign table ft3 depends on foreign table ft2
+-HINT: Use DROP ... CASCADE to drop the dependent objects too.
++ERROR: foreign table "ft2" does not exist
+ DROP FOREIGN TABLE ft2 CASCADE;
+-NOTICE: drop cascades to 2 other objects
+-DETAIL: drop cascades to table ct3
+-drop cascades to foreign table ft3
++ERROR: foreign table "ft2" does not exist
+ CREATE FOREIGN TABLE ft2 (
+ c1 integer NOT NULL,
+ c2 text,
+ c3 date
+ ) SERVER s0 OPTIONS (delimiter ',', quote '"', "be quoted" 'value');
++ERROR: server "s0" does not exist
+ -- child must have parent's INHERIT constraints
+ ALTER FOREIGN TABLE ft2 INHERIT fd_pt1; -- ERROR
+-ERROR: child table is missing constraint "fd_pt1chk2"
++ERROR: relation "ft2" does not exist
+ ALTER FOREIGN TABLE ft2 ADD CONSTRAINT fd_pt1chk2 CHECK (c2 <> '');
++ERROR: relation "ft2" does not exist
+ ALTER FOREIGN TABLE ft2 INHERIT fd_pt1;
++ERROR: relation "ft2" does not exist
+ -- child does not inherit NO INHERIT constraints
+ \d+ fd_pt1
+ Table "public.fd_pt1"
+@@ -1721,21 +1355,8 @@
+ Check constraints:
+ "fd_pt1chk1" CHECK (c1 > 0) NO INHERIT
+ "fd_pt1chk2" CHECK (c2 <> ''::text)
+-Child tables: ft2, FOREIGN
+ 
+ \d+ ft2
+-Foreign table "public.ft2"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | |
+-c2 | text | | | | | extended | |
+-c3 | date | | | | | plain | |
+-Check constraints:
+-"fd_pt1chk2" CHECK (c2 <> ''::text)
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-Inherits: fd_pt1
+-
+ -- drop constraints recursively
+ ALTER TABLE fd_pt1 DROP CONSTRAINT fd_pt1chk1 CASCADE;
+ ALTER TABLE fd_pt1 DROP CONSTRAINT fd_pt1chk2 CASCADE;
+@@ -1751,22 +1372,8 @@
+ c3 | date | | | | plain | |
+ Check constraints:
+ "fd_pt1chk3" CHECK (c2 <> ''::text) NOT VALID
+-Child tables: ft2, FOREIGN
+ 
+ \d+ ft2
+-Foreign table "public.ft2"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | |
+-c2 | text | | | | | extended | |
+-c3 | date | | | | | plain | |
+-Check constraints:
+-"fd_pt1chk2" CHECK (c2 <> ''::text)
+-"fd_pt1chk3" CHECK (c2 <> ''::text) NOT VALID
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-Inherits: fd_pt1
+-
+ -- VALIDATE CONSTRAINT need do nothing on foreign tables
+ ALTER TABLE fd_pt1 VALIDATE CONSTRAINT fd_pt1chk3;
+ \d+ fd_pt1
+@@ -1778,22 +1385,8 @@
+ c3 | date | | | | plain | |
+ Check constraints:
+ "fd_pt1chk3" CHECK (c2 <> ''::text)
+-Child tables: ft2, FOREIGN
+ 
+ \d+ ft2
+-Foreign table "public.ft2"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | |
+-c2 | text | | | | | extended | |
+-c3 | date | | | | | plain | |
+-Check constraints:
+-"fd_pt1chk2" CHECK (c2 <> ''::text)
+-"fd_pt1chk3" CHECK (c2 <> ''::text)
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-Inherits: fd_pt1
+-
+ -- changes name of an attribute recursively
+ ALTER TABLE fd_pt1 RENAME COLUMN c1 TO f1;
+ ALTER TABLE fd_pt1 RENAME COLUMN c2 TO f2;
+@@ -1809,48 +1402,30 @@
+ f3 | date | | | | plain | |
+ Check constraints:
+ "f2_check" CHECK (f2 <> ''::text)
+-Child tables: ft2, FOREIGN
+ 
+ \d+ ft2
+-Foreign table "public.ft2"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-f1 | integer | | not null | | | plain | |
+-f2 | text | | | | | extended | |
+-f3 | date | | | | | plain | |
+-Check constraints:
+-"f2_check" CHECK (f2 <> ''::text)
+-"fd_pt1chk2" CHECK (f2 <> ''::text)
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-Inherits: fd_pt1
+-
+ DROP TABLE fd_pt1 CASCADE;
+-NOTICE: drop cascades to foreign table ft2
+ -- IMPORT FOREIGN SCHEMA
+ IMPORT FOREIGN SCHEMA s1 FROM SERVER s9 INTO public; -- ERROR
+-ERROR: foreign-data wrapper "foo" has no handler
++ERROR: server "s9" does not exist
+ IMPORT FOREIGN SCHEMA s1 LIMIT TO (t1) FROM SERVER s9 INTO public; --ERROR
+-ERROR: foreign-data wrapper "foo" has no handler
++ERROR: server "s9" does not exist
+ IMPORT FOREIGN SCHEMA s1 EXCEPT (t1) FROM SERVER s9 INTO public; -- ERROR
+-ERROR: foreign-data wrapper "foo" has no handler
++ERROR: server "s9" does not exist
+ IMPORT FOREIGN SCHEMA s1 EXCEPT (t1, t2) FROM SERVER s9 INTO public
+ OPTIONS (option1 'value1', option2 'value2'); -- ERROR
+-ERROR: foreign-data wrapper "foo" has no handler
++ERROR: server "s9" does not exist
+ -- DROP FOREIGN TABLE
+ DROP FOREIGN TABLE no_table; -- ERROR
+ ERROR: foreign table "no_table" does not exist
+ DROP FOREIGN TABLE IF EXISTS no_table;
+ NOTICE: foreign table "no_table" does not exist, skipping
+ DROP FOREIGN TABLE foreign_schema.foreign_table_1;
++ERROR: foreign table "foreign_table_1" does not exist
+ -- REASSIGN OWNED/DROP OWNED of foreign objects
+ REASSIGN OWNED BY regress_test_role TO regress_test_role2;
+ DROP OWNED BY regress_test_role2;
+-ERROR: cannot drop desired object(s) because other objects depend on them
+-DETAIL: user mapping for regress_test_role on server s5 depends on server s5
+-HINT: Use DROP ... CASCADE to drop the dependent objects too.
+ DROP OWNED BY regress_test_role2 CASCADE;
+-NOTICE: drop cascades to user mapping for regress_test_role on server s5
+ -- Foreign partition DDL stuff
+ CREATE TABLE fd_pt2 (
+ c1 integer NOT NULL,
+@@ -1859,51 +1434,7 @@
+ ) PARTITION BY LIST (c1);
+ CREATE FOREIGN TABLE fd_pt2_1 PARTITION OF fd_pt2 FOR VALUES IN (1)
+ SERVER s0 OPTIONS (delimiter ',', quote '"', "be quoted" 'value');
+-\d+ fd_pt2
+-Partitioned table "public.fd_pt2"
+-Column | Type | Collation | Nullable | Default | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+----------+--------------+-------------
+-c1 | integer | | not null | | plain | |
+-c2 | text | | | | extended | |
+-c3 | date | | | | plain | |
+-Partition key: LIST (c1)
+-Partitions: fd_pt2_1 FOR VALUES IN (1), FOREIGN
+-
+-\d+ fd_pt2_1
+-Foreign table "public.fd_pt2_1"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | |
+-c2 | text | | | | | extended | |
+-c3 | date | | | | | plain | |
+-Partition of: fd_pt2 FOR VALUES IN (1)
+-Partition constraint: ((c1 IS NOT NULL) AND (c1 = 1))
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-
+--- partition cannot have additional columns
+-DROP FOREIGN TABLE fd_pt2_1;
+-CREATE FOREIGN TABLE fd_pt2_1 (
+-c1 integer NOT NULL,
+-c2 text,
+-c3 date,
+-c4 char
+-) SERVER s0 OPTIONS (delimiter ',', quote '"', "be quoted" 'value');
+-\d+ fd_pt2_1
+-Foreign table "public.fd_pt2_1"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+--------------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | |
+-c2 | text | | | | | extended | |
+-c3 | date | | | | | plain | |
+-c4 | character(1) | | | | | extended | |
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-
+-ALTER TABLE fd_pt2 ATTACH PARTITION fd_pt2_1 FOR VALUES IN (1); -- ERROR
+-ERROR: table "fd_pt2_1" contains column "c4" not found in parent "fd_pt2"
+-DETAIL: The new partition may contain only the columns present in parent.
+-DROP FOREIGN TABLE fd_pt2_1;
++ERROR: server "s0" does not exist
+ \d+ fd_pt2
+ Partitioned table "public.fd_pt2"
+ Column | Type | Collation | Nullable | Default | Storage | Stats target | Description
+@@ -1914,23 +1445,22 @@
+ Partition key: LIST (c1)
+ Number of partitions: 0
+ 
++\d+ fd_pt2_1
++-- partition cannot have additional columns
++DROP FOREIGN TABLE fd_pt2_1;
++ERROR: foreign table "fd_pt2_1" does not exist
+ CREATE FOREIGN TABLE fd_pt2_1 (
+ c1 integer NOT NULL,
+ c2 text,
+-c3 date
++c3 date,
++c4 char
+ ) SERVER s0 OPTIONS (delimiter ',', quote '"', "be quoted" 'value');
++ERROR: server "s0" does not exist
+ \d+ fd_pt2_1
+-Foreign table "public.fd_pt2_1"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | |
+-c2 | text | | | | | extended | |
+-c3 | date | | | | | plain | |
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-
+--- no attach partition validation occurs for foreign tables
+-ALTER TABLE fd_pt2 ATTACH PARTITION fd_pt2_1 FOR VALUES IN (1);
++ALTER TABLE fd_pt2 ATTACH PARTITION fd_pt2_1 FOR VALUES IN (1); -- ERROR
++ERROR: relation "fd_pt2_1" does not exist
++DROP FOREIGN TABLE fd_pt2_1;
++ERROR: foreign table "fd_pt2_1" does not exist
+ \d+ fd_pt2
+ Partitioned table "public.fd_pt2"
+ Column | Type | Collation | Nullable | Default | Storage | Stats target | Description
+@@ -1939,26 +1469,18 @@
+ c2 | text | | | | extended | |
+ c3 | date | | | | plain | |
+ Partition key: LIST (c1)
+-Partitions: fd_pt2_1 FOR VALUES IN (1), FOREIGN
+-
++Number of partitions: 0
++
++CREATE FOREIGN TABLE fd_pt2_1 (
++c1 integer NOT NULL,
++c2 text,
++c3 date
++) SERVER s0 OPTIONS (delimiter ',', quote '"', "be quoted" 'value');
++ERROR: server "s0" does not exist
+ \d+ fd_pt2_1
+-Foreign table "public.fd_pt2_1"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | |
+-c2 | text | | | | | extended | |
+-c3 | date | | | | | plain | |
+-Partition of: fd_pt2 FOR VALUES IN (1)
+-Partition constraint: ((c1 IS NOT NULL) AND (c1 = 1))
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-
+--- cannot add column to a partition
+-ALTER TABLE fd_pt2_1 ADD c4 char;
+-ERROR: cannot add column to a partition
+--- ok to have a partition's own constraints though
+-ALTER TABLE fd_pt2_1 ALTER c3 SET NOT NULL;
+-ALTER TABLE fd_pt2_1 ADD CONSTRAINT p21chk CHECK (c2 <> '');
++-- no attach partition validation occurs for foreign tables
++ALTER TABLE fd_pt2 ATTACH PARTITION fd_pt2_1 FOR VALUES IN (1);
++ERROR: relation "fd_pt2_1" does not exist
+ \d+ fd_pt2
+ Partitioned table "public.fd_pt2"
+ Column | Type | Collation | Nullable | Default | Storage | Stats target | Description
+@@ -1967,27 +1489,34 @@
+ c2 | text | | | | extended | |
+ c3 | date | | | | plain | |
+ Partition key: LIST (c1)
+-Partitions: fd_pt2_1 FOR VALUES IN (1), FOREIGN
++Number of partitions: 0
+ 
+ \d+ fd_pt2_1
+-Foreign table "public.fd_pt2_1"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | |
+-c2 | text | | | | | extended | |
+-c3 | date | | not null | | | plain | |
+-Partition of: fd_pt2 FOR VALUES IN (1)
+-Partition constraint: ((c1 IS NOT NULL) AND (c1 = 1))
+-Check constraints:
+-"p21chk" CHECK (c2 <> ''::text)
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-
++-- cannot add column to a partition
++ALTER TABLE fd_pt2_1 ADD c4 char;
++ERROR: relation "fd_pt2_1" does not exist
++-- ok to have a partition's own constraints though
++ALTER TABLE fd_pt2_1 ALTER c3 SET NOT NULL;
++ERROR: relation "fd_pt2_1" does not exist
++ALTER TABLE fd_pt2_1 ADD CONSTRAINT p21chk CHECK (c2 <> '');
++ERROR: relation "fd_pt2_1" does not exist
++\d+ fd_pt2
++Partitioned table "public.fd_pt2"
++Column | Type | Collation | Nullable | Default | Storage | Stats target | Description
++--------+---------+-----------+----------+---------+----------+--------------+-------------
++c1 | integer | | not null | | plain | |
++c2 | text | | | | extended | |
++c3 | date | | | | plain | |
++Partition key: LIST (c1)
++Number of partitions: 0
++
++\d+ fd_pt2_1
+ -- cannot drop inherited NOT NULL constraint from a partition
+ ALTER TABLE fd_pt2_1 ALTER c1 DROP NOT NULL;
+-ERROR: column "c1" is marked NOT NULL in parent table
++ERROR: relation "fd_pt2_1" does not exist
+ -- partition must have parent's constraints
+ ALTER TABLE fd_pt2 DETACH PARTITION fd_pt2_1;
++ERROR: relation "fd_pt2_1" does not exist
+ ALTER TABLE fd_pt2 ALTER c2 SET NOT NULL;
+ \d+ fd_pt2
+ Partitioned table "public.fd_pt2"
+@@ -2000,22 +1529,14 @@
+ Number of partitions: 0
+ 
+ \d+ fd_pt2_1
+-Foreign table "public.fd_pt2_1"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | |
+-c2 | text | | | | | extended | |
+-c3 | date | | not null | | | plain | |
+-Check constraints:
+-"p21chk" CHECK (c2 <> ''::text)
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-
+ ALTER TABLE fd_pt2 ATTACH PARTITION fd_pt2_1 FOR VALUES IN (1); -- ERROR
+-ERROR: column "c2" in child table must be marked NOT NULL
++ERROR: relation "fd_pt2_1" does not exist
+ ALTER FOREIGN TABLE fd_pt2_1 ALTER c2 SET NOT NULL;
++ERROR: relation "fd_pt2_1" does not exist
+ ALTER TABLE fd_pt2 ATTACH PARTITION fd_pt2_1 FOR VALUES IN (1);
++ERROR: relation "fd_pt2_1" does not exist
+ ALTER TABLE fd_pt2 DETACH PARTITION fd_pt2_1;
++ERROR: relation "fd_pt2_1" does not exist
+ ALTER TABLE fd_pt2 ADD CONSTRAINT fd_pt2chk1 CHECK (c1 > 0);
+ \d+ fd_pt2
+ Partitioned table "public.fd_pt2"
+@@ -2030,22 +1551,14 @@
+ Number of partitions: 0
+ 
+ \d+ fd_pt2_1
+-Foreign table "public.fd_pt2_1"
+-Column | Type | Collation | Nullable | Default | FDW options | Storage | Stats target | Description
+---------+---------+-----------+----------+---------+-------------+----------+--------------+-------------
+-c1 | integer | | not null | | | plain | |
+-c2 | text | | not null | | | extended | |
+-c3 | date | | not null | | | plain | |
+-Check constraints:
+-"p21chk" CHECK (c2 <> ''::text)
+-Server: s0
+-FDW options: (delimiter ',', quote '"', "be quoted" 'value')
+-
+ ALTER TABLE fd_pt2 ATTACH PARTITION fd_pt2_1 FOR VALUES IN (1); -- ERROR
+-ERROR: child table is missing constraint "fd_pt2chk1"
++ERROR: relation "fd_pt2_1" does not exist
+ ALTER FOREIGN TABLE fd_pt2_1 ADD CONSTRAINT fd_pt2chk1 CHECK (c1 > 0);
++ERROR: relation "fd_pt2_1" does not exist
+ ALTER TABLE fd_pt2 ATTACH PARTITION fd_pt2_1 FOR VALUES IN (1);
++ERROR: relation "fd_pt2_1" does not exist
+ DROP FOREIGN TABLE fd_pt2_1;
++ERROR: foreign table "fd_pt2_1" does not exist
+ DROP TABLE fd_pt2;
+ -- foreign table cannot be part of partition tree made of temporary
+ -- relations.
+@@ -2054,42 +1567,33 @@
+ SERVER s0; -- ERROR
+ ERROR: cannot create a permanent relation as partition of temporary relation "temp_parted"
+ CREATE FOREIGN TABLE foreign_part (a int) SERVER s0;
++ERROR: server "s0" does not exist
+ ALTER TABLE temp_parted ATTACH PARTITION foreign_part DEFAULT; -- ERROR
+-ERROR: cannot attach a permanent relation as partition of temporary relation "temp_parted"
++ERROR: relation "foreign_part" does not exist
+ DROP FOREIGN TABLE foreign_part;
++ERROR: foreign table "foreign_part" does not exist
+ DROP TABLE temp_parted;
+ -- Cleanup
+ DROP SCHEMA foreign_schema CASCADE;
+ DROP ROLE regress_test_role; -- ERROR
+-ERROR: role "regress_test_role" cannot be dropped because some objects depend on it
+-DETAIL: privileges for foreign-data wrapper foo
+-privileges for server s4
+-owner of user mapping for regress_test_role on server s6
+ DROP SERVER t1 CASCADE;
+-NOTICE: drop cascades to user mapping for public on server t1
++ERROR: server "t1" does not exist
+ DROP USER MAPPING FOR regress_test_role SERVER s6;
+ DROP FOREIGN DATA WRAPPER foo CASCADE;
+-NOTICE: drop cascades to 5 other objects
+-DETAIL: drop cascades to server s4
+-drop cascades to user mapping for regress_foreign_data_user on server s4
+-drop cascades to server s6
+-drop cascades to server s9
+-drop cascades to user mapping for regress_unprivileged_role on server s9
++ERROR: foreign-data wrapper "foo" does not exist
+ DROP SERVER s8 CASCADE;
+-NOTICE: drop cascades to 2 other objects
+-DETAIL: drop cascades to user mapping for regress_foreign_data_user on server s8
+-drop cascades to user mapping for public on server s8
++ERROR: server "s8" does not exist
+ DROP ROLE regress_test_indirect;
+ DROP ROLE regress_test_role;
+ DROP ROLE regress_unprivileged_role; -- ERROR
+-ERROR: role "regress_unprivileged_role" cannot be dropped because some objects depend on it
+-DETAIL: privileges for foreign-data wrapper postgresql
+ REVOKE ALL ON FOREIGN DATA WRAPPER postgresql FROM regress_unprivileged_role;
++ERROR: foreign-data wrapper "postgresql" does not exist
+ DROP ROLE regress_unprivileged_role;
+ DROP ROLE regress_test_role2;
+ DROP FOREIGN DATA WRAPPER postgresql CASCADE;
++ERROR: foreign-data wrapper "postgresql" does not exist
+ DROP FOREIGN DATA WRAPPER dummy CASCADE;
+-NOTICE: drop cascades to server s0
++ERROR: foreign-data wrapper "dummy" does not exist
+ \c
+ DROP ROLE regress_foreign_data_user;
+ -- At this point we should have no wrappers, no servers, and no mappings.

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/misc_functions.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/misc_functions.patch
@@ -1,0 +1,121 @@
+# Accepted security divergence: Multigres rejects PostgreSQL functions that
+# read the server filesystem. The client must not be able to inspect files on a
+# pooled PostgreSQL host. Every hunk below is one of pg_read_file,
+# pg_read_binary_file, pg_stat_file, or pg_ls_dir returning that policy error.
+# See go/services/multigateway/planner/unsafe_funccall.go.
+--- a
++++ b
+@@ -374,95 +374,52 @@
+ 
+ -- pg_read_file()
+ select length(pg_read_file('postmaster.pid')) > 20;
+-?column?
+-----------
+-t
+-(1 row)
+-
++ERROR: pg_read_file is not supported: server filesystem access is not permitted through the connection pooler
+ select length(pg_read_file('postmaster.pid', 1, 20));
+-length
+---------
+-20
+-(1 row)
+-
++ERROR: pg_read_file is not supported: server filesystem access is not permitted through the connection pooler
+ -- Test missing_ok
+ select pg_read_file('does not exist'); -- error
+-ERROR: could not open file "does not exist" for reading: No such file or directory
++ERROR: pg_read_file is not supported: server filesystem access is not permitted through the connection pooler
+ select pg_read_file('does not exist', true) IS NULL; -- ok
+-?column?
+-----------
+-t
+-(1 row)
+-
++ERROR: pg_read_file is not supported: server filesystem access is not permitted through the connection pooler
+ -- Test invalid argument
+ select pg_read_file('does not exist', 0, -1); -- error
+-ERROR: requested length cannot be negative
++ERROR: pg_read_file is not supported: server filesystem access is not permitted through the connection pooler
+ select pg_read_file('does not exist', 0, -1, true); -- error
+-ERROR: requested length cannot be negative
++ERROR: pg_read_file is not supported: server filesystem access is not permitted through the connection pooler
+ -- pg_read_binary_file()
+ select length(pg_read_binary_file('postmaster.pid')) > 20;
+-?column?
+-----------
+-t
+-(1 row)
+-
++ERROR: pg_read_binary_file is not supported: server filesystem access is not permitted through the connection pooler
+ select length(pg_read_binary_file('postmaster.pid', 1, 20));
+-length
+---------
+-20
+-(1 row)
+-
++ERROR: pg_read_binary_file is not supported: server filesystem access is not permitted through the connection pooler
+ -- Test missing_ok
+ select pg_read_binary_file('does not exist'); -- error
+-ERROR: could not open file "does not exist" for reading: No such file or directory
++ERROR: pg_read_binary_file is not supported: server filesystem access is not permitted through the connection pooler
+ select pg_read_binary_file('does not exist', true) IS NULL; -- ok
+-?column?
+-----------
+-t
+-(1 row)
+-
++ERROR: pg_read_binary_file is not supported: server filesystem access is not permitted through the connection pooler
+ -- Test invalid argument
+ select pg_read_binary_file('does not exist', 0, -1); -- error
+-ERROR: requested length cannot be negative
++ERROR: pg_read_binary_file is not supported: server filesystem access is not permitted through the connection pooler
+ select pg_read_binary_file('does not exist', 0, -1, true); -- error
+-ERROR: requested length cannot be negative
++ERROR: pg_read_binary_file is not supported: server filesystem access is not permitted through the connection pooler
+ -- pg_stat_file()
+ select size > 20, isdir from pg_stat_file('postmaster.pid');
+-?column? | isdir
+-----------+-------
+-t | f
+-(1 row)
+-
++ERROR: pg_stat_file is not supported: server filesystem access is not permitted through the connection pooler
+ -- pg_ls_dir()
+ select * from (select pg_ls_dir('.') a) a where a = 'base' limit 1;
+-a
+-------
+-base
+-(1 row)
+-
++ERROR: pg_ls_dir is not supported: server filesystem access is not permitted through the connection pooler
+ -- Test missing_ok (second argument)
+ select pg_ls_dir('does not exist', false, false); -- error
+-ERROR: could not open directory "does not exist": No such file or directory
++ERROR: pg_ls_dir is not supported: server filesystem access is not permitted through the connection pooler
+ select pg_ls_dir('does not exist', true, false); -- ok
+-pg_ls_dir
+------------
+-(0 rows)
+-
++ERROR: pg_ls_dir is not supported: server filesystem access is not permitted through the connection pooler
+ -- Test include_dot_dirs (third argument)
+ select count(*) = 1 as dot_found
+ from pg_ls_dir('.', false, true) as ls where ls = '.';
+-dot_found
+------------
+-t
+-(1 row)
+-
++ERROR: pg_ls_dir is not supported: server filesystem access is not permitted through the connection pooler
+ select count(*) = 1 as dot_found
+ from pg_ls_dir('.', false, false) as ls where ls = '.';
+-dot_found
+------------
+-f
+-(1 row)
+-
++ERROR: pg_ls_dir is not supported: server filesystem access is not permitted through the connection pooler
+ -- pg_timezone_names()
+ select * from (select (pg_timezone_names()).name) ptn where name='UTC' limit 1;
+ name

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/privileges.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/privileges.patch
@@ -1,0 +1,31 @@
+# Accepted security divergence: lo_import and lo_export expose the PostgreSQL
+# server filesystem and are blocked before PostgreSQL performs function ACL
+# checks. Identity-safe lo_compat_privileges replay differences are deliberately
+# excluded and remain residual failures.
+# See go/services/multigateway/planner/unsafe_funccall.go.
+--- a
++++ b
+@@ -2120,11 +2120,11 @@
+ SELECT lo_unlink(1002); -- to be denied
+ ERROR: must be owner of large object 1002
+ SELECT lo_export(1001, '/dev/null'); -- to be denied
+-ERROR: permission denied for function lo_export
++ERROR: lo_export is not supported: server filesystem access is not permitted through the connection pooler
+ SELECT lo_import('/dev/null'); -- to be denied
+-ERROR: permission denied for function lo_import
++ERROR: lo_import is not supported: server filesystem access is not permitted through the connection pooler
+ SELECT lo_import('/dev/null', 2003); -- to be denied
+-ERROR: permission denied for function lo_import
++ERROR: lo_import is not supported: server filesystem access is not permitted through the connection pooler
+ \c -
+ SET lo_compat_privileges = true; -- compatibility mode
+ SET SESSION AUTHORIZATION regress_priv_user4;
+@@ -2153,7 +2153,7 @@
+ (1 row)
+ 
+ SELECT lo_export(1001, '/dev/null'); -- to be denied
+-ERROR: permission denied for function lo_export
++ERROR: lo_export is not supported: server filesystem access is not permitted through the connection pooler
+ -- don't allow unpriv users to access pg_largeobject contents
+ \c -
+ SELECT * FROM pg_largeobject LIMIT 0;

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/publication.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/publication.patch
@@ -1,0 +1,15 @@
+# Accepted availability divergence: CREATE UNLOGGED TABLE emits Multigres's
+# failover warning because unlogged data is not replicated and is lost on
+# promotion. Database-name and permission differences are intentionally not
+# included in this baseline. See docs/query_serving/unlogged_tables.md.
+--- a
++++ b
+@@ -1099,6 +1099,8 @@
+ DETAIL: This operation is not supported for temporary tables.
+ DROP TABLE testpub_temptbl;
+ CREATE UNLOGGED TABLE testpub_unloggedtbl(a int);
++WARNING: unlogged table data is not replicated and is lost on failover
++HINT: On failover the table is dropped, or left empty if other objects depend on it; rebuild it from scratch. See docs/query_serving/unlogged_tables.md.
+ -- fail - unlogged table
+ CREATE PUBLICATION testpub_forunloggedtbl FOR TABLE testpub_unloggedtbl;
+ ERROR: cannot add relation "testpub_unloggedtbl" to publication

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/subscription.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/subscription.patch
@@ -1,0 +1,698 @@
+# Accepted security divergence: Multigres blocks CREATE SUBSCRIPTION so pooled
+# clients cannot create replication connections or slots. Missing-subscription
+# catalog, ALTER, and cleanup output is direct fallout. GRANT/REVOKE failures for
+# the absent regression database are excluded and remain residual failures.
+# See go/services/multigateway/planner/unsafe_stmt.go.
+--- a
++++ b
+@@ -19,229 +19,219 @@
+ -- fail - cannot do CREATE SUBSCRIPTION CREATE SLOT inside transaction block
+ BEGIN;
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'testconn' PUBLICATION testpub WITH (create_slot);
+-ERROR: CREATE SUBSCRIPTION ... WITH (create_slot = true) cannot run inside a transaction block
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ COMMIT;
+ -- fail - invalid connection string
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'testconn' PUBLICATION testpub;
+-ERROR: invalid connection string syntax: missing "=" after "testconn" in connection info string
+-
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ -- fail - duplicate publications
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'dbname=regress_doesnotexist' PUBLICATION foo, testpub, foo WITH (connect = false);
+-ERROR: publication name "foo" used more than once
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ -- ok
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (connect = false);
+-WARNING: subscription was created, but is not connected
+-HINT: To initiate replication, you must manually create the replication slot, enable the subscription, and refresh the subscription.
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ COMMENT ON SUBSCRIPTION regress_testsub IS 'test subscription';
++ERROR: subscription "regress_testsub" does not exist
+ SELECT obj_description(s.oid, 'pg_subscription') FROM pg_subscription s;
+ obj_description
+--------------------
+-test subscription
+-(1 row)
++-----------------
++(0 rows)
+ 
+ -- Check if the subscription stats are created and stats_reset is updated
+ -- by pg_stat_reset_subscription_stats().
+ SELECT subname, stats_reset IS NULL stats_reset_is_null FROM pg_stat_subscription_stats WHERE subname = 'regress_testsub';
+ subname | stats_reset_is_null
+------------------+---------------------
+-regress_testsub | t
+-(1 row)
++---------+---------------------
++(0 rows)
+ 
+ SELECT pg_stat_reset_subscription_stats(oid) FROM pg_subscription WHERE subname = 'regress_testsub';
+ pg_stat_reset_subscription_stats
+ ----------------------------------
+-
+-(1 row)
++(0 rows)
+ 
+ SELECT subname, stats_reset IS NULL stats_reset_is_null FROM pg_stat_subscription_stats WHERE subname = 'regress_testsub';
+ subname | stats_reset_is_null
+------------------+---------------------
+-regress_testsub | f
+-(1 row)
++---------+---------------------
++(0 rows)
+ 
+ -- Reset the stats again and check if the new reset_stats is updated.
+ SELECT stats_reset as prev_stats_reset FROM pg_stat_subscription_stats WHERE subname = 'regress_testsub' \gset
++no rows returned for \gset
+ SELECT pg_stat_reset_subscription_stats(oid) FROM pg_subscription WHERE subname = 'regress_testsub';
+ pg_stat_reset_subscription_stats
+ ----------------------------------
+-
+-(1 row)
++(0 rows)
+ 
+ SELECT :'prev_stats_reset' < stats_reset FROM pg_stat_subscription_stats WHERE subname = 'regress_testsub';
+-?column?
+-----------
+-t
+-(1 row)
+-
++ERROR: syntax error at or near ":"
++LINE 1: SELECT :'prev_stats_reset' < stats_reset FROM pg_stat_subscr...
++^
+ -- fail - name already exists
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (connect = false);
+-ERROR: subscription "regress_testsub" already exists
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ -- fail - must be superuser
+ SET SESSION AUTHORIZATION 'regress_subscription_user2';
+ CREATE SUBSCRIPTION regress_testsub2 CONNECTION 'dbname=regress_doesnotexist' PUBLICATION foo WITH (connect = false);
+-ERROR: permission denied to create subscription
+-DETAIL: Only roles with privileges of the "pg_create_subscription" role may create subscriptions.
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ SET SESSION AUTHORIZATION 'regress_subscription_user';
+ -- fail - invalid option combinations
+ CREATE SUBSCRIPTION regress_testsub2 CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (connect = false, copy_data = true);
+-ERROR: connect = false and copy_data = true are mutually exclusive options
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ CREATE SUBSCRIPTION regress_testsub2 CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (connect = false, enabled = true);
+-ERROR: connect = false and enabled = true are mutually exclusive options
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ CREATE SUBSCRIPTION regress_testsub2 CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (connect = false, create_slot = true);
+-ERROR: connect = false and create_slot = true are mutually exclusive options
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ CREATE SUBSCRIPTION regress_testsub2 CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (slot_name = NONE, enabled = true);
+-ERROR: slot_name = NONE and enabled = true are mutually exclusive options
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ CREATE SUBSCRIPTION regress_testsub2 CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (slot_name = NONE, enabled = false, create_slot = true);
+-ERROR: slot_name = NONE and create_slot = true are mutually exclusive options
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ CREATE SUBSCRIPTION regress_testsub2 CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (slot_name = NONE);
+-ERROR: subscription with slot_name = NONE must also set enabled = false
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ CREATE SUBSCRIPTION regress_testsub2 CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (slot_name = NONE, enabled = false);
+-ERROR: subscription with slot_name = NONE must also set create_slot = false
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ CREATE SUBSCRIPTION regress_testsub2 CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (slot_name = NONE, create_slot = false);
+-ERROR: subscription with slot_name = NONE must also set enabled = false
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ -- ok - with slot_name = NONE
+ CREATE SUBSCRIPTION regress_testsub3 CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (slot_name = NONE, connect = false);
+-WARNING: subscription was created, but is not connected
+-HINT: To initiate replication, you must manually create the replication slot, enable the subscription, and refresh the subscription.
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ -- fail
+ ALTER SUBSCRIPTION regress_testsub3 ENABLE;
+-ERROR: cannot enable subscription that does not have a slot name
++ERROR: subscription "regress_testsub3" does not exist
+ ALTER SUBSCRIPTION regress_testsub3 REFRESH PUBLICATION;
+-ERROR: ALTER SUBSCRIPTION ... REFRESH is not allowed for disabled subscriptions
++ERROR: subscription "regress_testsub3" does not exist
+ -- fail - origin must be either none or any
+ CREATE SUBSCRIPTION regress_testsub4 CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (slot_name = NONE, connect = false, origin = foo);
+-ERROR: unrecognized origin value: "foo"
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ -- now it works
+ CREATE SUBSCRIPTION regress_testsub4 CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (slot_name = NONE, connect = false, origin = none);
+-WARNING: subscription was created, but is not connected
+-HINT: To initiate replication, you must manually create the replication slot, enable the subscription, and refresh the subscription.
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ \dRs+ regress_testsub4
+ List of subscriptions
+ Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+-------------------+---------------------------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+-----------------------------+----------
+-regress_testsub4 | regress_subscription_user | f | {testpub} | f | off | d | f | none | t | f | f | off | dbname=regress_doesnotexist | 0/0
+-(1 row)
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
+ 
+ ALTER SUBSCRIPTION regress_testsub4 SET (origin = any);
++ERROR: subscription "regress_testsub4" does not exist
+ \dRs+ regress_testsub4
+ List of subscriptions
+ Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+-------------------+---------------------------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+-----------------------------+----------
+-regress_testsub4 | regress_subscription_user | f | {testpub} | f | off | d | f | any | t | f | f | off | dbname=regress_doesnotexist | 0/0
+-(1 row)
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
+ 
+ DROP SUBSCRIPTION regress_testsub3;
++ERROR: subscription "regress_testsub3" does not exist
+ DROP SUBSCRIPTION regress_testsub4;
++ERROR: subscription "regress_testsub4" does not exist
+ -- fail, connection string does not parse
+ CREATE SUBSCRIPTION regress_testsub5 CONNECTION 'i_dont_exist=param' PUBLICATION testpub;
+-ERROR: invalid connection string syntax: invalid connection option "i_dont_exist"
+-
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ -- fail, connection string parses, but doesn't work (and does so without
+ -- connecting, so this is reliable and safe)
+ CREATE SUBSCRIPTION regress_testsub5 CONNECTION 'port=-1' PUBLICATION testpub;
+-ERROR: could not connect to the publisher: invalid port number: "-1"
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ -- fail - invalid connection string during ALTER
+ ALTER SUBSCRIPTION regress_testsub CONNECTION 'foobar';
+-ERROR: invalid connection string syntax: missing "=" after "foobar" in connection info string
+-
+-\dRs+
+-List of subscriptions
+-Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+------------------+---------------------------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+-----------------------------+----------
+-regress_testsub | regress_subscription_user | f | {testpub} | f | off | d | f | any | t | f | f | off | dbname=regress_doesnotexist | 0/0
+-(1 row)
++ERROR: subscription "regress_testsub" does not exist
++\dRs+
++List of subscriptions
++Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
+ 
+ ALTER SUBSCRIPTION regress_testsub SET PUBLICATION testpub2, testpub3 WITH (refresh = false);
++ERROR: subscription "regress_testsub" does not exist
+ ALTER SUBSCRIPTION regress_testsub CONNECTION 'dbname=regress_doesnotexist2';
++ERROR: subscription "regress_testsub" does not exist
+ ALTER SUBSCRIPTION regress_testsub SET (slot_name = 'newname');
++ERROR: subscription "regress_testsub" does not exist
+ ALTER SUBSCRIPTION regress_testsub SET (password_required = false);
++ERROR: subscription "regress_testsub" does not exist
+ ALTER SUBSCRIPTION regress_testsub SET (run_as_owner = true);
+-\dRs+
+-List of subscriptions
+-Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+------------------+---------------------------+---------+---------------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+------------------------------+----------
+-regress_testsub | regress_subscription_user | f | {testpub2,testpub3} | f | off | d | f | any | f | t | f | off | dbname=regress_doesnotexist2 | 0/0
+-(1 row)
++ERROR: subscription "regress_testsub" does not exist
++\dRs+
++List of subscriptions
++Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
+ 
+ ALTER SUBSCRIPTION regress_testsub SET (password_required = true);
++ERROR: subscription "regress_testsub" does not exist
+ ALTER SUBSCRIPTION regress_testsub SET (run_as_owner = false);
++ERROR: subscription "regress_testsub" does not exist
+ -- fail
+ ALTER SUBSCRIPTION regress_testsub SET (slot_name = '');
+-ERROR: replication slot name "" is too short
++ERROR: subscription "regress_testsub" does not exist
+ -- fail
+ ALTER SUBSCRIPTION regress_doesnotexist CONNECTION 'dbname=regress_doesnotexist2';
+ ERROR: subscription "regress_doesnotexist" does not exist
+ ALTER SUBSCRIPTION regress_testsub SET (create_slot = false);
+-ERROR: unrecognized subscription parameter: "create_slot"
++ERROR: subscription "regress_testsub" does not exist
+ -- ok
+ ALTER SUBSCRIPTION regress_testsub SKIP (lsn = '0/12345');
+-\dRs+
+-List of subscriptions
+-Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+------------------+---------------------------+---------+---------------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+------------------------------+----------
+-regress_testsub | regress_subscription_user | f | {testpub2,testpub3} | f | off | d | f | any | t | f | f | off | dbname=regress_doesnotexist2 | 0/12345
+-(1 row)
++ERROR: subscription "regress_testsub" does not exist
++\dRs+
++List of subscriptions
++Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
+ 
+ -- ok - with lsn = NONE
+ ALTER SUBSCRIPTION regress_testsub SKIP (lsn = NONE);
++ERROR: subscription "regress_testsub" does not exist
+ -- fail
+ ALTER SUBSCRIPTION regress_testsub SKIP (lsn = '0/0');
+-ERROR: invalid WAL location (LSN): 0/0
+-\dRs+
+-List of subscriptions
+-Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+------------------+---------------------------+---------+---------------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+------------------------------+----------
+-regress_testsub | regress_subscription_user | f | {testpub2,testpub3} | f | off | d | f | any | t | f | f | off | dbname=regress_doesnotexist2 | 0/0
+-(1 row)
++ERROR: subscription "regress_testsub" does not exist
++\dRs+
++List of subscriptions
++Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
+ 
+ BEGIN;
+ ALTER SUBSCRIPTION regress_testsub ENABLE;
++ERROR: subscription "regress_testsub" does not exist
+ \dRs
+-List of subscriptions
+-Name | Owner | Enabled | Publication
+------------------+---------------------------+---------+---------------------
+-regress_testsub | regress_subscription_user | t | {testpub2,testpub3}
+-(1 row)
+-
++ERROR: current transaction is aborted, commands ignored until end of transaction block
+ ALTER SUBSCRIPTION regress_testsub DISABLE;
++ERROR: current transaction is aborted, commands ignored until end of transaction block
+ \dRs
+-List of subscriptions
+-Name | Owner | Enabled | Publication
+------------------+---------------------------+---------+---------------------
+-regress_testsub | regress_subscription_user | f | {testpub2,testpub3}
+-(1 row)
+-
++ERROR: current transaction is aborted, commands ignored until end of transaction block
+ COMMIT;
+ -- fail - must be owner of subscription
+ SET ROLE regress_subscription_user_dummy;
+ ALTER SUBSCRIPTION regress_testsub RENAME TO regress_testsub_dummy;
+-ERROR: must be owner of subscription regress_testsub
++ERROR: subscription "regress_testsub" does not exist
+ RESET ROLE;
+ ALTER SUBSCRIPTION regress_testsub RENAME TO regress_testsub_foo;
++ERROR: subscription "regress_testsub" does not exist
+ ALTER SUBSCRIPTION regress_testsub_foo SET (synchronous_commit = local);
++ERROR: subscription "regress_testsub_foo" does not exist
+ ALTER SUBSCRIPTION regress_testsub_foo SET (synchronous_commit = foobar);
+-ERROR: invalid value for parameter "synchronous_commit": "foobar"
+-HINT: Available values: local, remote_write, remote_apply, on, off.
+-\dRs+
+-List of subscriptions
+-Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+----------------------+---------------------------+---------+---------------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+------------------------------+----------
+-regress_testsub_foo | regress_subscription_user | f | {testpub2,testpub3} | f | off | d | f | any | t | f | f | local | dbname=regress_doesnotexist2 | 0/0
+-(1 row)
++ERROR: subscription "regress_testsub_foo" does not exist
++\dRs+
++List of subscriptions
++Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
+ 
+ -- rename back to keep the rest simple
+ ALTER SUBSCRIPTION regress_testsub_foo RENAME TO regress_testsub;
++ERROR: subscription "regress_testsub_foo" does not exist
+ -- ok, we're a superuser
+ ALTER SUBSCRIPTION regress_testsub OWNER TO regress_subscription_user2;
++ERROR: subscription "regress_testsub" does not exist
+ -- fail - cannot do DROP SUBSCRIPTION inside transaction block with slot name
+ BEGIN;
+ DROP SUBSCRIPTION regress_testsub;
+-ERROR: DROP SUBSCRIPTION cannot run inside a transaction block
++ERROR: subscription "regress_testsub" does not exist
+ COMMIT;
+ ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);
+--- now it works
+-BEGIN;
+-DROP SUBSCRIPTION regress_testsub;
++ERROR: subscription "regress_testsub" does not exist
++-- now it works
++BEGIN;
++DROP SUBSCRIPTION regress_testsub;
++ERROR: subscription "regress_testsub" does not exist
+ COMMIT;
+ DROP SUBSCRIPTION IF EXISTS regress_testsub;
+ NOTICE: subscription "regress_testsub" does not exist, skipping
+@@ -249,235 +239,239 @@
+ ERROR: subscription "regress_testsub" does not exist
+ -- fail - binary must be boolean
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (connect = false, binary = foo);
+-ERROR: binary requires a Boolean value
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ -- now it works
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (connect = false, binary = true);
+-WARNING: subscription was created, but is not connected
+-HINT: To initiate replication, you must manually create the replication slot, enable the subscription, and refresh the subscription.
+-\dRs+
+-List of subscriptions
+-Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+------------------+---------------------------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+-----------------------------+----------
+-regress_testsub | regress_subscription_user | f | {testpub} | t | off | d | f | any | t | f | f | off | dbname=regress_doesnotexist | 0/0
+-(1 row)
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
++\dRs+
++List of subscriptions
++Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
+ 
+ ALTER SUBSCRIPTION regress_testsub SET (binary = false);
+-ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);
+-\dRs+
+-List of subscriptions
+-Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+------------------+---------------------------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+-----------------------------+----------
+-regress_testsub | regress_subscription_user | f | {testpub} | f | off | d | f | any | t | f | f | off | dbname=regress_doesnotexist | 0/0
+-(1 row)
+-
+-DROP SUBSCRIPTION regress_testsub;
++ERROR: subscription "regress_testsub" does not exist
++ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);
++ERROR: subscription "regress_testsub" does not exist
++\dRs+
++List of subscriptions
++Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
++
++DROP SUBSCRIPTION regress_testsub;
++ERROR: subscription "regress_testsub" does not exist
+ -- fail - streaming must be boolean or 'parallel'
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (connect = false, streaming = foo);
+-ERROR: streaming requires a Boolean value or "parallel"
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ -- now it works
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (connect = false, streaming = true);
+-WARNING: subscription was created, but is not connected
+-HINT: To initiate replication, you must manually create the replication slot, enable the subscription, and refresh the subscription.
+-\dRs+
+-List of subscriptions
+-Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+------------------+---------------------------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+-----------------------------+----------
+-regress_testsub | regress_subscription_user | f | {testpub} | f | on | d | f | any | t | f | f | off | dbname=regress_doesnotexist | 0/0
+-(1 row)
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
++\dRs+
++List of subscriptions
++Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
+ 
+ ALTER SUBSCRIPTION regress_testsub SET (streaming = parallel);
+-\dRs+
+-List of subscriptions
+-Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+------------------+---------------------------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+-----------------------------+----------
+-regress_testsub | regress_subscription_user | f | {testpub} | f | parallel | d | f | any | t | f | f | off | dbname=regress_doesnotexist | 0/0
+-(1 row)
++ERROR: subscription "regress_testsub" does not exist
++\dRs+
++List of subscriptions
++Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
+ 
+ ALTER SUBSCRIPTION regress_testsub SET (streaming = false);
+-ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);
+-\dRs+
+-List of subscriptions
+-Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+------------------+---------------------------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+-----------------------------+----------
+-regress_testsub | regress_subscription_user | f | {testpub} | f | off | d | f | any | t | f | f | off | dbname=regress_doesnotexist | 0/0
+-(1 row)
++ERROR: subscription "regress_testsub" does not exist
++ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);
++ERROR: subscription "regress_testsub" does not exist
++\dRs+
++List of subscriptions
++Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
+ 
+ -- fail - publication already exists
+ ALTER SUBSCRIPTION regress_testsub ADD PUBLICATION testpub WITH (refresh = false);
+-ERROR: publication "testpub" is already in subscription "regress_testsub"
++ERROR: subscription "regress_testsub" does not exist
+ -- fail - publication used more than once
+ ALTER SUBSCRIPTION regress_testsub ADD PUBLICATION testpub1, testpub1 WITH (refresh = false);
+-ERROR: publication name "testpub1" used more than once
++ERROR: subscription "regress_testsub" does not exist
+ -- ok - add two publications into subscription
+ ALTER SUBSCRIPTION regress_testsub ADD PUBLICATION testpub1, testpub2 WITH (refresh = false);
++ERROR: subscription "regress_testsub" does not exist
+ -- fail - publications already exist
+ ALTER SUBSCRIPTION regress_testsub ADD PUBLICATION testpub1, testpub2 WITH (refresh = false);
+-ERROR: publication "testpub1" is already in subscription "regress_testsub"
+-\dRs+
+-List of subscriptions
+-Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+------------------+---------------------------+---------+-----------------------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+-----------------------------+----------
+-regress_testsub | regress_subscription_user | f | {testpub,testpub1,testpub2} | f | off | d | f | any | t | f | f | off | dbname=regress_doesnotexist | 0/0
+-(1 row)
++ERROR: subscription "regress_testsub" does not exist
++\dRs+
++List of subscriptions
++Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
+ 
+ -- fail - publication used more than once
+ ALTER SUBSCRIPTION regress_testsub DROP PUBLICATION testpub1, testpub1 WITH (refresh = false);
+-ERROR: publication name "testpub1" used more than once
++ERROR: subscription "regress_testsub" does not exist
+ -- fail - all publications are deleted
+ ALTER SUBSCRIPTION regress_testsub DROP PUBLICATION testpub, testpub1, testpub2 WITH (refresh = false);
+-ERROR: cannot drop all the publications from a subscription
++ERROR: subscription "regress_testsub" does not exist
+ -- fail - publication does not exist in subscription
+ ALTER SUBSCRIPTION regress_testsub DROP PUBLICATION testpub3 WITH (refresh = false);
+-ERROR: publication "testpub3" is not in subscription "regress_testsub"
++ERROR: subscription "regress_testsub" does not exist
+ -- ok - delete publications
+ ALTER SUBSCRIPTION regress_testsub DROP PUBLICATION testpub1, testpub2 WITH (refresh = false);
+-\dRs+
+-List of subscriptions
+-Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+------------------+---------------------------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+-----------------------------+----------
+-regress_testsub | regress_subscription_user | f | {testpub} | f | off | d | f | any | t | f | f | off | dbname=regress_doesnotexist | 0/0
+-(1 row)
+-
+-DROP SUBSCRIPTION regress_testsub;
++ERROR: subscription "regress_testsub" does not exist
++\dRs+
++List of subscriptions
++Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
++
++DROP SUBSCRIPTION regress_testsub;
++ERROR: subscription "regress_testsub" does not exist
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'dbname=regress_doesnotexist' PUBLICATION mypub
+ WITH (connect = false, create_slot = false, copy_data = false);
+-WARNING: subscription was created, but is not connected
+-HINT: To initiate replication, you must manually create the replication slot, enable the subscription, and refresh the subscription.
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ ALTER SUBSCRIPTION regress_testsub ENABLE;
++ERROR: subscription "regress_testsub" does not exist
+ -- fail - ALTER SUBSCRIPTION with refresh is not allowed in a transaction
+ -- block or function
+ BEGIN;
+ ALTER SUBSCRIPTION regress_testsub SET PUBLICATION mypub WITH (refresh = true);
+-ERROR: ALTER SUBSCRIPTION with refresh cannot run inside a transaction block
++ERROR: subscription "regress_testsub" does not exist
+ END;
+ BEGIN;
+ ALTER SUBSCRIPTION regress_testsub REFRESH PUBLICATION;
+-ERROR: ALTER SUBSCRIPTION ... REFRESH cannot run inside a transaction block
++ERROR: subscription "regress_testsub" does not exist
+ END;
+ CREATE FUNCTION func() RETURNS VOID AS
+ $$ ALTER SUBSCRIPTION regress_testsub SET PUBLICATION mypub WITH (refresh = true) $$ LANGUAGE SQL;
+ SELECT func();
+-ERROR: ALTER SUBSCRIPTION with refresh cannot be executed from a function
++ERROR: subscription "regress_testsub" does not exist
+ CONTEXT: SQL function "func" statement 1
+ ALTER SUBSCRIPTION regress_testsub DISABLE;
+-ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);
+-DROP SUBSCRIPTION regress_testsub;
++ERROR: subscription "regress_testsub" does not exist
++ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);
++ERROR: subscription "regress_testsub" does not exist
++DROP SUBSCRIPTION regress_testsub;
++ERROR: subscription "regress_testsub" does not exist
+ DROP FUNCTION func;
+ -- fail - two_phase must be boolean
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (connect = false, two_phase = foo);
+-ERROR: two_phase requires a Boolean value
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ -- now it works
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (connect = false, two_phase = true);
+-WARNING: subscription was created, but is not connected
+-HINT: To initiate replication, you must manually create the replication slot, enable the subscription, and refresh the subscription.
+-\dRs+
+-List of subscriptions
+-Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+------------------+---------------------------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+-----------------------------+----------
+-regress_testsub | regress_subscription_user | f | {testpub} | f | off | p | f | any | t | f | f | off | dbname=regress_doesnotexist | 0/0
+-(1 row)
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
++\dRs+
++List of subscriptions
++Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
+ 
+ --fail - alter of two_phase option not supported.
+ ALTER SUBSCRIPTION regress_testsub SET (two_phase = false);
+-ERROR: unrecognized subscription parameter: "two_phase"
++ERROR: subscription "regress_testsub" does not exist
+ -- but can alter streaming when two_phase enabled
+ ALTER SUBSCRIPTION regress_testsub SET (streaming = true);
+-\dRs+
+-List of subscriptions
+-Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+------------------+---------------------------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+-----------------------------+----------
+-regress_testsub | regress_subscription_user | f | {testpub} | f | on | p | f | any | t | f | f | off | dbname=regress_doesnotexist | 0/0
+-(1 row)
+-
+-ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);
+-DROP SUBSCRIPTION regress_testsub;
++ERROR: subscription "regress_testsub" does not exist
++\dRs+
++List of subscriptions
++Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
++
++ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);
++ERROR: subscription "regress_testsub" does not exist
++DROP SUBSCRIPTION regress_testsub;
++ERROR: subscription "regress_testsub" does not exist
+ -- two_phase and streaming are compatible.
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (connect = false, streaming = true, two_phase = true);
+-WARNING: subscription was created, but is not connected
+-HINT: To initiate replication, you must manually create the replication slot, enable the subscription, and refresh the subscription.
+-\dRs+
+-List of subscriptions
+-Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+------------------+---------------------------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+-----------------------------+----------
+-regress_testsub | regress_subscription_user | f | {testpub} | f | on | p | f | any | t | f | f | off | dbname=regress_doesnotexist | 0/0
+-(1 row)
+-
+-ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);
+-DROP SUBSCRIPTION regress_testsub;
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
++\dRs+
++List of subscriptions
++Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
++
++ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);
++ERROR: subscription "regress_testsub" does not exist
++DROP SUBSCRIPTION regress_testsub;
++ERROR: subscription "regress_testsub" does not exist
+ -- fail - disable_on_error must be boolean
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (connect = false, disable_on_error = foo);
+-ERROR: disable_on_error requires a Boolean value
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ -- now it works
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (connect = false, disable_on_error = false);
+-WARNING: subscription was created, but is not connected
+-HINT: To initiate replication, you must manually create the replication slot, enable the subscription, and refresh the subscription.
+-\dRs+
+-List of subscriptions
+-Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+------------------+---------------------------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+-----------------------------+----------
+-regress_testsub | regress_subscription_user | f | {testpub} | f | off | d | f | any | t | f | f | off | dbname=regress_doesnotexist | 0/0
+-(1 row)
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
++\dRs+
++List of subscriptions
++Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
+ 
+ ALTER SUBSCRIPTION regress_testsub SET (disable_on_error = true);
+-\dRs+
+-List of subscriptions
+-Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
+------------------+---------------------------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+-----------------------------+----------
+-regress_testsub | regress_subscription_user | f | {testpub} | f | off | d | t | any | t | f | f | off | dbname=regress_doesnotexist | 0/0
+-(1 row)
+-
+-ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);
+-DROP SUBSCRIPTION regress_testsub;
++ERROR: subscription "regress_testsub" does not exist
++\dRs+
++List of subscriptions
++Name | Owner | Enabled | Publication | Binary | Streaming | Two-phase commit | Disable on error | Origin | Password required | Run as owner? | Failover | Synchronous commit | Conninfo | Skip LSN
++------+-------+---------+-------------+--------+-----------+------------------+------------------+--------+-------------------+---------------+----------+--------------------+----------+----------
++(0 rows)
++
++ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);
++ERROR: subscription "regress_testsub" does not exist
++DROP SUBSCRIPTION regress_testsub;
++ERROR: subscription "regress_testsub" does not exist
+ -- let's do some tests with pg_create_subscription rather than superuser
+ SET SESSION AUTHORIZATION regress_subscription_user3;
+ -- fail, not enough privileges
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (connect = false);
+-ERROR: permission denied for database regression
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ -- fail, must specify password
+ RESET SESSION AUTHORIZATION;
+ GRANT CREATE ON DATABASE REGRESSION TO regress_subscription_user3;
+ SET SESSION AUTHORIZATION regress_subscription_user3;
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (connect = false);
+-ERROR: password is required
+-DETAIL: Non-superusers must provide a password in the connection string.
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ -- fail, can't set password_required=false
+ RESET SESSION AUTHORIZATION;
+ GRANT CREATE ON DATABASE REGRESSION TO regress_subscription_user3;
+ SET SESSION AUTHORIZATION regress_subscription_user3;
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'dbname=regress_doesnotexist' PUBLICATION testpub WITH (connect = false, password_required = false);
+-ERROR: password_required=false is superuser-only
+-HINT: Subscriptions with the password_required option set to false may only be created or modified by the superuser.
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ -- ok
+ RESET SESSION AUTHORIZATION;
+ GRANT CREATE ON DATABASE REGRESSION TO regress_subscription_user3;
+ SET SESSION AUTHORIZATION regress_subscription_user3;
+ CREATE SUBSCRIPTION regress_testsub CONNECTION 'dbname=regress_doesnotexist password=regress_fakepassword' PUBLICATION testpub WITH (connect = false);
+-WARNING: subscription was created, but is not connected
+-HINT: To initiate replication, you must manually create the replication slot, enable the subscription, and refresh the subscription.
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+ -- we cannot give the subscription away to some random user
+ ALTER SUBSCRIPTION regress_testsub OWNER TO regress_subscription_user;
+-ERROR: must be able to SET ROLE "regress_subscription_user"
++ERROR: subscription "regress_testsub" does not exist
+ -- but we can rename the subscription we just created
+ ALTER SUBSCRIPTION regress_testsub RENAME TO regress_testsub2;
++ERROR: subscription "regress_testsub" does not exist
+ -- ok, even after losing pg_create_subscription we can still rename it
+ RESET SESSION AUTHORIZATION;
+ REVOKE pg_create_subscription FROM regress_subscription_user3;
+ SET SESSION AUTHORIZATION regress_subscription_user3;
+ ALTER SUBSCRIPTION regress_testsub2 RENAME TO regress_testsub;
++ERROR: subscription "regress_testsub2" does not exist
+ -- fail, after losing CREATE on the database we can't rename it any more
+ RESET SESSION AUTHORIZATION;
+ REVOKE CREATE ON DATABASE REGRESSION FROM regress_subscription_user3;
+ SET SESSION AUTHORIZATION regress_subscription_user3;
+ ALTER SUBSCRIPTION regress_testsub RENAME TO regress_testsub2;
+-ERROR: permission denied for database regression
++ERROR: subscription "regress_testsub" does not exist
+ -- fail - cannot do ALTER SUBSCRIPTION SET (failover) inside transaction block
+ BEGIN;
+ ALTER SUBSCRIPTION regress_testsub SET (failover);
+-ERROR: ALTER SUBSCRIPTION ... SET (failover) cannot run inside a transaction block
++ERROR: subscription "regress_testsub" does not exist
+ COMMIT;
+ -- ok, owning it is enough for this stuff
+ ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);
+-DROP SUBSCRIPTION regress_testsub;
++ERROR: subscription "regress_testsub" does not exist
++DROP SUBSCRIPTION regress_testsub;
++ERROR: subscription "regress_testsub" does not exist
+ RESET SESSION AUTHORIZATION;
+ DROP ROLE regress_subscription_user;
+ DROP ROLE regress_subscription_user2;

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/xmlmap.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/xmlmap.patch
@@ -1,0 +1,107 @@
+# pgregress-expected-file: xmlmap_1.out
+# Accepted security divergence: this PostgreSQL build has no libxml, so
+# xmlmap_1.out is the stock baseline. Multigres rejects table/query/cursor XML
+# helpers first because they execute caller-supplied SQL or expose a backend
+# cursor through a pooled session. Non-blocklisted XML behavior is unchanged.
+# See go/services/multigateway/planner/unsafe_funccall.go.
+--- a
++++ b
+@@ -12,70 +12,49 @@
+ '21:07', '21:11 +05', '2009-06-08 21:07:30', '2009-06-08 21:07:30 -07', '2009-06-08',
+ NULL, 'ABC', true, 'XYZ');
+ SELECT table_to_xml('testxmlschema.test1', false, false, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: table_to_xml is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT table_to_xml('testxmlschema.test1', true, false, 'foo');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: table_to_xml is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT table_to_xml('testxmlschema.test1', false, true, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: table_to_xml is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT table_to_xml('testxmlschema.test1', true, true, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: table_to_xml is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT table_to_xml('testxmlschema.test2', false, false, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: table_to_xml is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT table_to_xmlschema('testxmlschema.test1', false, false, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: table_to_xmlschema is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT table_to_xmlschema('testxmlschema.test1', true, false, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: table_to_xmlschema is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT table_to_xmlschema('testxmlschema.test1', false, true, 'foo');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: table_to_xmlschema is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT table_to_xmlschema('testxmlschema.test1', true, true, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: table_to_xmlschema is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT table_to_xmlschema('testxmlschema.test2', false, false, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: table_to_xmlschema is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT table_to_xml_and_xmlschema('testxmlschema.test1', false, false, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: table_to_xml_and_xmlschema is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT table_to_xml_and_xmlschema('testxmlschema.test1', true, false, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: table_to_xml_and_xmlschema is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT table_to_xml_and_xmlschema('testxmlschema.test1', false, true, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: table_to_xml_and_xmlschema is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT table_to_xml_and_xmlschema('testxmlschema.test1', true, true, 'foo');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: table_to_xml_and_xmlschema is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT query_to_xml('SELECT * FROM testxmlschema.test1', false, false, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: query_to_xml is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT query_to_xmlschema('SELECT * FROM testxmlschema.test1', false, false, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: query_to_xmlschema is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT query_to_xml_and_xmlschema('SELECT * FROM testxmlschema.test1', true, true, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: query_to_xml_and_xmlschema is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ DECLARE xc CURSOR WITH HOLD FOR SELECT * FROM testxmlschema.test1 ORDER BY 1, 2;
+ SELECT cursor_to_xml('xc'::refcursor, 5, false, true, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: cursor_to_xml is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT cursor_to_xmlschema('xc'::refcursor, false, true, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: cursor_to_xmlschema is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ MOVE BACKWARD ALL IN xc;
+ SELECT cursor_to_xml('xc'::refcursor, 5, true, false, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: cursor_to_xml is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT cursor_to_xmlschema('xc'::refcursor, true, false, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: cursor_to_xmlschema is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler
+ SELECT schema_to_xml('testxmlschema', false, true, '');
+ ERROR: unsupported XML feature
+ DETAIL: This functionality requires the server to be built with libxml support.
+@@ -103,5 +82,4 @@
+ ERROR: unsupported XML feature
+ DETAIL: This functionality requires the server to be built with libxml support.
+ SELECT table_to_xml('testxmlschema.test3', true, true, '');
+-ERROR: unsupported XML feature
+-DETAIL: This functionality requires the server to be built with libxml support.
++ERROR: table_to_xml is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler

--- a/go/test/endtoend/pgregresstest/testdata/pg17/regression_overrides.conf
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/regression_overrides.conf
@@ -20,3 +20,10 @@ lc_time = 'C'
 # PostgreSQL's default is 0, which turns every PREPARE TRANSACTION into an
 # environment failure rather than exercising Multigres transaction-state parity.
 max_prepared_transactions = 10
+
+# PostgreSQL defaults both worker ceilings to 8. pgctld's production defaults
+# are intentionally smaller, but select_parallel requests four workers and its
+# upstream expected output assumes they can all launch. Keep this override
+# scoped to the compatibility cluster.
+max_worker_processes = 8
+max_parallel_workers = 8


### PR DESCRIPTION
## Summary

- accept PostgreSQL core expected-output variants before applying Multigres patches, including `_0.out` through `_9.out` and resultmap-backed TAP passes
- select the pinned no-libxml baselines deterministically for `xml` and `xmlmap`
- raise parallel-worker ceilings only in the pg_regress test cluster
- add reviewed compatibility patches for intentional filesystem, FDW/server, subscription, XML-helper, CREATE DATABASE, and unlogged-table behavior
- label compatibility output as upstream-compatible, accepted divergence, or residual failure

## Intentionally deferred

- running the core suite in a dedicated `regression` database
- deterministic physical-backend lifecycle for the core `stats` test

The new baselines deliberately leave database/role, session-state, and prepared-statement differences as residual failures.

## Validation

- `go test ./go/test/endtoend/pgregresstest/... -run 'Test(Verify|Generate|Normalize|Expected|Prefer|Markdown|Mark)' -count=1`
- local core patch-generation run completed all 222 tests
- a subsequent verify-mode integration attempt was blocked by a local multigateway startup timeout; the labeled extended-query-serving CI run is the authoritative Linux verification
