### PR TITLE
fix(multigateway): route RESET ROLE to the pinned backend mid-transaction

### DIFF
--- a/go/services/multigateway/planner/variable_set_stmt.go
+++ b/go/services/multigateway/planner/variable_set_stmt.go
@@ -55,12 +55,34 @@ func (p *Planner) planVariableSetStmt(
 	}
 
 	// Role/session authorization are replayable session state, but they are not
-	// ordinary GUCs for validation/replay purposes. Keep them on the local
-	// tracking path (so pooled backends don't get mutated behind connstate), and
-	// let ApplySettings replay them as SET SESSION AUTHORIZATION / SET ROLE in
-	// PostgreSQL-compatible order.
+	// ordinary GUCs for validation/replay purposes. Outside an explicit
+	// transaction, keep RESET/SET-TO-DEFAULT on the local tracking path (so
+	// pooled backends don't get mutated behind connstate) and let ApplySettings
+	// replay them as SET SESSION AUTHORIZATION / SET ROLE in PostgreSQL-compatible
+	// order before the next query.
+	//
+	// Inside an explicit transaction, a backend is already pinned for the
+	// transaction's duration and won't be replayed onto until the *next*
+	// transaction. `SET LOCAL ROLE`/`SET LOCAL SESSION AUTHORIZATION` passes
+	// straight through to that pinned backend untracked (see the IsLocal branch
+	// below) specifically because "the backend is authoritative" for LOCAL
+	// variables — so gateway-only tracking has nothing to clear when a RESET
+	// follows a LOCAL set, and the pinned backend's real role would otherwise
+	// stay changed for the rest of the transaction. Route the real RESET to that
+	// same backend (mirroring the route-then-track SET plan below) so it takes
+	// effect immediately, then track locally for pool-rotation replay after the
+	// transaction ends.
 	if isRoleAuthVariable(stmt.Name) && !stmt.IsLocal {
 		if stmt.Kind == ast.VAR_SET_DEFAULT || stmt.Kind == ast.VAR_RESET {
+			if conn != nil && conn.IsInTransaction() {
+				route := engine.NewRoute(p.defaultTableGroup, constants.DefaultShard, sql, stmt)
+				track := engine.NewApplySessionStateSilent(sql, stmt)
+				plan := engine.NewPlan(sql, engine.NewSequence([]engine.Primitive{route, track}))
+				p.logger.Debug("created route-then-track role/session authorization reset plan inside transaction",
+					"kind", stmt.Kind, "variable", stmt.Name, "plan", plan.String())
+				return plan, nil
+			}
+
 			plan := engine.NewPlan(sql, engine.NewApplySessionState(sql, stmt))
 			p.logger.Debug("created role/session authorization reset plan",
 				"kind", stmt.Kind, "variable", stmt.Name, "plan", plan.String())

--- a/go/services/multigateway/planner/variable_set_stmt_test.go
+++ b/go/services/multigateway/planner/variable_set_stmt_test.go
@@ -134,6 +134,25 @@ func TestPlanVariableSetStmt_RESET_RoleAuth_InTransactionRoutesThenTracks(t *tes
 	}
 }
 
+func TestPlanVariableSetStmt_RESET_RoleAuth_OutsideTransactionStaysLocalOnly(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	p := NewPlanner("default", logger, nil)
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	// No SetTxnStatus call: testConn defaults to no active transaction.
+
+	stmt := &ast.VariableSetStmt{Kind: ast.VAR_RESET, Name: "role"}
+
+	plan, err := p.planVariableSetStmt("RESET ROLE", stmt, testConn.Conn)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	// Outside a transaction there is no backend pinned to route to yet — keep
+	// the existing local-tracking-only behavior; ApplySettings replays this
+	// before the next query lands on a (possibly different) backend.
+	_, ok := plan.Primitive.(*engine.ApplySessionState)
+	assert.True(t, ok, "expected ApplySessionState primitive (no backend round-trip outside a transaction), got %T", plan.Primitive)
+}
+
 func TestPlanVariableSetStmt_SET_IdleSessionTimeoutGatewayManaged(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
 	p := NewPlanner("default", logger, nil)

--- a/go/services/multigateway/planner/variable_set_stmt_test.go
+++ b/go/services/multigateway/planner/variable_set_stmt_test.go
@@ -80,6 +80,60 @@ func TestPlanVariableSetStmt_SET_InTransactionRoutesThenTracks(t *testing.T) {
 	assert.True(t, track.SilentTracking)
 }
 
+func TestPlanVariableSetStmt_RESET_RoleAuth_InTransactionRoutesThenTracks(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+
+	tests := []struct {
+		name string
+		sql  string
+		stmt *ast.VariableSetStmt
+	}{
+		{
+			name: "RESET ROLE",
+			sql:  "RESET ROLE",
+			stmt: &ast.VariableSetStmt{Kind: ast.VAR_RESET, Name: "role"},
+		},
+		{
+			name: "RESET SESSION AUTHORIZATION",
+			sql:  "RESET SESSION AUTHORIZATION",
+			stmt: &ast.VariableSetStmt{Kind: ast.VAR_RESET, Name: "session_authorization"},
+		},
+		{
+			name: "SET ROLE TO DEFAULT",
+			sql:  "SET ROLE TO DEFAULT",
+			stmt: &ast.VariableSetStmt{Kind: ast.VAR_SET_DEFAULT, Name: "role"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewPlanner("default", logger, nil)
+			testConn := server.NewTestConn(&bytes.Buffer{})
+			testConn.Conn.SetTxnStatus(protocol.TxnStatusInBlock)
+
+			plan, err := p.planVariableSetStmt(tt.sql, tt.stmt, testConn.Conn)
+			require.NoError(t, err)
+			require.NotNil(t, plan)
+
+			// Inside a transaction, a backend is already pinned for its duration.
+			// If an earlier `SET LOCAL ROLE`/`SET LOCAL SESSION AUTHORIZATION` on
+			// this same connection changed the backend's real role (SET LOCAL
+			// passes straight through untracked — see the IsLocal branch), only
+			// routing the real RESET to that same backend can undo it. Gateway-only
+			// tracking has nothing to clear and leaves the backend's real role
+			// unchanged for the rest of the transaction — the bug this test guards.
+			seq, ok := plan.Primitive.(*engine.Sequence)
+			require.True(t, ok, "expected Sequence primitive (route real RESET, then track), got %T", plan.Primitive)
+			require.Len(t, seq.Primitives, 2, "expected [Route, silent ApplySessionState]")
+			_, ok = seq.Primitives[0].(*engine.Route)
+			assert.True(t, ok, "first primitive should route the real RESET to the pinned backend, got %T", seq.Primitives[0])
+			track, ok := seq.Primitives[1].(*engine.ApplySessionState)
+			require.True(t, ok, "second primitive should track after success, got %T", seq.Primitives[1])
+			assert.True(t, track.SilentTracking)
+		})
+	}
+}
+
 func TestPlanVariableSetStmt_SET_IdleSessionTimeoutGatewayManaged(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
 	p := NewPlanner("default", logger, nil)

--- a/go/test/endtoend/queryserving/session_settings_test.go
+++ b/go/test/endtoend/queryserving/session_settings_test.go
@@ -501,6 +501,51 @@ func TestMultigateway_SessionSettings(t *testing.T) {
 				require.Equal(t, "session_path", after, "iteration %d: SET LOCAL must not persist past COMMIT", i)
 			}
 		})
+
+		t.Run("RESET ROLE reverts SET LOCAL ROLE mid-transaction", func(t *testing.T) {
+			// A throwaway, unprivileged role to SET LOCAL into. NOLOGIN is fine —
+			// we only ever SET ROLE into it as the superuser test connection, we
+			// never authenticate as it.
+			_, err := conn.ExecContext(ctx, "DROP ROLE IF EXISTS test_reset_role_mid_txn")
+			require.NoError(t, err, "failed to drop pre-existing test role")
+			_, err = conn.ExecContext(ctx, "CREATE ROLE test_reset_role_mid_txn NOLOGIN")
+			require.NoError(t, err, "failed to create test role")
+			defer func() {
+				_, err := conn.ExecContext(ctx, "DROP ROLE IF EXISTS test_reset_role_mid_txn")
+				assert.NoError(t, err, "failed to clean up test role")
+			}()
+
+			var original string
+			err = conn.QueryRowContext(ctx, "SELECT current_user").Scan(&original)
+			require.NoError(t, err, "failed to read original current_user")
+			require.NotEqual(t, "test_reset_role_mid_txn", original, "test role must differ from the connection's own login role")
+
+			tx, err := conn.BeginTx(ctx, nil)
+			require.NoError(t, err, "failed to BEGIN")
+
+			_, err = tx.ExecContext(ctx, "SET LOCAL ROLE test_reset_role_mid_txn")
+			require.NoError(t, err, "failed to SET LOCAL ROLE")
+
+			var duringRole string
+			err = tx.QueryRowContext(ctx, "SELECT current_user").Scan(&duringRole)
+			require.NoError(t, err, "failed to SELECT current_user after SET LOCAL ROLE")
+			require.Equal(t, "test_reset_role_mid_txn", duringRole, "SET LOCAL ROLE should apply within the txn")
+
+			_, err = tx.ExecContext(ctx, "RESET ROLE")
+			require.NoError(t, err, "failed to RESET ROLE")
+
+			// This is the regression this test guards: before the fix, RESET ROLE
+			// was gateway-tracking-only and never reached the backend that
+			// SET LOCAL ROLE had already (correctly) changed for real, so
+			// current_user stayed test_reset_role_mid_txn for the rest of the
+			// transaction instead of reverting immediately.
+			var afterReset string
+			err = tx.QueryRowContext(ctx, "SELECT current_user").Scan(&afterReset)
+			require.NoError(t, err, "failed to SELECT current_user after RESET ROLE")
+			assert.Equal(t, original, afterReset, "RESET ROLE must revert mid-transaction, not just at COMMIT/ROLLBACK")
+
+			require.NoError(t, tx.Rollback(), "failed to ROLLBACK")
+		})
 	})
 }
 


### PR DESCRIPTION
## Problem

`RESET ROLE` / `RESET SESSION AUTHORIZATION` (and `SET ROLE DEFAULT` / `SET SESSION AUTHORIZATION DEFAULT`) silently no-op when they run inside an explicit transaction that earlier used `SET LOCAL ROLE` / `SET LOCAL SESSION AUTHORIZATION`. The backend's real `current_user` stays changed for the rest of the transaction instead of reverting.

Repro:
```sql
BEGIN;
SET LOCAL ROLE authenticated;
SELECT current_user;   -- authenticated  (correct)
RESET ROLE;
SELECT current_user;   -- authenticated  (WRONG — should be the original login role)
ROLLBACK;
```

Root cause: the planner planned every non-local `RESET ROLE`/`RESET SESSION AUTHORIZATION` as a gateway-local-only `ApplySessionState` primitive (no backend round-trip), on the assumption that any prior `SET` for that variable was itself gateway-tracked. `SET LOCAL ROLE` breaks that assumption — it's deliberately passed straight through to the backend untracked, since the backend is authoritative for `SET LOCAL`. So the gateway has nothing tracked to clear when `RESET ROLE` runs, and the pinned backend's real role never gets reverted.

## Solution

Mirror the plan shape already used for a plain (non-local) `SET var = value` inside a transaction — route the real statement to PostgreSQL, then track it locally afterward — for the role/session-authorization RESET branch too, but only when a backend is actually pinned (`conn.IsInTransaction()`). Outside a transaction, the existing local-tracking-only behavior is unchanged and correct, since a future autocommit statement may land on a freshly checked-out backend that the gateway already resyncs via its settings-replay path.

Added unit test coverage in `variable_set_stmt_test.go` for both the fixed (in-transaction) and unchanged (outside-transaction) cases, plus an end-to-end regression test against a real gateway/pooler/Postgres cluster in `session_settings_test.go`.