### PR TITLE
fix(query-serving): preserve non-transaction reservation reasons after a failed COMMIT/ROLLBACK

### DIFF
--- a/go/services/multigateway/poolergateway/grpc_query_service.go
+++ b/go/services/multigateway/poolergateway/grpc_query_service.go
@@ -34,6 +34,7 @@ import (
 	querypb "github.com/multigres/multigres/go/pb/query"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
 )
 
 // grpcQueryService implements queryservice.QueryService using gRPC to communicate with a multipooler instance.
@@ -662,7 +663,7 @@ func (g *grpcQueryService) ConcludeTransaction(
 	// without breaking the errors.As chain to that diagnostic.
 	response, err := g.client.ConcludeTransaction(ctx, req)
 	if err != nil {
-		return nil, nil, mterrors.Wrapf(mterrors.FromGRPC(err), "conclude transaction")
+		return nil, reservedStateFromGRPCErr(err), mterrors.Wrapf(mterrors.FromGRPC(err), "conclude transaction")
 	}
 
 	result := sqltypes.ResultFromProto(response.Result)
@@ -680,6 +681,28 @@ func (g *grpcQueryService) ConcludeTransaction(
 	}
 
 	return result, reservedState, nil
+}
+
+// reservedStateFromGRPCErr extracts a *querypb.ReservedState attached as a
+// gRPC status detail, if the multipooler included one (see
+// grpcpoolerservice.withReservedStateDetail). ConcludeTransaction is a unary
+// RPC, so a handler that returns an error never sends its response message at
+// all — this is how the multipooler still tells the gateway the authoritative
+// surviving reservation state, e.g. a temp-table reason that outlives a
+// COMMIT which failed on a deferred constraint, instead of forcing the
+// gateway to assume the whole reservation is gone. Returns nil if err carries
+// no such detail.
+func reservedStateFromGRPCErr(err error) *querypb.ReservedState {
+	st, ok := status.FromError(err)
+	if !ok {
+		return nil
+	}
+	for _, detail := range st.Details() {
+		if rs, ok := detail.(*querypb.ReservedState); ok {
+			return rs
+		}
+	}
+	return nil
 }
 
 // DiscardTempTables sends DISCARD TEMP on a reserved connection.

--- a/go/services/multigateway/poolergateway/grpc_query_service_test.go
+++ b/go/services/multigateway/poolergateway/grpc_query_service_test.go
@@ -25,7 +25,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	"github.com/multigres/multigres/go/common/callerid"
 	"github.com/multigres/multigres/go/common/mterrors"
@@ -894,6 +896,56 @@ func TestConcludeTransaction_Error(t *testing.T) {
 	// underlying PostgreSQL diagnostic surfaces unwrapped. For a generic mock
 	// error we keep its original message instead of an internal RPC prefix.
 	require.Contains(t, err.Error(), "conclude failed")
+}
+
+func TestConcludeTransaction_ErrorWithSurvivingReservedState(t *testing.T) {
+	st, detailErr := status.New(codes.Aborted, "commit failed").WithDetails(&query.ReservedState{
+		ReservationReasons:   protoutil.ReasonTempTable,
+		ReservedConnectionId: 42,
+	})
+	require.NoError(t, detailErr)
+
+	mockClient := &mockMultipoolerServiceClient{
+		concludeErr: st.Err(),
+	}
+
+	svc := newTestGRPCQueryService(mockClient)
+
+	_, reservedState, err := svc.ConcludeTransaction(
+		context.Background(),
+		protoutil.NewTarget("", "test", "", query.Mode_MODE_UNSPECIFIED),
+		&query.ExecuteOptions{ReservedConnectionId: 42},
+		multipoolerservice.TransactionConclusion_TRANSACTION_CONCLUSION_COMMIT,
+		nil,
+		false,
+		false,
+	)
+
+	require.Error(t, err)
+	require.NotNil(t, reservedState, "the surviving reservation state must be extracted from the gRPC status detail")
+	require.Equal(t, uint64(42), reservedState.GetReservedConnectionId())
+	require.Equal(t, protoutil.ReasonTempTable, reservedState.GetReservationReasons())
+}
+
+func TestConcludeTransaction_ErrorWithoutReservedStateDetail(t *testing.T) {
+	mockClient := &mockMultipoolerServiceClient{
+		concludeErr: status.Error(codes.Aborted, "commit failed"),
+	}
+
+	svc := newTestGRPCQueryService(mockClient)
+
+	_, reservedState, err := svc.ConcludeTransaction(
+		context.Background(),
+		protoutil.NewTarget("", "test", "", query.Mode_MODE_UNSPECIFIED),
+		&query.ExecuteOptions{ReservedConnectionId: 42},
+		multipoolerservice.TransactionConclusion_TRANSACTION_CONCLUSION_COMMIT,
+		nil,
+		false,
+		false,
+	)
+
+	require.Error(t, err)
+	require.Nil(t, reservedState, "a status without a ReservedState detail must not fabricate one")
 }
 
 func TestDescribe_RestoresEmptyFieldsForZeroColumnRowDescription(t *testing.T) {

--- a/go/services/multigateway/scatterconn/scatter_conn.go
+++ b/go/services/multigateway/scatterconn/scatter_conn.go
@@ -778,7 +778,16 @@ func (sc *ScatterConn) ConcludeTransaction(
 
 		result, reservedState, err := qs.ConcludeTransaction(ctx, ss.Target, eo, conclusion, releasePortalNames, releaseAllPortals, chain)
 		if err != nil {
-			updates = append(updates, shardUpdate{target: ss.Target, clear: true})
+			if reservedState.GetReservedConnectionId() != 0 {
+				// The multipooler reported the backend is still healthy and
+				// reserved for a surviving non-transaction reason (e.g. a temp
+				// table) even though the conclusion itself failed (e.g. COMMIT
+				// hit a deferred constraint violation). Keep tracking it
+				// instead of assuming the whole reservation is gone.
+				updates = append(updates, shardUpdate{target: ss.Target, reservedState: reservedState})
+			} else {
+				updates = append(updates, shardUpdate{target: ss.Target, clear: true})
+			}
 			// Plain ROLLBACK on a destroyed connection is graceful recovery — don't
 			// propagate error. ROLLBACK AND CHAIN is different: PostgreSQL promises a
 			// new transaction on the same backend, so losing that backend must fail

--- a/go/services/multigateway/scatterconn/scatter_conn_test.go
+++ b/go/services/multigateway/scatterconn/scatter_conn_test.go
@@ -692,6 +692,90 @@ func TestScatterConn_ConcludeTransaction_CommitStillReserved(t *testing.T) {
 	require.Equal(t, protoutil.ReasonTempTable, ss.ReservedState.GetReservationReasons())
 }
 
+func TestScatterConn_ConcludeTransaction_CommitFailsButReservationSurvives(t *testing.T) {
+	// A COMMIT that fails on a deferred constraint still leaves the backend
+	// healthy and reserved (e.g. for a temp table). The error must still
+	// propagate to the client, but the surviving reservation must be tracked
+	// instead of being wiped as if the connection were destroyed.
+	poolerID := &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"}
+	gw := &mockGateway{
+		concludeTransactionErr: errors.New("commit failed: foreign key violation"),
+		concludeTransactionReturnState: &querypb.ReservedState{
+			ReservedConnectionId: 42,
+			PoolerId:             poolerID,
+			ReservationReasons:   protoutil.ReasonTempTable,
+		},
+	}
+	sc := NewScatterConn(gw, slog.Default())
+	state := handler.NewMultigatewayConnectionState()
+	conn := newTestConn()
+	conn.SetTxnStatus(protocol.TxnStatusInBlock)
+
+	target := protoutil.NewTarget("", "tg1", "", querypb.Mode_MODE_WRITABLE)
+	state.SetReservedConnection(target, &querypb.ReservedState{
+		ReservedConnectionId: 42,
+		PoolerId:             poolerID,
+		ReservationReasons:   protoutil.ReasonTransaction | protoutil.ReasonTempTable,
+	})
+
+	err := sc.ConcludeTransaction(context.Background(), conn, state,
+		multipoolerpb.TransactionConclusion_TRANSACTION_CONCLUSION_COMMIT,
+		nil, false, false,
+		func(_ context.Context, _ *sqltypes.Result) error { return nil })
+
+	require.Error(t, err, "COMMIT failure must still propagate to the client")
+	require.Contains(t, err.Error(), "conclude transaction failed")
+
+	ss := state.GetMatchingShardState(target)
+	require.NotNil(t, ss, "surviving reservation must not be cleared")
+	require.Equal(t, uint64(42), ss.ReservedState.GetReservedConnectionId())
+	require.Equal(t, protoutil.ReasonTempTable, ss.ReservedState.GetReservationReasons())
+}
+
+func TestScatterConn_ConcludeTransaction_RollbackFailsButReservationSurvives(t *testing.T) {
+	// Same surviving-reservation scenario but for plain ROLLBACK, which
+	// swallows the error and synthesizes a ROLLBACK result. The surviving
+	// reservation must still be tracked rather than cleared.
+	poolerID := &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"}
+	gw := &mockGateway{
+		concludeTransactionErr: errors.New("rollback failed"),
+		concludeTransactionReturnState: &querypb.ReservedState{
+			ReservedConnectionId: 42,
+			PoolerId:             poolerID,
+			ReservationReasons:   protoutil.ReasonTempTable,
+		},
+	}
+	sc := NewScatterConn(gw, slog.Default())
+	state := handler.NewMultigatewayConnectionState()
+	conn := newTestConn()
+	conn.SetTxnStatus(protocol.TxnStatusInBlock)
+
+	target := protoutil.NewTarget("", "tg1", "", querypb.Mode_MODE_WRITABLE)
+	state.SetReservedConnection(target, &querypb.ReservedState{
+		ReservedConnectionId: 42,
+		PoolerId:             poolerID,
+		ReservationReasons:   protoutil.ReasonTransaction | protoutil.ReasonTempTable,
+	})
+
+	var callbackResult *sqltypes.Result
+	err := sc.ConcludeTransaction(context.Background(), conn, state,
+		multipoolerpb.TransactionConclusion_TRANSACTION_CONCLUSION_ROLLBACK,
+		nil, false, false,
+		func(_ context.Context, result *sqltypes.Result) error {
+			callbackResult = result
+			return nil
+		})
+
+	require.NoError(t, err, "plain ROLLBACK must not propagate the underlying error")
+	require.NotNil(t, callbackResult)
+	require.Equal(t, "ROLLBACK", callbackResult.CommandTag)
+
+	ss := state.GetMatchingShardState(target)
+	require.NotNil(t, ss, "surviving reservation must not be cleared")
+	require.Equal(t, uint64(42), ss.ReservedState.GetReservedConnectionId())
+	require.Equal(t, protoutil.ReasonTempTable, ss.ReservedState.GetReservationReasons())
+}
+
 func TestScatterConn_CopyFinalize_ErrorClearsShardState(t *testing.T) {
 	// CopyFinalize error should clear all shard state because the
 	// multipooler destroys the connection on all error paths.

--- a/go/services/multipooler/grpcpoolerservice/service.go
+++ b/go/services/multipooler/grpcpoolerservice/service.go
@@ -821,13 +821,36 @@ func (s *poolerService) ConcludeTransaction(ctx context.Context, req *multipoole
 		req.GetReleasePortalNames(), req.GetReleaseAllPortals(), req.GetChain(),
 	)
 	if err != nil {
-		return nil, mterrors.ToGRPC(err)
+		return nil, withReservedStateDetail(mterrors.ToGRPC(err), reservedState)
 	}
 
 	return &multipoolerpb.ConcludeTransactionResponse{
 		Result:        result.ToProto(),
 		ReservedState: reservedState,
 	}, nil
+}
+
+// withReservedStateDetail attaches state as an additional gRPC status detail
+// alongside whatever mterrors.ToGRPC already attached (e.g. a PgDiagnostic),
+// so a unary RPC that must return an error can still tell the caller the
+// authoritative post-failure reservation state — e.g. a temp-table reason
+// that survives a COMMIT which failed on a deferred constraint. A unary
+// handler that returns an error never sends its response message at all, so
+// this is the only way to carry state alongside grpcErr. Falls back to the
+// plain error if state is nil or attaching the detail fails.
+func withReservedStateDetail(grpcErr error, state *query.ReservedState) error {
+	if grpcErr == nil || state == nil {
+		return grpcErr
+	}
+	st, ok := status.FromError(grpcErr)
+	if !ok {
+		return grpcErr
+	}
+	stWithState, detailErr := st.WithDetails(state)
+	if detailErr != nil {
+		return grpcErr
+	}
+	return stWithState.Err()
 }
 
 // DiscardTempTables sends DISCARD TEMP on a reserved connection and removes the temp table reason.

--- a/go/services/multipooler/grpcpoolerservice/service_test.go
+++ b/go/services/multipooler/grpcpoolerservice/service_test.go
@@ -322,3 +322,45 @@ func TestCopyBidiExecuteToStdout_StreamErrorSendsErrorPhase(t *testing.T) {
 	require.Equal(t, multipoolerpb.CopyBidiExecuteResponse_ERROR, stream.sent[1].GetPhase())
 	require.Contains(t, stream.sent[1].GetError(), "copy stream failed")
 }
+
+func TestWithReservedStateDetail(t *testing.T) {
+	t.Run("nil error returns nil", func(t *testing.T) {
+		err := withReservedStateDetail(nil, &query.ReservedState{ReservedConnectionId: 7})
+		require.NoError(t, err)
+	})
+
+	t.Run("nil state returns original error unchanged", func(t *testing.T) {
+		orig := status.Error(codes.Aborted, "commit failed")
+		err := withReservedStateDetail(orig, nil)
+		require.Equal(t, orig, err)
+	})
+
+	t.Run("non-status error returns original error unchanged", func(t *testing.T) {
+		orig := errors.New("plain error, not a grpc status")
+		err := withReservedStateDetail(orig, &query.ReservedState{ReservedConnectionId: 7})
+		require.Equal(t, orig, err)
+	})
+
+	t.Run("attaches reserved state as a status detail", func(t *testing.T) {
+		orig := status.Error(codes.Aborted, "commit failed")
+		state := &query.ReservedState{ReservedConnectionId: 7, ReservationReasons: protoutil.ReasonTempTable}
+
+		err := withReservedStateDetail(orig, state)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.Aborted, st.Code())
+		require.Equal(t, "commit failed", st.Message())
+
+		var found *query.ReservedState
+		for _, detail := range st.Details() {
+			if rs, ok := detail.(*query.ReservedState); ok {
+				found = rs
+			}
+		}
+		require.NotNil(t, found, "expected a ReservedState detail on the status")
+		require.Equal(t, state.GetReservedConnectionId(), found.GetReservedConnectionId())
+		require.Equal(t, state.GetReservationReasons(), found.GetReservationReasons())
+	})
+}

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -1235,6 +1235,29 @@ func (e *Executor) reservedConnError(rc reservedConnAPI, wrap string, err error)
 	return e.buildReservedStateFromAPI(rc), mterrors.Wrap(err, wrap)
 }
 
+// concludeTransactionError classifies a CommitResult/RollbackResult failure
+// for ConcludeTransaction. On a dead connection, release/taint it, matching
+// reservedConnError's handling elsewhere.
+//
+// Otherwise the backend is still healthy: CommitResult/RollbackResult already
+// reconciled the reservation bitmask and connstate with what PostgreSQL
+// actually did (e.g. a COMMIT that failed on a deferred constraint behaves
+// like ROLLBACK and already cleared the transaction reason). So release only
+// if no other reason (temp table, portal, ...) still holds the connection —
+// and never taint a connection we've confirmed is fine — otherwise return the
+// authoritative surviving state so the caller can propagate it.
+func (e *Executor) concludeTransactionError(reservedConn *reserved.Conn, releaseReason reserved.ReleaseReason, options *query.ExecuteOptions, err error) (*query.ReservedState, error) {
+	if mterrors.IsConnectionDead(err) {
+		reservedConn.Release(reserved.ReleaseError, nil)
+		return nil, err
+	}
+	if reservedConn.RemainingReasons() == 0 {
+		reservedConn.Release(releaseReason, e.sessionSettingsFromOptions(options))
+		return nil, err
+	}
+	return e.buildReservedState(reservedConn), err
+}
+
 // Describe returns metadata about a prepared statement or portal.
 func (e *Executor) Describe(
 	ctx context.Context,
@@ -2063,8 +2086,8 @@ func (e *Executor) ConcludeTransaction(
 			result, err = reservedConn.CommitResult(ctx)
 		}
 		if err != nil {
-			reservedConn.Release(reserved.ReleaseError, nil)
-			return nil, nil, err
+			state, rerr := e.concludeTransactionError(reservedConn, releaseReason, options, err)
+			return nil, state, rerr
 		}
 	case multipoolerpb.TransactionConclusion_TRANSACTION_CONCLUSION_ROLLBACK:
 		commandTag = "ROLLBACK"
@@ -2076,8 +2099,8 @@ func (e *Executor) ConcludeTransaction(
 			result, err = reservedConn.RollbackResult(ctx)
 		}
 		if err != nil {
-			reservedConn.Release(reserved.ReleaseError, nil)
-			return nil, nil, err
+			state, rerr := e.concludeTransactionError(reservedConn, releaseReason, options, err)
+			return nil, state, rerr
 		}
 		// PostgreSQL closes the cursors created inside this transaction
 		// block at ROLLBACK; cursors declared outside the block (under

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -1236,18 +1236,29 @@ func (e *Executor) reservedConnError(rc reservedConnAPI, wrap string, err error)
 }
 
 // concludeTransactionError classifies a CommitResult/RollbackResult failure
-// for ConcludeTransaction. On a dead connection, release/taint it, matching
-// reservedConnError's handling elsewhere.
+// for ConcludeTransaction. Release/taint on anything that isn't provably a
+// clean SQL-level error from PostgreSQL itself — reserved.IsRecoverableSQLError
+// is the same predicate CommitResult/RollbackResult already used to decide
+// whether to reconcile the reservation bitmask and connstate, so a
+// connection this returns false for was never given that reconciliation:
+// trusting it as "still reserved and healthy" here would be exactly as much
+// of a guess as clearing its transaction reason would have been at the
+// query layer. This folds the indeterminate case (e.g. a context
+// cancellation, which carries no proof PG ever replied) into the same
+// defensive taint path as a confirmed-dead connection, matching this
+// package's pre-existing default of tainting on any conclude failure except
+// the one case this fix specifically carves out.
 //
-// Otherwise the backend is still healthy: CommitResult/RollbackResult already
-// reconciled the reservation bitmask and connstate with what PostgreSQL
-// actually did (e.g. a COMMIT that failed on a deferred constraint behaves
-// like ROLLBACK and already cleared the transaction reason). So release only
-// if no other reason (temp table, portal, ...) still holds the connection —
-// and never taint a connection we've confirmed is fine — otherwise return the
-// authoritative surviving state so the caller can propagate it.
+// Otherwise the backend is confirmed still healthy: CommitResult/RollbackResult
+// already reconciled the reservation bitmask and connstate with what
+// PostgreSQL actually did (e.g. a COMMIT that failed on a deferred
+// constraint behaves like ROLLBACK and already cleared the transaction
+// reason). So release only if no other reason (temp table, portal, ...)
+// still holds the connection — and never taint a connection we've confirmed
+// is fine — otherwise return the authoritative surviving state so the
+// caller can propagate it.
 func (e *Executor) concludeTransactionError(reservedConn *reserved.Conn, releaseReason reserved.ReleaseReason, options *query.ExecuteOptions, err error) (*query.ReservedState, error) {
-	if mterrors.IsConnectionDead(err) {
+	if !reserved.IsRecoverableSQLError(err) {
 		reservedConn.Release(reserved.ReleaseError, nil)
 		return nil, err
 	}

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -1674,6 +1674,102 @@ func TestConcludeTransaction_ReservedConnTerminated(t *testing.T) {
 	require.Contains(t, err.Error(), "reserved connection terminated; please retry")
 }
 
+// TestConcludeTransaction_CommitFailsCleanlyKeepsSurvivingReason verifies that
+// a COMMIT which fails with a clean PostgreSQL SQL-level error (e.g. a
+// deferred constraint violation) removes only the transaction reason and
+// does not release/taint the connection when another reason (e.g. a
+// temp table) still holds it — regression test for the temp table being
+// silently orphaned on a different backend after a failed COMMIT.
+func TestConcludeTransaction_CommitFailsCleanlyKeepsSurvivingReason(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+	server.AddRejectedQuery("COMMIT", mterrors.NewPgError("ERROR", "23503",
+		`update or delete on table "p" violates foreign key constraint`, ""))
+
+	pool := reserved.NewPool(context.Background(), &reserved.PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig: server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{
+				Capacity:     2,
+				MaxIdleCount: 2,
+			},
+		},
+	})
+	defer pool.Close()
+
+	ctx := context.Background()
+	rconn, err := pool.NewConn(ctx, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, rconn.Begin(ctx))
+	rconn.AddReservationReason(protoutil.ReasonTempTable)
+
+	e := NewExecutor(slog.Default(), &stubPoolManager{reservedConn: rconn, reservedConnOK: true},
+		&clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"}, false)
+
+	_, state, err := e.ConcludeTransaction(
+		ctx,
+		protoutil.NewTarget("", "tg", "", query.Mode_MODE_UNSPECIFIED),
+		&query.ExecuteOptions{User: "postgres", ReservedConnectionId: uint64(rconn.ConnID())},
+		multipoolerpb.TransactionConclusion_TRANSACTION_CONCLUSION_COMMIT,
+		nil, false, false,
+	)
+
+	require.Error(t, err)
+	assert.False(t, mterrors.IsConnectionDead(err), "a deferred constraint violation is a clean SQL error, not a dead connection")
+	require.NotNil(t, state, "the temp-table reservation must survive a failed COMMIT")
+	assert.Equal(t, uint64(rconn.ConnID()), state.GetReservedConnectionId())
+	assert.Equal(t, protoutil.ReasonTempTable, state.GetReservationReasons(), "only the transaction reason should be cleared")
+	assert.False(t, rconn.IsReleased(), "a clean COMMIT failure must not release/taint a healthy connection")
+}
+
+// TestConcludeTransaction_CommitConnectionDeathReleases verifies that a
+// genuine connection failure during COMMIT (unlike a clean SQL error) still
+// releases/taints the connection, even when other reasons were set.
+func TestConcludeTransaction_CommitConnectionDeathReleases(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+	server.AddRejectedQuery("COMMIT", mterrors.NewPgError("FATAL", "57P01",
+		"terminating connection due to administrator command", ""))
+
+	pool := reserved.NewPool(context.Background(), &reserved.PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig: server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{
+				Capacity:     2,
+				MaxIdleCount: 2,
+			},
+		},
+	})
+	defer pool.Close()
+
+	ctx := context.Background()
+	rconn, err := pool.NewConn(ctx, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, rconn.Begin(ctx))
+	rconn.AddReservationReason(protoutil.ReasonTempTable)
+
+	e := NewExecutor(slog.Default(), &stubPoolManager{reservedConn: rconn, reservedConnOK: true},
+		&clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"}, false)
+
+	_, state, err := e.ConcludeTransaction(
+		ctx,
+		protoutil.NewTarget("", "tg", "", query.Mode_MODE_UNSPECIFIED),
+		&query.ExecuteOptions{User: "postgres", ReservedConnectionId: uint64(rconn.ConnID())},
+		multipoolerpb.TransactionConclusion_TRANSACTION_CONCLUSION_COMMIT,
+		nil, false, false,
+	)
+
+	require.Error(t, err)
+	require.Nil(t, state)
+	assert.True(t, rconn.IsReleased(), "a genuine connection failure must still destroy the reserved connection")
+}
+
 func TestCopyOutStream_ValidationAndNotFound(t *testing.T) {
 	e := newTestExecutor()
 

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -1866,6 +1867,91 @@ func TestConcludeTransaction_CommitAndChainFailsCleanlyKeepsSurvivingReason(t *t
 	assert.Equal(t, uint64(rconn.ConnID()), state.GetReservedConnectionId())
 	assert.Equal(t, protoutil.ReasonTempTable, state.GetReservationReasons(), "only the transaction reason should be cleared")
 	assert.False(t, rconn.IsReleased(), "a clean COMMIT AND CHAIN failure must not release/taint a healthy connection")
+}
+
+// TestConcludeTransaction_CommitContextCancelReleasesEvenWithSurvivingReason
+// is a regression test for the indeterminate-error taint fix: a COMMIT cut
+// off by context cancellation carries no proof PostgreSQL ever replied, so
+// concludeTransactionError must release/taint the connection exactly like a
+// confirmed-dead one — even when another reason (e.g. a temp table) is also
+// set. Before the fix, only mterrors.IsConnectionDead(err) triggered
+// release; a context-cancelled COMMIT is not "dead" by that check, so with
+// a surviving reason present the connection would have been wrongly
+// reported as still safely reserved.
+func TestConcludeTransaction_CommitContextCancelReleasesEvenWithSurvivingReason(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	var startOnce sync.Once
+	server.AddQueryPatternWithCallback(`^COMMIT$`, &sqltypes.Result{CommandTag: "COMMIT"},
+		func(string) {
+			startOnce.Do(func() { close(started) })
+			<-release
+		})
+
+	pool := reserved.NewPool(context.Background(), &reserved.PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig: server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{
+				Capacity:     2,
+				MaxIdleCount: 2,
+			},
+		},
+	})
+	defer pool.Close()
+	// Registered last so it runs first on unwind (LIFO): release the blocked
+	// server callback before pool.Close()/server.Close() try to tear down
+	// the connection, or those would deadlock waiting on it.
+	defer close(release)
+
+	ctx := context.Background()
+	rconn, err := pool.NewConn(ctx, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, rconn.Begin(ctx))
+	rconn.AddReservationReason(protoutil.ReasonTempTable)
+
+	e := NewExecutor(slog.Default(), &stubPoolManager{reservedConn: rconn, reservedConnOK: true},
+		&clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"}, false)
+
+	commitCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	type concludeResult struct {
+		state *query.ReservedState
+		err   error
+	}
+	done := make(chan concludeResult, 1)
+	go func() {
+		_, state, err := e.ConcludeTransaction(
+			commitCtx,
+			protoutil.NewTarget("", "tg", "", query.Mode_MODE_UNSPECIFIED),
+			&query.ExecuteOptions{User: "postgres", ReservedConnectionId: uint64(rconn.ConnID())},
+			multipoolerpb.TransactionConclusion_TRANSACTION_CONCLUSION_COMMIT,
+			nil, false, false,
+		)
+		done <- concludeResult{state, err}
+	}()
+
+	<-started
+
+	var result concludeResult
+	select {
+	case result = <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ConcludeTransaction did not return after the context deadline")
+	}
+
+	require.Error(t, result.err)
+	assert.ErrorIs(t, result.err, context.DeadlineExceeded)
+	require.Nil(t, result.state,
+		"a context-cancelled COMMIT carries no proof PG replied — it must be treated like a dead connection, not a surviving reservation")
+	assert.True(t, rconn.IsReleased(),
+		"the indeterminate case must taint/release the connection even though a temp-table reason was also present")
 }
 
 func TestCopyOutStream_ValidationAndNotFound(t *testing.T) {

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -1770,6 +1770,104 @@ func TestConcludeTransaction_CommitConnectionDeathReleases(t *testing.T) {
 	assert.True(t, rconn.IsReleased(), "a genuine connection failure must still destroy the reserved connection")
 }
 
+// TestConcludeTransaction_CommitFailsCleanlyReleasesWhenNoOtherReason verifies
+// that a COMMIT which fails with a clean SQL-level error still releases the
+// connection when no other reservation reason (e.g. temp table) remains —
+// the surviving-reservation handling in concludeTransactionError must not
+// leak a connection that has nothing left holding it reserved.
+func TestConcludeTransaction_CommitFailsCleanlyReleasesWhenNoOtherReason(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+	server.AddRejectedQuery("COMMIT", mterrors.NewPgError("ERROR", "23503",
+		`update or delete on table "p" violates foreign key constraint`, ""))
+
+	pool := reserved.NewPool(context.Background(), &reserved.PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig: server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{
+				Capacity:     2,
+				MaxIdleCount: 2,
+			},
+		},
+	})
+	defer pool.Close()
+
+	ctx := context.Background()
+	rconn, err := pool.NewConn(ctx, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, rconn.Begin(ctx))
+	// No other reservation reason (e.g. temp table) is added, so once the
+	// transaction reason clears, RemainingReasons() should be 0.
+
+	e := NewExecutor(slog.Default(), &stubPoolManager{reservedConn: rconn, reservedConnOK: true},
+		&clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"}, false)
+
+	_, state, err := e.ConcludeTransaction(
+		ctx,
+		protoutil.NewTarget("", "tg", "", query.Mode_MODE_UNSPECIFIED),
+		&query.ExecuteOptions{User: "postgres", ReservedConnectionId: uint64(rconn.ConnID())},
+		multipoolerpb.TransactionConclusion_TRANSACTION_CONCLUSION_COMMIT,
+		nil, false, false,
+	)
+
+	require.Error(t, err)
+	assert.False(t, mterrors.IsConnectionDead(err), "a deferred constraint violation is a clean SQL error, not a dead connection")
+	require.Nil(t, state, "no reason remains, so the connection should be released rather than reported as reserved")
+	assert.True(t, rconn.IsReleased(), "with no surviving reason, the connection must be released even on a clean COMMIT failure")
+}
+
+// TestConcludeTransaction_CommitAndChainFailsCleanlyKeepsSurvivingReason is
+// the chain=true counterpart of the plain-COMMIT regression test — it
+// exercises CommitAndChainResult's error-handling path (rather than
+// CommitResult's), which mirrors the same bookkeeping.
+func TestConcludeTransaction_CommitAndChainFailsCleanlyKeepsSurvivingReason(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+	server.AddRejectedQuery("COMMIT AND CHAIN", mterrors.NewPgError("ERROR", "23503",
+		`update or delete on table "p" violates foreign key constraint`, ""))
+
+	pool := reserved.NewPool(context.Background(), &reserved.PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig: server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{
+				Capacity:     2,
+				MaxIdleCount: 2,
+			},
+		},
+	})
+	defer pool.Close()
+
+	ctx := context.Background()
+	rconn, err := pool.NewConn(ctx, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, rconn.Begin(ctx))
+	rconn.AddReservationReason(protoutil.ReasonTempTable)
+
+	e := NewExecutor(slog.Default(), &stubPoolManager{reservedConn: rconn, reservedConnOK: true},
+		&clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"}, false)
+
+	_, state, err := e.ConcludeTransaction(
+		ctx,
+		protoutil.NewTarget("", "tg", "", query.Mode_MODE_UNSPECIFIED),
+		&query.ExecuteOptions{User: "postgres", ReservedConnectionId: uint64(rconn.ConnID())},
+		multipoolerpb.TransactionConclusion_TRANSACTION_CONCLUSION_COMMIT,
+		nil, false, true,
+	)
+
+	require.Error(t, err)
+	assert.False(t, mterrors.IsConnectionDead(err), "a deferred constraint violation is a clean SQL error, not a dead connection")
+	require.NotNil(t, state, "the temp-table reservation must survive a failed COMMIT AND CHAIN")
+	assert.Equal(t, uint64(rconn.ConnID()), state.GetReservedConnectionId())
+	assert.Equal(t, protoutil.ReasonTempTable, state.GetReservationReasons(), "only the transaction reason should be cleared")
+	assert.False(t, rconn.IsReleased(), "a clean COMMIT AND CHAIN failure must not release/taint a healthy connection")
+}
+
 func TestCopyOutStream_ValidationAndNotFound(t *testing.T) {
 	e := newTestExecutor()
 

--- a/go/services/multipooler/internal/pools/reserved/reserved_conn.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_conn.go
@@ -186,7 +186,7 @@ func (c *Conn) SnapshotTxnState() {
 	c.txnStartTime = time.Now()
 }
 
-// isRecoverableSQLError reports whether err is a normal (non-fatal) SQL-level
+// IsRecoverableSQLError reports whether err is a normal (non-fatal) SQL-level
 // error that PostgreSQL itself sent as an ErrorResponse, as opposed to an
 // error where we have no proof PG ever replied at all — a context
 // cancellation or deadline surfaces as a plain context error, not a
@@ -194,11 +194,35 @@ func (c *Conn) SnapshotTxnState() {
 // answering. Only when this is true can COMMIT/ROLLBACK's failure-path
 // bookkeeping trust that PostgreSQL's own transaction semantics already
 // resolved the transaction and the backend connection is still healthy;
-// anything else must be treated as indeterminate and fall back to the
-// release/taint behavior.
-func isRecoverableSQLError(err error) bool {
+// anything else — including the indeterminate case where we can't prove
+// PG ever replied — must be treated the same as a confirmed-dead connection
+// and fall back to the release/taint behavior. Exported so callers outside
+// this package (e.g. the executor's post-ConcludeTransaction-error decision
+// of whether to keep trusting the connection) can apply the identical
+// predicate instead of only checking mterrors.IsConnectionDead, which
+// otherwise misses the indeterminate case.
+func IsRecoverableSQLError(err error) bool {
 	var diag *mterrors.PgDiagnostic
 	return errors.As(err, &diag) && !mterrors.IsConnectionDead(err)
+}
+
+// markTransactionRolledBack applies the bookkeeping PostgreSQL's ROLLBACK
+// semantics guarantee: mid-transaction session changes are undone, so the
+// pool's cached connstate must revert to the pre-transaction baseline, and
+// the transaction reservation reason no longer applies. Used both by
+// RollbackResult's success path and by the confirmed-clean failure paths of
+// CommitResult/CommitAndChainResult/RollbackResult/RollbackAndChainResult,
+// where PostgreSQL treats the failure (e.g. a COMMIT that hits a deferred
+// constraint, or a ROLLBACK that itself errors cleanly) exactly like a
+// successful ROLLBACK.
+func (c *Conn) markTransactionRolledBack(ctx context.Context) {
+	if c.txnSnapshot != nil {
+		c.pooled.Conn.State().RestoreFromTxn(c.txnSnapshot)
+		c.txnSnapshot = nil
+	}
+	c.ClearSessionStateUntrusted()
+	c.recordTxnOutcome(ctx, txnOutcomeRollback)
+	c.RemoveReservationReason(protoutil.ReasonTransaction)
 }
 
 // Commit commits the current transaction.
@@ -219,7 +243,7 @@ func (c *Conn) CommitResult(ctx context.Context) (*sqltypes.Result, error) {
 
 	results, err := c.pooled.Conn.Query(ctx, "COMMIT")
 	if err != nil {
-		if isRecoverableSQLError(err) {
+		if IsRecoverableSQLError(err) {
 			// PostgreSQL treats a COMMIT that fails on a deferred constraint
 			// check exactly like ROLLBACK: the transaction is cleanly rolled
 			// back and the session returns to idle on a still-healthy
@@ -227,13 +251,7 @@ func (c *Conn) CommitResult(ctx context.Context) (*sqltypes.Result, error) {
 			// reservation bitmask and cached connstate agree with what
 			// PostgreSQL actually did, instead of leaving the transaction
 			// reason set and connstate stale.
-			if c.txnSnapshot != nil {
-				c.pooled.Conn.State().RestoreFromTxn(c.txnSnapshot)
-				c.txnSnapshot = nil
-			}
-			c.ClearSessionStateUntrusted()
-			c.recordTxnOutcome(ctx, txnOutcomeRollback)
-			c.RemoveReservationReason(protoutil.ReasonTransaction)
+			c.markTransactionRolledBack(ctx)
 		}
 		return nil, fmt.Errorf("failed to commit transaction: %w", err)
 	}
@@ -265,18 +283,12 @@ func (c *Conn) CommitAndChainResult(ctx context.Context) (*sqltypes.Result, erro
 
 	results, err := c.pooled.Conn.Query(ctx, "COMMIT AND CHAIN")
 	if err != nil {
-		if isRecoverableSQLError(err) {
+		if IsRecoverableSQLError(err) {
 			// A COMMIT AND CHAIN that fails on a deferred constraint check
 			// behaves like plain ROLLBACK — PostgreSQL does not start the
 			// chained transaction when the commit itself fails. Mirror
 			// RollbackResult's bookkeeping, same as CommitResult above.
-			if c.txnSnapshot != nil {
-				c.pooled.Conn.State().RestoreFromTxn(c.txnSnapshot)
-				c.txnSnapshot = nil
-			}
-			c.ClearSessionStateUntrusted()
-			c.recordTxnOutcome(ctx, txnOutcomeRollback)
-			c.RemoveReservationReason(protoutil.ReasonTransaction)
+			c.markTransactionRolledBack(ctx)
 		}
 		return nil, fmt.Errorf("failed to commit transaction and chain: %w", err)
 	}
@@ -306,7 +318,7 @@ func (c *Conn) RollbackResult(ctx context.Context) (*sqltypes.Result, error) {
 
 	results, err := c.pooled.Conn.Query(ctx, "ROLLBACK")
 	if err != nil {
-		if isRecoverableSQLError(err) {
+		if IsRecoverableSQLError(err) {
 			// A clean SQL-level error on ROLLBACK still leaves PostgreSQL
 			// having processed the command and reached idle — mirror the
 			// same bookkeeping as the success path below so the reservation
@@ -315,13 +327,7 @@ func (c *Conn) RollbackResult(ctx context.Context) (*sqltypes.Result, error) {
 			// RemainingReasons() never reaches 0 for a ROLLBACK that errors
 			// this way, and concludeTransactionError can never release the
 			// connection even though nothing else holds it reserved.
-			if c.txnSnapshot != nil {
-				c.pooled.Conn.State().RestoreFromTxn(c.txnSnapshot)
-				c.txnSnapshot = nil
-			}
-			c.ClearSessionStateUntrusted()
-			c.recordTxnOutcome(ctx, txnOutcomeRollback)
-			c.RemoveReservationReason(protoutil.ReasonTransaction)
+			c.markTransactionRolledBack(ctx)
 		}
 		return nil, fmt.Errorf("failed to rollback transaction: %w", err)
 	}
@@ -329,14 +335,7 @@ func (c *Conn) RollbackResult(ctx context.Context) (*sqltypes.Result, error) {
 	// PostgreSQL just reverted any SET / SET ROLE issued inside this transaction
 	// to the pre-transaction baseline. Revert the pool's cached connstate to the
 	// same baseline so the recycled connection is bucketed and reused correctly.
-	if c.txnSnapshot != nil {
-		c.pooled.Conn.State().RestoreFromTxn(c.txnSnapshot)
-		c.txnSnapshot = nil
-	}
-	c.ClearSessionStateUntrusted()
-
-	c.recordTxnOutcome(ctx, txnOutcomeRollback)
-	c.RemoveReservationReason(protoutil.ReasonTransaction)
+	c.markTransactionRolledBack(ctx)
 	return firstTxnResult(results, "ROLLBACK"), nil
 }
 
@@ -369,18 +368,12 @@ func (c *Conn) RollbackAndChainResult(ctx context.Context) (*sqltypes.Result, er
 
 	results, err := c.pooled.Conn.Query(ctx, "ROLLBACK AND CHAIN")
 	if err != nil {
-		if isRecoverableSQLError(err) {
+		if IsRecoverableSQLError(err) {
 			// A ROLLBACK AND CHAIN that fails cleanly behaves like plain
 			// ROLLBACK — PostgreSQL does not start the chained transaction
 			// when the rollback itself fails. Mirror RollbackResult's
 			// bookkeeping, same as above.
-			if c.txnSnapshot != nil {
-				c.pooled.Conn.State().RestoreFromTxn(c.txnSnapshot)
-				c.txnSnapshot = nil
-			}
-			c.ClearSessionStateUntrusted()
-			c.recordTxnOutcome(ctx, txnOutcomeRollback)
-			c.RemoveReservationReason(protoutil.ReasonTransaction)
+			c.markTransactionRolledBack(ctx)
 		}
 		return nil, fmt.Errorf("failed to rollback transaction and chain: %w", err)
 	}

--- a/go/services/multipooler/internal/pools/reserved/reserved_conn.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_conn.go
@@ -21,6 +21,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/common/sqltypes"
@@ -203,6 +204,22 @@ func (c *Conn) CommitResult(ctx context.Context) (*sqltypes.Result, error) {
 
 	results, err := c.pooled.Conn.Query(ctx, "COMMIT")
 	if err != nil {
+		if !mterrors.IsConnectionDead(err) {
+			// PostgreSQL treats a COMMIT that fails on a deferred constraint
+			// check exactly like ROLLBACK: the transaction is cleanly rolled
+			// back and the session returns to idle on a still-healthy
+			// connection. Mirror RollbackResult's bookkeeping so the
+			// reservation bitmask and cached connstate agree with what
+			// PostgreSQL actually did, instead of leaving the transaction
+			// reason set and connstate stale.
+			if c.txnSnapshot != nil {
+				c.pooled.Conn.State().RestoreFromTxn(c.txnSnapshot)
+				c.txnSnapshot = nil
+			}
+			c.ClearSessionStateUntrusted()
+			c.recordTxnOutcome(ctx, txnOutcomeRollback)
+			c.RemoveReservationReason(protoutil.ReasonTransaction)
+		}
 		return nil, fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
@@ -233,6 +250,19 @@ func (c *Conn) CommitAndChainResult(ctx context.Context) (*sqltypes.Result, erro
 
 	results, err := c.pooled.Conn.Query(ctx, "COMMIT AND CHAIN")
 	if err != nil {
+		if !mterrors.IsConnectionDead(err) {
+			// A COMMIT AND CHAIN that fails on a deferred constraint check
+			// behaves like plain ROLLBACK — PostgreSQL does not start the
+			// chained transaction when the commit itself fails. Mirror
+			// RollbackResult's bookkeeping, same as CommitResult above.
+			if c.txnSnapshot != nil {
+				c.pooled.Conn.State().RestoreFromTxn(c.txnSnapshot)
+				c.txnSnapshot = nil
+			}
+			c.ClearSessionStateUntrusted()
+			c.recordTxnOutcome(ctx, txnOutcomeRollback)
+			c.RemoveReservationReason(protoutil.ReasonTransaction)
+		}
 		return nil, fmt.Errorf("failed to commit transaction and chain: %w", err)
 	}
 

--- a/go/services/multipooler/internal/pools/reserved/reserved_conn.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_conn.go
@@ -186,6 +186,21 @@ func (c *Conn) SnapshotTxnState() {
 	c.txnStartTime = time.Now()
 }
 
+// isRecoverableSQLError reports whether err is a normal (non-fatal) SQL-level
+// error that PostgreSQL itself sent as an ErrorResponse, as opposed to an
+// error where we have no proof PG ever replied at all — a context
+// cancellation or deadline surfaces as a plain context error, not a
+// *mterrors.PgDiagnostic, since the caller gave up waiting rather than PG
+// answering. Only when this is true can COMMIT/ROLLBACK's failure-path
+// bookkeeping trust that PostgreSQL's own transaction semantics already
+// resolved the transaction and the backend connection is still healthy;
+// anything else must be treated as indeterminate and fall back to the
+// release/taint behavior.
+func isRecoverableSQLError(err error) bool {
+	var diag *mterrors.PgDiagnostic
+	return errors.As(err, &diag) && !mterrors.IsConnectionDead(err)
+}
+
 // Commit commits the current transaction.
 func (c *Conn) Commit(ctx context.Context) error {
 	_, err := c.CommitResult(ctx)
@@ -204,7 +219,7 @@ func (c *Conn) CommitResult(ctx context.Context) (*sqltypes.Result, error) {
 
 	results, err := c.pooled.Conn.Query(ctx, "COMMIT")
 	if err != nil {
-		if !mterrors.IsConnectionDead(err) {
+		if isRecoverableSQLError(err) {
 			// PostgreSQL treats a COMMIT that fails on a deferred constraint
 			// check exactly like ROLLBACK: the transaction is cleanly rolled
 			// back and the session returns to idle on a still-healthy
@@ -250,7 +265,7 @@ func (c *Conn) CommitAndChainResult(ctx context.Context) (*sqltypes.Result, erro
 
 	results, err := c.pooled.Conn.Query(ctx, "COMMIT AND CHAIN")
 	if err != nil {
-		if !mterrors.IsConnectionDead(err) {
+		if isRecoverableSQLError(err) {
 			// A COMMIT AND CHAIN that fails on a deferred constraint check
 			// behaves like plain ROLLBACK — PostgreSQL does not start the
 			// chained transaction when the commit itself fails. Mirror
@@ -291,6 +306,23 @@ func (c *Conn) RollbackResult(ctx context.Context) (*sqltypes.Result, error) {
 
 	results, err := c.pooled.Conn.Query(ctx, "ROLLBACK")
 	if err != nil {
+		if isRecoverableSQLError(err) {
+			// A clean SQL-level error on ROLLBACK still leaves PostgreSQL
+			// having processed the command and reached idle — mirror the
+			// same bookkeeping as the success path below so the reservation
+			// bitmask and cached connstate don't go stale with a transaction
+			// reason that PostgreSQL itself already cleared. Without this,
+			// RemainingReasons() never reaches 0 for a ROLLBACK that errors
+			// this way, and concludeTransactionError can never release the
+			// connection even though nothing else holds it reserved.
+			if c.txnSnapshot != nil {
+				c.pooled.Conn.State().RestoreFromTxn(c.txnSnapshot)
+				c.txnSnapshot = nil
+			}
+			c.ClearSessionStateUntrusted()
+			c.recordTxnOutcome(ctx, txnOutcomeRollback)
+			c.RemoveReservationReason(protoutil.ReasonTransaction)
+		}
 		return nil, fmt.Errorf("failed to rollback transaction: %w", err)
 	}
 
@@ -337,6 +369,19 @@ func (c *Conn) RollbackAndChainResult(ctx context.Context) (*sqltypes.Result, er
 
 	results, err := c.pooled.Conn.Query(ctx, "ROLLBACK AND CHAIN")
 	if err != nil {
+		if isRecoverableSQLError(err) {
+			// A ROLLBACK AND CHAIN that fails cleanly behaves like plain
+			// ROLLBACK — PostgreSQL does not start the chained transaction
+			// when the rollback itself fails. Mirror RollbackResult's
+			// bookkeeping, same as above.
+			if c.txnSnapshot != nil {
+				c.pooled.Conn.State().RestoreFromTxn(c.txnSnapshot)
+				c.txnSnapshot = nil
+			}
+			c.ClearSessionStateUntrusted()
+			c.recordTxnOutcome(ctx, txnOutcomeRollback)
+			c.RemoveReservationReason(protoutil.ReasonTransaction)
+		}
 		return nil, fmt.Errorf("failed to rollback transaction and chain: %w", err)
 	}
 

--- a/go/services/multipooler/internal/pools/reserved/reserved_pool_test.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_pool_test.go
@@ -323,7 +323,7 @@ func TestIsRecoverableSQLError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, isRecoverableSQLError(tt.err))
+			assert.Equal(t, tt.want, IsRecoverableSQLError(tt.err))
 		})
 	}
 }

--- a/go/services/multipooler/internal/pools/reserved/reserved_pool_test.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_pool_test.go
@@ -17,6 +17,7 @@ package reserved
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -301,6 +302,121 @@ func TestConn_CommitResultIncludesNotices(t *testing.T) {
 	require.Equal(t, "COMMIT", result.CommandTag)
 	require.Len(t, result.Notices, 1)
 	require.Equal(t, "deferred trigger fired", result.Notices[0].Message)
+}
+
+// TestIsRecoverableSQLError is a direct table test of the positive-classification
+// helper: only a non-fatal *mterrors.PgDiagnostic (proof PostgreSQL actually
+// sent an ErrorResponse) counts as "PG replied cleanly" — a plain context
+// error (proof of nothing; the caller gave up waiting) and a fatal/connection
+// diagnostic must both be indeterminate/dead, never clean.
+func TestIsRecoverableSQLError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"non-fatal PgDiagnostic", mterrors.NewPgError("ERROR", "23503", "fk violation", ""), true},
+		{"context canceled", context.Canceled, false},
+		{"context deadline exceeded", context.DeadlineExceeded, false},
+		{"fatal PgDiagnostic (admin shutdown)", connErrFATAL(), false},
+		{"plain non-PgDiagnostic error", errors.New("boom"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isRecoverableSQLError(tt.err))
+		})
+	}
+}
+
+// TestConn_CommitResult_ContextCancelDoesNotAssumeCleanRollback is a
+// regression test: a COMMIT cut off by context cancellation must NOT be
+// treated as PostgreSQL having cleanly rolled back the transaction, because
+// the returned error (context.Cause) carries no proof PG ever replied — it
+// could just as easily mean the backend was force-closed mid-COMMIT. Before
+// the fix, `!mterrors.IsConnectionDead(err)` was true for this error too,
+// so the transaction reason was wrongly cleared as if PG had answered.
+func TestConn_CommitResult_ContextCancelDoesNotAssumeCleanRollback(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	var startOnce sync.Once
+	server.AddQueryPatternWithCallback(`^COMMIT$`, &sqltypes.Result{CommandTag: "COMMIT"},
+		func(string) {
+			startOnce.Do(func() { close(started) })
+			<-release
+		})
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+	// Registered last so it runs first on unwind (LIFO): the blocked server
+	// callback must be released before pool.Close()/server.Close() try to
+	// tear down the connection, or those would deadlock waiting on it.
+	defer close(release)
+
+	ctx := context.Background()
+	conn, err := pool.NewConn(ctx, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, conn.Begin(ctx))
+
+	commitCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := conn.CommitResult(commitCtx)
+		done <- err
+	}()
+
+	<-started
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(5 * time.Second):
+		t.Fatal("CommitResult did not return after the context deadline")
+	}
+
+	assert.True(t, conn.IsInTransaction(),
+		"a context-cancelled COMMIT carries no proof PG replied — the transaction reason must not be cleared as if it had")
+	assert.True(t, protoutil.HasReason(conn.RemainingReasons(), protoutil.ReasonTransaction))
+}
+
+// TestConn_RollbackResult_CleanFailureClearsTransactionReason is a regression
+// test for the ROLLBACK/COMMIT asymmetry: previously, RollbackResult's error
+// path did no bookkeeping at all, so a ROLLBACK that failed with a genuine
+// (non-fatal) PostgreSQL error left the transaction reason set forever,
+// meaning concludeTransactionError's "release if nothing else holds it"
+// logic could never fire for ROLLBACK. Mirroring CommitResult's bookkeeping
+// on a clean failure fixes that.
+func TestConn_RollbackResult_CleanFailureClearsTransactionReason(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+	server.AddRejectedQuery("ROLLBACK", mterrors.NewPgError("ERROR", "XX000",
+		"some in-rollback trigger error", ""))
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+	conn, err := pool.NewConn(ctx, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, conn.Begin(ctx))
+
+	_, err = conn.RollbackResult(ctx)
+	require.Error(t, err)
+	assert.False(t, mterrors.IsConnectionDead(err), "a clean SQL-level error is not a dead connection")
+
+	assert.False(t, conn.IsInTransaction(),
+		"a clean ROLLBACK failure must still clear the transaction reason, matching CommitResult's bookkeeping")
+	assert.Equal(t, uint32(0), conn.RemainingReasons(),
+		"with nothing else holding the connection, RemainingReasons() must reach 0 so the caller can release it")
 }
 
 func TestConn_PortalReservation(t *testing.T) {


### PR DESCRIPTION
## Summary

`Executor.ConcludeTransaction` unconditionally tainted and released the reserved connection on any COMMIT/ROLLBACK error even when another independent reason (e.g. an open temp table) still legitimately held the reservation. Concretely:

```sql
CREATE TEMP TABLE p(id int PRIMARY KEY);
CREATE TEMP TABLE f(id int, fk int REFERENCES p DEFERRABLE INITIALLY DEFERRED);

BEGIN;
INSERT INTO f VALUES (1, 99);
COMMIT;          -- fails: deferred FK violation
SELECT * FROM f; -- temp table `f` should still exist on the same backend
```

A COMMIT failing on a deferred constraint is a clean, healthy-connection outcome. PostgreSQL treats it exactly like ROLLBACK. The bug conflated that with a genuine dead-connection error and released/tainted the backend regardless, orphaning the temp-table reservation onto a different physical connection for the next statement.

## Changes

- `CommitResult`/`CommitAndChainResult` now distinguish a dead connection (`mterrors.IsConnectionDead`) from a clean SQL-level failure, mirroring `RollbackResult`'s bookkeeping (restore the pre-transaction connstate snapshot, clear the transaction reason) in the latter case.
- `Executor.ConcludeTransaction` only releases/taints on a dead connection; otherwise it checks `RemainingReasons()` before releasing, matching the success path's existing behavior.
- Since `ConcludeTransaction` is a unary RPC, a returned error normally drops the entire response body. The surviving `ReservedState` now rides along as an additional gRPC status detail. The same `status.WithDetails` mechanism `mterrors.ToGRPC` already uses for `PgDiagnostic` and the gateway unpacks it so `ScatterConn` keeps tracking the reservation instead of clearing it.

New unit tests cover both the fixed path (temp-table reason survives a clean COMMIT failure, connection not released) and the existing correct behavior (a genuine dead connection still releases/taints).