### PR TITLE
fix(multipooler): reject stale-source RewindToSource with a term-aware guard

### DIFF
--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -2615,9 +2615,18 @@ func (x *BackupMetadata) GetPgVersion() string {
 type RewindToSourceRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Source multipooler (the primary) to rewind to
-	Source        *clustermetadata.Multipooler `protobuf:"bytes,1,opt,name=source,proto3" json:"source,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Source *clustermetadata.Multipooler `protobuf:"bytes,1,opt,name=source,proto3" json:"source,omitempty"`
+	// source_position is the rule position the caller believes the source holds
+	// (the shard's highest-known rule). RewindToSource restarts this node as a
+	// standby of source, so the target refuses the rewind when its own fresh rule
+	// position is not dominated by source_position (i.e. the target outranks the
+	// source) or when source_position names a rule this node has already revoked.
+	// This mirrors the SetPrimary staleness gate and stops a stale coordinator from
+	// demoting a higher-term primary onto an older node. Optional for backward
+	// compatibility: when unset the gate is skipped (legacy/forced callers).
+	SourcePosition *clustermetadata.RulePosition `protobuf:"bytes,2,opt,name=source_position,json=sourcePosition,proto3" json:"source_position,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *RewindToSourceRequest) Reset() {
@@ -2653,6 +2662,13 @@ func (*RewindToSourceRequest) Descriptor() ([]byte, []int) {
 func (x *RewindToSourceRequest) GetSource() *clustermetadata.Multipooler {
 	if x != nil {
 		return x.Source
+	}
+	return nil
+}
+
+func (x *RewindToSourceRequest) GetSourcePosition() *clustermetadata.RulePosition {
+	if x != nil {
+		return x.SourcePosition
 	}
 	return nil
 }
@@ -2957,9 +2973,10 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\aUNKNOWN\x10\x00\x12\x0e\n" +
 	"\n" +
 	"INCOMPLETE\x10\x01\x12\f\n" +
-	"\bCOMPLETE\x10\x02\"M\n" +
+	"\bCOMPLETE\x10\x02\"\x95\x01\n" +
 	"\x15RewindToSourceRequest\x124\n" +
-	"\x06source\x18\x01 \x01(\v2\x1c.clustermetadata.MultipoolerR\x06source\"\x82\x01\n" +
+	"\x06source\x18\x01 \x01(\v2\x1c.clustermetadata.MultipoolerR\x06source\x12F\n" +
+	"\x0fsource_position\x18\x02 \x01(\v2\x1d.clustermetadata.RulePositionR\x0esourcePosition\"\x82\x01\n" +
 	"\x16RewindToSourceResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12#\n" +
 	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\x12)\n" +
@@ -3074,6 +3091,7 @@ var file_multipoolermanagerdata_proto_goTypes = []any{
 	(*clustermetadata.RuleNumber)(nil),         // 52: clustermetadata.RuleNumber
 	(clustermetadata.RoutingRole)(0),           // 53: clustermetadata.RoutingRole
 	(*clustermetadata.Multipooler)(nil),        // 54: clustermetadata.Multipooler
+	(*clustermetadata.RulePosition)(nil),       // 55: clustermetadata.RulePosition
 }
 var file_multipoolermanagerdata_proto_depIdxs = []int32{
 	46, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
@@ -3124,11 +3142,12 @@ var file_multipoolermanagerdata_proto_depIdxs = []int32{
 	47, // 45: multipoolermanagerdata.BackupMetadata.start_timestamp:type_name -> google.protobuf.Timestamp
 	47, // 46: multipoolermanagerdata.BackupMetadata.stop_timestamp:type_name -> google.protobuf.Timestamp
 	54, // 47: multipoolermanagerdata.RewindToSourceRequest.source:type_name -> clustermetadata.Multipooler
-	48, // [48:48] is the sub-list for method output_type
-	48, // [48:48] is the sub-list for method input_type
-	48, // [48:48] is the sub-list for extension type_name
-	48, // [48:48] is the sub-list for extension extendee
-	0,  // [0:48] is the sub-list for field type_name
+	55, // 48: multipoolermanagerdata.RewindToSourceRequest.source_position:type_name -> clustermetadata.RulePosition
+	49, // [49:49] is the sub-list for method output_type
+	49, // [49:49] is the sub-list for method input_type
+	49, // [49:49] is the sub-list for extension type_name
+	49, // [49:49] is the sub-list for extension extendee
+	0,  // [0:49] is the sub-list for field type_name
 }
 
 func init() { file_multipoolermanagerdata_proto_init() }

--- a/go/services/multiorch/recovery/actions/fix_replication.go
+++ b/go/services/multiorch/recovery/actions/fix_replication.go
@@ -234,7 +234,7 @@ func (a *FixReplicationAction) fixNotReplicating(
 				leader.Health().Multipooler.Id.Name)
 		}
 
-		if rewindErr := a.tryPgRewind(ctx, leader, replica); rewindErr != nil {
+		if rewindErr := a.tryPgRewind(ctx, leader, replica, highestKnownPosition); rewindErr != nil {
 			return mterrors.Wrap(rewindErr, "pg_rewind failed")
 		}
 		// Re-verify replication after rewind. RewindToSource restarts
@@ -269,14 +269,19 @@ func (a *FixReplicationAction) tryPgRewind(
 	ctx context.Context,
 	primary *store.Pooler,
 	replica *store.Pooler,
+	sourcePosition *clustermetadatapb.RulePosition,
 ) error {
 	a.logger.InfoContext(ctx, "attempting pg_rewind",
 		"replica", replica.Health().Multipooler.Id.Name,
 		"primary", primary.Health().Multipooler.Id.Name)
 
-	// Call RewindToSource - it handles the entire flow atomically
+	// Call RewindToSource - it handles the entire flow atomically. Pass the
+	// source's rule position so the target refuses the rewind if it outranks the
+	// source (staleness gate); on refusal the RPC returns an error and we retry
+	// next cycle rather than demoting a higher-term node.
 	rewindReq := &multipoolermanagerdatapb.RewindToSourceRequest{
-		Source: primary.Health().Multipooler,
+		Source:         primary.Health().Multipooler,
+		SourcePosition: sourcePosition,
 	}
 	rewindResp, err := a.rpcClient.RewindToSource(ctx, replica.Health().Multipooler, rewindReq)
 	if err != nil {

--- a/go/services/multipooler/internal/grpcconsensusservice/service.go
+++ b/go/services/multipooler/internal/grpcconsensusservice/service.go
@@ -87,7 +87,7 @@ func (s *consensusService) SetPrimary(ctx context.Context, req *consensusdata.Se
 
 // RewindToSource performs pg_rewind to synchronize this server with a source
 func (s *consensusService) RewindToSource(ctx context.Context, req *multipoolermanagerdatapb.RewindToSourceRequest) (*multipoolermanagerdatapb.RewindToSourceResponse, error) {
-	resp, err := s.manager.RewindToSource(ctx, req.Source)
+	resp, err := s.manager.RewindToSource(ctx, req.Source, req.SourcePosition)
 	if err != nil {
 		return nil, mterrors.ToGRPC(err)
 	}

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -774,7 +774,7 @@ func (pm *MultipoolerManager) demoteToStandbyLocked(ctx context.Context, consens
 // RewindToSource pg_rewinds this server against source and brings it back as a
 // standby. The heavy lifting (stop, rewind, restart-as-standby, resume) is
 // shared with the stale-primary demote path via stopRewindRestartAsStandbyLocked.
-func (pm *MultipoolerManager) RewindToSource(ctx context.Context, source *clustermetadatapb.Multipooler) (*multipoolermanagerdatapb.RewindToSourceResponse, error) {
+func (pm *MultipoolerManager) RewindToSource(ctx context.Context, source *clustermetadatapb.Multipooler, sourcePosition *clustermetadatapb.RulePosition) (*multipoolermanagerdatapb.RewindToSourceResponse, error) {
 	if err := pm.checkReady(); err != nil {
 		return nil, mterrors.Wrap(err, "multipooler not ready")
 	}
@@ -797,6 +797,37 @@ func (pm *MultipoolerManager) RewindToSource(ctx context.Context, source *cluste
 		return nil, mterrors.Wrap(err, "failed to acquire action lock")
 	}
 	defer pm.actionLock.Release(ctx)
+
+	// Defense-in-depth staleness gate, mirroring SetPrimary (rpc_consensus.go).
+	// RewindToSource restarts this node as a standby of source, so it must never
+	// run when this node outranks the source: a stale coordinator that still
+	// believes an older node is primary could otherwise demote the legitimate
+	// higher-term primary onto it. When the caller tells us the source's rule
+	// position, refuse if that rule is one we've revoked, or if our own fresh
+	// position is not strictly dominated by it. Compared by rule position only
+	// (LSN is not part of the gate, same as SetPrimary). source_position is
+	// optional for backward compatibility; when unset the gate is skipped.
+	if sourcePosition != nil {
+		revocation, err := pm.consensusMgr.Promises().GetRevocation(ctx)
+		if err != nil {
+			return nil, mterrors.Wrap(err, "failed to read revocation while validating RewindToSource")
+		}
+		if commonconsensus.IsRuleRevoked(sourcePosition, revocation) {
+			return nil, mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
+				"refusing RewindToSource: source rule %s is revoked by this node's promise (revoked_below_term %d); deferring",
+				commonconsensus.FormatRulePosition(sourcePosition), revocation.GetRevokedBelowTerm())
+		}
+		selfPos, err := pm.consensusMgr.Rules().ObservePosition(ctx)
+		if err != nil {
+			return nil, mterrors.Wrap(err, "failed to observe local position while validating RewindToSource")
+		}
+		if commonconsensus.CompareRulePosition(sourcePosition, selfPos.GetPosition()) <= 0 {
+			return nil, mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
+				"refusing RewindToSource: source position %s does not dominate this node's position %s (stale coordinator view); deferring",
+				commonconsensus.FormatRulePosition(sourcePosition),
+				commonconsensus.FormatRulePosition(selfPos.GetPosition()))
+		}
+	}
 
 	if err := pm.actionLock.SetAction(ctx, multipoolermanagerdatapb.PostgresAction_POSTGRES_ACTION_REWIND); err != nil {
 		pm.logger.ErrorContext(ctx, "RewindToSource: failed to set action", "error", err)

--- a/go/services/multipooler/internal/manager/rpc_manager_test.go
+++ b/go/services/multipooler/internal/manager/rpc_manager_test.go
@@ -1030,7 +1030,7 @@ func TestRewindToSource_ManagerReopenedOnError(t *testing.T) {
 	}
 
 	// Call RewindToSource - this should fail during the Stop call
-	_, err = manager.RewindToSource(ctx, source)
+	_, err = manager.RewindToSource(ctx, source, nil)
 
 	// Verify the call failed as expected
 	require.Error(t, err)
@@ -1044,6 +1044,58 @@ func TestRewindToSource_ManagerReopenedOnError(t *testing.T) {
 		defer manager.mu.Unlock()
 		return manager.isOpen
 	}, 2*time.Second, 50*time.Millisecond, "REGRESSION: Manager should be reopened even when RewindToSource fails")
+}
+
+// TestRewindToSource_StalenessGate verifies the defense-in-depth guard: when the
+// caller supplies the source's rule position, RewindToSource refuses (before
+// touching postgres) if this node's own fresh position is not strictly dominated
+// by the source's — i.e. this node outranks the source. This stops a stale
+// coordinator from demoting a higher-term primary onto an older node (MUL-1091).
+func TestRewindToSource_StalenessGate(t *testing.T) {
+	ctx := context.Background()
+
+	rulePosAtTerm := func(term int64) *clustermetadatapb.RulePosition {
+		return &clustermetadatapb.RulePosition{
+			Decision: &clustermetadatapb.ShardRule{
+				RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: term},
+			},
+		}
+	}
+
+	source := &clustermetadatapb.Multipooler{
+		Id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "source-pooler"},
+		Hostname: "source-host",
+		PortMap:  map[string]int32{"postgres": 5432},
+	}
+
+	tests := []struct {
+		name        string
+		selfTerm    int64
+		sourceTerm  int64
+		wantRefused bool
+	}{
+		{name: "source older than self is refused", selfTerm: 3, sourceTerm: 2, wantRefused: true},
+		{name: "source equal to self is refused (must strictly dominate)", selfTerm: 3, sourceTerm: 3, wantRefused: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Fresh local position at selfTerm; empty promises => no revocation.
+			fake := &fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Position: rulePosAtTerm(tc.selfTerm)}}
+			pm := newTestManager(t, withRuleStore(fake))
+			pm.mu.Lock()
+			pm.state = ManagerStateReady
+			pm.mu.Unlock()
+
+			_, err := pm.RewindToSource(ctx, source, rulePosAtTerm(tc.sourceTerm))
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "does not dominate",
+				"a non-dominating source position must be refused by the staleness gate")
+			assert.GreaterOrEqual(t, fake.observePositionCallCount(), 1,
+				"the gate must consult the fresh local position")
+		})
+	}
 }
 
 // TestRewindToSource_RestoresPrimaryConnInfo is a regression test for the bug where
@@ -1148,7 +1200,7 @@ func TestRewindToSource_RestoresPrimaryConnInfo(t *testing.T) {
 		PortMap:  map[string]int32{"postgres": 5433},
 	}
 
-	resp, err := manager.RewindToSource(ctx, source)
+	resp, err := manager.RewindToSource(ctx, source, nil)
 	require.NoError(t, err)
 	assert.True(t, resp.RewindPerformed, "actual pg_rewind should have run (divergence detected)")
 
@@ -1266,7 +1318,7 @@ func TestRewindToSource_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
 		PortMap:  map[string]int32{"postgres": 5433},
 	}
 
-	resp, err := manager.RewindToSource(ctx, source)
+	resp, err := manager.RewindToSource(ctx, source, nil)
 	require.NoError(t, err)
 	assert.False(t, resp.RewindPerformed, "no divergence reported, so actual pg_rewind should not have run")
 
@@ -1356,7 +1408,7 @@ func TestRewindToSource_InvalidArgs(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			resp, err := manager.RewindToSource(ctx, tc.source)
+			resp, err := manager.RewindToSource(ctx, tc.source, nil)
 			require.Error(t, err)
 			assert.Nil(t, resp)
 			assert.Equal(t, mtrpcpb.Code_INVALID_ARGUMENT, mterrors.Code(err),

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -580,6 +580,16 @@ message BackupMetadata {
 message RewindToSourceRequest {
   // Source multipooler (the primary) to rewind to
   clustermetadata.Multipooler source = 1;
+
+  // source_position is the rule position the caller believes the source holds
+  // (the shard's highest-known rule). RewindToSource restarts this node as a
+  // standby of source, so the target refuses the rewind when its own fresh rule
+  // position is not dominated by source_position (i.e. the target outranks the
+  // source) or when source_position names a rule this node has already revoked.
+  // This mirrors the SetPrimary staleness gate and stops a stale coordinator from
+  // demoting a higher-term primary onto an older node. Optional for backward
+  // compatibility: when unset the gate is skipped (legacy/forced callers).
+  clustermetadata.RulePosition source_position = 2;
 }
 
 message RewindToSourceResponse {

--- a/web/multiadmin/lib/api/generated/multipoolermanagerdata_pb.ts
+++ b/web/multiadmin/lib/api/generated/multipoolermanagerdata_pb.ts
@@ -19,7 +19,7 @@
 
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
 import { Duration, Message, proto3, protoInt64, Timestamp } from "@bufbuild/protobuf";
-import { AvailabilityStatus, ConsensusStatus, ID, Multipooler, PoolerType, RoutingRole, RuleNumber } from "./clustermetadata_pb";
+import { AvailabilityStatus, ConsensusStatus, ID, Multipooler, PoolerType, RoutingRole, RuleNumber, RulePosition } from "./clustermetadata_pb";
 
 /**
  * PostgresStatus is the observed state of the PostgreSQL server process.
@@ -2208,6 +2208,20 @@ export class RewindToSourceRequest extends Message<RewindToSourceRequest> {
    */
   source?: Multipooler;
 
+  /**
+   * source_position is the rule position the caller believes the source holds
+   * (the shard's highest-known rule). RewindToSource restarts this node as a
+   * standby of source, so the target refuses the rewind when its own fresh rule
+   * position is not dominated by source_position (i.e. the target outranks the
+   * source) or when source_position names a rule this node has already revoked.
+   * This mirrors the SetPrimary staleness gate and stops a stale coordinator from
+   * demoting a higher-term primary onto an older node. Optional for backward
+   * compatibility: when unset the gate is skipped (legacy/forced callers).
+   *
+   * @generated from field: clustermetadata.RulePosition source_position = 2;
+   */
+  sourcePosition?: RulePosition;
+
   constructor(data?: PartialMessage<RewindToSourceRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -2217,6 +2231,7 @@ export class RewindToSourceRequest extends Message<RewindToSourceRequest> {
   static readonly typeName = "multipoolermanagerdata.RewindToSourceRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "source", kind: "message", T: Multipooler },
+    { no: 2, name: "source_position", kind: "message", T: RulePosition },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RewindToSourceRequest {


### PR DESCRIPTION
## What

Make `RewindToSource` independently safe with a term-aware staleness gate, mirroring the existing `SetPrimary` gate.

`RewindToSource` restarts the target as a standby of the source, but the RPC carried **no consensus position and performed no validation** — its safety relied entirely on the caller always passing `SetPrimary`'s staleness gate first. A future or refactored caller that invoked `RewindToSource` directly, or against a live-but-stale source, could demote a **higher-term primary onto an older node** (the failure mode tracked as MUL-1091).

## Changes

- **proto**: add optional `source_position` (`RulePosition`) to `RewindToSourceRequest`.
- **multipooler** (`internal/manager/rpc_manager.go`): `RewindToSource` reads its own **fresh** position via `consensusMgr.Rules().ObservePosition` and refuses with `FAILED_PRECONDITION` when the source rule is revoked by this node's promise, or when `source_position` does not **strictly dominate** this node's position. Compared by rule position only (LSN is not part of the gate, same as `SetPrimary`). `source_position` is optional; when unset the gate is skipped, so existing callers are unaffected.
- **multiorch** (`recovery/actions/fix_replication.go`): `tryPgRewind` passes the shard's highest-known rule position as `source_position`; on a term-based refusal the RPC errors and the next recovery cycle retries rather than demoting the node.

## Why defense-in-depth (not a live bug on main)

MUL-1091 is **already prevented on `main`**: `FixReplication` calls `SetPrimary` first, whose `ObservePosition` + revocation gate no-ops a stale demote, and `recruit_blocked_until` blocks re-promotion of a rewound node. This change removes the reliance on caller ordering so `RewindToSource` is safe on its own.

(The original scalar-`consensus_term` fix was developed against the pre-reorg consensus model on the `start-postgres-as-standby` line, where the bug is live; on `main`'s rule-position/revocation model the guard is expressed in terms of `RulePosition` instead.)

## Testing

- New `TestRewindToSource_StalenessGate` (table): a source position older-than / equal-to this node's fresh position is refused before any postgres interaction.
- Existing `RewindToSource` tests pass unchanged (they pass `nil` source_position → gate skipped).
- `go build ./...`, `go vet`, and the `internal/manager`, `recovery/actions`, `grpcconsensusservice`, and `rpcclient` suites pass.

Refs: MUL-1091
