### PR TITLE
feat(query-serving): report ParameterStatus for in-transaction SET/RESET and ROLLBACK

### DIFF
--- a/go/common/pgprotocol/client/parameter_status_test.go
+++ b/go/common/pgprotocol/client/parameter_status_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+	"github.com/multigres/multigres/go/common/sqltypes"
+)
+
+// buildCommandComplete and buildParameterStatus are shared test helpers defined
+// in copy_done_response_test.go and replication_test.go.
+
+// TestProcessQueryResponses_ForwardsParameterStatus verifies the streaming read
+// loop surfaces a backend ParameterStatus as its own Result (so a routed
+// SET/RESET's GUC change reaches the caller) and records it on the connection.
+func TestProcessQueryResponses_ForwardsParameterStatus(t *testing.T) {
+	var input bytes.Buffer
+	input.Write(buildCommandComplete("SET"))
+	input.Write(buildParameterStatus("client_encoding", "LATIN1"))
+	input.Write(buildReadyForQuery(protocol.TxnStatusIdle))
+
+	c := newTestReadOnlyConn(input.Bytes())
+
+	var forwarded []string
+	err := c.processQueryResponses(context.Background(), func(_ context.Context, r *sqltypes.Result) error {
+		if v, ok := r.ParameterStatus["client_encoding"]; ok {
+			forwarded = append(forwarded, v)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"LATIN1"}, forwarded, "ParameterStatus must be forwarded to the callback")
+	assert.Equal(t, "LATIN1", c.serverParams["client_encoding"], "and recorded on the connection")
+}
+
+// TestQuery_AttachesTrailingParameterStatus verifies the buffered Query path
+// attaches a ParameterStatus that arrives *after* CommandComplete (as ROLLBACK's
+// revert does) to the finalized result rather than orphaning it.
+func TestQuery_AttachesTrailingParameterStatus(t *testing.T) {
+	var input bytes.Buffer
+	input.Write(buildCommandComplete("ROLLBACK"))
+	input.Write(buildParameterStatus("client_encoding", "LATIN1"))
+	input.Write(buildReadyForQuery(protocol.TxnStatusIdle))
+
+	c := newTestReadOnlyConn(input.Bytes())
+
+	results, err := c.Query(context.Background(), "ROLLBACK")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "ROLLBACK", results[0].CommandTag)
+	assert.Equal(t, map[string]string{"client_encoding": "LATIN1"}, results[0].ParameterStatus,
+		"a post-CommandComplete ParameterStatus must attach to the finalized result")
+}

--- a/go/common/pgprotocol/client/query.go
+++ b/go/common/pgprotocol/client/query.go
@@ -19,6 +19,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strconv"
 
 	"go.opentelemetry.io/otel/codes"
@@ -98,6 +99,26 @@ func (c *Conn) Query(ctx context.Context, queryStr string) ([]*sqltypes.Result, 
 	var currentResult *sqltypes.Result
 
 	err := c.QueryStreaming(ctx, queryStr, func(ctx context.Context, result *sqltypes.Result) error {
+		// Handle ParameterStatus-only results (a GUC_REPORT value changed). These
+		// carry no rows/tag; a routed SET/RESET emits one, and a ROLLBACK emits the
+		// reverted values *after* CommandComplete, so attach a post-tag update to
+		// the already-finalized result rather than orphaning it.
+		if len(result.ParameterStatus) > 0 && len(result.Rows) == 0 && result.CommandTag == "" && len(result.Notices) == 0 {
+			target := currentResult
+			if target == nil && len(results) > 0 {
+				target = results[len(results)-1]
+			}
+			if target == nil {
+				currentResult = &sqltypes.Result{}
+				target = currentResult
+			}
+			if target.ParameterStatus == nil {
+				target.ParameterStatus = make(map[string]string, len(result.ParameterStatus))
+			}
+			maps.Copy(target.ParameterStatus, result.ParameterStatus)
+			return nil
+		}
+
 		// Handle notice-only results (zero-buffering notice delivery).
 		if len(result.Notices) > 0 && len(result.Rows) == 0 && result.CommandTag == "" {
 			// Accumulate notices into current result.
@@ -431,9 +452,23 @@ func (c *Conn) processQueryResponses(ctx context.Context, callback func(ctx cont
 			}
 
 		case protocol.MsgParameterStatus:
-			// Handle parameter status updates. Capture error but continue draining.
-			if firstErr == nil {
-				firstErr = c.handleParameterStatus(body)
+			// Record the update on the connection, and also stream it to the caller
+			// as a standalone Result so a routed statement that changes a
+			// GUC_REPORT parameter (SET/RESET inside a transaction, the revert on
+			// ROLLBACK) reaches the client. On the wire ParameterStatus follows
+			// CommandComplete, whose Result was already flushed, so this is emitted
+			// as its own Result — like a notice. Capture error but continue draining.
+			name, value, perr := c.recordParameterStatus(body)
+			if perr != nil {
+				if firstErr == nil {
+					firstErr = perr
+				}
+				break
+			}
+			if callback != nil && firstErr == nil {
+				firstErr = callback(ctx, &sqltypes.Result{
+					ParameterStatus: map[string]string{name: value},
+				})
 			}
 
 		default:

--- a/go/common/pgprotocol/client/startup.go
+++ b/go/common/pgprotocol/client/startup.go
@@ -355,20 +355,28 @@ func (c *Conn) handleBackendKeyData(body []byte) error {
 
 // handleParameterStatus handles a ParameterStatus message.
 func (c *Conn) handleParameterStatus(body []byte) error {
+	_, _, err := c.recordParameterStatus(body)
+	return err
+}
+
+// recordParameterStatus parses a ParameterStatus message, records the new value
+// on the connection, and returns the (name, value) so a caller on the query path
+// can also forward it to the client.
+func (c *Conn) recordParameterStatus(body []byte) (string, string, error) {
 	reader := NewMessageReader(body)
 
 	name, err := reader.ReadString()
 	if err != nil {
-		return fmt.Errorf("failed to read parameter name: %w", err)
+		return "", "", fmt.Errorf("failed to read parameter name: %w", err)
 	}
 
 	value, err := reader.ReadString()
 	if err != nil {
-		return fmt.Errorf("failed to read parameter value: %w", err)
+		return "", "", fmt.Errorf("failed to read parameter value: %w", err)
 	}
 
 	c.serverParams[name] = value
-	return nil
+	return name, value, nil
 }
 
 // handleReadyForQuery handles a ReadyForQuery message.

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -1048,19 +1048,18 @@ func (c *Conn) handleQuery() error {
 				return fmt.Errorf("writing command complete: %w", err)
 			}
 
-			// Report changed GUC_REPORT parameters after CommandComplete and
-			// before ReadyForQuery, matching PostgreSQL's order (postgres.c
-			// reports them just before ReadyForQuery). Carried on the result for
-			// a SET that named a reportable GUC; reportParameterStatus drops the
-			// ones whose value did not actually change.
-			for name, value := range result.ParameterStatus {
-				if err := c.reportParameterStatus(name, value); err != nil {
-					return fmt.Errorf("writing parameter status: %w", err)
-				}
-			}
-
 			// Reset state for next result set (if any).
 			sentRowDescription = false
+		}
+
+		// Report changed GUC_REPORT parameters. PostgreSQL reports them just
+		// before ReadyForQuery (postgres.c), so after any CommandComplete above.
+		// They ride the SET/RESET result on the local set_config path, and arrive
+		// as their own CommandTag-less result on the routed (in-transaction /
+		// ROLLBACK) path; either way reportParameterStatus drops the ones whose
+		// value did not actually change.
+		if err := c.reportParameterStatuses(result.ParameterStatus); err != nil {
+			return err
 		}
 
 		return nil
@@ -1397,17 +1396,16 @@ func (c *Conn) handleExecute() error {
 			if err := c.writeCommandComplete(result.CommandTag); err != nil {
 				return fmt.Errorf("writing command complete: %w", err)
 			}
+		}
 
-			// Report changed GUC_REPORT parameters, as the simple-query path
-			// does: a SET run over the extended protocol changes the session
-			// just the same, and the client is owed the new value. Sent after
-			// CommandComplete and before the ReadyForQuery that Sync will
-			// write, matching PostgreSQL's order.
-			for name, value := range result.ParameterStatus {
-				if err := c.reportParameterStatus(name, value); err != nil {
-					return fmt.Errorf("writing parameter status: %w", err)
-				}
-			}
+		// Report changed GUC_REPORT parameters, as the simple-query path does: a
+		// SET/RESET run over the extended protocol changes the session just the
+		// same, whether it took the local set_config path (value rides the
+		// CommandTag result) or was routed to the backend (value arrives as its
+		// own result). Sent after any CommandComplete and before the
+		// ReadyForQuery that Sync writes, matching PostgreSQL's order.
+		if err := c.reportParameterStatuses(result.ParameterStatus); err != nil {
+			return err
 		}
 
 		return nil

--- a/go/common/pgprotocol/server/parameter_status_test.go
+++ b/go/common/pgprotocol/server/parameter_status_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+	"github.com/multigres/multigres/go/common/sqltypes"
+)
+
+// writeSimpleQuery appends a simple-query ('Q' body, no type byte — handleQuery
+// reads the length-prefixed body directly) message for queryStr to buf.
+func writeSimpleQuery(buf *bytes.Buffer, queryStr string) {
+	writeTestInt32(buf, int32(4+len(queryStr)+1))
+	writeTestString(buf, queryStr)
+}
+
+// wireParameterStatuses walks a pgwire byte stream and returns the (name, value)
+// of every ParameterStatus ('S') message, in order.
+func wireParameterStatuses(t *testing.T, wire []byte) [][2]string {
+	t.Helper()
+	var out [][2]string
+	for i := 0; i+5 <= len(wire); {
+		bodyLen := int(wire[i+1])<<24 | int(wire[i+2])<<16 | int(wire[i+3])<<8 | int(wire[i+4])
+		msgEnd := i + 1 + bodyLen
+		if bodyLen < 4 || msgEnd > len(wire) {
+			break
+		}
+		if wire[i] == protocol.MsgParameterStatus {
+			parts := bytes.SplitN(wire[i+5:msgEnd], []byte{0}, 3)
+			require.GreaterOrEqual(t, len(parts), 2, "ParameterStatus body must be name\\0value\\0")
+			out = append(out, [2]string{string(parts[0]), string(parts[1])})
+		}
+		i = msgEnd
+	}
+	return out
+}
+
+// wireMsgIndex returns the byte offset of the first message of typ, or -1.
+func wireMsgIndex(wire []byte, typ byte) int {
+	for i := 0; i+5 <= len(wire); {
+		bodyLen := int(wire[i+1])<<24 | int(wire[i+2])<<16 | int(wire[i+3])<<8 | int(wire[i+4])
+		if bodyLen < 4 || i+1+bodyLen > len(wire) {
+			return -1
+		}
+		if wire[i] == typ {
+			return i
+		}
+		i += 1 + bodyLen
+	}
+	return -1
+}
+
+func runOneQuery(t *testing.T, c *Conn, netConn *countingNetConn) []byte {
+	t.Helper()
+	c.startWriterBuffering()
+	require.NoError(t, c.handleQuery())
+	require.NoError(t, c.endWriterBuffering())
+	wire := append([]byte(nil), netConn.writeBuf.Bytes()...)
+	netConn.writeBuf.Reset()
+	return wire
+}
+
+// TestHandleQuery_EmitsParameterStatusAfterCommandComplete verifies that a SET
+// result carrying a GUC_REPORT value is emitted as a ParameterStatus message,
+// after CommandComplete and before ReadyForQuery — PostgreSQL's order.
+func TestHandleQuery_EmitsParameterStatusAfterCommandComplete(t *testing.T) {
+	var readBuf bytes.Buffer
+	writeSimpleQuery(&readBuf, "SET client_encoding = 'LATIN1'")
+	handler := &testHandler{
+		queryFunc: func(ctx context.Context, _ *Conn, _ string, callback func(context.Context, *sqltypes.Result) error) error {
+			return callback(ctx, &sqltypes.Result{
+				CommandTag:      "SET",
+				ParameterStatus: map[string]string{"client_encoding": "LATIN1"},
+			})
+		},
+	}
+
+	c, netConn := newBufferingTestConn(t, &readBuf, handler)
+	wire := runOneQuery(t, c, netConn)
+
+	ps := wireParameterStatuses(t, wire)
+	require.Len(t, ps, 1, "expected exactly one ParameterStatus")
+	assert.Equal(t, [2]string{"client_encoding", "LATIN1"}, ps[0])
+
+	cc := wireMsgIndex(wire, protocol.MsgCommandComplete)
+	psIdx := wireMsgIndex(wire, protocol.MsgParameterStatus)
+	rfq := wireMsgIndex(wire, protocol.MsgReadyForQuery)
+	require.NotEqual(t, -1, cc)
+	require.NotEqual(t, -1, psIdx)
+	require.NotEqual(t, -1, rfq)
+	assert.Less(t, cc, psIdx, "ParameterStatus must come after CommandComplete")
+	assert.Less(t, psIdx, rfq, "ParameterStatus must come before ReadyForQuery")
+}
+
+// TestHandleQuery_ParameterStatusOnlyResult verifies that a CommandTag-less
+// result carrying a ParameterStatus (the routed-forward path, e.g. an in-txn SET
+// whose value arrives from the backend) still emits the message.
+func TestHandleQuery_ParameterStatusOnlyResult(t *testing.T) {
+	var readBuf bytes.Buffer
+	writeSimpleQuery(&readBuf, "SET client_encoding = 'UTF8'")
+	handler := &testHandler{
+		queryFunc: func(ctx context.Context, _ *Conn, _ string, callback func(context.Context, *sqltypes.Result) error) error {
+			if err := callback(ctx, &sqltypes.Result{CommandTag: "SET"}); err != nil {
+				return err
+			}
+			return callback(ctx, &sqltypes.Result{ParameterStatus: map[string]string{"client_encoding": "UTF8"}})
+		},
+	}
+
+	c, netConn := newBufferingTestConn(t, &readBuf, handler)
+	wire := runOneQuery(t, c, netConn)
+
+	ps := wireParameterStatuses(t, wire)
+	require.Len(t, ps, 1)
+	assert.Equal(t, [2]string{"client_encoding", "UTF8"}, ps[0])
+}
+
+// TestHandleQuery_ParameterStatusChangeDetection verifies the wire server does
+// not re-emit a ParameterStatus whose value did not change — PostgreSQL reports
+// a GUC_REPORT parameter on change only.
+func TestHandleQuery_ParameterStatusChangeDetection(t *testing.T) {
+	var readBuf bytes.Buffer
+	writeSimpleQuery(&readBuf, "SET client_encoding = 'LATIN1'")
+	writeSimpleQuery(&readBuf, "SET client_encoding = 'LATIN1'")
+	handler := &testHandler{
+		queryFunc: func(ctx context.Context, _ *Conn, _ string, callback func(context.Context, *sqltypes.Result) error) error {
+			return callback(ctx, &sqltypes.Result{
+				CommandTag:      "SET",
+				ParameterStatus: map[string]string{"client_encoding": "LATIN1"},
+			})
+		},
+	}
+
+	c, netConn := newBufferingTestConn(t, &readBuf, handler)
+
+	first := runOneQuery(t, c, netConn)
+	assert.Len(t, wireParameterStatuses(t, first), 1, "first SET reports the change")
+
+	second := runOneQuery(t, c, netConn)
+	assert.Empty(t, wireParameterStatuses(t, second), "identical second SET must be deduped")
+}

--- a/go/common/pgprotocol/server/startup.go
+++ b/go/common/pgprotocol/server/startup.go
@@ -1177,6 +1177,18 @@ func (c *Conn) reportParameterStatus(name, value string) error {
 	return c.sendParameterStatus(name, value)
 }
 
+// reportParameterStatuses reports every changed GUC_REPORT parameter in params
+// (a no-op for an empty map), each subject to the same change-detection as
+// reportParameterStatus.
+func (c *Conn) reportParameterStatuses(params map[string]string) error {
+	for name, value := range params {
+		if err := c.reportParameterStatus(name, value); err != nil {
+			return fmt.Errorf("writing parameter status: %w", err)
+		}
+	}
+	return nil
+}
+
 // isClientAbortError reports whether a TLS handshake error looks like the
 // client closed the connection (network teardown, EOF, or use of an already-
 // closed socket) rather than a server-side or crypto failure. Used to split

--- a/go/common/sqltypes/sqltypes.go
+++ b/go/common/sqltypes/sqltypes.go
@@ -257,6 +257,7 @@ func (r *Result) ToProto() *query.QueryResult {
 			PassthroughRowCount: uint32(r.PassthroughRowCount),
 			CommandTag:          r.CommandTag,
 			Notices:             protoNotices,
+			ParameterStatus:     r.ParameterStatus,
 		}
 	}
 	protoRows := make([]*query.Row, len(r.Rows))
@@ -264,12 +265,13 @@ func (r *Result) ToProto() *query.QueryResult {
 		protoRows[i] = row.ToProto()
 	}
 	return &query.QueryResult{
-		Fields:       r.Fields,
-		HasFields:    r.Fields != nil,
-		RowsAffected: r.RowsAffected,
-		Rows:         protoRows,
-		CommandTag:   r.CommandTag,
-		Notices:      protoNotices,
+		Fields:          r.Fields,
+		HasFields:       r.Fields != nil,
+		RowsAffected:    r.RowsAffected,
+		Rows:            protoRows,
+		CommandTag:      r.CommandTag,
+		Notices:         protoNotices,
+		ParameterStatus: r.ParameterStatus,
 	}
 }
 
@@ -299,6 +301,7 @@ func ResultFromProto(pr *query.QueryResult) *Result {
 			PassthroughRowCount: int(pr.PassthroughRowCount),
 			CommandTag:          pr.CommandTag,
 			Notices:             notices,
+			ParameterStatus:     pr.ParameterStatus,
 		}
 	}
 	rows := make([]*Row, len(pr.Rows))
@@ -306,11 +309,12 @@ func ResultFromProto(pr *query.QueryResult) *Result {
 		rows[i] = RowFromProto(row)
 	}
 	return &Result{
-		Fields:       fields,
-		RowsAffected: pr.RowsAffected,
-		Rows:         rows,
-		CommandTag:   pr.CommandTag,
-		Notices:      notices,
+		Fields:          fields,
+		RowsAffected:    pr.RowsAffected,
+		Rows:            rows,
+		CommandTag:      pr.CommandTag,
+		Notices:         notices,
+		ParameterStatus: pr.ParameterStatus,
 	}
 }
 

--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -247,8 +247,15 @@ type QueryResult struct {
 	// passthrough_block. rows is empty in passthrough mode, so this preserves the
 	// row count for metrics and row-limit accounting.
 	PassthroughRowCount uint32 `protobuf:"varint,8,opt,name=passthrough_row_count,json=passthroughRowCount,proto3" json:"passthrough_row_count,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// parameter_status carries GUC_REPORT values (keyed by PostgreSQL's exact
+	// ParameterStatus display name, e.g. "DateStyle") that a routed statement
+	// changed on the backend. The multipooler forwards the backend's own
+	// ParameterStatus messages here so the multigateway can relay them to the
+	// client, covering the paths that run the real statement on PostgreSQL
+	// (SET/RESET inside a transaction, and the revert on ROLLBACK).
+	ParameterStatus map[string]string `protobuf:"bytes,9,rep,name=parameter_status,json=parameterStatus,proto3" json:"parameter_status,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *QueryResult) Reset() {
@@ -335,6 +342,13 @@ func (x *QueryResult) GetPassthroughRowCount() uint32 {
 		return x.PassthroughRowCount
 	}
 	return 0
+}
+
+func (x *QueryResult) GetParameterStatus() map[string]string {
+	if x != nil {
+		return x.ParameterStatus
+	}
+	return nil
 }
 
 // Field represents metadata about a column in the result set.
@@ -1637,7 +1651,7 @@ const file_query_proto_rawDesc = "" +
 	"diagnostic\x18\x02 \x01(\v2\x13.query.PgDiagnosticH\x00R\n" +
 	"diagnostic\x12;\n" +
 	"\fnotification\x18\x03 \x01(\v2\x15.query.PgNotificationH\x00R\fnotificationB\t\n" +
-	"\apayload\"\xc8\x02\n" +
+	"\apayload\"\xe0\x03\n" +
 	"\vQueryResult\x12$\n" +
 	"\x06fields\x18\x01 \x03(\v2\f.query.FieldR\x06fields\x12#\n" +
 	"\rrows_affected\x18\x02 \x01(\x04R\frowsAffected\x12\x1e\n" +
@@ -1649,7 +1663,11 @@ const file_query_proto_rawDesc = "" +
 	"has_fields\x18\x05 \x01(\bR\thasFields\x12-\n" +
 	"\anotices\x18\x06 \x03(\v2\x13.query.PgDiagnosticR\anotices\x12+\n" +
 	"\x11passthrough_block\x18\a \x01(\fR\x10passthroughBlock\x122\n" +
-	"\x15passthrough_row_count\x18\b \x01(\rR\x13passthroughRowCount\"\x89\x02\n" +
+	"\x15passthrough_row_count\x18\b \x01(\rR\x13passthroughRowCount\x12R\n" +
+	"\x10parameter_status\x18\t \x03(\v2'.query.QueryResult.ParameterStatusEntryR\x0fparameterStatus\x1aB\n" +
+	"\x14ParameterStatusEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x89\x02\n" +
 	"\x05Field\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x1b\n" +
@@ -1772,7 +1790,7 @@ func file_query_proto_rawDescGZIP() []byte {
 }
 
 var file_query_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_query_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_query_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
 var file_query_proto_goTypes = []any{
 	(Mode)(0),                           // 0: query.Mode
 	(*QueryResultPayload)(nil),          // 1: query.QueryResultPayload
@@ -1791,10 +1809,11 @@ var file_query_proto_goTypes = []any{
 	(*ExecuteOptions)(nil),              // 14: query.ExecuteOptions
 	(*UserAuth)(nil),                    // 15: query.UserAuth
 	(*ReservationOptions)(nil),          // 16: query.ReservationOptions
-	nil,                                 // 17: query.ExecuteOptions.SessionSettingsEntry
-	nil,                                 // 18: query.ExecuteOptions.PostQuerySessionSettingsEntry
-	(*clustermetadata.ShardKey)(nil),    // 19: clustermetadata.ShardKey
-	(*clustermetadata.ID)(nil),          // 20: clustermetadata.ID
+	nil,                                 // 17: query.QueryResult.ParameterStatusEntry
+	nil,                                 // 18: query.ExecuteOptions.SessionSettingsEntry
+	nil,                                 // 19: query.ExecuteOptions.PostQuerySessionSettingsEntry
+	(*clustermetadata.ShardKey)(nil),    // 20: clustermetadata.ShardKey
+	(*clustermetadata.ID)(nil),          // 21: clustermetadata.ID
 }
 var file_query_proto_depIdxs = []int32{
 	2,  // 0: query.QueryResultPayload.result:type_name -> query.QueryResult
@@ -1803,21 +1822,22 @@ var file_query_proto_depIdxs = []int32{
 	3,  // 3: query.QueryResult.fields:type_name -> query.Field
 	4,  // 4: query.QueryResult.rows:type_name -> query.Row
 	5,  // 5: query.QueryResult.notices:type_name -> query.PgDiagnostic
-	8,  // 6: query.StatementDescription.parameters:type_name -> query.ParameterDescription
-	3,  // 7: query.StatementDescription.fields:type_name -> query.Field
-	19, // 8: query.Target.shard_key:type_name -> clustermetadata.ShardKey
-	0,  // 9: query.Target.mode:type_name -> query.Mode
-	10, // 10: query.ExecuteSqlPreparedStatement.prepared_statement:type_name -> query.PreparedStatement
-	20, // 11: query.ReservedState.pooler_id:type_name -> clustermetadata.ID
-	17, // 12: query.ExecuteOptions.session_settings:type_name -> query.ExecuteOptions.SessionSettingsEntry
-	15, // 13: query.ExecuteOptions.user_auth:type_name -> query.UserAuth
-	11, // 14: query.ExecuteOptions.execute_sql_prepared_statement:type_name -> query.ExecuteSqlPreparedStatement
-	18, // 15: query.ExecuteOptions.post_query_session_settings:type_name -> query.ExecuteOptions.PostQuerySessionSettingsEntry
-	16, // [16:16] is the sub-list for method output_type
-	16, // [16:16] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	17, // 6: query.QueryResult.parameter_status:type_name -> query.QueryResult.ParameterStatusEntry
+	8,  // 7: query.StatementDescription.parameters:type_name -> query.ParameterDescription
+	3,  // 8: query.StatementDescription.fields:type_name -> query.Field
+	20, // 9: query.Target.shard_key:type_name -> clustermetadata.ShardKey
+	0,  // 10: query.Target.mode:type_name -> query.Mode
+	10, // 11: query.ExecuteSqlPreparedStatement.prepared_statement:type_name -> query.PreparedStatement
+	21, // 12: query.ReservedState.pooler_id:type_name -> clustermetadata.ID
+	18, // 13: query.ExecuteOptions.session_settings:type_name -> query.ExecuteOptions.SessionSettingsEntry
+	15, // 14: query.ExecuteOptions.user_auth:type_name -> query.UserAuth
+	11, // 15: query.ExecuteOptions.execute_sql_prepared_statement:type_name -> query.ExecuteSqlPreparedStatement
+	19, // 16: query.ExecuteOptions.post_query_session_settings:type_name -> query.ExecuteOptions.PostQuerySessionSettingsEntry
+	17, // [17:17] is the sub-list for method output_type
+	17, // [17:17] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_query_proto_init() }
@@ -1836,7 +1856,7 @@ func file_query_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_query_proto_rawDesc), len(file_query_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   18,
+			NumMessages:   19,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/services/multigateway/engine/apply_session_state.go
+++ b/go/services/multigateway/engine/apply_session_state.go
@@ -402,10 +402,19 @@ func (s *ApplySessionState) prepareSilentTrackingAction(
 		}
 		action, preview, err := prepareTrackedSetActionWithBackendPreview(conn, state, resolved.name, resolved.value, resolved.isLocal)
 		return silentTrackingAction{apply: action, previewPostSessionSettings: preview}, true, err
-	case ast.VAR_SET_DEFAULT:
-		return silentTrackingAction{apply: func() { resetTrackedSessionVariable(state, s.VariableStmt.Name) }}, true, nil
-	case ast.VAR_RESET:
-		return silentTrackingAction{apply: func() { resetTrackedSessionVariable(state, s.VariableStmt.Name) }}, true, nil
+	case ast.VAR_SET_DEFAULT, ast.VAR_RESET:
+		// A routed RESET (in-transaction) reverts the real backend GUC, so the
+		// multipooler must record the reverted state or its connstate drifts from
+		// the backend. The preview drops the variable from the recorded settings,
+		// mirroring the gateway-side reset in the apply closure.
+		name := s.VariableStmt.Name
+		preview := func(settings map[string]string) map[string]string {
+			return removeBackendSessionVariableFromMap(settings, name)
+		}
+		return silentTrackingAction{
+			apply:                      func() { resetTrackedSessionVariable(state, name) },
+			previewPostSessionSettings: preview,
+		}, true, nil
 	case ast.VAR_RESET_ALL:
 		return silentTrackingAction{apply: func() {
 			resetAllSessionVariablesPreservingRoleAuth(state)
@@ -615,6 +624,33 @@ func applyBackendSessionVariableToMap(settings map[string]string, name, value st
 		}
 	default:
 		settings[pgsettings.CanonicalGUCName(name)] = value
+	}
+	if len(settings) == 0 {
+		return nil
+	}
+	return settings
+}
+
+// removeBackendSessionVariableFromMap is the RESET counterpart of
+// applyBackendSessionVariableToMap: it drops the variable from the backend
+// session-settings snapshot the multipooler records for a reserved connection.
+// Without it, an in-transaction RESET routed to PostgreSQL reverts the real
+// backend GUC but leaves the pooler's recorded connstate stale, so a later
+// checkout trusts the stale value and hands back a connection whose actual GUC
+// state does not match — mirroring resetTrackedSessionVariable's gateway-side
+// clearing on the backend-settings map.
+func removeBackendSessionVariableFromMap(settings map[string]string, name string) map[string]string {
+	if settings == nil {
+		return nil
+	}
+	switch pgsettings.CanonicalGUCName(name) {
+	case "session_authorization":
+		delete(settings, "session_authorization")
+		delete(settings, "role")
+	case "role":
+		delete(settings, "role")
+	default:
+		delete(settings, pgsettings.CanonicalGUCName(name))
 	}
 	if len(settings) == 0 {
 		return nil

--- a/go/services/multigateway/planner/variable_set_stmt.go
+++ b/go/services/multigateway/planner/variable_set_stmt.go
@@ -172,7 +172,18 @@ func (p *Planner) planVariableSetStmt(
 		// is forwarded. Non-reportable RESET keeps the round-trip-free fast path:
 		// clearing local tracking is enough, and the pool falls back to the
 		// startup/default value on the next query.
-		if _, reportable := pgsettings.ReportableGUCName(stmt.Name); reportable && conn != nil && !conn.IsInTransaction() {
+		if _, reportable := pgsettings.ReportableGUCName(stmt.Name); reportable && conn != nil {
+			if conn.IsInTransaction() {
+				// Inside a transaction, route the real RESET to PostgreSQL (like
+				// in-transaction SET) and track it silently; the backend's
+				// ParameterStatus for the reverted value is forwarded to the client.
+				route := engine.NewRoute(p.defaultTableGroup, constants.DefaultShard, sql, stmt)
+				track := engine.NewApplySessionStateSilent(sql, stmt)
+				plan := engine.NewPlan(sql, engine.NewSequence([]engine.Primitive{route, track}))
+				p.logger.Debug("created route-then-track RESET plan inside transaction",
+					"variable", stmt.Name, "plan", plan.String())
+				return plan, nil
+			}
 			validate := engine.NewValidateSettingReset(p.defaultTableGroup, constants.DefaultShard, stmt.Name, sql)
 			track := engine.NewApplySessionState(sql, stmt)
 			plan := engine.NewPlan(sql, engine.NewSequence([]engine.Primitive{validate, track}))

--- a/go/services/multipooler/grpcpoolerservice/service.go
+++ b/go/services/multipooler/grpcpoolerservice/service.go
@@ -157,7 +157,7 @@ func (s *poolerService) StreamExecute(req *multipoolerpb.StreamExecuteRequest, s
 		// Send row data (if any). Notices are streamed above as separate
 		// diagnostics, so keep the result payload notice-free to avoid duplicate
 		// NoticeResponse frames on the gateway.
-		if len(result.Rows) > 0 || len(result.PassthroughBlock) > 0 || result.CommandTag != "" {
+		if len(result.Rows) > 0 || len(result.PassthroughBlock) > 0 || result.CommandTag != "" || len(result.ParameterStatus) > 0 {
 			protoResult := result.ToProto()
 			protoResult.Notices = nil
 			rowPayload := &query.QueryResultPayload{
@@ -404,7 +404,7 @@ func (s *poolerService) PortalStreamExecute(req *multipoolerpb.PortalStreamExecu
 			// Send row data (if any). Notices are streamed above as separate
 			// diagnostics, so keep the result payload notice-free to avoid duplicate
 			// NoticeResponse frames on the gateway.
-			if len(result.Rows) > 0 || len(result.PassthroughBlock) > 0 || result.CommandTag != "" {
+			if len(result.Rows) > 0 || len(result.PassthroughBlock) > 0 || result.CommandTag != "" || len(result.ParameterStatus) > 0 {
 				protoResult := result.ToProto()
 				protoResult.Notices = nil
 				rowPayload := &query.QueryResultPayload{

--- a/go/test/endtoend/queryserving/session_settings_test.go
+++ b/go/test/endtoend/queryserving/session_settings_test.go
@@ -1132,6 +1132,175 @@ func TestParameterStatusReporting_Reset(t *testing.T) {
 	}
 }
 
+// TestParameterStatusReporting_InTransaction verifies that a SET or RESET of a
+// GUC_REPORT parameter issued inside an explicit transaction reports the change
+// to the client, exactly as PostgreSQL does. These route the real statement to
+// the backend, whose ParameterStatus is forwarded through the multipooler; a
+// fresh connection per case keeps the reserved-backend state deterministic.
+func TestParameterStatusReporting_InTransaction(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping ParameterStatus test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping ParameterStatus test")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, 60*time.Second)
+
+	// Each case starts a fresh session, sets a starting value outside the
+	// transaction, then runs the in-transaction statement whose report we check.
+	cases := []struct {
+		name     string
+		start    string // value set (outside txn) before the checked statement
+		stmt     string // the in-transaction statement under test
+		expected string // client_encoding value the checked statement must report
+	}{
+		{"in-txn SET", "LATIN1", "SET client_encoding = 'UTF8'", "UTF8"},
+		{"in-txn RESET", "LATIN1", "RESET client_encoding", "UTF8"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reported := map[string]string{}
+			for _, target := range setup.GetComparisonTargets(t) {
+				connStr := shardsetup.GetTestUserDSN("localhost", target.Port, "sslmode=disable")
+				cfg, err := pgconn.ParseConfig(connStr)
+				require.NoError(t, err)
+
+				var trace bytes.Buffer
+				cfg.BuildFrontend = func(r io.Reader, w io.Writer) *pgproto3.Frontend {
+					fe := pgproto3.NewFrontend(r, w)
+					fe.Trace(&trace, pgproto3.TracerOptions{SuppressTimestamps: true})
+					return fe
+				}
+				conn, err := pgconn.ConnectConfig(ctx, cfg)
+				require.NoError(t, err)
+
+				_, err = conn.Exec(ctx, "SET client_encoding = '"+tc.start+"'").ReadAll()
+				require.NoError(t, err)
+				_, err = conn.Exec(ctx, "BEGIN").ReadAll()
+				require.NoError(t, err)
+
+				trace.Reset()
+				_, err = conn.Exec(ctx, tc.stmt).ReadAll()
+				require.NoError(t, err, "%s should be accepted", tc.stmt)
+
+				var val string
+				for l := range strings.SplitSeq(trace.String(), "\n") {
+					if strings.Contains(l, "\tParameterStatus\t") && strings.Contains(l, `"client_encoding"`) {
+						if i := strings.LastIndex(l, `"`); i > 0 {
+							if j := strings.LastIndex(l[:i], `"`); j >= 0 {
+								val = l[j+1 : i]
+							}
+						}
+					}
+				}
+				_, _ = conn.Exec(ctx, "COMMIT").ReadAll()
+				conn.Close(context.Background())
+
+				t.Logf("%s: %s reported client_encoding=%q", target.Name, tc.name, val)
+				reported[target.Name] = val
+			}
+
+			require.Equal(t, tc.expected, reported["postgres"],
+				"sanity: PostgreSQL reports %q for %s", tc.expected, tc.name)
+			assert.Equal(t, reported["postgres"], reported["multigateway"],
+				"multigateway must report the same client_encoding as PostgreSQL for %s", tc.name)
+		})
+	}
+}
+
+// TestParameterStatusReporting_Rollback verifies that ROLLBACK reports the
+// reverted value of every GUC_REPORT parameter changed inside the transaction,
+// exactly as PostgreSQL does. Reporting the in-transaction change (which this PR
+// now does) makes reporting the revert mandatory: otherwise the client would be
+// left believing the rolled-back value. Two cases: reverting to a value set
+// before the transaction, and reverting to the default (no pre-transaction
+// value). The reverted value is read from a fresh connection's wire trace.
+func TestParameterStatusReporting_Rollback(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping ParameterStatus test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping ParameterStatus test")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, 60*time.Second)
+
+	cases := []struct {
+		name     string
+		setup    []string // statements run (outside the checked step) to establish state
+		expected string   // client_encoding value ROLLBACK must report
+	}{
+		{
+			// Pre-transaction value LATIN1; in-txn SET UTF8; ROLLBACK reverts to LATIN1.
+			name:     "revert to prior value",
+			setup:    []string{"SET client_encoding = 'LATIN1'", "BEGIN", "SET client_encoding = 'UTF8'"},
+			expected: "LATIN1",
+		},
+		{
+			// No pre-transaction value (default UTF8); in-txn SET LATIN1; ROLLBACK
+			// reverts to the default UTF8.
+			name:     "revert to default",
+			setup:    []string{"RESET client_encoding", "BEGIN", "SET client_encoding = 'LATIN1'"},
+			expected: "UTF8",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reported := map[string]string{}
+			for _, target := range setup.GetComparisonTargets(t) {
+				connStr := shardsetup.GetTestUserDSN("localhost", target.Port, "sslmode=disable")
+				cfg, err := pgconn.ParseConfig(connStr)
+				require.NoError(t, err)
+
+				var trace bytes.Buffer
+				cfg.BuildFrontend = func(r io.Reader, w io.Writer) *pgproto3.Frontend {
+					fe := pgproto3.NewFrontend(r, w)
+					fe.Trace(&trace, pgproto3.TracerOptions{SuppressTimestamps: true})
+					return fe
+				}
+				conn, err := pgconn.ConnectConfig(ctx, cfg)
+				require.NoError(t, err)
+
+				for _, s := range tc.setup {
+					_, err := conn.Exec(ctx, s).ReadAll()
+					require.NoError(t, err, "%s should be accepted", s)
+				}
+
+				trace.Reset()
+				_, err = conn.Exec(ctx, "ROLLBACK").ReadAll()
+				require.NoError(t, err, "ROLLBACK should be accepted")
+
+				var val string
+				for l := range strings.SplitSeq(trace.String(), "\n") {
+					if strings.Contains(l, "\tParameterStatus\t") && strings.Contains(l, `"client_encoding"`) {
+						if i := strings.LastIndex(l, `"`); i > 0 {
+							if j := strings.LastIndex(l[:i], `"`); j >= 0 {
+								val = l[j+1 : i]
+							}
+						}
+					}
+				}
+				_ = conn.Close(context.Background())
+
+				t.Logf("%s: ROLLBACK (%s) reported client_encoding=%q", target.Name, tc.name, val)
+				reported[target.Name] = val
+			}
+
+			require.Equal(t, tc.expected, reported["postgres"],
+				"sanity: PostgreSQL reports %q on ROLLBACK for %q", tc.expected, tc.name)
+			assert.Equal(t, reported["postgres"], reported["multigateway"],
+				"multigateway must report the same reverted client_encoding as PostgreSQL for %q", tc.name)
+		})
+	}
+}
+
 // Helper Functions
 
 // execAndVerify executes SET and verifies SHOW returns expected value

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -77,6 +77,14 @@ message QueryResult {
   // passthrough_block. rows is empty in passthrough mode, so this preserves the
   // row count for metrics and row-limit accounting.
   uint32 passthrough_row_count = 8;
+
+  // parameter_status carries GUC_REPORT values (keyed by PostgreSQL's exact
+  // ParameterStatus display name, e.g. "DateStyle") that a routed statement
+  // changed on the backend. The multipooler forwards the backend's own
+  // ParameterStatus messages here so the multigateway can relay them to the
+  // client, covering the paths that run the real statement on PostgreSQL
+  // (SET/RESET inside a transaction, and the revert on ROLLBACK).
+  map<string, string> parameter_status = 9;
 }
 
 // Field represents metadata about a column in the result set.


### PR DESCRIPTION
## Summary

- Reports `ParameterStatus` for a `SET`/`RESET` of a `GUC_REPORT` parameter issued **inside a transaction**, and for the reverts on **`ROLLBACK`** — the in-transaction follow-up to the base ParameterStatus support, matching PostgreSQL's behavior and timing.
- Treats PostgreSQL as authoritative for reserved (transaction) connections: routes the real statement to the pinned backend and forwards the backend's own `ParameterStatus` messages, rather than reconstructing them gateway-side.
- Adds a `parameter_status` field to `QueryResult` so the multipooler forwards the backend's `ParameterStatus` across gRPC; the multigateway relays it with the existing change-detection dedup, over both the simple and extended protocols. `ROLLBACK`/`COMMIT` reverts ride the same field on `ConcludeTransactionResponse.result`, so no extra proto surface is needed.

## Problem

Outside a transaction, SET/RESET already report `ParameterStatus`. Inside a transaction the report was missing: an in-transaction RESET only updated the gateway's local tracking, and the backend caught up lazily on the *next* query via internal settings reconciliation — whose `ParameterStatus` is never surfaced. So the client was never told, and the report (when it eventually happened) was at the wrong time relative to PostgreSQL.

## Solution

For reserved connections, route the real SET/RESET to the pinned backend so PostgreSQL emits the correct `ParameterStatus` immediately — including the reverts on `ROLLBACK` (and `ROLLBACK TO SAVEPOINT`, which already routes). The pgprotocol client surfaces those updates as results, the multipooler forwards them on the query result, and the wire server emits them after `CommandComplete` and before `ReadyForQuery`, matching PostgreSQL's order.

Routing an in-transaction RESET reverts the real backend GUC, so the multipooler must record the reverted state or its per-connection settings tracker drifts from the backend — a later checkout would then trust a stale value and hand back a connection whose actual GUC state does not match. Fixed by giving the RESET path the same `previewPostSessionSettings` the in-transaction SET path already has (dropping the variable from the recorded settings), keeping the pooler's connstate in sync with the backend.

New end-to-end tests compare the reported values on the wire against a direct PostgreSQL connection for in-transaction SET, in-transaction RESET, and ROLLBACK (revert-to-prior-value and revert-to-default).