### PR TITLE
fix(rpcclient): Add multipooler peer service span attribute

### DIFF
--- a/go/common/rpcclient/options.go
+++ b/go/common/rpcclient/options.go
@@ -23,16 +23,15 @@ import (
 
 // PoolerSpanAttributes returns OpenTelemetry span attributes for gRPC clients
 // connecting to multipooler instances. It sets:
+// - peer.service: the remote service name ("multipooler")
 // - multigres.pooler.id: the global pooler identifier (e.g., "multipooler-zone1-0")
 //
 // Use with grpccommon.WithAttributes() when creating gRPC clients:
 //
 //	grpccommon.NewClient(addr, grpccommon.WithAttributes(rpcclient.PoolerSpanAttributes(poolerID)...))
-//
-// TODO: Add peer.service="multipooler" to match OTel semantic conventions where
-// peer.service should match the remote service's service.name resource attribute.
 func PoolerSpanAttributes(poolerID *clustermetadatapb.ID) []attribute.KeyValue {
 	return []attribute.KeyValue{
+		attribute.String("peer.service", "multipooler"),
 		attribute.String("multigres.pooler.id", string(topoclient.ComponentIDString(poolerID))),
 	}
 }

--- a/go/common/rpcclient/options_test.go
+++ b/go/common/rpcclient/options_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+)
+
+func TestPoolerSpanAttributes(t *testing.T) {
+	poolerID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "zone1",
+		Name:      "0",
+	}
+
+	assert.Equal(t, []attribute.KeyValue{
+		attribute.String("peer.service", "multipooler"),
+		attribute.String("multigres.pooler.id", "multipooler-zone1-0"),
+	}, PoolerSpanAttributes(poolerID))
+}


### PR DESCRIPTION
## Summary

* Add `peer.service="multipooler"` to the attributes returned by `PoolerSpanAttributes`.
* Add unit coverage verifying the new `peer.service` attribute and the existing `multigres.pooler.id` attribute.
* Remove the resolved TODO.

## Testing

* `go test ./go/common/rpcclient`
