### PR TITLE
test: stabilize two coverage-job flakes (copy-fault + slow-recruit)

### DIFF
--- a/go/services/multiorch/consensus/rule_change_test.go
+++ b/go/services/multiorch/consensus/rule_change_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"testing"
 	"time"
 
@@ -534,8 +535,14 @@ func TestRun_SlowRecruitDoesNotBlockAfterQuorum(t *testing.T) {
 	assert.Less(t, elapsed, 2*time.Second,
 		"Run blocked waiting for slow recruit; Phase 2 should not wait for in-flight goroutines after quorum")
 	// mp2's Recruit RPC was issued (no pre-filtering on health), but its slow
-	// response did not delay Run.
-	assert.Contains(t, fc.GetCallLog(), fmt.Sprintf("Recruit(%s)", string(mp2Key)),
+	// response did not delay Run. The recruit fan-out runs in a background
+	// goroutine, so poll for the logged call rather than asserting immediately:
+	// Run can return before mp2's goroutine has been scheduled far enough to
+	// record the call, especially under slow (e.g. coverage-instrumented)
+	// scheduling.
+	assert.Eventually(t, func() bool {
+		return slices.Contains(fc.GetCallLog(), fmt.Sprintf("Recruit(%s)", string(mp2Key)))
+	}, 5*time.Second, 10*time.Millisecond,
 		"Recruit should be issued to all cohort members regardless of health status")
 }
 

--- a/go/test/endtoend/queryserving/pgbouncertests/copy_fault_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/copy_fault_test.go
@@ -100,6 +100,15 @@ func TestCopyInterruptedByBackendCrash(t *testing.T) {
 	// A fresh connection must serve queries again after recovery.
 	conn2 := connectGateway(t, ctx, gatewayDSN)
 	defer conn2.Close(ctx)
+
+	// Disable statement_timeout on the recovery connection. This test isn't
+	// exercising timeout behavior — it just needs the post-restart queries to
+	// complete. Under coverage-instrumented binaries (which run ~2-3x slower) a
+	// query issued right after crash recovery can otherwise exceed the gateway's
+	// default statement_timeout and fail with SQLSTATE 57014.
+	_, err = conn2.Exec(ctx, "SET statement_timeout = 0")
+	require.NoError(t, err)
+
 	require.Eventually(t, func() bool {
 		recoverCtx := utils.WithShortDeadline(t)
 		var n int


### PR DESCRIPTION
Fixes MUL-998

## Summary

Fixes two **pre-existing** flaky tests that only manifest in the **Code Coverage** CI job. Coverage-instrumented binaries run ~2-3x slower and alter goroutine scheduling, so both failures are timing sensitivities, not logic bugs. The regular integration job passes for both.

Both fixes are test-only — no product code is touched.

## 1. `TestCopyInterruptedByBackendCrash`

`go/test/endtoend/queryserving/pgbouncertests/copy_fault_test.go`

The test SIGKILLs the primary's postgres, the monitor auto-restarts it, then a query runs against the recovered backend. The multigateway applies a default **30s `statement_timeout`**, and under coverage the post-restart query exceeded it, failing with:

```
ERROR: canceling statement due to statement timeout (SQLSTATE 57014)
```

(Observed failing all 3 attempts in a Code Coverage run while the regular integration job passed.)

This test isn't exercising timeout behavior — it just needs the post-recovery queries to complete. Fix: **disable `statement_timeout` on the recovery connection**.

This does not risk a hang: the query still runs on the test's existing 120s client context (`utils.WithTimeout(t, 120*time.Second)`), so a genuine hang surfaces as a clean context-deadline failure rather than a spurious 57014. It just removes the tight server-side guillotine that a legitimately-slow-but-succeeding post-restart query was tripping under coverage.

**Verified:** passes 5/5 with `-cover` locally.

## 2. `TestRun_SlowRecruitDoesNotBlockAfterQuorum`

`go/services/multiorch/consensus/rule_change_test.go`

The test asserts that `Recruit` was issued to a slow cohort member (`mp2`) whose recruit call is delayed 20s in a background goroutine. The fake client logs the call at the *very start* of `Recruit` (before the delay), so the assertion raced the goroutine merely being scheduled — under coverage's altered scheduling the call could be unrecorded when `Run` returns (<2s).

Fix: **poll for the logged call with `assert.Eventually`** instead of asserting immediately.

**Verified:** passes 20/20 under `-race` locally.