### PR TITLE
test(pgprotocol): fix flaky staticcheck SA5011 in ssl_test

### DIFF
--- a/go/common/pgprotocol/client/ssl_test.go
+++ b/go/common/pgprotocol/client/ssl_test.go
@@ -28,6 +28,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseSSLMode(t *testing.T) {
@@ -121,9 +123,7 @@ func TestBuildTLSConfig_RequireAndPrefer(t *testing.T) {
 		if err != nil {
 			t.Fatalf("BuildTLSConfig(%s): unexpected error %v", mode, err)
 		}
-		if cfg == nil {
-			t.Fatalf("BuildTLSConfig(%s) = nil, want non-nil", mode)
-		}
+		require.NotNilf(t, cfg, "BuildTLSConfig(%s) = nil, want non-nil", mode)
 		if !cfg.InsecureSkipVerify {
 			t.Errorf("BuildTLSConfig(%s).InsecureSkipVerify = false, want true (libpq parity)", mode)
 		}
@@ -292,9 +292,7 @@ func writeTestCertCNOnly(t *testing.T, cn string) (caPath string, certPEM, keyPE
 func tlsStateFromPEM(t *testing.T, certPEM, keyPEM []byte) tls.ConnectionState {
 	t.Helper()
 	block, _ := pem.Decode(certPEM)
-	if block == nil {
-		t.Fatal("failed to decode cert PEM")
-	}
+	require.NotNil(t, block, "failed to decode cert PEM")
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Problem

The `golangci-lint` CI job (pinned to v2.12.2) intermittently fails on `go/common/pgprotocol/client/ssl_test.go` with staticcheck **SA5011 "possible nil pointer dereference"**:

```
ssl_test.go:124:6  SA5011(related information): this check suggests that the pointer can be nil
ssl_test.go:127:11 SA5011: possible nil pointer dereference
ssl_test.go:130:10 SA5011: possible nil pointer dereference
ssl_test.go:295:5  SA5011(related information)
ssl_test.go:298:43 SA5011: possible nil pointer dereference
```

Because `golangci-lint` runs the whole repo with `only-new-issues: false`, this fails **every PR's** lint check regardless of whether the PR touches this file — it is currently blocking unrelated PRs. It is also **nondeterministic**: with an identical file and the same pinned linter, main's lint has both passed and failed across commits, so reruns sometimes pass.

## Root cause

Both spots use the pattern:

```go
cfg, err := BuildTLSConfig(...)
if err != nil { t.Fatalf(...) }
if cfg == nil { t.Fatalf(...) }   // <- SA5011 latches onto this comparison
... cfg.InsecureSkipVerify ...    // <- flagged as possible nil deref
```

staticcheck's SA5011 treats the explicit `== nil` comparison as evidence the pointer can be nil, then flags the later dereference — because it does not always know `t.Fatalf` terminates the goroutine. The `noreturn` fact for `testing.Fatalf` is not reliably propagated under whole-repo concurrent analysis, which is what makes the failure flaky.

## Fix

Replace the explicit nil-comparison guards with `require.NotNil` (testify, already a repo dependency) in both affected functions — `TestBuildTLSConfig_RequireAndPrefer` and the `tlsStateFromPEM` helper. Removing the explicit `== nil` comparison eliminates the trigger SA5011 latches onto, so the subsequent dereference is no longer flagged. Behavior is unchanged (both still fail-fast on nil).

## Verification

Using the CI-pinned **golangci-lint v2.12.2**, with `cache clean` between every run:

- `golangci-lint run ./go/common/pgprotocol/...` — 5 consecutive clean runs (0 issues)
- `golangci-lint run` (full repo) — 3 consecutive clean runs (0 issues)
- `go test ./go/common/pgprotocol/client/` — passes
