### PR TITLE
fix(multigateway): improve error; report credential lookup outages as 57P03

### DIFF
--- a/go/common/mterrors/code.go
+++ b/go/common/mterrors/code.go
@@ -40,6 +40,7 @@ const (
 	PgSSSyntaxError             = "42601" // syntax_error
 	PgSSUndefinedObject         = "42704" // undefined_object
 	PgSSQueryCanceled           = "57014" // query_canceled
+	PgSSCannotConnectNow        = "57P03" // cannot_connect_now
 	PgSSIdleSessionTimeout      = "57P05" // idle_session_timeout
 	PgSSInternalError           = "XX000" // internal_error
 	PgSSReadOnlyTransaction     = "25006" // read_only_sql_transaction

--- a/go/common/mterrors/errors_test.go
+++ b/go/common/mterrors/errors_test.go
@@ -59,6 +59,24 @@ func TestWrap(t *testing.T) {
 	}
 }
 
+// Credential lookup errors are used in two ways: the gateway checks the RPC
+// code when routing requests, while Postgres clients read the diagnostic.
+// This test makes sure that wrapping the error does not lose either one.
+func TestWithCodePreservesStructuredCause(t *testing.T) {
+	diagnostic := NewPgError("ERROR", PgSSCannotConnectNow, "temporarily unavailable", "")
+	err := WithCode(Wrap(diagnostic, "routing failed"), mtrpcpb.Code_UNAVAILABLE)
+	err = fmt.Errorf("credential lookup failed: %w", err)
+
+	assert.Equal(t, mtrpcpb.Code_UNAVAILABLE, Code(err))
+	assert.ErrorIs(t, err, diagnostic)
+
+	var gotDiagnostic *PgDiagnostic
+	assert.ErrorAs(t, err, &gotDiagnostic)
+	assert.Same(t, diagnostic, gotDiagnostic)
+	assert.Contains(t, err.Error(), "routing failed")
+	assert.Nil(t, WithCode(nil, mtrpcpb.Code_UNAVAILABLE))
+}
+
 func TestUnwrap(t *testing.T) {
 	tests := []struct {
 		err       error
@@ -323,6 +341,12 @@ func TestCode(t *testing.T) {
 		want: mtrpcpb.Code_CANCELED,
 	}, {
 		in:   context.DeadlineExceeded,
+		want: mtrpcpb.Code_DEADLINE_EXCEEDED,
+	}, {
+		in:   fmt.Errorf("request canceled: %w", context.Canceled),
+		want: mtrpcpb.Code_CANCELED,
+	}, {
+		in:   fmt.Errorf("request timed out: %w", context.DeadlineExceeded),
 		want: mtrpcpb.Code_DEADLINE_EXCEEDED,
 	}}
 	for _, tcase := range testcases {

--- a/go/common/mterrors/mterrors.go
+++ b/go/common/mterrors/mterrors.go
@@ -239,27 +239,22 @@ func (f *fundamental) Format(s fmt.State, verb rune) {
 	}
 }
 
-// Code returns the error code if it's a mtError.
-// If err is nil, it returns ok.
+// Code returns the error code associated with err or any error in its standard
+// unwrap chain. If err is nil, it returns OK.
 func Code(err error) mtrpcpb.Code {
 	if err == nil {
 		return mtrpcpb.Code_OK
 	}
-	if err, ok := err.(ErrorWithCode); ok {
-		return err.ErrorCode()
-	}
-
-	cause := Cause(err)
-	if cause != err && cause != nil {
-		// If we did not find an error code at the outer level, let's find the cause and check it's code
-		return Code(cause)
+	var coded ErrorWithCode
+	if errors.As(err, &coded) {
+		return coded.ErrorCode()
 	}
 
 	// Handle some special cases.
-	switch err {
-	case context.Canceled:
+	switch {
+	case errors.Is(err, context.Canceled):
 		return mtrpcpb.Code_CANCELED
-	case context.DeadlineExceeded:
+	case errors.Is(err, context.DeadlineExceeded):
 		return mtrpcpb.Code_DEADLINE_EXCEEDED
 	}
 	return mtrpcpb.Code_UNKNOWN

--- a/go/common/mterrors/state.go
+++ b/go/common/mterrors/state.go
@@ -21,3 +21,23 @@ type ErrorWithCode interface {
 	error
 	ErrorCode() mtrpcpb.Code
 }
+
+// codedError associates an RPC error code with an existing error while
+// preserving the original error chain for errors.Is and errors.As.
+type codedError struct {
+	err  error
+	code mtrpcpb.Code
+}
+
+func (e *codedError) Error() string           { return e.err.Error() }
+func (e *codedError) Unwrap() error           { return e.err }
+func (e *codedError) ErrorCode() mtrpcpb.Code { return e.code }
+
+// WithCode associates code with err without replacing err or obscuring its
+// structured causes. It returns nil when err is nil.
+func WithCode(err error, code mtrpcpb.Code) error {
+	if err == nil {
+		return nil
+	}
+	return &codedError{err: err, code: code}
+}

--- a/go/common/pgprotocol/server/startup.go
+++ b/go/common/pgprotocol/server/startup.go
@@ -774,13 +774,9 @@ func (c *Conn) authenticateSCRAM() (outcome string, err error) {
 			c.logger.Warn("authentication failed: password expired", "user", c.user)
 			return AuthOutcomePasswordExpired, c.sendAuthError("password authentication failed for user \"" + c.user + "\"")
 		}
-		// Generic credential-lookup failure. If the upstream returned a
-		// PgDiagnostic (e.g. "planned failover in progress" from the
-		// pooler), forward it so the client can distinguish a transient
-		// cluster condition from a wrong password and act accordingly
-		// (retry, alert, etc.). For all other errors (transport, parse,
-		// pooler unreachable) fail closed with the opaque password-auth
-		// message so the client does not learn whether the user exists.
+		// Forward structured lookup errors, such as 57P03 when no primary is
+		// available. Other failures use the opaque auth error so clients cannot
+		// tell whether the role exists.
 		c.logger.Error("credential lookup failed", "user", c.user, "error", err)
 		var pgDiag *mterrors.PgDiagnostic
 		if errors.As(err, &pgDiag) {

--- a/go/common/pgprotocol/server/startup_test.go
+++ b/go/common/pgprotocol/server/startup_test.go
@@ -1351,7 +1351,7 @@ func TestReplicationStartup_RejectedOnCredentialLookupError(t *testing.T) {
 // cluster condition from a wrong password.
 func TestSCRAM_CredentialLookupPgDiagnosticForwarded(t *testing.T) {
 	provider := newMockCredentialProvider("postgres")
-	provider.err = mterrors.NewPgError("ERROR", "57P03", "planned failover in progress", "")
+	provider.err = mterrors.NewPgError("ERROR", mterrors.PgSSCannotConnectNow, "no writable primary is currently available", "")
 	_, clientConn, errCh := newReplicationTestConn(t, provider)
 
 	writeStartupPacketToPipe(t, clientConn, protocol.ProtocolVersionNumber, map[string]string{
@@ -1365,8 +1365,8 @@ func TestSCRAM_CredentialLookupPgDiagnosticForwarded(t *testing.T) {
 	require.Equal(t, byte(protocol.MsgErrorResponse), msgType)
 	fields := parseErrorFields(body)
 	assert.Equal(t, "FATAL", fields['S'], "severity must be promoted to FATAL")
-	assert.Equal(t, "57P03", fields['C'], "SQLSTATE must be forwarded verbatim")
-	assert.Contains(t, fields['M'], "planned failover in progress")
+	assert.Equal(t, mterrors.PgSSCannotConnectNow, fields['C'], "SQLSTATE must be forwarded verbatim")
+	assert.Equal(t, "no writable primary is currently available", fields['M'])
 
 	require.ErrorIs(t, <-errCh, errAuthRejected)
 	assert.Equal(t, 1, provider.calls)

--- a/go/services/multigateway/poolergateway/availability_errors.go
+++ b/go/services/multigateway/poolergateway/availability_errors.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package poolergateway
+
+import (
+	"github.com/multigres/multigres/go/common/mterrors"
+	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
+)
+
+// newUnavailablePgError preserves the canonical UNAVAILABLE classification
+// used by gateway routing while exposing a PostgreSQL diagnostic to pgwire
+// callers. The diagnostic is safe to forward only for failures known to occur
+// before a role lookup.
+func newUnavailablePgError(message, internalFormat string, args ...any) error {
+	diagnostic := mterrors.NewPgError("ERROR", mterrors.PgSSCannotConnectNow, message, "")
+	return mterrors.WithCode(
+		mterrors.Wrapf(diagnostic, internalFormat, args...),
+		mtrpcpb.Code_UNAVAILABLE,
+	)
+}
+
+func newNoWritablePrimaryError(internalFormat string, args ...any) error {
+	return newUnavailablePgError(
+		"no writable primary is currently available",
+		internalFormat,
+		args...,
+	)
+}
+
+// isCredentialSourceUnavailable recognizes only errors that occur before the
+// pooler can inspect pg_authid. Buffer terminal errors retain the semantics of
+// the MTF01 that caused credential lookup to enter failover buffering.
+func isCredentialSourceUnavailable(err error) bool {
+	return mterrors.Code(err) == mtrpcpb.Code_UNAVAILABLE ||
+		mterrors.IsErrorCode(err,
+			mterrors.MTF01.ID,
+			mterrors.MTB01.ID,
+			mterrors.MTB02.ID,
+			mterrors.MTB03.ID,
+		)
+}

--- a/go/services/multigateway/poolergateway/grpc_query_service_test.go
+++ b/go/services/multigateway/poolergateway/grpc_query_service_test.go
@@ -104,6 +104,10 @@ type mockMultipoolerServiceClient struct {
 	// Describe behavior
 	describeResponse *multipoolerservice.DescribeResponse
 	describeErr      error
+
+	// GetAuthCredentials behavior
+	authResponse *multipoolerservice.GetAuthCredentialsResponse
+	authErr      error
 }
 
 func (m *mockMultipoolerServiceClient) CopyBidiExecute(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[multipoolerservice.CopyBidiExecuteRequest, multipoolerservice.CopyBidiExecuteResponse], error) {
@@ -138,7 +142,7 @@ func (m *mockMultipoolerServiceClient) Describe(ctx context.Context, in *multipo
 }
 
 func (m *mockMultipoolerServiceClient) GetAuthCredentials(ctx context.Context, in *multipoolerservice.GetAuthCredentialsRequest, opts ...grpc.CallOption) (*multipoolerservice.GetAuthCredentialsResponse, error) {
-	return nil, nil
+	return m.authResponse, m.authErr
 }
 
 func (m *mockMultipoolerServiceClient) ConcludeTransaction(ctx context.Context, in *multipoolerservice.ConcludeTransactionRequest, opts ...grpc.CallOption) (*multipoolerservice.ConcludeTransactionResponse, error) {

--- a/go/services/multigateway/poolergateway/load_balancer.go
+++ b/go/services/multigateway/poolergateway/load_balancer.go
@@ -401,18 +401,18 @@ func (lb *loadBalancer) getConnection(target *query.Target) (*poolerConnection, 
 	routesToLeader := mode == query.Mode_MODE_WRITABLE || mode == query.Mode_MODE_CONSISTENT
 	if routesToLeader {
 		if !haveLeader {
-			return nil, mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
+			return nil, newNoWritablePrimaryError(
 				"no leader observed yet for database=%s, tablegroup=%s, shard=%s",
 				sk.GetDatabase(), sk.GetTableGroup(), sk.GetShard())
 		}
 		if lb.cache == nil {
-			return nil, mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
+			return nil, newNoWritablePrimaryError(
 				"leader %s known but not connected for database=%s, tablegroup=%s, shard=%s",
 				leaderID, sk.GetDatabase(), sk.GetTableGroup(), sk.GetShard())
 		}
 		conn, ok := lb.cache.GetRider(leaderID)
 		if !ok || conn == nil {
-			return nil, mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
+			return nil, newNoWritablePrimaryError(
 				"leader %s known but not connected for database=%s, tablegroup=%s, shard=%s",
 				leaderID, sk.GetDatabase(), sk.GetTableGroup(), sk.GetShard())
 		}

--- a/go/services/multigateway/poolergateway/load_balancer_test.go
+++ b/go/services/multigateway/poolergateway/load_balancer_test.go
@@ -15,6 +15,7 @@
 package poolergateway
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -163,6 +164,59 @@ func TestLoadBalancer_GetConnection_NilTarget(t *testing.T) {
 	_, err := lb.getConnection(nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "target cannot be nil")
+}
+
+func TestLoadBalancer_WritableUnavailableCarriesCannotConnectNow(t *testing.T) {
+	const expectedMessage = "no writable primary is currently available"
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T) *loadBalancer
+	}{
+		{
+			name: "no writable leader observed",
+			setup: func(t *testing.T) *loadBalancer {
+				return newTestLB(t, "zone1")
+			},
+		},
+		{
+			name: "writable leader known but not connected",
+			setup: func(t *testing.T) *loadBalancer {
+				lb := newTestLB(t, "zone1")
+				leader := createTestMultipooler("disconnected-leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+				setLeaderForTest(t, lb, constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0",
+					leader.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
+				return lb
+			},
+		},
+		{
+			name: "writable leader known with unavailable cache",
+			setup: func(t *testing.T) *loadBalancer {
+				lb := newTestLB(t, "zone1")
+				leader := createTestMultipooler("disconnected-leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+				setLeaderForTest(t, lb, constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0",
+					leader.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
+				lb.cache = nil
+				return lb
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lb := tt.setup(t)
+			target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
+
+			_, err := lb.getConnection(target)
+			require.Error(t, err)
+			assert.Equal(t, mtrpcpb.Code_UNAVAILABLE, mterrors.Code(err))
+
+			var diagnostic *mterrors.PgDiagnostic
+			require.True(t, errors.As(err, &diagnostic), "routing error must carry a PostgreSQL diagnostic")
+			assert.Equal(t, mterrors.PgSSCannotConnectNow, diagnostic.Code)
+			assert.Equal(t, expectedMessage, diagnostic.Message)
+		})
+	}
 }
 
 func TestLoadBalancer_GetConnection_NoMatch(t *testing.T) {

--- a/go/services/multigateway/poolergateway/pooler_gateway.go
+++ b/go/services/multigateway/poolergateway/pooler_gateway.go
@@ -618,6 +618,21 @@ func (pg *PoolerGateway) GetAuthCredentials(ctx context.Context, req *multipoole
 		// Convert gRPC error so classifyError can read the PgDiagnostic SQLSTATE for buffering.
 		return mterrors.FromGRPC(err)
 	})
+	if err != nil {
+		if mterrors.IsErrorCode(err, mterrors.PgSSCannotConnectNow) {
+			return nil, err
+		}
+
+		// Failover and backend outages happen before pg_authid is read, so 57P03
+		// does not reveal whether the role exists. Keep other errors opaque.
+		if isCredentialSourceUnavailable(err) {
+			return nil, newUnavailablePgError(
+				"database is temporarily unavailable; please retry",
+				"credential lookup unavailable: %v",
+				err,
+			)
+		}
+	}
 	return resp, err
 }
 

--- a/go/services/multigateway/poolergateway/pooler_gateway_test.go
+++ b/go/services/multigateway/poolergateway/pooler_gateway_test.go
@@ -15,14 +15,31 @@
 package poolergateway
 
 import (
+	"context"
 	"errors"
+	"log/slog"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
+	pgclient "github.com/multigres/multigres/go/common/pgprotocol/client"
+	pgserver "github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/common/protoutil"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
+	multipoolerpb "github.com/multigres/multigres/go/pb/multipoolerservice"
 	"github.com/multigres/multigres/go/pb/query"
+	"github.com/multigres/multigres/go/services/multigateway/auth"
+	gatewaybuffer "github.com/multigres/multigres/go/services/multigateway/buffer"
+	gatewayhandler "github.com/multigres/multigres/go/services/multigateway/handler"
+	"github.com/multigres/multigres/go/tools/viperutil"
 )
 
 func TestClassifyError(t *testing.T) {
@@ -94,6 +111,136 @@ func TestClassifyError(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestGetAuthCredentials_InfrastructureFailureCarriesCannotConnectNow(t *testing.T) {
+	tests := []struct {
+		name    string
+		authErr error
+	}{
+		{
+			name:    "PostgreSQL unavailable behind pooler",
+			authErr: status.Error(codes.Unavailable, "failed to connect to PostgreSQL socket"),
+		},
+		{
+			name:    "pooler reports planned failover",
+			authErr: mterrors.ToGRPC(mterrors.MTF01.New()),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lb := newTestLB(t, "zone1")
+			primary := createTestMultipooler("primary", "zone1", constants.DefaultTableGroup, constants.DefaultShard, clustermetadatapb.PoolerType_PRIMARY)
+			addPoolerForTest(t, lb, primary)
+
+			conn := connForTest(t, lb, primary)
+			require.NotNil(t, conn)
+			conn.cancel()
+			<-conn.checkConnDone
+			conn.client = &mockMultipoolerServiceClient{authErr: tt.authErr}
+			setLeaderForTest(t, lb, constants.DefaultPostgresDatabase, constants.DefaultTableGroup, constants.DefaultShard,
+				primary.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
+
+			pg := &PoolerGateway{loadBalancer: lb, logger: slog.Default()}
+			_, err := pg.GetAuthCredentials(t.Context(), &multipoolerpb.GetAuthCredentialsRequest{
+				Database: constants.DefaultPostgresDatabase,
+				Username: "postgres",
+			})
+			require.Error(t, err)
+			assert.Equal(t, mtrpcpb.Code_UNAVAILABLE, mterrors.Code(err))
+
+			var diagnostic *mterrors.PgDiagnostic
+			require.ErrorAs(t, err, &diagnostic)
+			assert.Equal(t, mterrors.PgSSCannotConnectNow, diagnostic.Code)
+			assert.Equal(t, "database is temporarily unavailable; please retry", diagnostic.Message)
+		})
+	}
+}
+
+func TestGetAuthCredentials_FailoverBufferTimeoutCarriesCannotConnectNow(t *testing.T) {
+	lb := newTestLB(t, "zone1")
+	primary := createTestMultipooler("primary", "zone1", constants.DefaultTableGroup, constants.DefaultShard, clustermetadatapb.PoolerType_PRIMARY)
+	addPoolerForTest(t, lb, primary)
+
+	conn := connForTest(t, lb, primary)
+	require.NotNil(t, conn)
+	conn.cancel()
+	<-conn.checkConnDone
+	conn.client = &mockMultipoolerServiceClient{authErr: mterrors.ToGRPC(mterrors.MTF01.New())}
+	setLeaderForTest(t, lb, constants.DefaultPostgresDatabase, constants.DefaultTableGroup, constants.DefaultShard,
+		primary.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
+
+	bufferConfig := gatewaybuffer.NewConfig(viperutil.NewRegistry())
+	bufferConfig.Enabled.Set(true)
+	bufferConfig.Window.Set(20 * time.Millisecond)
+	bufferConfig.Size.Set(1)
+	bufferConfig.MaxFailoverDuration.Set(time.Second)
+	bufferConfig.MinTimeBetweenFailovers.Set(0)
+	bufferConfig.DrainConcurrency.Set(1)
+	logger := slog.New(slog.DiscardHandler)
+	failoverBuffer := gatewaybuffer.New(t.Context(), bufferConfig, logger)
+	t.Cleanup(failoverBuffer.Shutdown)
+
+	pg := &PoolerGateway{loadBalancer: lb, buffer: failoverBuffer, logger: logger}
+	_, err := pg.GetAuthCredentials(t.Context(), &multipoolerpb.GetAuthCredentialsRequest{
+		Database: constants.DefaultPostgresDatabase,
+		Username: "postgres",
+	})
+	require.Error(t, err)
+	assert.Equal(t, mtrpcpb.Code_UNAVAILABLE, mterrors.Code(err))
+	assert.Contains(t, err.Error(), "failover buffer timeout")
+
+	var diagnostic *mterrors.PgDiagnostic
+	require.ErrorAs(t, err, &diagnostic)
+	assert.Equal(t, mterrors.PgSSCannotConnectNow, diagnostic.Code)
+	assert.Equal(t, "database is temporarily unavailable; please retry", diagnostic.Message)
+}
+
+func TestGetAuthCredentials_NoWritablePrimaryReachesClientAsCannotConnectNow(t *testing.T) {
+	lb := newTestLB(t, "zone1")
+	logger := slog.New(slog.DiscardHandler)
+	pg := &PoolerGateway{loadBalancer: lb, logger: logger}
+	credentialProvider := auth.NewPoolerCredentialProvider(pg, nil)
+
+	listener, err := pgserver.NewListener(pgserver.ListenerConfig{
+		Address:               "127.0.0.1:0",
+		Handler:               gatewayhandler.NewMultigatewayHandler(nil, logger, 0),
+		CredentialProvider:    credentialProvider,
+		AuthenticationTimeout: 5 * time.Second,
+		Logger:                logger,
+	})
+	require.NoError(t, err)
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- listener.Serve() }()
+	t.Cleanup(func() {
+		require.NoError(t, listener.Close())
+		require.NoError(t, <-serveErr)
+	})
+
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	clientConn, err := pgclient.Connect(ctx, ctx, &pgclient.Config{
+		Host:     addr.IP.String(),
+		Port:     addr.Port,
+		User:     "postgres",
+		Password: "credentials-are-not-consulted",
+		Database: constants.DefaultPostgresDatabase,
+		SSLMode:  pgclient.SSLModeDisable,
+	})
+	if clientConn != nil {
+		require.NoError(t, clientConn.Close())
+	}
+	require.Error(t, err)
+
+	var diagnostic *mterrors.PgDiagnostic
+	require.ErrorAs(t, err, &diagnostic)
+	assert.Equal(t, "FATAL", diagnostic.Severity)
+	assert.Equal(t, mterrors.PgSSCannotConnectNow, diagnostic.Code)
+	assert.Equal(t, "no writable primary is currently available", diagnostic.Message)
+	assert.NotEqual(t, mterrors.PgSSAuthFailed, diagnostic.Code)
 }
 
 // TestIsSingleQuery covers the classification that decides whether a request

--- a/go/test/endtoend/queryserving/pgbouncertests/nonexistent_db_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/nonexistent_db_test.go
@@ -41,11 +41,10 @@ import (
 // and the auth-vs-database error ordering.
 //
 // **Known divergence**: the multigateway rejects a nonexistent connection
-// database with 28P01 (auth failure) instead of 3D000 / "no such database" —
-// which is what both PostgreSQL and pgbouncer return. See
+// database with 57P03 (cannot_connect_now) instead of 3D000 / "no such
+// database", which is what both PostgreSQL and pgbouncer return. See
 // TestNonexistentDatabaseConnectBehavior; the eventual fix is to align with
-// pgbouncer. The auth-ordering case (28P01 when both password is wrong AND
-// database is missing) matches between the two.
+// pgbouncer.
 
 // nonexistentDB is a database name that is not registered in the test topology
 // nor created in postgres.
@@ -57,15 +56,12 @@ const nonexistentDB = "no_such_db_xyz"
 //     (invalid_catalog_name) at connect time.
 //   - The multigateway routes the credential lookup to the requested database;
 //     no pooler is registered for an unknown database, so the credential
-//     provider's error path surfaces as 28P01 (auth failure) at connect time.
+//     provider's error path surfaces as 57P03 (cannot_connect_now) at connect
+//     time.
 //
-// The multigateway's 28P01 is misleading and **diverges from both PostgreSQL
-// and pgbouncer**: pgbouncer's test_no_database asserts the client sees a "no
-// such database" error (3D000-shaped), and only switches to "password
-// authentication failed" (28P01) when the password is genuinely wrong
-// (test_no_database_authfail). The multigateway conflates the two. The
-// eventual fix is to translate "no pooler for database" into 3D000. Until
-// that lands, this test guards the current shape so we notice if it shifts.
+// The multigateway still diverges from PostgreSQL and pgbouncer, but does not
+// misreport the routing failure as bad credentials. The eventual fix is to
+// translate "no pooler for database" into 3D000.
 func TestNonexistentDatabaseConnectBehavior(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping in short mode")
@@ -88,23 +84,20 @@ func TestNonexistentDatabaseConnectBehavior(t *testing.T) {
 
 	// Multigateway (DIVERGENCE): the credential lookup is routed to the
 	// requested database and fails because no pooler is registered for it.
-	// The current error path surfaces this as 28P01 — misleading, since the
-	// password is correct. The eventual fix is to translate
-	// "no pooler for database" into 3D000 so we align with pgbouncer.
+	// The lookup fails before credentials can be inspected, so the gateway
+	// reports 57P03. A future change can translate an unknown database to 3D000.
 	code, stage, err = probeConnect(t, ctx, targetPort(t, targets, "multigateway"), nonexistentDB, shardsetup.TestPostgresPassword)
 	require.Error(t, err, "multigateway must reject a nonexistent database")
 	t.Logf("multigateway: failed at %s stage with SQLSTATE %q", stage, code)
-	assert.Equal(t, "28P01", code,
-		"DIVERGENCE: multigateway currently returns 28P01 (auth failure) for a missing database; PostgreSQL and pgbouncer return 3D000-shaped 'no such database' instead")
+	assert.Equal(t, "57P03", code,
+		"multigateway should report that the credential source is unavailable")
 	assert.Equal(t, "connect", stage, "multigateway rejects the database at connect time")
 }
 
-// TestAuthErrorPrecedesDatabaseError asserts that when both the password is wrong
-// AND the database does not exist, both targets report the authentication error
-// (28P01) at connect time — authentication is checked before the database is
-// resolved, so the bad-database error never surfaces. This case matches between
-// PostgreSQL and the multigateway.
-func TestAuthErrorPrecedesDatabaseError(t *testing.T) {
+// TestAuthAndDatabaseErrorPrecedence documents how each target handles a wrong
+// password for a nonexistent database. PostgreSQL checks the password first;
+// multigateway cannot route the credential lookup and never inspects it.
+func TestAuthAndDatabaseErrorPrecedence(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping in short mode")
 	}
@@ -120,10 +113,13 @@ func TestAuthErrorPrecedesDatabaseError(t *testing.T) {
 			code, stage, err := probeConnect(t, ctx, target.Port, nonexistentDB, "definitely_the_wrong_password")
 			require.Error(t, err, "a wrong password must fail the connection")
 			t.Logf("%s: failed at %s stage with SQLSTATE %q", target.Name, stage, code)
-			assert.Equalf(t, "28P01", code,
-				"auth failure (28P01) must win over the nonexistent-database error, got %q", code)
+			expectedCode := "28P01"
+			if target.Name == "multigateway" {
+				expectedCode = "57P03"
+			}
+			assert.Equal(t, expectedCode, code)
 			assert.Equalf(t, "connect", stage,
-				"the auth failure must be reported at connect time, got %s", stage)
+				"the connection failure must be reported at connect time, got %s", stage)
 		})
 	}
 }


### PR DESCRIPTION
## Description
this PR addresses a misleading error that frequently appears during failover and topo recovery issues. When Multigateway could not reach a writable primary to look up credentials, clients received `28P01 password authentication failed`, which made a number of scenarios look like credential problems, sending the wrong signal.

With this change, failures that occur before the credential lookup now return `57P03 cannot_connect_now`, while genuine credential failures remain as 28P01 responses.
## Main Changes
- Preserve RPC error codes alongside structured PostgreSQL diagnostics through wrapped errors.
- Return `57P03` when the primary, pooler, Postgres backend, or failover buffer is unavailable.
- Preserve internal failure details while exposing a stable, retryable message to clients.
## Testing
Added coverage for missing and disconnected primaries, unavailable backends, planned failover, buffer expiry, and the complete client-facing authentication path. 