### PR TITLE
fix(pgprotocol): flush extended-query errors immediately, not at Sync

### DIFF
--- a/go/common/pgprotocol/server/buffering_test.go
+++ b/go/common/pgprotocol/server/buffering_test.go
@@ -273,12 +273,29 @@ func TestBufferingWindow_SimpleQueryFlushesOnce(t *testing.T) {
 			"ReadyForQuery in order — got %v", gotTypes)
 }
 
-// TestBufferingWindow_ParseErrorDeferredToSync verifies that a Parse
-// error packet stays buffered and is delivered together with the
-// trailing Sync's ReadyForQuery — matching what postgres itself does.
-// If we accidentally re-introduce an early flush in the error path,
-// this test catches it.
-func TestBufferingWindow_ParseErrorDeferredToSync(t *testing.T) {
+// TestBufferingWindow_ParseErrorFlushesImmediately verifies that a Parse
+// error packet is flushed to the client as soon as it's written, not
+// deferred until the trailing Sync's ReadyForQuery.
+//
+// This matches directly-observed PostgreSQL behavior: a tshark-decoded
+// packet capture against a live PostgreSQL 17.6 instance shows it
+// delivers an extended-query ErrorResponse in ~0.6ms with no Flush
+// message from the client at all. The protocol spec's general "buffer
+// until Flush" language
+// (https://www.postgresql.org/docs/current/protocol-flow.html) is
+// ambiguous about whether it extends to the error case; PostgreSQL's
+// actual behavior settles it. A client that hasn't seen the error yet
+// has no reason to send Sync, so deferring delivery until Sync arrives
+// can stall indefinitely against any client — like Postgrex in
+// mode: :savepoint — that pipelines a recovery attempt without an
+// explicit Flush or Sync.
+//
+// This test previously asserted the opposite (that the error must NOT
+// flush early) under the mistaken belief that deferring matched
+// PostgreSQL. It didn't. If this test starts failing because a change
+// re-introduces the old deferred-flush behavior, that's the regression
+// to catch — not the other way around.
+func TestBufferingWindow_ParseErrorFlushesImmediately(t *testing.T) {
 	var readBuf bytes.Buffer
 	handler := &testHandler{
 		parseFunc: func(ctx context.Context, conn *Conn, name, query string, paramTypes []uint32) error {
@@ -299,15 +316,15 @@ func TestBufferingWindow_ParseErrorDeferredToSync(t *testing.T) {
 	c, netConn := newBufferingTestConn(t, &readBuf, handler)
 
 	c.startWriterBuffering()
-	require.NoError(t, c.handleParse()) // writes ErrorResponse, no flush
-	require.Equal(t, int64(0), netConn.writes.Load(),
-		"Parse error must not trigger an early flush — got %d writes", netConn.writes.Load())
+	require.NoError(t, c.handleParse()) // writes ErrorResponse, flushes immediately
+	require.Equal(t, int64(1), netConn.writes.Load(),
+		"Parse error must flush immediately — got %d writes", netConn.writes.Load())
 
 	require.NoError(t, c.handleSync())
 	require.NoError(t, c.endWriterBuffering())
 
-	assert.Equal(t, int64(1), netConn.writes.Load(),
-		"ErrorResponse + ReadyForQuery should coalesce — got %d", netConn.writes.Load())
+	assert.Equal(t, int64(2), netConn.writes.Load(),
+		"the error's own flush plus Sync's ReadyForQuery — got %d", netConn.writes.Load())
 }
 
 // TestHandleMessage_FlushConsumesLength pins the regression for an

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -1147,8 +1147,9 @@ func (c *Conn) handleParse() error {
 		// cause protocol desynchronization: pgx would read the premature ReadyForQuery
 		// and think the pipeline is done, but stale responses from subsequent messages
 		// (Describe, Sync) would corrupt the next query's response stream.
-		// The error packet stays buffered until Sync flushes the batch — same shape
-		// as upstream PostgreSQL, which also defers error delivery to Sync/Flush.
+		// writeExtendedQueryError flushes the error packet immediately — it
+		// does not wait for Sync (see that function's comment for why).
+		// ReadyForQuery itself still only comes from Sync, per the protocol.
 		//
 		// Preserve a structured PostgreSQL diagnostic (e.g. 42601 syntax_error
 		// from the parser); only opaque errors are wrapped as MTD04, a genuinely
@@ -1237,8 +1238,10 @@ func (c *Conn) handleBind() error {
 	// Call the handler to create and bind the portal with parameters.
 	if err := c.handler.HandleBind(c.ctx, c, portalName, stmtName, params, paramFormats, resultFormats); err != nil {
 		// Do NOT send ReadyForQuery here — same reasoning as handleParse.
-		// ReadyForQuery is sent only in response to Sync. The error packet
-		// stays buffered until Sync flushes the batch.
+		// ReadyForQuery is sent only in response to Sync.
+		// writeExtendedQueryError flushes the error packet immediately —
+		// see that function's comment. ReadyForQuery itself still only
+		// comes from Sync, per the protocol.
 		//
 		// Preserve a structured diagnostic (e.g. 26000 for a Bind referencing a
 		// prepared statement that was never Parsed); only opaque errors become
@@ -1632,7 +1635,38 @@ func (c *Conn) writeExtendedQueryError(err error) error {
 		c.logger.Info("relayed FATAL diagnostic; closing connection", "sqlstate", diag.Code)
 		return errFatalDiagnosticSent
 	}
-	return nil
+	// Flush now rather than leaving the ErrorResponse buffered until Sync.
+	//
+	// Execute (and Parse/Bind/Describe/Close) aren't flush boundaries by
+	// design — see the isBatchBoundary comment in serve() — so without this,
+	// the buffer would sit until a Sync arrives. That's fine for a client
+	// that plans to send Sync regardless of the result. It's not fine for a
+	// client that pipelines a recovery attempt WITHOUT Sync and decides what
+	// to send next based on whether this errored (e.g. Postgrex's
+	// mode: :savepoint, which pipelines Bind + Execute + an optimistic
+	// "RELEASE SAVEPOINT ..." with no Flush/Sync): it can't know to send
+	// Sync until it has actually seen this error, so it never does, and the
+	// buffered response would sit here until something else — like the
+	// client's own timeout, then disconnecting — eventually forces a flush.
+	//
+	// The PostgreSQL protocol spec is genuinely ambiguous about whether the
+	// general "buffer until Flush" discretion
+	// (https://www.postgresql.org/docs/current/protocol-flow.html, Extended
+	// Query section) extends to this error case — "the backend issues
+	// ErrorResponse" doesn't explicitly say "flushes immediately." This
+	// isn't fixing a protocol violation; it's resolving that ambiguity to
+	// match what a real PostgreSQL 17.6 instance actually does on the wire
+	// (confirmed via a tshark-decoded packet capture: it delivers an
+	// extended-query ErrorResponse in ~0.6ms with no Flush message sent by
+	// the client). Matching that observed behavior, not a narrower reading
+	// of the ambiguous prose, is the correct target for a wire-compatible
+	// proxy.
+	//
+	// This does not touch the discard-until-Sync gate itself (still correct,
+	// still spec-compliant — a message pipelined after the error is properly
+	// discarded, not dispatched, until Sync). Only the timing of delivering
+	// the already-written ErrorResponse changes.
+	return c.flush()
 }
 
 // handleSync handles an 'S' (Sync) message - extended query protocol.

--- a/go/common/pgprotocol/server/extended_query_test.go
+++ b/go/common/pgprotocol/server/extended_query_test.go
@@ -1261,7 +1261,6 @@ func TestPipelinedParseErrorRecovery(t *testing.T) {
 // ErrorResponse and ReadyForQuery; the original wire trace came from a
 // Parse / Bind / Execute / Close / Sync flight, but the gate applies to
 // every Parse/Bind/Describe/Execute/Close after an error.
-// See ~/dev/multigres-plans/investigations/2026-05-20-multigateway-extended-query-close-after-error.md.
 func TestExtendedQueryErrorDiscardsUntilSync(t *testing.T) {
 	var readBuf, writeBuf bytes.Buffer
 	handler := &testHandler{


### PR DESCRIPTION
Multigres was queuing an ErrorResponse for a failed extended-query message (Parse/Bind/Describe/Execute/Close) but leaving it buffered until a `Sync` arrived to flush it. This surfaced as a real breakage in Realtime's test suite: Postgrex's `mode: :savepoint` pipelines a recovery attempt (Bind + Execute + an optimistic `RELEASE SAVEPOINT ...`) without sending Flush or Sync, since it can't know it needs to recover until it's actually seen the error. Multigres never delivered the error, so the client waited out its own ~15s timeout and disconnected — and only that disconnect forced the flush, far too late to matter.

The [PostgreSQL protocol spec](https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY) ("Extended Query" section) is genuinely ambiguous here: its general "buffer until Flush" language for extended-query output doesn't explicitly say whether that discretion extends to the error case, and the Sync/error-recovery paragraph just says the backend "issues ErrorResponse" without specifying flush timing. A packet capture against a real PostgreSQL 17.6 instance settles it empirically — it flushes the ErrorResponse in ~0.6ms with no Flush message from the client at all. This PR makes `writeExtendedQueryError` (`go/common/pgprotocol/server/conn.go`) flush immediately after writing the error, matching that observed behavior, and corrects two stale comments that had asserted the old deferred-flush behavior matched upstream PostgreSQL. The discard-until-Sync logic for messages pipelined after the error is unchanged.