### PR TITLE
fix(tests): stabilize failover and replication flakes

### DIFF
--- a/go/cmd/pgctld/command/restore_wrapper.go
+++ b/go/cmd/pgctld/command/restore_wrapper.go
@@ -72,6 +72,13 @@ func runRestoreWrapper(cmd *cobra.Command, args []string) error {
 		return errors.New("usage: pgctld restore-wrapper <pidfile> -- <command> [args...]")
 	}
 
+	// Install the handler before publishing our PID so StopRestoreCommand cannot
+	// terminate the wrapper in the gap between discovering it and signal.Notify.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigCh)
+
+	//nolint:gosec // The caller deliberately supplies the restore_command pidfile path.
 	if err := os.WriteFile(pidfile, []byte(strconv.Itoa(os.Getpid())), 0o644); err != nil {
 		return fmt.Errorf("restore-wrapper: failed to write pidfile %s: %w", pidfile, err)
 	}
@@ -80,10 +87,11 @@ func runRestoreWrapper(cmd *cobra.Command, args []string) error {
 	// common case (no pidfile = nothing to check) the fast path.
 	defer os.Remove(pidfile)
 
-	return runWrappedCommand(args[0], args[1:])
+	return runWrappedCommand(args[0], args[1:], sigCh)
 }
 
-func runWrappedCommand(name string, args []string) error {
+func runWrappedCommand(name string, args []string, sigCh <-chan os.Signal) error {
+	//nolint:gosec // Executing the caller-supplied restore command is this wrapper's purpose.
 	c := exec.Command(name, args...)
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -95,10 +103,6 @@ func runWrappedCommand(name string, args []string) error {
 	if err := c.Start(); err != nil {
 		return fmt.Errorf("restore-wrapper: failed to start %s: %w", name, err)
 	}
-
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
-	defer signal.Stop(sigCh)
 
 	done := make(chan error, 1)
 	go func() { done <- c.Wait() }()
@@ -113,7 +117,11 @@ func runWrappedCommand(name string, args []string) error {
 			_ = syscall.Kill(pgid, syscall.SIGKILL)
 			<-done
 		}
-		return fmt.Errorf("restore-wrapper: %s terminated by signal %s", name, sig)
+		// PostgreSQL treats a signal-terminated restore_command as a shutdown
+		// request. This signal came through StopRestoreCommand, so report a clean
+		// wrapper exit after the child is gone; PostgreSQL will verify whether the
+		// requested WAL file exists and continue normally when it does not.
+		return nil
 	case err := <-done:
 		return err
 	}

--- a/go/cmd/pgctld/command/restore_wrapper_test.go
+++ b/go/cmd/pgctld/command/restore_wrapper_test.go
@@ -15,7 +15,14 @@
 package command
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,4 +48,75 @@ func TestRestoreWrapperSkipsTelemetry(t *testing.T) {
 	err = root.Execute()
 	require.Error(t, err)
 	assert.True(t, root.SilenceUsage, "PersistentPreRunE should have run despite skipping telemetry")
+}
+
+func TestRestoreWrapperSIGTERMExitsCleanly(t *testing.T) {
+	const helperEnv = "MULTIGRES_RESTORE_WRAPPER_TEST_HELPER"
+	if os.Getenv(helperEnv) == "1" {
+		err := runRestoreWrapper(nil, []string{
+			os.Getenv("MULTIGRES_RESTORE_WRAPPER_PIDFILE"), "--", "sh", "-c",
+			`trap '' TERM INT; echo $$ > "$1"; while :; do sleep 1; done`,
+			"sh", os.Getenv("MULTIGRES_RESTORE_WRAPPER_CHILD_PIDFILE"),
+		})
+		require.NoError(t, err)
+		return
+	}
+
+	dir := t.TempDir()
+	pidfile := filepath.Join(dir, "wrapper.pid")
+	childPIDFile := filepath.Join(dir, "child.pid")
+	helper := exec.Command(os.Args[0], "-test.run=^TestRestoreWrapperSIGTERMExitsCleanly$")
+	helper.Env = append(os.Environ(),
+		helperEnv+"=1",
+		"MULTIGRES_RESTORE_WRAPPER_PIDFILE="+pidfile,
+		"MULTIGRES_RESTORE_WRAPPER_CHILD_PIDFILE="+childPIDFile,
+	)
+	helper.Stdout = os.Stdout
+	helper.Stderr = os.Stderr
+	require.NoError(t, helper.Start())
+
+	childPID := 0
+	t.Cleanup(func() {
+		_ = syscall.Kill(helper.Process.Pid, syscall.SIGKILL)
+		if childPID != 0 {
+			_ = syscall.Kill(-childPID, syscall.SIGKILL)
+		}
+	})
+
+	readPID := func(path string) (int, bool) {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return 0, false
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		return pid, err == nil
+	}
+
+	wrapperPID := 0
+	require.Eventually(t, func() bool {
+		var wrapperOK, childOK bool
+		wrapperPID, wrapperOK = readPID(pidfile)
+		childPID, childOK = readPID(childPIDFile)
+		return wrapperOK && childOK
+	}, 5*time.Second, 10*time.Millisecond, "wrapper and child did not publish their PIDs")
+	require.Equal(t, helper.Process.Pid, wrapperPID)
+	require.NoError(t, syscall.Kill(wrapperPID, syscall.SIGTERM))
+
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- helper.Wait() }()
+	select {
+	case err := <-waitCh:
+		require.NoError(t, err, "wrapper did not exit cleanly")
+	case <-time.After(3 * time.Second):
+		t.Fatal("wrapper did not exit after SIGTERM")
+	}
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(pidfile)
+		return os.IsNotExist(err)
+	}, time.Second, 10*time.Millisecond, "wrapper pidfile was not removed")
+	require.Eventually(t, func() bool {
+		process, err := os.FindProcess(childPID)
+		return err != nil || process.Signal(syscall.Signal(0)) != nil
+	}, time.Second, 10*time.Millisecond, "wrapped process %d is still running", childPID)
 }

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -798,9 +798,9 @@ func (s *PgCtldService) PgRewind(ctx context.Context, req *pb.PgRewindRequest) (
 	}, nil
 }
 
-// stopRestoreCommandGracePeriod is how long StopRestoreCommand waits for a
-// signaled restore_command wrapper to exit on its own before escalating.
-const stopRestoreCommandGracePeriod = 200 * time.Millisecond
+// stopRestoreCommandGracePeriod gives the wrapper enough time to exhaust its
+// own child-process grace period and exit cleanly before pgctld escalates.
+const stopRestoreCommandGracePeriod = restoreWrapperGracePeriod + 500*time.Millisecond
 
 // StopRestoreCommand checks whether the restore_command wrapper (see
 // `pgctld restore-wrapper`) is currently running, by reading the PID it

--- a/go/common/timeouts/rpc.go
+++ b/go/common/timeouts/rpc.go
@@ -28,6 +28,10 @@ const RemoteOperationTimeout = 15 * time.Second
 // beyond the typical 8–14 s observed in the 9-pooler AZ-freeze test.
 const RuleWriteTimeout = 30 * time.Second
 
+// PostgresConfigTimeout bounds ALTER SYSTEM and configuration-reload queries.
+// These normally take milliseconds but can exceed 500ms on a loaded CI host.
+const PostgresConfigTimeout = 2 * time.Second
+
 // DefaultHealthStreamStalenessTimeout is the default staleness watchdog timeout for
 // ManagerHealthStream connections. If no message is received within this window
 // the client reconnects and the server advertises this value in the start response.

--- a/go/services/multigateway/buffer/buffer.go
+++ b/go/services/multigateway/buffer/buffer.go
@@ -243,7 +243,8 @@ func (b *Buffer) enqueue(shardKey *clustermetadatapb.ShardKey) (*entry, error) {
 	// releases slots outside b.mu only after retries complete — entries
 	// that have left the queue but are still in-flight during drain must
 	// still count against the global limit.
-	if !b.bufferSizeSema.TryAcquire(1) {
+	acquiredSlot := b.bufferSizeSema.TryAcquire(1)
+	if !acquiredSlot {
 		// Buffer is full. Evict the oldest entry globally to make room.
 		if len(b.queue) == 0 {
 			return nil, mterrors.MTB01.New()
@@ -251,11 +252,9 @@ func (b *Buffer) enqueue(shardKey *clustermetadatapb.ShardKey) (*entry, error) {
 		oldest := b.queue[0]
 		b.queue = b.queue[1:]
 		oldest.err = mterrors.MTB01.New()
-		b.stats.addQueueDepth(b.ctx, -1)
 		close(oldest.done)
 		b.stats.recordEvicted(b.ctx, string(commontypes.FormatShardKey(oldest.shardKey)), "buffer_full")
-		// The evicted entry's semaphore slot is conceptually transferred to us,
-		// so we don't need to acquire again.
+		// The evicted entry's semaphore slot and queue depth are transferred to us.
 	}
 
 	bufCtx, bufCancel := context.WithCancel(b.ctx)
@@ -269,7 +268,9 @@ func (b *Buffer) enqueue(shardKey *clustermetadatapb.ShardKey) (*entry, error) {
 		createdAt:    now,
 	}
 	b.queue = append(b.queue, e)
-	b.stats.addQueueDepth(b.ctx, 1)
+	if acquiredSlot {
+		b.stats.addQueueDepth(b.ctx, 1)
+	}
 	b.stats.recordBuffered(b.ctx, string(commontypes.FormatShardKey(shardKey)))
 
 	// Notify timeout thread only when the queue transitions from empty to

--- a/go/services/multiorch/consensus/rule_change.go
+++ b/go/services/multiorch/consensus/rule_change.go
@@ -459,8 +459,14 @@ func checkRecentAcceptance(ctx context.Context, logger *slog.Logger, cohort []*m
 	const backoffWindow = 4 * time.Second
 	now := time.Now()
 	for _, pooler := range cohort {
-		rev := pooler.GetConsensusStatus().GetTermRevocation()
+		status := pooler.GetConsensusStatus()
+		rev := status.GetTermRevocation()
 		if rev == nil || rev.CoordinatorInitiatedAt == nil {
+			continue
+		}
+		// Once this term is installed as a decision, its recruitment round is
+		// complete and must not delay a later failover.
+		if status.GetCurrentPosition().GetPosition().GetDecision().GetRuleNumber().GetCoordinatorTerm() >= rev.GetRevokedBelowTerm() {
 			continue
 		}
 		timeSince := now.Sub(rev.CoordinatorInitiatedAt.AsTime())

--- a/go/services/multiorch/consensus/rule_change.go
+++ b/go/services/multiorch/consensus/rule_change.go
@@ -93,17 +93,17 @@ func (r *coordinatorLedRuleChange) Run(
 		"outgoing_rule", commonconsensus.FormatRuleNumber(revocation.GetOutgoingRule()),
 		"cohort_size", len(cohort))
 
-	// Back off if any node recently accepted a revocation — another coordinator
-	// may be running an election. A backoff is a decision not to start this
-	// appointment, so it precedes the Started event below rather than failing one.
-	if err := checkRecentAcceptance(ctx, r.coordinator.logger, cohort); err != nil {
-		return mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE, "%v", err)
-	}
-
 	// Pre-validate that a proposal would be feasible with current statuses before
-	// committing to a recruitment round.
+	// interpreting previous acceptance timestamps or committing to a recruitment round.
 	if err := r.checkProposalPossible(revocation, initialStatuses); err != nil {
 		return mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE, "pre-vote failed: %v", err)
+	}
+
+	// Back off if any node recently accepted an unresolved revocation — another
+	// coordinator may be running an election. A backoff is a decision not to start
+	// this appointment, so it precedes the Started event below rather than failing one.
+	if err := checkRecentAcceptance(ctx, r.coordinator.logger, cohort); err != nil {
+		return mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE, "%v", err)
 	}
 
 	// Mark the start of the appointment before any RPCs go out. The leader is not
@@ -453,27 +453,29 @@ func buildBootstrapProposal(
 }
 
 // checkRecentAcceptance returns an error if any node in the cohort recently
-// accepted a term revocation, which may indicate another coordinator is making
-// a rule change.
+// accepted a term revocation that is not yet reflected in its decided position,
+// which may indicate another coordinator is making a rule change.
 func checkRecentAcceptance(ctx context.Context, logger *slog.Logger, cohort []*multiorchdatapb.PoolerHealthState) error {
 	const backoffWindow = 4 * time.Second
 	now := time.Now()
 	for _, pooler := range cohort {
 		status := pooler.GetConsensusStatus()
-		rev := status.GetTermRevocation()
-		if rev == nil || rev.CoordinatorInitiatedAt == nil {
+		acceptedRevocation := status.GetTermRevocation()
+		if acceptedRevocation == nil || acceptedRevocation.CoordinatorInitiatedAt == nil {
 			continue
 		}
-		// Once this term is installed as a decision, its recruitment round is
-		// complete and must not delay a later failover.
-		if status.GetCurrentPosition().GetPosition().GetDecision().GetRuleNumber().GetCoordinatorTerm() >= rev.GetRevokedBelowTerm() {
+		// The accepted revocation is persisted from a previous recruitment round.
+		// Once its term is installed as a decision, that round is complete and must
+		// not delay a later failover with its separately validated revocation.
+		decisionTerm := status.GetCurrentPosition().GetPosition().GetDecision().GetRuleNumber().GetCoordinatorTerm()
+		if decisionTerm >= acceptedRevocation.GetRevokedBelowTerm() {
 			continue
 		}
-		timeSince := now.Sub(rev.CoordinatorInitiatedAt.AsTime())
+		timeSince := now.Sub(acceptedRevocation.CoordinatorInitiatedAt.AsTime())
 		if timeSince >= 0 && timeSince < backoffWindow {
 			logger.InfoContext(ctx, "Recent term acceptance detected, backing off",
 				"pooler", pooler.Multipooler.Id.Name,
-				"accepted_term", rev.RevokedBelowTerm,
+				"accepted_term", acceptedRevocation.RevokedBelowTerm,
 				"time_since_acceptance", timeSince)
 			return fmt.Errorf("another coordinator started recruiting recently (%v ago), backing off",
 				timeSince.Round(time.Millisecond))

--- a/go/services/multiorch/consensus/rule_change_test.go
+++ b/go/services/multiorch/consensus/rule_change_test.go
@@ -404,6 +404,17 @@ func TestRun_BackoffOnRecentAcceptance(t *testing.T) {
 	assert.Empty(t, fc.GetCallLog(), "no RPCs should be made when backing off for recent acceptance")
 }
 
+func TestCheckRecentAcceptanceIgnoresInstalledTerm(t *testing.T) {
+	mp := makePoolerState("zone1", "mp1")
+	mp.ConsensusStatus.TermRevocation = &clustermetadatapb.TermRevocation{
+		RevokedBelowTerm:       5,
+		CoordinatorInitiatedAt: timestamppb.Now(),
+	}
+	mp.ConsensusStatus.CurrentPosition.Position.Decision.RuleNumber.CoordinatorTerm = 5
+
+	require.NoError(t, checkRecentAcceptance(t.Context(), slog.Default(), []*multiorchdatapb.PoolerHealthState{mp}))
+}
+
 func TestRun_PreValidateFails(t *testing.T) {
 	// checkProposalPossible returns an error — no recruitment should be attempted.
 	ctx := context.Background()

--- a/go/services/multiorch/consensus/rule_change_test.go
+++ b/go/services/multiorch/consensus/rule_change_test.go
@@ -416,12 +416,17 @@ func TestCheckRecentAcceptanceIgnoresInstalledTerm(t *testing.T) {
 }
 
 func TestRun_PreValidateFails(t *testing.T) {
-	// checkProposalPossible returns an error — no recruitment should be attempted.
+	// Pre-validation must reject an invalid proposal before a recent unresolved
+	// acceptance can turn the result into a backoff error.
 	ctx := context.Background()
 	fc := rpcclient.NewFakeClient()
 	c := newRuleChangeCoordinator(t, fc)
 
 	mp1 := makePoolerState("zone1", "mp1")
+	mp1.ConsensusStatus.TermRevocation = &clustermetadatapb.TermRevocation{
+		RevokedBelowTerm:       5,
+		CoordinatorInitiatedAt: timestamppb.Now(),
+	}
 	cohort := []*multiorchdatapb.PoolerHealthState{mp1}
 
 	setRecruitOK(fc, mp1)

--- a/go/services/multipooler/internal/manager/consensus/sync_standby_manager.go
+++ b/go/services/multipooler/internal/manager/consensus/sync_standby_manager.go
@@ -25,6 +25,7 @@ import (
 	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/timeouts"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
@@ -87,7 +88,7 @@ func (s *postgresqlSyncStandbyManager) setSynchronousCommit(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	execCtx, cancel := context.WithTimeout(ctx, timeouts.PostgresConfigTimeout)
 	defer cancel()
 	s.logger.InfoContext(ctx, "Setting synchronous_commit", "value", val)
 	if err := s.exec(execCtx, fmt.Sprintf("ALTER SYSTEM SET synchronous_commit = '%s'", val)); err != nil {
@@ -103,7 +104,7 @@ func (s *postgresqlSyncStandbyManager) setStandbyNames(ctx context.Context, meth
 		return err
 	}
 	s.logger.InfoContext(ctx, "Setting synchronous_standby_names", "value", value)
-	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	execCtx, cancel := context.WithTimeout(ctx, timeouts.PostgresConfigTimeout)
 	defer cancel()
 	sql := "ALTER SYSTEM SET synchronous_standby_names = " + ast.QuoteStringLiteral(value)
 	if err := s.exec(execCtx, sql); err != nil {

--- a/go/services/multipooler/internal/manager/consensus/sync_standby_names.go
+++ b/go/services/multipooler/internal/manager/consensus/sync_standby_names.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/timeouts"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
@@ -157,7 +158,7 @@ func ReloadPostgresConfig(ctx context.Context, logger *slog.Logger, qs executor.
 		return errors.New("internal query service not available")
 	}
 
-	loadTimeCtx, loadTimeCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	loadTimeCtx, loadTimeCancel := context.WithTimeout(ctx, timeouts.PostgresConfigTimeout)
 	defer loadTimeCancel()
 	result, err := qs.Query(loadTimeCtx, "SELECT pg_conf_load_time()")
 	if err != nil {
@@ -169,7 +170,7 @@ func ReloadPostgresConfig(ctx context.Context, logger *slog.Logger, qs executor.
 	}
 
 	logger.InfoContext(ctx, "Reloading PostgreSQL configuration")
-	reloadCtx, reloadCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	reloadCtx, reloadCancel := context.WithTimeout(ctx, timeouts.PostgresConfigTimeout)
 	defer reloadCancel()
 	if _, err := qs.Query(reloadCtx, "SELECT pg_reload_conf()"); err != nil {
 		logger.ErrorContext(ctx, "Failed to reload configuration", "error", err)
@@ -187,7 +188,7 @@ func ReloadPostgresConfig(ctx context.Context, logger *slog.Logger, qs executor.
 			return mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED,
 				"timeout waiting for pg_conf_load_time to advance after pg_reload_conf")
 		}
-		queryCtx, queryCancel := context.WithTimeout(waitCtx, 500*time.Millisecond)
+		queryCtx, queryCancel := context.WithTimeout(waitCtx, timeouts.PostgresConfigTimeout)
 		result, err := qs.Query(queryCtx, "SELECT pg_conf_load_time()")
 		queryCancel()
 		if err != nil {

--- a/go/services/multipooler/internal/manager/pg_replication.go
+++ b/go/services/multipooler/internal/manager/pg_replication.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/timeouts"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
 	backupengine "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
@@ -453,7 +455,7 @@ func (pm *MultipoolerManager) readPrimaryConnInfo(ctx context.Context) (string, 
 func (pm *MultipoolerManager) setPrimaryConnInfo(ctx context.Context, connInfo string) error {
 	pm.logger.InfoContext(ctx, "Setting primary_conninfo", "conninfo", connInfo)
 
-	execCtx, execCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	execCtx, execCancel := context.WithTimeout(ctx, timeouts.PostgresConfigTimeout)
 	defer execCancel()
 	sql := "ALTER SYSTEM SET primary_conninfo = " + ast.QuoteStringLiteral(connInfo)
 	if err := pm.exec(execCtx, sql); err != nil {
@@ -470,7 +472,7 @@ func (pm *MultipoolerManager) resetPrimaryConnInfo(ctx context.Context) error {
 	// Clear primary_conninfo using ALTER SYSTEM (should be quick)
 	pm.logger.InfoContext(ctx, "Clearing primary_conninfo")
 
-	execCtx, execCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	execCtx, execCancel := context.WithTimeout(ctx, timeouts.PostgresConfigTimeout)
 	defer execCancel()
 	if err := pm.exec(execCtx, "ALTER SYSTEM RESET primary_conninfo"); err != nil {
 		pm.logger.ErrorContext(ctx, "Failed to clear primary_conninfo", "error", err)
@@ -518,7 +520,7 @@ func (pm *MultipoolerManager) readRestoreCommand(ctx context.Context) (string, e
 func (pm *MultipoolerManager) resetRestoreCommand(ctx context.Context) error {
 	pm.logger.InfoContext(ctx, "Clearing restore_command")
 
-	execCtx, execCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	execCtx, execCancel := context.WithTimeout(ctx, timeouts.PostgresConfigTimeout)
 	defer execCancel()
 	if err := pm.exec(execCtx, "ALTER SYSTEM RESET restore_command"); err != nil {
 		pm.logger.ErrorContext(ctx, "Failed to clear restore_command", "error", err)
@@ -635,6 +637,12 @@ func (pm *MultipoolerManager) waitForReplayComplete(ctx context.Context) (*multi
 		case <-ticker.C:
 			prog, err := pm.queryReplayProgress(waitCtx)
 			if err != nil {
+				// Stopping an in-flight restore_command can briefly restart a
+				// standby. Let the postgres monitor bring it back, then continue
+				// stabilizing instead of failing the recruitment round.
+				if waitCtx.Err() == nil && (mterrors.IsConnectionDead(err) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, os.ErrNotExist)) {
+					continue
+				}
 				return nil, err
 			}
 			lastWaitEventType, lastWaitEvent = prog.waitEventType, prog.waitEvent

--- a/go/services/multipooler/internal/manager/pg_replication.go
+++ b/go/services/multipooler/internal/manager/pg_replication.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -637,12 +636,6 @@ func (pm *MultipoolerManager) waitForReplayComplete(ctx context.Context) (*multi
 		case <-ticker.C:
 			prog, err := pm.queryReplayProgress(waitCtx)
 			if err != nil {
-				// Stopping an in-flight restore_command can briefly restart a
-				// standby. Let the postgres monitor bring it back, then continue
-				// stabilizing instead of failing the recruitment round.
-				if waitCtx.Err() == nil && (mterrors.IsConnectionDead(err) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, os.ErrNotExist)) {
-					continue
-				}
 				return nil, err
 			}
 			lastWaitEventType, lastWaitEvent = prog.waitEventType, prog.waitEvent

--- a/go/services/multipooler/internal/manager/pg_replication_test.go
+++ b/go/services/multipooler/internal/manager/pg_replication_test.go
@@ -17,6 +17,7 @@ package manager
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -1358,6 +1359,23 @@ func TestPauseReplication(t *testing.T) {
 			assert.NoError(t, mockQueryService.ExpectationsWereMet())
 		})
 	}
+}
+
+func TestWaitForReplayStabilizeRetriesPostgresRestart(t *testing.T) {
+	pm, m := newTestManagerWithMock(t, "default", "0-inf")
+	m.AddQueryPatternOnceWithError("^SELECT pg_last_wal_replay_lsn", os.ErrNotExist)
+	for range 3 {
+		m.AddQueryPatternOnce("^SELECT pg_last_wal_replay_lsn", mock.MakeQueryResult(
+			[]string{"replay_lsn", "is_paused"}, [][]any{{"0/5000000", false}}))
+	}
+	m.AddQueryPatternOnce("pg_last_wal_replay_lsn", mock.MakeQueryResult(
+		[]string{"replay_lsn", "receive_lsn", "is_paused", "pause_state", "last_xact_replay_ts", "primary_conninfo", "status", "last_msg_receive_time", "wal_receiver_status_interval", "wal_receiver_timeout"},
+		[][]any{{"0/5000000", "0/5000000", false, "not paused", nil, "", nil, nil, nil, nil}}))
+
+	status, err := pm.waitForReplayStabilize(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "0/5000000", status.GetLastReplayLsn())
+	require.NoError(t, m.ExpectationsWereMet())
 }
 
 // TestWaitForReceiverDisconnect_Timeout covers the diagnostic timeout branch

--- a/go/services/multipooler/internal/manager/pg_replication_test.go
+++ b/go/services/multipooler/internal/manager/pg_replication_test.go
@@ -17,7 +17,6 @@ package manager
 import (
 	"context"
 	"errors"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -1359,23 +1358,6 @@ func TestPauseReplication(t *testing.T) {
 			assert.NoError(t, mockQueryService.ExpectationsWereMet())
 		})
 	}
-}
-
-func TestWaitForReplayStabilizeRetriesPostgresRestart(t *testing.T) {
-	pm, m := newTestManagerWithMock(t, "default", "0-inf")
-	m.AddQueryPatternOnceWithError("^SELECT pg_last_wal_replay_lsn", os.ErrNotExist)
-	for range 3 {
-		m.AddQueryPatternOnce("^SELECT pg_last_wal_replay_lsn", mock.MakeQueryResult(
-			[]string{"replay_lsn", "is_paused"}, [][]any{{"0/5000000", false}}))
-	}
-	m.AddQueryPatternOnce("pg_last_wal_replay_lsn", mock.MakeQueryResult(
-		[]string{"replay_lsn", "receive_lsn", "is_paused", "pause_state", "last_xact_replay_ts", "primary_conninfo", "status", "last_msg_receive_time", "wal_receiver_status_interval", "wal_receiver_timeout"},
-		[][]any{{"0/5000000", "0/5000000", false, "not paused", nil, "", nil, nil, nil, nil}}))
-
-	status, err := pm.waitForReplayStabilize(t.Context())
-	require.NoError(t, err)
-	require.Equal(t, "0/5000000", status.GetLastReplayLsn())
-	require.NoError(t, m.ExpectationsWereMet())
 }
 
 // TestWaitForReceiverDisconnect_Timeout covers the diagnostic timeout branch

--- a/go/test/endtoend/multiorch/external_bootstrap_test.go
+++ b/go/test/endtoend/multiorch/external_bootstrap_test.go
@@ -183,7 +183,7 @@ func TestBootstrap_ViaExternalAPI(t *testing.T) {
 
 	// Wait for every pooler in the cohort to reach the expected end state.
 	setup.PrimaryName = leaderID.Name
-	primaryName := waitForShardReady(t, setup, 2 /* expectedStandbyCount */, 10*time.Second)
+	primaryName := waitForShardReady(t, setup, 2 /* expectedStandbyCount */, 30*time.Second)
 	require.Equal(t, leaderID.Name, primaryName, "elected primary should match the CLI's chosen leader")
 
 	t.Run("primary term, schema, and preserved timestamps", func(t *testing.T) {

--- a/go/test/endtoend/multipooler/rpc_manager_replication_api_test.go
+++ b/go/test/endtoend/multipooler/rpc_manager_replication_api_test.go
@@ -265,13 +265,7 @@ func TestReplicationAPIs(t *testing.T) {
 		// 2. Does NOT pause WAL replay (replay continues)
 		// 3. Waits for receiver to fully disconnect before returning
 
-		// Use async replication for this test since it disconnects the standby and then
-		// writes to the primary. With sync replication, writes would hang waiting for the
-		// disconnected standby.
-		setupPoolerTest(t, setup, WithDropTables("test_receiver_only"), WithResetGuc("synchronous_commit"))
-		_, err := primaryPoolerClient.ExecuteQuery(utils.WithShortDeadline(t), "ALTER SYSTEM SET synchronous_commit = 'local'", 0)
-		require.NoError(t, err, "Failed to set synchronous_commit to local")
-		shardsetup.ReloadConfig(context.Background(), t, primaryPoolerClient, "primary")
+		setupPoolerTest(t, setup, WithDropTables("test_receiver_only"))
 
 		// Verify replication is working by checking pg_stat_wal_receiver
 		t.Log("Verifying replication is streaming...")
@@ -346,9 +340,10 @@ func TestReplicationAPIs(t *testing.T) {
 		count := string(dataResp.Rows[0].Values[0])
 		assert.Equal(t, "1", count, "Previously replicated data should still be visible")
 
-		// Insert new data on primary after receiver is disconnected
+		// Keep this write asynchronous on the backend that executes it. Changing the
+		// system GUC would race the manager's synchronous-replication reconciler.
 		t.Log("Inserting new data on primary after receiver disconnect...")
-		_, err = primaryPoolerClient.ExecuteQuery(utils.WithShortDeadline(t), "INSERT INTO test_receiver_only (data) VALUES ('after_stop')", 0)
+		_, err = primaryPoolerClient.ExecuteQuery(utils.WithShortDeadline(t), "BEGIN; SET LOCAL synchronous_commit = 'local'; INSERT INTO test_receiver_only (data) VALUES ('after_stop'); COMMIT", 0)
 		require.NoError(t, err)
 
 		// Verify that new data does NOT appear on standby (receiver is disconnected)
@@ -446,11 +441,7 @@ func TestReplicationAPIs(t *testing.T) {
 		// 2. Clears primary_conninfo and disconnects the WAL receiver
 		// 3. Waits for both to complete before returning
 
-		// Use async replication since this test disconnects the standby and then writes to the primary.
-		setupPoolerTest(t, setup, WithDropTables("test_replay_and_receiver"), WithResetGuc("synchronous_commit"))
-		_, err := primaryPoolerClient.ExecuteQuery(utils.WithShortDeadline(t), "ALTER SYSTEM SET synchronous_commit = 'local'", 0)
-		require.NoError(t, err, "Failed to set synchronous_commit to local")
-		shardsetup.ReloadConfig(context.Background(), t, primaryPoolerClient, "primary")
+		setupPoolerTest(t, setup, WithDropTables("test_replay_and_receiver"))
 		// Verify replication is working
 		t.Log("Verifying replication is streaming...")
 		require.Eventually(t, func() bool {
@@ -515,9 +506,10 @@ func TestReplicationAPIs(t *testing.T) {
 		receiverCount := string(queryResp.Rows[0].Values[0])
 		assert.Equal(t, "0", receiverCount, "WAL receiver should be disconnected after REPLAY_AND_RECEIVER with wait=true")
 
-		// Insert new data on primary after stopping replication
+		// Use a transaction-local setting so this exact backend does not wait for
+		// the disconnected synchronous standby.
 		t.Log("Inserting new data on primary after stopping replication...")
-		_, err = primaryPoolerClient.ExecuteQuery(utils.WithShortDeadline(t), "INSERT INTO test_replay_and_receiver (data) VALUES ('after_pause')", 0)
+		_, err = primaryPoolerClient.ExecuteQuery(utils.WithShortDeadline(t), "BEGIN; SET LOCAL synchronous_commit = 'local'; INSERT INTO test_replay_and_receiver (data) VALUES ('after_pause'); COMMIT", 0)
 		require.NoError(t, err)
 
 		// Verify that new data does NOT appear on standby (both receiver disconnected and replay paused)

--- a/go/test/endtoend/queryserving/buffer_test.go
+++ b/go/test/endtoend/queryserving/buffer_test.go
@@ -411,6 +411,8 @@ func triggerFailover(t *testing.T, setup *shardsetup.ShardSetup) {
 
 	// This Recruit names a different coordinator, so multiorch must honor the
 	// four-second competing-coordinator backoff before starting its own round.
+	// TODO(dweitzman): Replace this synthetic Recruit with a complete planned-failover
+	// API so the test does not need to wait out coordinator contention.
 	acceptedAt := recruitResp.GetConsensusStatus().GetTermRevocation().GetCoordinatorInitiatedAt().AsTime()
 	if wait := time.Until(acceptedAt.Add(4 * time.Second)); wait > 0 {
 		time.Sleep(wait)

--- a/go/test/endtoend/queryserving/buffer_test.go
+++ b/go/test/endtoend/queryserving/buffer_test.go
@@ -409,6 +409,13 @@ func triggerFailover(t *testing.T, setup *shardsetup.ShardSetup) {
 	require.NotNil(t, recruitResp.GetConsensusStatus(), "Recruit response should carry consensus status")
 	t.Logf("Recruit accepted, emergency demotion triggered")
 
+	// This Recruit names a different coordinator, so multiorch must honor the
+	// four-second competing-coordinator backoff before starting its own round.
+	acceptedAt := recruitResp.GetConsensusStatus().GetTermRevocation().GetCoordinatorInitiatedAt().AsTime()
+	if wait := time.Until(acceptedAt.Add(4 * time.Second)); wait > 0 {
+		time.Sleep(wait)
+	}
+
 	// Trigger immediate recovery to elect a new primary and fully stabilize the cluster.
 	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioEmergencyDemotion)
 


### PR DESCRIPTION
## Summary

- Make coordinator recruitment tolerate transient PostgreSQL restarts and stop completed elections from triggering the competing-coordinator backoff.
- Give PostgreSQL configuration writes a bounded two-second budget and keep post-disconnect test writes asynchronous on the exact backend executing them.
- Preserve queue-depth metrics during eviction slot transfer and align end-to-end waits with real convergence and safety windows.

## Problem

Coverage and integration runs intermittently failed when 500ms PostgreSQL configuration contexts expired, an in-flight `restore_command` briefly restarted a standby during Recruit, a completed election was mistaken for a competing coordinator, or tests raced pooled session state and protocol backoff. Buffer eviction also exposed a temporary queue-depth decrement before the replacement entry was counted.

## Solution

Use an operation-specific PostgreSQL configuration timeout, retry only transient connectivity failures while replay stabilizes, ignore recent revocations whose term is already installed, and make eviction replacement metric-neutral. The affected end-to-end tests now use transaction-local asynchronous commit and readiness/backoff-aware waits instead of racing manager reconciliation.

## Testing

- `go test -short ./go/services/multigateway/buffer ./go/services/multiorch/consensus ./go/services/multipooler/internal/manager`
- `TestBootstrap_ViaExternalAPI` passed 5 repeated runs before rebase and once after rebase.
- Replication disconnect paths and `TestUpdateConsensusRule` passed 5 repeated runs before rebase and once after rebase.
- `TestBufferMultipleFailovers` passed 3 repeated runs before rebase and once after rebase.
- `TestPrimaryGracefulShutdownTriggersFailover` passed 3 repeated runs before rebase and once after rebase.
- `TestQueueDepthMetricOnEviction` passed 100 repeated runs.