### PR TITLE
fix(pgctld): derive WAL limits from volume size

### DIFF
--- a/config/postgres/template.cnf
+++ b/config/postgres/template.cnf
@@ -87,7 +87,7 @@ wal_buffers = {{.WalBuffers}}			# min 32kB, -1 sets based on shared_buffers
 					# (change requires restart)
 min_wal_size = {{.MinWalSize}}
 max_wal_size = {{.MaxWalSize}}
-wal_keep_size = 1000
+wal_keep_size = {{.WalKeepSize}}
 
 # - Checkpoints -
 
@@ -115,7 +115,9 @@ max_wal_senders = {{.MaxWalSenders}}		# max number of walsender processes
 					# (change requires restart)
 max_replication_slots = {{.MaxReplicationSlots}}	# max number of replication slots
 					# (change requires restart)
-max_slot_wal_keep_size = 4096   # in megabytes; -1 disables
+# Protect the primary's disk; a logical consumer that exceeds this cap can
+# lose its slot at checkpoint and require resynchronization.
+max_slot_wal_keep_size = {{.MaxSlotWalKeepSize}}   # in megabytes; -1 disables
 
 # - Primary Server -
 

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	golang.org/x/mod v0.37.0
 	golang.org/x/net v0.56.0
 	golang.org/x/sync v0.22.0
+	golang.org/x/sys v0.46.0
 	golang.org/x/tools v0.47.0
 	gonum.org/v1/gonum v0.17.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa
@@ -159,7 +160,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20240213143201-ec583247a57a // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect

--- a/go/services/pgctld/postgresconfig.go
+++ b/go/services/pgctld/postgresconfig.go
@@ -69,6 +69,11 @@ type PostgresServerConfig struct {
 	WalBuffers string
 	MinWalSize string
 	MaxWalSize string
+	// WalKeepSize keeps WAL for physical replicas, which connect without slots.
+	// MaxSlotWalKeepSize caps WAL kept for logical slots; a slot that exceeds
+	// the cap may need resynchronization. Both scale with the data volume size.
+	WalKeepSize        string
+	MaxSlotWalKeepSize string
 
 	// Checkpoint settings
 	CheckpointCompletionTarget float64
@@ -326,6 +331,16 @@ func ReadPostgresServerConfig(pgConfig *PostgresServerConfig, waitTime time.Dura
 		return nil, errors.New("max_wal_size not found in config file")
 	} else {
 		pgConfig.MaxWalSize = val
+	}
+	if val, err := pgConfig.lookupWithDefault("wal_keep_size", ""); err != nil {
+		return nil, errors.New("wal_keep_size not found in config file")
+	} else {
+		pgConfig.WalKeepSize = val
+	}
+	if val, err := pgConfig.lookupWithDefault("max_slot_wal_keep_size", ""); err != nil {
+		return nil, errors.New("max_slot_wal_keep_size not found in config file")
+	} else {
+		pgConfig.MaxSlotWalKeepSize = val
 	}
 
 	// Checkpoint settings - required in our controlled config

--- a/go/services/pgctld/postgresconfig_gen.go
+++ b/go/services/pgctld/postgresconfig_gen.go
@@ -87,8 +87,26 @@ func GeneratePostgresServerConfig(poolerDir string, pgUser string, extraConfFile
 	cnf.MaxParallelWorkersPerGather = 1
 	cnf.MaxParallelMaintenanceWorkers = 1
 	cnf.WalBuffers = "1920kB"
-	cnf.MinWalSize = "1GB"
-	cnf.MaxWalSize = "4GB"
+
+	// WAL disk-usage settings scale with the volume backing the data
+	// directory; fixed defaults let WAL alone fill small volumes (MUL-1021).
+	volBytes, err := volumeTotalBytes(cnf.DataDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to size WAL settings for data volume: %w", err)
+	}
+	segmentBytes, err := walSegmentSizeBytes(cnf.DataDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read WAL segment size: %w", err)
+	}
+	ws, err := deriveWalSettings(volBytes, segmentBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive WAL settings: %w", err)
+	}
+	cnf.MinWalSize = fmt.Sprintf("%dMB", ws.minWalSizeMB)
+	cnf.MaxWalSize = fmt.Sprintf("%dMB", ws.maxWalSizeMB)
+	cnf.WalKeepSize = fmt.Sprintf("%dMB", ws.walKeepSizeMB)
+	cnf.MaxSlotWalKeepSize = fmt.Sprintf("%dMB", ws.maxSlotWalKeepSizeMB)
+
 	cnf.CheckpointCompletionTarget = 0.9
 	cnf.MaxWalSenders = 25
 	cnf.MaxReplicationSlots = 25

--- a/go/services/pgctld/postgresconfig_gen_test.go
+++ b/go/services/pgctld/postgresconfig_gen_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/config"
 	"github.com/multigres/multigres/go/common/constants"
 )
 
@@ -169,6 +170,22 @@ func TestMakePostgresConfInvalidTemplate(t *testing.T) {
 			assert.Error(t, err, "MakePostgresConf should return error for invalid template")
 		})
 	}
+}
+
+func TestPostgresTemplateUsesWalSettings(t *testing.T) {
+	serverConfig := &PostgresServerConfig{
+		MinWalSize:         "60MB",
+		MaxWalSize:         "243MB",
+		WalKeepSize:        "121MB",
+		MaxSlotWalKeepSize: "243MB",
+	}
+
+	result, err := serverConfig.MakePostgresConf(config.PostgresConfigDefaultTmpl)
+	require.NoError(t, err)
+	assert.Contains(t, result, "min_wal_size = 60MB")
+	assert.Contains(t, result, "max_wal_size = 243MB")
+	assert.Contains(t, result, "wal_keep_size = 121MB")
+	assert.Contains(t, result, "max_slot_wal_keep_size = 243MB")
 }
 
 func TestGeneratePostgresServerConfigExtraConfFiles(t *testing.T) {

--- a/go/services/pgctld/postgresconfig_test.go
+++ b/go/services/pgctld/postgresconfig_test.go
@@ -211,6 +211,32 @@ func TestReadPostgresServerConfig(t *testing.T) {
 	// are NOT read from config files - they are set via flags/code and passed as command-line parameters
 }
 
+func TestReadPostgresServerConfigRequiresWalRetentionSettings(t *testing.T) {
+	tests := []struct {
+		setting string
+	}{
+		{setting: "wal_keep_size"},
+		{setting: "max_slot_wal_keep_size"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.setting, func(t *testing.T) {
+			settings := make(map[string]string, len(configSettings))
+			for key, value := range configSettings {
+				settings[key] = value
+			}
+			delete(settings, tt.setting)
+
+			configPath := filepath.Join(t.TempDir(), "postgresql.conf")
+			err := os.WriteFile(configPath, []byte(generateConfigFromMap(settings)), 0o644)
+			require.NoError(t, err)
+
+			_, err = ReadPostgresServerConfig(&PostgresServerConfig{Path: configPath}, 0)
+			require.EqualError(t, err, tt.setting+" not found in config file")
+		})
+	}
+}
+
 func TestReadPostgresServerConfigEmptyFile(t *testing.T) {
 	// Create a temporary empty config file
 	tmpDir := t.TempDir()

--- a/go/services/pgctld/postgresconfig_test.go
+++ b/go/services/pgctld/postgresconfig_test.go
@@ -16,6 +16,7 @@ package pgctld
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -222,9 +223,7 @@ func TestReadPostgresServerConfigRequiresWalRetentionSettings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.setting, func(t *testing.T) {
 			settings := make(map[string]string, len(configSettings))
-			for key, value := range configSettings {
-				settings[key] = value
-			}
+			maps.Copy(settings, configSettings)
 			delete(settings, tt.setting)
 
 			configPath := filepath.Join(t.TempDir(), "postgresql.conf")

--- a/go/services/pgctld/postgresconfig_test.go
+++ b/go/services/pgctld/postgresconfig_test.go
@@ -288,6 +288,8 @@ max_parallel_maintenance_workers = 1
 wal_buffers = 1920kB
 min_wal_size = 1GB
 max_wal_size = 4GB
+wal_keep_size = 1000MB
+max_slot_wal_keep_size = 4096MB
 checkpoint_completion_target = 0.9
 max_wal_senders = 5
 max_replication_slots = 5
@@ -337,6 +339,16 @@ func TestGenerateAndReadConfigRoundTrip(t *testing.T) {
 	// Generate config using the template
 	generatedConfig, err := GeneratePostgresServerConfig(tmpDir, "postgres", []string{})
 	require.NoError(t, err, "GeneratePostgresServerConfig should not return error")
+	volumeBytes, err := volumeTotalBytes(generatedConfig.DataDir)
+	require.NoError(t, err)
+	segmentBytes, err := walSegmentSizeBytes(generatedConfig.DataDir)
+	require.NoError(t, err)
+	wantWalSettings, err := deriveWalSettings(volumeBytes, segmentBytes)
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("%dMB", wantWalSettings.minWalSizeMB), generatedConfig.MinWalSize)
+	assert.Equal(t, fmt.Sprintf("%dMB", wantWalSettings.maxWalSizeMB), generatedConfig.MaxWalSize)
+	assert.Equal(t, fmt.Sprintf("%dMB", wantWalSettings.walKeepSizeMB), generatedConfig.WalKeepSize)
+	assert.Equal(t, fmt.Sprintf("%dMB", wantWalSettings.maxSlotWalKeepSizeMB), generatedConfig.MaxSlotWalKeepSize)
 
 	// Read the generated config back from disk
 	readConfig := &PostgresServerConfig{Path: generatedConfig.Path}
@@ -359,6 +371,8 @@ func TestGenerateAndReadConfigRoundTrip(t *testing.T) {
 	assert.NotEmpty(t, result.WalBuffers, "WalBuffers should be set")
 	assert.NotEmpty(t, result.MinWalSize, "MinWalSize should be set")
 	assert.NotEmpty(t, result.MaxWalSize, "MaxWalSize should be set")
+	assert.NotEmpty(t, result.WalKeepSize, "WalKeepSize should be set")
+	assert.NotEmpty(t, result.MaxSlotWalKeepSize, "MaxSlotWalKeepSize should be set")
 	assert.NotZero(t, result.CheckpointCompletionTarget, "CheckpointCompletionTarget should be set")
 	assert.NotZero(t, result.MaxWalSenders, "MaxWalSenders should be set")
 	assert.NotZero(t, result.MaxReplicationSlots, "MaxReplicationSlots should be set")

--- a/go/services/pgctld/walsize.go
+++ b/go/services/pgctld/walsize.go
@@ -1,0 +1,154 @@
+// Copyright 2025 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgctld
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	megabyte                   = uint64(1 << 20)
+	defaultWalSegmentSizeBytes = 16 * megabyte
+	maxWalSizeCapMB            = uint64(4096)
+)
+
+// walSettings holds the postgres WAL disk-usage settings derived from the
+// size of the volume backing the data directory, in megabytes.
+type walSettings struct {
+	minWalSizeMB         uint64
+	maxWalSizeMB         uint64
+	walKeepSizeMB        uint64
+	maxSlotWalKeepSizeMB uint64
+}
+
+// deriveWalSettings scales postgres' WAL disk-usage knobs to the volume so
+// routine WAL retention is budgeted below the disk size. Fixed values
+// (previously max_wal_size=4GB, wal_keep_size=1000MB) could fill a small
+// volume. The upper clamps preserve the previous values on large volumes;
+// smaller volumes scale down proportionally. PostgreSQL requires min_wal_size
+// and max_wal_size to be at least two WAL segments, so the lower clamps also
+// account for the segment size selected at initdb time.
+func deriveWalSettings(volumeBytes, walSegmentSizeBytes uint64) (walSettings, error) {
+	if walSegmentSizeBytes == 0 || walSegmentSizeBytes%megabyte != 0 {
+		return walSettings{}, fmt.Errorf("WAL segment size must be a non-zero whole number of megabytes, got %d bytes", walSegmentSizeBytes)
+	}
+
+	volMB := volumeBytes / megabyte
+	walSegmentSizeMB := walSegmentSizeBytes / megabyte
+	// Keep enough distance between the two PostgreSQL minimums that
+	// min_wal_size does not consume the entire max_wal_size allowance.
+	maxWalFloor := max(uint64(64), 4*walSegmentSizeMB)
+	if maxWalFloor > maxWalSizeCapMB {
+		return walSettings{}, fmt.Errorf("WAL segment size %dMB requires max_wal_size above the supported %dMB cap", walSegmentSizeMB, maxWalSizeCapMB)
+	}
+	minWalFloor := max(uint64(32), 2*walSegmentSizeMB)
+	maxWal := clampMB(volMB/4, maxWalFloor, maxWalSizeCapMB)
+
+	return walSettings{
+		// min_wal_size is WAL that is recycled rather than removed at
+		// checkpoint, so it must stay well under max_wal_size; a quarter
+		// preserves the previous 1GB:4GB ratio.
+		minWalSizeMB: clampMB(maxWal/4, minWalFloor, max(uint64(1024), minWalFloor)),
+		maxWalSizeMB: maxWal,
+		// wal_keep_size is what lets a lagging replica reconnect without a
+		// reseed. Physical replicas currently connect without slots, so
+		// shrinking this on small volumes trades reconnect headroom for not
+		// filling the primary's disk.
+		walKeepSizeMB: clampMB(volMB/8, max(uint64(32), walSegmentSizeMB), max(uint64(1000), walSegmentSizeMB)),
+		// Logical replication does use slots. A bounded cap protects the
+		// primary's disk, at the explicit cost that a consumer lagging beyond
+		// the cap can lose its slot at checkpoint and require resynchronization.
+		maxSlotWalKeepSizeMB: maxWal,
+	}, nil
+}
+
+func clampMB(v, lo, hi uint64) uint64 {
+	return min(max(v, lo), hi)
+}
+
+// walSegmentSizeBytes returns the segment size recorded in pg_control. Config
+// generation normally runs after initdb, including when --wal-segsize was
+// supplied. Some unit-test and utility callers generate config before initdb;
+// for an absent pg_control, PostgreSQL's default segment size is used.
+func walSegmentSizeBytes(dataDir string) (uint64, error) {
+	pgControlPath := filepath.Join(dataDir, "global", "pg_control")
+	if _, err := os.Stat(pgControlPath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return defaultWalSegmentSizeBytes, nil
+		}
+		return 0, fmt.Errorf("stat %s: %w", pgControlPath, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "pg_controldata", dataDir)
+	// pg_controldata localizes its labels. Force stable output for parsing.
+	cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("pg_controldata %s: %w (output: %s)", dataDir, err, strings.TrimSpace(string(output)))
+	}
+
+	segmentBytes, err := parseWalSegmentSizeBytes(string(output))
+	if err != nil {
+		return 0, fmt.Errorf("pg_controldata %s: %w", dataDir, err)
+	}
+	return segmentBytes, nil
+}
+
+func parseWalSegmentSizeBytes(output string) (uint64, error) {
+	const field = "Bytes per WAL segment:"
+	for line := range strings.SplitSeq(output, "\n") {
+		if !strings.HasPrefix(strings.TrimSpace(line), field) {
+			continue
+		}
+		value := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), field))
+		segmentBytes, err := strconv.ParseUint(value, 10, 64)
+		if err != nil || segmentBytes == 0 {
+			return 0, fmt.Errorf("invalid %s value %q", field, value)
+		}
+		return segmentBytes, nil
+	}
+	return 0, fmt.Errorf("%s not found", field)
+}
+
+// volumeTotalBytes returns the total size of the filesystem backing dir. If
+// dir doesn't exist yet, the nearest existing ancestor is used — that is the
+// volume the directory would be created on.
+func volumeTotalBytes(dir string) (uint64, error) {
+	for {
+		var st unix.Statfs_t
+		err := unix.Statfs(dir, &st)
+		if err == nil {
+			return uint64(st.Blocks) * uint64(st.Bsize), nil
+		}
+		parent := filepath.Dir(dir)
+		if !errors.Is(err, fs.ErrNotExist) || parent == dir {
+			return 0, fmt.Errorf("statfs %s: %w", dir, err)
+		}
+		dir = parent
+	}
+}

--- a/go/services/pgctld/walsize.go
+++ b/go/services/pgctld/walsize.go
@@ -20,13 +20,14 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
 	"golang.org/x/sys/unix"
+
+	"github.com/multigres/multigres/go/tools/executil"
 )
 
 const (
@@ -102,11 +103,11 @@ func walSegmentSizeBytes(dataDir string) (uint64, error) {
 		return 0, fmt.Errorf("stat %s: %w", pgControlPath, err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "pg_controldata", dataDir)
+	cmd := executil.Command(ctx, "pg_controldata", dataDir)
 	// pg_controldata localizes its labels. Force stable output for parsing.
-	cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")
+	cmd.AddEnv("LC_ALL=C", "LANG=C")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return 0, fmt.Errorf("pg_controldata %s: %w (output: %s)", dataDir, err, strings.TrimSpace(string(output)))
@@ -143,7 +144,7 @@ func volumeTotalBytes(dir string) (uint64, error) {
 		var st unix.Statfs_t
 		err := unix.Statfs(dir, &st)
 		if err == nil {
-			return uint64(st.Blocks) * uint64(st.Bsize), nil
+			return st.Blocks * uint64(st.Bsize), nil
 		}
 		parent := filepath.Dir(dir)
 		if !errors.Is(err, fs.ErrNotExist) || parent == dir {

--- a/go/services/pgctld/walsize_test.go
+++ b/go/services/pgctld/walsize_test.go
@@ -1,0 +1,143 @@
+// Copyright 2025 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgctld
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeriveWalSettings(t *testing.T) {
+	tests := []struct {
+		name            string
+		volumeBytes     uint64
+		walSegmentBytes uint64
+		wantWalSettings walSettings
+	}{
+		{
+			name:            "tiny volume uses postgres-compatible floors",
+			volumeBytes:     1,
+			walSegmentBytes: defaultWalSegmentSizeBytes,
+			wantWalSettings: walSettings{
+				minWalSizeMB:         32,
+				maxWalSizeMB:         64,
+				walKeepSizeMB:        32,
+				maxSlotWalKeepSizeMB: 64,
+			},
+		},
+		{
+			name:            "one GiB volume scales down",
+			volumeBytes:     1 << 30,
+			walSegmentBytes: defaultWalSegmentSizeBytes,
+			wantWalSettings: walSettings{
+				minWalSizeMB:         64,
+				maxWalSizeMB:         256,
+				walKeepSizeMB:        128,
+				maxSlotWalKeepSizeMB: 256,
+			},
+		},
+		{
+			name:            "972 MiB filesystem scales down",
+			volumeBytes:     972 << 20,
+			walSegmentBytes: defaultWalSegmentSizeBytes,
+			wantWalSettings: walSettings{
+				minWalSizeMB:         60,
+				maxWalSizeMB:         243,
+				walKeepSizeMB:        121,
+				maxSlotWalKeepSizeMB: 243,
+			},
+		},
+		{
+			name:            "sixteen GiB volume preserves previous limits",
+			volumeBytes:     16 << 30,
+			walSegmentBytes: defaultWalSegmentSizeBytes,
+			wantWalSettings: walSettings{
+				minWalSizeMB:         1024,
+				maxWalSizeMB:         4096,
+				walKeepSizeMB:        1000,
+				maxSlotWalKeepSizeMB: 4096,
+			},
+		},
+		{
+			name:            "large volume remains capped",
+			volumeBytes:     1 << 40,
+			walSegmentBytes: defaultWalSegmentSizeBytes,
+			wantWalSettings: walSettings{
+				minWalSizeMB:         1024,
+				maxWalSizeMB:         4096,
+				walKeepSizeMB:        1000,
+				maxSlotWalKeepSizeMB: 4096,
+			},
+		},
+		{
+			name:            "custom WAL segments raise postgres-compatible floors",
+			volumeBytes:     1 << 30,
+			walSegmentBytes: 64 << 20,
+			wantWalSettings: walSettings{
+				minWalSizeMB:         128,
+				maxWalSizeMB:         256,
+				walKeepSizeMB:        128,
+				maxSlotWalKeepSizeMB: 256,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := deriveWalSettings(tt.volumeBytes, tt.walSegmentBytes)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantWalSettings, got)
+		})
+	}
+}
+
+func TestDeriveWalSettingsRejectsUnsupportedSegmentSizes(t *testing.T) {
+	for _, walSegmentBytes := range []uint64{0, megabyte + 1, 2 << 30} {
+		_, err := deriveWalSettings(16<<30, walSegmentBytes)
+		require.Error(t, err)
+	}
+}
+
+func TestParseWalSegmentSizeBytes(t *testing.T) {
+	output := `pg_control version number:            1300
+Bytes per WAL segment:                67108864
+Data page checksum version:           1
+`
+
+	got, err := parseWalSegmentSizeBytes(output)
+	require.NoError(t, err)
+	require.Equal(t, uint64(64<<20), got)
+
+	_, err = parseWalSegmentSizeBytes("Database cluster state: shut down\n")
+	require.Error(t, err)
+}
+
+func TestWalSegmentSizeBytesDefaultsBeforeInitdb(t *testing.T) {
+	got, err := walSegmentSizeBytes(filepath.Join(t.TempDir(), "pg_data"))
+	require.NoError(t, err)
+	require.Equal(t, defaultWalSegmentSizeBytes, got)
+}
+
+func TestVolumeTotalBytesUsesNearestExistingAncestor(t *testing.T) {
+	tempDir := t.TempDir()
+	want, err := volumeTotalBytes(tempDir)
+	require.NoError(t, err)
+
+	got, err := volumeTotalBytes(filepath.Join(tempDir, "pg_data", "not-created-yet"))
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}

--- a/go/test/endtoend/pgctld/pgctld_test.go
+++ b/go/test/endtoend/pgctld/pgctld_test.go
@@ -514,6 +514,111 @@ func TestPgInitdbExtraConfWithInclude(t *testing.T) {
 	assert.Equal(t, "on", show("track_io_timing"))
 }
 
+// TestPostgreSQLAcceptsScaledWalSettingsWithCustomSegmentSize checks that the
+// scaled-down WAL settings for a 1 GiB volume actually start a real PostgreSQL
+// initialized with non-default WAL segments. Unit tests already cover how the
+// values are derived; this makes sure PostgreSQL accepts them at startup.
+func TestPostgreSQLAcceptsScaledWalSettingsWithCustomSegmentSize(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	if !utils.HasPostgreSQLBinaries() {
+		t.Fatal("PostgreSQL binaries not found, make sure to install PostgreSQL and add it to the PATH")
+	}
+
+	tempDir, cleanup := testutil.TempDir(t, "pgctld_wal_segment_size_test")
+	t.Cleanup(cleanup)
+
+	poolerDir := filepath.Join(tempDir, "data")
+	extraConf := filepath.Join(tempDir, "scaled-wal.conf")
+	require.NoError(t, os.WriteFile(extraConf, []byte(
+		"min_wal_size = 128MB\n"+
+			"max_wal_size = 256MB\n"+
+			"wal_keep_size = 128MB\n"+
+			"max_slot_wal_keep_size = 256MB\n",
+	), 0o644))
+
+	port := utils.GetFreePort(t)
+	initCmd := executil.Command(t.Context(), "pgctld", "init",
+		"--pooler-dir", poolerDir,
+		"--pg-port", strconv.Itoa(port),
+		"--pg-initdb-args=--wal-segsize=64",
+		"--pg-initdb-extra-conf", extraConf,
+	)
+	setupTestEnv(initCmd, poolerDir)
+	initOut, err := initCmd.CombinedOutput()
+	require.NoError(t, err, "pgctld init failed: %s", string(initOut))
+
+	startCmd := executil.Command(t.Context(), "pgctld", "start",
+		"--pooler-dir", poolerDir,
+		"--pg-port", strconv.Itoa(port),
+	)
+	setupTestEnv(startCmd, poolerDir)
+	startOut, err := startCmd.CombinedOutput()
+	require.NoError(t, err, "pgctld start failed: %s", string(startOut))
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		stopCmd := executil.Command(cleanupCtx, "pgctld", "stop",
+			"--pooler-dir", poolerDir,
+			"--pg-port", strconv.Itoa(port),
+		)
+		setupTestEnv(stopCmd, poolerDir)
+		_ = stopCmd.Run()
+	})
+
+	socketDir := filepath.Join(poolerDir, "pg_sockets")
+	query := func(sql string) string {
+		t.Helper()
+		cmd := executil.Command(t.Context(), "psql",
+			"-h", socketDir,
+			"-p", strconv.Itoa(port),
+			"-U", "postgres",
+			"-d", "postgres",
+			"-Atc", sql,
+		)
+		setupTestEnv(cmd, poolerDir)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "psql query failed (%s): %s", sql, string(out))
+		return strings.TrimSpace(string(out))
+	}
+	show := func(setting string) string {
+		t.Helper()
+		return query("SHOW " + setting)
+	}
+
+	assert.Equal(t, "64MB", show("wal_segment_size"))
+	assert.Equal(t, "128MB", show("min_wal_size"))
+	assert.Equal(t, "256MB", show("max_wal_size"))
+	assert.Equal(t, "128MB", show("wal_keep_size"))
+	assert.Equal(t, "256MB", show("max_slot_wal_keep_size"))
+
+	// Force a slot past the 128 MB cap. Segments are 64 MB here, so a few
+	// switch/checkpoint cycles let the checkpointer recycle WAL the idle slot
+	// still needs. Postgres marks it lost, meaning the consumer must resync.
+	query("ALTER SYSTEM SET max_wal_size = '128MB'")
+	query("ALTER SYSTEM SET wal_keep_size = '0'")
+	query("ALTER SYSTEM SET max_slot_wal_keep_size = '128MB'")
+	assert.Equal(t, "t", query("SELECT pg_reload_conf()"))
+	require.Eventually(t, func() bool {
+		return show("max_wal_size") == "128MB" &&
+			show("wal_keep_size") == "0" &&
+			show("max_slot_wal_keep_size") == "128MB"
+	}, 10*time.Second, 100*time.Millisecond)
+
+	query("SELECT slot_name FROM pg_create_logical_replication_slot('wal_cap_test', 'pgoutput')")
+	var slotStatus string
+	for range 8 {
+		query("SELECT pg_switch_wal()")
+		query("CHECKPOINT")
+		slotStatus = query("SELECT wal_status FROM pg_replication_slots WHERE slot_name = 'wal_cap_test'")
+		if slotStatus == "lost" {
+			break
+		}
+	}
+	require.Equal(t, "lost", slotStatus, "logical slot should be invalidated after exceeding the WAL cap")
+}
+
 // TestPostgreSQLAuthentication tests PostgreSQL authentication with POSTGRES_PASSWORD
 func TestPostgreSQLAuthentication(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
## Description

this PR derives WAL sizing and retention limits from the filesystem backing PGDATA instead of applying fixed values. It preserves the existing limits on volumes of 16 GiB or larger while balancing disk safety, physical replica reconnect headroom, and logical replication slot retention.

## Main changes

- Derives `min_wal_size`, `max_wal_size`, `wal_keep_size`, and `max_slot_wal_keep_size` from total volume capacity with bounded floors and caps.
- Accounts for the cluster's WAL segment size so generated values satisfy Postgres startup constraints, including non-default `initdb --wal-segsize` values.
- Reads volume capacity from the nearest existing filesystem ancestor and renders the derived values through the Postgres configuration template.
- Tests and documents the trade-off that a lagging logical replication slot can require resynchronization after exceeding its disk-safe retention cap.
- Preserves the previous WAL limits on volumes of at least 16 GiB.

## Testing

Validated with pgctld unit tests, the full binary build, and a real Postgres integration test using 64 MiB WAL segments. The integration test verifies that scaled settings are accepted at startup and that Postgres marks a logical slot as lost after it exceeds the configured retention cap. 