### PR TITLE
fix(multipooler): stop blaming a nonexistent failover for reserved-conn kills

### DIFF
--- a/go/common/mterrors/code.go
+++ b/go/common/mterrors/code.go
@@ -70,8 +70,14 @@ func NewIdleSessionTimeout() *PgDiagnostic {
 
 // NewReservedConnectionTerminated creates a PgDiagnostic for a reserved
 // connection that was terminated before its in-flight work could continue or
-// be concluded — e.g. force-closed when a planned failover drain exceeded its
-// grace period while the client sat idle. The message is deliberately not
+// be concluded. This fires for several distinct, unrelated reasons — most
+// commonly the reserved pool's own idle-connection reaper (see
+// reserved.Pool's InactivityTimeout), but also an explicit kill, an ordinary
+// release racing a lookup, or a planned-failover drain exceeding its grace
+// period. The message deliberately does not name a specific cause: it isn't
+// determinable at this call site, and naming the wrong one (e.g. blaming
+// "planned failover" for what's actually a routine idle timeout) misleads
+// whoever reads it during an incident. The message is also deliberately not
 // transaction-specific: a reserved connection may hold a transaction or only
 // non-transactional session state (temp tables, portals, COPY, LISTEN), and
 // the same termination applies to all of them. SQLSTATE 40001
@@ -82,7 +88,7 @@ func NewIdleSessionTimeout() *PgDiagnostic {
 // to buffer or auto-retry inside the cluster — only the client can replay it.
 func NewReservedConnectionTerminated(reservedConnID uint64) *PgDiagnostic {
 	return NewPgError("ERROR", PgSSSerializationFailure,
-		"reserved connection terminated during a planned failover; please retry",
+		"reserved connection terminated; please retry",
 		fmt.Sprintf("reserved connection %d was terminated", reservedConnID))
 }
 

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -1523,7 +1523,7 @@ func TestCopyOutReady_ReservedConnectionNotFound(t *testing.T) {
 	)
 	require.Error(t, err)
 	assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSSerializationFailure), "expected 40001, got: %v", err)
-	require.Contains(t, err.Error(), "terminated during a planned failover")
+	require.Contains(t, err.Error(), "reserved connection terminated; please retry")
 }
 
 // TestConcludeTransaction_ReservedConnTerminated covers the failover-leak fix:
@@ -1548,7 +1548,7 @@ func TestConcludeTransaction_ReservedConnTerminated(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSSerializationFailure), "expected 40001, got: %v", err)
 	assert.False(t, mterrors.IsErrorCode(err, mterrors.MTF01.ID), "must not surface MTF01: %v", err)
-	require.Contains(t, err.Error(), "terminated during a planned failover")
+	require.Contains(t, err.Error(), "reserved connection terminated; please retry")
 }
 
 func TestCopyOutStream_ValidationAndNotFound(t *testing.T) {
@@ -1575,7 +1575,7 @@ func TestCopyOutStream_ValidationAndNotFound(t *testing.T) {
 		)
 		require.Error(t, err)
 		assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSSerializationFailure), "expected 40001, got: %v", err)
-		require.Contains(t, err.Error(), "terminated during a planned failover")
+		require.Contains(t, err.Error(), "reserved connection terminated; please retry")
 	})
 }
 


### PR DESCRIPTION
`NewReservedConnectionTerminated` fires for several unrelated reasons — most commonly the reserved pool's own 30s idle-connection reaper, but also an explicit kill, an ordinary release, or an actual planned-failover drain — yet the message always blamed "a planned failover." Confirmed live that a plain idle session with zero failover activity in multiorch's logs produces the same error, which misleads whoever reads it during a real incident. This generalizes the message to "reserved connection terminated; please retry", which is accurate for all four causes. SQLSTATE and retry semantics are unchanged.