### PR TITLE
fix(multigateway): match statement_timeout out-of-range error to PostgreSQL

### DIFF
--- a/go/services/multigateway/handler/statement_timeout.go
+++ b/go/services/multigateway/handler/statement_timeout.go
@@ -142,13 +142,13 @@ func invalidParamError(paramName, value, hint string) *mterrors.PgDiagnostic {
 
 // outOfRangeParamError returns a PgDiagnostic for an out-of-range statement_timeout
 // value (SQLSTATE 22023). ms is the value in the base unit (milliseconds). The
-// message matches PostgreSQL's guc.c exactly: the "ms" unit is appended to the
-// value and to both range bounds, e.g.
+// message matches PostgreSQL: "ms" is appended to the value, but range bounds
+// are bare integers, e.g.
 //
-//	-1 ms is outside the valid range for parameter "statement_timeout" (0 ms .. 2147483647 ms)
+//	-1 ms is outside the valid range for parameter "statement_timeout" (0 .. 2147483647)
 func outOfRangeParamError(paramName string, ms int64) *mterrors.PgDiagnostic {
 	return mterrors.NewPgError("ERROR", mterrors.PgSSInvalidParameterValue,
-		fmt.Sprintf("%d ms is outside the valid range for parameter %q (0 ms .. %d ms)",
+		fmt.Sprintf("%d ms is outside the valid range for parameter %q (0 .. %d)",
 			ms, paramName, constants.MaxStatementTimeoutMS), "")
 }
 

--- a/go/services/multigateway/handler/statement_timeout_test.go
+++ b/go/services/multigateway/handler/statement_timeout_test.go
@@ -129,20 +129,20 @@ func TestParsePostgresInterval(t *testing.T) {
 			name:        "negative integer",
 			value:       "-1",
 			wantErr:     true,
-			errContains: `-1 ms is outside the valid range for parameter "statement_timeout" (0 ms .. 2147483647 ms)`,
+			errContains: `-1 ms is outside the valid range for parameter "statement_timeout" (0 .. 2147483647)`,
 		},
 		{
 			name:        "negative seconds unit",
 			value:       "-5s",
 			wantErr:     true,
-			errContains: `-5000 ms is outside the valid range for parameter "statement_timeout" (0 ms .. 2147483647 ms)`,
+			errContains: `-5000 ms is outside the valid range for parameter "statement_timeout" (0 .. 2147483647)`,
 		},
 		{
 			// Rounds to -1 ms, not a misleading 0 ms (truncation would report 0).
 			name:        "negative sub-millisecond duration",
 			value:       "-600us",
 			wantErr:     true,
-			errContains: `-1 ms is outside the valid range for parameter "statement_timeout" (0 ms .. 2147483647 ms)`,
+			errContains: `-1 ms is outside the valid range for parameter "statement_timeout" (0 .. 2147483647)`,
 		},
 		{
 			// Sub-millisecond magnitude rounds to 0 ms (no timeout), matching PG.
@@ -154,7 +154,7 @@ func TestParsePostgresInterval(t *testing.T) {
 			name:        "over max integer",
 			value:       "2147483648",
 			wantErr:     true,
-			errContains: `2147483648 ms is outside the valid range for parameter "statement_timeout" (0 ms .. 2147483647 ms)`,
+			errContains: `2147483648 ms is outside the valid range for parameter "statement_timeout" (0 .. 2147483647)`,
 		},
 		{
 			name:    "invalid string",


### PR DESCRIPTION
## Summary
- Align `outOfRangeParamError` range bounds with live PostgreSQL: `(0 .. max)` instead of `(0 ms .. max ms)`
- Update unit expectations; verified by `TestStatementTimeoutErrorParity`

## Test plan
- [x] `go test -short ./go/services/multigateway/handler/ -run TestParsePostgresInterval`
- [x] `TestStatementTimeoutErrorParity` (pgregresstest e2e)