### PR TITLE
feat(multigateway): reject non-temporary replication slot creation

### DIFF
--- a/go/cmd/pgctld/command/restore_wrapper.go
+++ b/go/cmd/pgctld/command/restore_wrapper.go
@@ -78,6 +78,7 @@ func runRestoreWrapper(cmd *cobra.Command, args []string) error {
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 	defer signal.Stop(sigCh)
 
+	//nolint:gosec // G703: the caller deliberately supplies the restore_command pidfile path.
 	if err := os.WriteFile(pidfile, []byte(strconv.Itoa(os.Getpid())), 0o644); err != nil {
 		return fmt.Errorf("restore-wrapper: failed to write pidfile %s: %w", pidfile, err)
 	}
@@ -90,6 +91,7 @@ func runRestoreWrapper(cmd *cobra.Command, args []string) error {
 }
 
 func runWrappedCommand(name string, args []string, sigCh <-chan os.Signal) error {
+	//nolint:gosec // G702: executing the caller-supplied restore command is this wrapper's purpose.
 	c := exec.Command(name, args...)
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr

--- a/go/common/mterrors/pgdiagnostic.go
+++ b/go/common/mterrors/pgdiagnostic.go
@@ -189,6 +189,22 @@ func NewFeatureNotSupported(message string) *PgDiagnostic {
 	}
 }
 
+// NewNonTemporaryReplicationSlotError returns a PgDiagnostic error rejecting
+// a replication slot creation request that isn't scoped to TEMPORARY
+// (session lifetime). subject identifies what's being rejected (e.g. a
+// function name, or "CREATE_REPLICATION_SLOT") and requirement is the
+// surface-specific fix (e.g. "temporary=true" for the SQL function form,
+// "TEMPORARY" for the wire-protocol command). Multigres cannot yet migrate
+// a replication slot's position across a primary failover, so this
+// rationale is shared by every enforcement point that creates a slot —
+// the planner's function-call check and the replication-protocol preamble
+// — so they can't drift out of sync.
+func NewNonTemporaryReplicationSlotError(subject, requirement string) *PgDiagnostic {
+	return NewFeatureNotSupported(fmt.Sprintf(
+		"%s requires %s: Multigres cannot yet migrate a replication slot across a primary failover, so only temporary (session-scoped) slots are supported",
+		subject, requirement))
+}
+
 // PgDiagnosticToProto converts mterrors PgDiagnostic to proto format for gRPC serialization.
 func PgDiagnosticToProto(d *PgDiagnostic) *query.PgDiagnostic {
 	if d == nil {

--- a/go/common/parser/ast/normalizer.go
+++ b/go/common/parser/ast/normalizer.go
@@ -68,10 +68,13 @@ func FingerprintSQL(sql string) string {
 // The same applies inside built-in function calls whose arguments the planner
 // inspects literally — `set_config(name, value, is_local)`, where the planner
 // rewrites a bare SELECT into the equivalent SET and needs the literal values to
-// build the SessionSettings update, and `current_setting(name[, missing_ok])`,
+// build the SessionSettings update; `current_setting(name[, missing_ok])`,
 // where the planner reads the literal name to decide whether the setting is
 // gateway-managed and, if so, rewrites the call to return the gateway-owned
-// value. See go/services/multigateway/planner/unsafe_funccall.go.
+// value; and `pg_create_physical_replication_slot`/
+// `pg_create_logical_replication_slot`, where the planner rejects a call
+// whose `temporary` argument isn't a literal `true`. See
+// go/services/multigateway/planner/unsafe_funccall.go.
 //
 // NULL constants (A_Const with Isnull=true) are NOT normalized because NULL
 // is a keyword that affects query semantics (e.g., IS NULL vs IS $1).
@@ -150,9 +153,14 @@ func Normalize(stmt Stmt) *NormalizeResult {
 
 // isPlannerLiteralFunc reports whether the planner inspects this function
 // call's arguments as literal values and therefore needs normalization
-// skipped for its subtree. This covers `set_config(name, value, is_local)` and
-// `current_setting(name[, missing_ok])`; callers schema-qualified to pg_catalog
-// resolve to the same entry.
+// skipped for its subtree. This covers `set_config(name, value, is_local)`,
+// `current_setting(name[, missing_ok])`, and
+// `pg_create_physical_replication_slot`/`pg_create_logical_replication_slot`
+// (the planner rejects a call whose `temporary` argument isn't a literal
+// `true` — see rejectNonTemporaryReplicationSlot in
+// go/services/multigateway/planner/unsafe_funccall.go — so that argument
+// must stay an A_Const); callers schema-qualified to pg_catalog resolve to
+// the same entry.
 //
 // Keeping this predicate in the ast package (next to the normalizer) trades
 // a little co-location for avoiding an import cycle — the planner package
@@ -163,10 +171,14 @@ func isPlannerLiteralFunc(funcname *NodeList) bool {
 	}
 	switch funcname.Len() {
 	case 1:
-		return funcNamePartEquals(funcname.Items[0], "set_config", "current_setting")
+		return funcNamePartEquals(funcname.Items[0],
+			"set_config", "current_setting",
+			"pg_create_physical_replication_slot", "pg_create_logical_replication_slot")
 	case 2:
 		return funcNamePartEquals(funcname.Items[0], "pg_catalog") &&
-			funcNamePartEquals(funcname.Items[1], "set_config", "current_setting")
+			funcNamePartEquals(funcname.Items[1],
+				"set_config", "current_setting",
+				"pg_create_physical_replication_slot", "pg_create_logical_replication_slot")
 	}
 	return false
 }

--- a/go/common/parser/ast/replication_slot.go
+++ b/go/common/parser/ast/replication_slot.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ast
+
+import "strings"
+
+// ReplicationSlotFuncTemporaryArgIndex maps the pg_create_*_replication_slot
+// builtins to the zero-based argument index of their `temporary` parameter:
+//
+//	pg_create_physical_replication_slot(slot_name, immediately_reserve DEFAULT false, temporary DEFAULT false)
+//	pg_create_logical_replication_slot(slot_name, plugin, temporary DEFAULT false, twophase DEFAULT false)
+//
+// This is the single source of truth for both enforcement points that reject
+// non-temporary replication slot creation: the planner's function-call check
+// (go/services/multigateway/planner/unsafe_funccall.go) and
+// FindNonTemporaryReplicationSlotCall below, used by the multigateway
+// replication preamble to catch these calls when they arrive as arbitrary
+// SQL over a replication=database connection. The two call sites can't share
+// more than this map — the planner imports the handler package (for
+// gateway-managed-variable lookups), so the handler can't import the planner
+// back without an import cycle.
+var ReplicationSlotFuncTemporaryArgIndex = map[string]int{
+	"pg_create_physical_replication_slot": 2,
+	"pg_create_logical_replication_slot":  2,
+}
+
+// FindNonTemporaryReplicationSlotCall walks stmt for a call to one of
+// ReplicationSlotFuncTemporaryArgIndex's functions whose `temporary`
+// argument is missing, non-literal, or false, and returns that function's
+// name. Returns ("", false) if stmt contains no such call. Fails closed,
+// matching the planner's own check: a missing, bound, or non-literal
+// argument is treated the same as an explicit `false`.
+func FindNonTemporaryReplicationSlotCall(stmt Stmt) (string, bool) {
+	if stmt == nil {
+		return "", false
+	}
+	var found string
+	Rewrite(stmt, func(cursor *Cursor) bool {
+		if found != "" {
+			return false
+		}
+		fc, ok := cursor.Node().(*FuncCall)
+		if !ok {
+			return true
+		}
+		name := replicationSlotFuncCallName(fc.Funcname)
+		temporaryArgIndex, isReplicationSlotFunc := ReplicationSlotFuncTemporaryArgIndex[name]
+		if !isReplicationSlotFunc {
+			return true
+		}
+		if fc.Args != nil && fc.Args.Len() > temporaryArgIndex {
+			if isTemp, ok := literalBoolArg(fc.Args.Items[temporaryArgIndex]); ok && isTemp {
+				return true
+			}
+		}
+		found = name
+		return false
+	}, nil)
+	return found, found != ""
+}
+
+// replicationSlotFuncCallName resolves a FuncCall's name for comparison
+// against ReplicationSlotFuncTemporaryArgIndex, handling both the bare and
+// pg_catalog-qualified forms.
+func replicationSlotFuncCallName(funcname *NodeList) string {
+	if funcname == nil {
+		return ""
+	}
+	switch funcname.Len() {
+	case 1:
+		return stringNodeValue(funcname.Items[0])
+	case 2:
+		if stringNodeValue(funcname.Items[0]) != "pg_catalog" {
+			return ""
+		}
+		return stringNodeValue(funcname.Items[1])
+	}
+	return ""
+}
+
+// stringNodeValue returns the lowercased value if n is a *String, or "" for
+// anything else. FuncCall.Funcname items are always *String in a
+// well-formed parse tree.
+func stringNodeValue(n Node) string {
+	s, ok := n.(*String)
+	if !ok {
+		return ""
+	}
+	return strings.ToLower(s.SVal)
+}
+
+// literalBoolArg reports whether n is a literal A_Const (after stripping any
+// TypeCast) that unambiguously spells a boolean, for checking the
+// `temporary` argument of a replication-slot-creating call.
+//
+// go/common/parser must be usable as a standalone library (see the
+// parser-isolation lint rule), so this can't depend on
+// go/common/sqltypes.ParseBool — unlike the planner's equivalent check
+// (constBoolArg in unsafe_funccall.go), it doesn't replicate postgres's full
+// unique-prefix boolean parsing (parse_bool_with_len), only exact
+// case-insensitive matches on the common spellings. That's strictly more
+// conservative, never less: an unrecognized spelling here is treated as
+// non-literal by the caller and rejected, which is the safe direction for a
+// check whose job is to fail closed.
+func literalBoolArg(n Node) (isTrue bool, isLiteralBool bool) {
+	tc, ok := n.(*TypeCast)
+	for ok {
+		n = tc.Arg
+		tc, ok = n.(*TypeCast)
+	}
+	c, ok := n.(*A_Const)
+	if !ok || c.Isnull {
+		return false, false
+	}
+	switch v := c.Val.(type) {
+	case *Boolean:
+		return v.BoolVal, true
+	case *String:
+		switch strings.ToLower(strings.TrimSpace(v.SVal)) {
+		case "true", "t", "yes", "y", "on", "1":
+			return true, true
+		case "false", "f", "no", "n", "off", "0":
+			return false, true
+		}
+	}
+	return false, false
+}

--- a/go/common/parser/ast/replication_slot_test.go
+++ b/go/common/parser/ast/replication_slot_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// selectReplicationSlotFuncCall builds the AST for
+// SELECT <funcname>(<args...>), qualifying with pg_catalog when qualified is
+// true — used to verify FindNonTemporaryReplicationSlotCall independent of
+// the SQL parser (this package can't import go/common/parser, which imports
+// ast).
+func selectReplicationSlotFuncCall(funcname string, qualified bool, args ...Node) Stmt {
+	nameItems := []Node{NewString(funcname)}
+	if qualified {
+		nameItems = []Node{NewString("pg_catalog"), NewString(funcname)}
+	}
+	fc := NewFuncCall(&NodeList{Items: nameItems}, &NodeList{Items: args}, 0)
+	return &SelectStmt{
+		TargetList: &NodeList{Items: []Node{NewResTarget("", fc)}},
+		Op:         SETOP_NONE,
+	}
+}
+
+func TestFindNonTemporaryReplicationSlotCall(t *testing.T) {
+	lit := func(v Value) Node { return NewA_Const(v, 0) }
+
+	tests := []struct {
+		name       string
+		stmt       Stmt
+		wantFound  bool
+		wantFnName string
+	}{
+		{
+			name: "physical: temporary=true literal accepted",
+			stmt: selectReplicationSlotFuncCall("pg_create_physical_replication_slot", false,
+				lit(NewString("s1")), lit(NewBoolean(false)), lit(NewBoolean(true))),
+		},
+		{
+			name: "physical: temporary=false literal rejected",
+			stmt: selectReplicationSlotFuncCall("pg_create_physical_replication_slot", false,
+				lit(NewString("s1")), lit(NewBoolean(false)), lit(NewBoolean(false))),
+			wantFound:  true,
+			wantFnName: "pg_create_physical_replication_slot",
+		},
+		{
+			name: "physical: temporary omitted rejected",
+			stmt: selectReplicationSlotFuncCall("pg_create_physical_replication_slot", false,
+				lit(NewString("s1"))),
+			wantFound:  true,
+			wantFnName: "pg_create_physical_replication_slot",
+		},
+		{
+			name: "physical: non-literal temporary (bound param) rejected",
+			stmt: selectReplicationSlotFuncCall("pg_create_physical_replication_slot", false,
+				lit(NewString("s1")), lit(NewBoolean(false)), NewParamRef(1, 0)),
+			wantFound:  true,
+			wantFnName: "pg_create_physical_replication_slot",
+		},
+		{
+			name: "physical: pg_catalog-qualified form accepted with temporary=true",
+			stmt: selectReplicationSlotFuncCall("pg_create_physical_replication_slot", true,
+				lit(NewString("s1")), lit(NewBoolean(false)), lit(NewBoolean(true))),
+		},
+		{
+			name: "logical: temporary=true literal accepted",
+			stmt: selectReplicationSlotFuncCall("pg_create_logical_replication_slot", false,
+				lit(NewString("s1")), lit(NewString("pgoutput")), lit(NewBoolean(true))),
+		},
+		{
+			name: "logical: temporary=false literal rejected",
+			stmt: selectReplicationSlotFuncCall("pg_create_logical_replication_slot", false,
+				lit(NewString("s1")), lit(NewString("pgoutput")), lit(NewBoolean(false))),
+			wantFound:  true,
+			wantFnName: "pg_create_logical_replication_slot",
+		},
+		{
+			name: "unrelated function is unaffected",
+			stmt: selectReplicationSlotFuncCall("pg_drop_replication_slot", false, lit(NewString("s1"))),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, found := FindNonTemporaryReplicationSlotCall(tt.stmt)
+			assert.Equal(t, tt.wantFound, found)
+			if tt.wantFound {
+				assert.Equal(t, tt.wantFnName, name)
+			}
+		})
+	}
+
+	t.Run("nil statement", func(t *testing.T) {
+		name, found := FindNonTemporaryReplicationSlotCall(nil)
+		assert.False(t, found)
+		assert.Empty(t, name)
+	})
+}

--- a/go/common/pgprotocol/server/packet.go
+++ b/go/common/pgprotocol/server/packet.go
@@ -321,22 +321,23 @@ func (c *Conn) writeRawByte(b byte) error {
 	return err
 }
 
-// writeRawDataBlock writes a block of pre-framed PostgreSQL DataRow ('D')
-// messages to the client byte for byte. Used for opaque row passthrough: the
-// block is the concatenated DataRow frames the multipooler captured from the
-// backend, so no per-row framing happens here. Goes through the bufferedWriter
-// if one is attached, otherwise straight to the conn. Mirrors writePacket's
-// write step but skips the startPacket sizing pass, since the bytes are already
-// framed.
-func (c *Conn) writeRawDataBlock(block []byte) error {
+// WriteRawMessage writes pre-framed PostgreSQL wire bytes to the client byte
+// for byte, with no re-serialization. Used both for opaque row passthrough
+// (the block is the concatenated DataRow frames the multipooler captured
+// from the backend) and for relaying replication-protocol messages verbatim
+// (see the multigateway replication preamble). Goes through the
+// bufferedWriter if one is attached, otherwise straight to the conn. Mirrors
+// writePacket's write step but skips the startPacket sizing pass, since the
+// bytes are already framed.
+func (c *Conn) WriteRawMessage(raw []byte) error {
 	c.bufMu.Lock()
 	defer c.bufMu.Unlock()
 
 	if c.bufferedWriter != nil {
-		_, err := c.bufferedWriter.Write(block)
+		_, err := c.bufferedWriter.Write(raw)
 		return err
 	}
-	_, err := c.conn.Write(block)
+	_, err := c.conn.Write(raw)
 	return err
 }
 

--- a/go/common/pgprotocol/server/packet_test.go
+++ b/go/common/pgprotocol/server/packet_test.go
@@ -145,6 +145,38 @@ func TestConnWriteAndReadMessage(t *testing.T) {
 	assert.Equal(t, body, readBody)
 }
 
+// TestReadMessageBody verifies the generic cross-package message-body reader:
+// a known-length body reads back exactly, a zero length reads nothing, a
+// negative length is rejected, and EOF mid-read is surfaced.
+func TestReadMessageBody(t *testing.T) {
+	t.Run("reads a known-length body", func(t *testing.T) {
+		conn := &Conn{bufferedReader: bufio.NewReader(bytes.NewReader([]byte("hello world")))}
+		body, err := conn.ReadMessageBody(11)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("hello world"), body)
+	})
+
+	t.Run("zero length returns nil", func(t *testing.T) {
+		conn := &Conn{bufferedReader: bufio.NewReader(bytes.NewReader(nil))}
+		body, err := conn.ReadMessageBody(0)
+		require.NoError(t, err)
+		assert.Nil(t, body)
+	})
+
+	t.Run("negative length is rejected", func(t *testing.T) {
+		conn := &Conn{bufferedReader: bufio.NewReader(bytes.NewReader(nil))}
+		_, err := conn.ReadMessageBody(-1)
+		assert.ErrorContains(t, err, "invalid message length")
+	})
+
+	t.Run("EOF mid-read is surfaced", func(t *testing.T) {
+		conn := &Conn{bufferedReader: bufio.NewReader(bytes.NewReader([]byte("short")))}
+		_, err := conn.ReadMessageBody(10)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to read message body")
+	})
+}
+
 // TestWritePacketSizeMismatchPanics verifies that writePacket panics
 // when the encoded byte count doesn't match the bodyLen passed to
 // startPacket — the safety net that catches sizing-arithmetic bugs in

--- a/go/common/pgprotocol/server/query.go
+++ b/go/common/pgprotocol/server/query.go
@@ -57,6 +57,26 @@ func (c *Conn) readQueryMessage() (string, error) {
 	return string(queryBytes[:len(queryBytes)-1]), nil
 }
 
+// ReadMessageBody reads a message body of the given length (as returned by
+// ReadMessageLength) from the connection. Exported for callers (e.g. the
+// replication-protocol preamble) that need to read an arbitrary frontend
+// message generically, not just Query/CopyData. Mirrors ReadCopyDataMessage's
+// plain-read shape — no buffer-pool interaction, so it's safe to call
+// cross-package without a matching release call.
+func (c *Conn) ReadMessageBody(length int) ([]byte, error) {
+	if length < 0 {
+		return nil, fmt.Errorf("invalid message length: %d", length)
+	}
+	if length == 0 {
+		return nil, nil
+	}
+	data := make([]byte, length)
+	if _, err := io.ReadFull(c.bufferedReader, data); err != nil {
+		return nil, fmt.Errorf("failed to read message body: %w", err)
+	}
+	return data, nil
+}
+
 // writeParameterDescription writes a 't' (ParameterDescription) message.
 // Format:
 //   - Type: 't'
@@ -143,7 +163,7 @@ func (c *Conn) writeDataRow(row *sqltypes.Row) error {
 // the multipooler), otherwise each structured row as its own DataRow frame.
 func (c *Conn) writeResultRows(result *sqltypes.Result) error {
 	if result.PassthroughBlock != nil {
-		if err := c.writeRawDataBlock(result.PassthroughBlock); err != nil {
+		if err := c.WriteRawMessage(result.PassthroughBlock); err != nil {
 			return fmt.Errorf("writing raw data block: %w", err)
 		}
 		return nil

--- a/go/common/pgprotocol/server/rawblock_test.go
+++ b/go/common/pgprotocol/server/rawblock_test.go
@@ -25,18 +25,18 @@ import (
 	"github.com/multigres/multigres/go/common/sqltypes"
 )
 
-// TestWriteRawDataBlock verifies the opaque passthrough write path emits the
+// TestWriteRawMessage verifies the opaque passthrough write path emits the
 // pre-framed DataRow block to the client verbatim, through both the buffered
 // writer (the normal path) and the direct connection fallback.
-func TestWriteRawDataBlock(t *testing.T) {
+func TestWriteRawMessage(t *testing.T) {
 	// block is two already-framed DataRow messages, as the multipooler forwards
-	// them; writeRawDataBlock must write the bytes unchanged.
+	// them; WriteRawMessage must write the bytes unchanged.
 	block := []byte("D\x00\x00\x00\x0bhelloD\x00\x00\x00\x0bworld")
 
 	t.Run("buffered writer", func(t *testing.T) {
 		var buf bytes.Buffer
 		c := &Conn{bufferedWriter: bufio.NewWriter(&buf)}
-		require.NoError(t, c.writeRawDataBlock(block))
+		require.NoError(t, c.WriteRawMessage(block))
 		require.NoError(t, c.bufferedWriter.Flush())
 		assert.Equal(t, block, buf.Bytes())
 	})
@@ -44,7 +44,7 @@ func TestWriteRawDataBlock(t *testing.T) {
 	t.Run("direct connection", func(t *testing.T) {
 		var buf bytes.Buffer
 		c := &Conn{conn: &mockNetConn{buf: &buf}} // bufferedWriter nil -> conn.Write
-		require.NoError(t, c.writeRawDataBlock(block))
+		require.NoError(t, c.WriteRawMessage(block))
 		assert.Equal(t, block, buf.Bytes())
 	})
 }

--- a/go/services/multigateway/handler/replication_copy_relay.go
+++ b/go/services/multigateway/handler/replication_copy_relay.go
@@ -1,0 +1,222 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"errors"
+	"io"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+)
+
+// errReplicationSessionResumed is returned by copyModeDownstreamReader once
+// a ReadyForQuery message has been fully relayed to the client: postgres has
+// returned to normal command mode after the COPY session ended. Multigres
+// does not support resuming command mode on a replication connection — a
+// survey of the most widely used open-source software that consumes
+// PostgreSQL logical replication found none that do this either — so
+// seeing this signals the caller to tear the connection down rather than
+// continue relaying.
+var errReplicationSessionResumed = errors.New("replication session returned to command mode; connection reuse is not supported")
+
+// copyModeDownstreamReader relays postgres's responses to the client during
+// an active COPY-BOTH replication session. Its next() method matches the
+// RecvFunc shape (commonrepl.RecvFunc) so it plugs directly into the
+// existing, unmodified commonrepl.Tunnel — see replication_stream.go.
+//
+// CopyData bodies are never accumulated further than what's already been
+// delivered: logical replication's CopyData frames are not size-bounded (a
+// single large row change can be one multi-megabyte frame), so waiting for
+// a whole frame before forwarding any of it would spike memory and add real
+// latency versus today's incremental byte-blind relay. A next() call
+// returns whatever's already buffered for
+// the current frame (header plus as much of the body as has already
+// arrived — all of it, if it arrived together) and never blocks on
+// recv() for more just to fill out the rest of the body; any remaining
+// body bytes are relayed as later recv() calls deliver them. Every other
+// message type is small (control messages: CommandComplete, ErrorResponse,
+// NoticeResponse, ParameterStatus, ReadyForQuery, ...) and is buffered
+// whole, same as pgMsgReader already does for the preamble.
+type copyModeDownstreamReader struct {
+	recv func() ([]byte, error)
+	buf  []byte // unconsumed bytes not yet classified into a message
+
+	passthroughRemaining int // bytes left in the in-flight CopyData body to relay verbatim
+}
+
+// next returns the next chunk to forward to the client. Matches
+// commonrepl.RecvFunc: a non-nil error means no more chunks will come, but
+// any returned bytes must still be forwarded first (mirrors io.Reader's
+// "process n>0 before considering err" contract, which the underlying
+// recv()/net.Conn read already honors).
+func (r *copyModeDownstreamReader) next() ([]byte, error) {
+	if r.passthroughRemaining > 0 {
+		return r.readPassthrough()
+	}
+	return r.readNextMessage()
+}
+
+// readPassthrough returns up to passthroughRemaining bytes of an in-flight
+// CopyData body, pulling more from recv() only once buf is empty. Never
+// accumulates the whole body — just relays whatever's already available,
+// bounded by what's left to deliver for this message. If recv() returns
+// bytes alongside a terminal error (e.g. io.EOF), those bytes are used now;
+// the error resurfaces on a later call once recv() is asked again and
+// returns nothing.
+func (r *copyModeDownstreamReader) readPassthrough() ([]byte, error) {
+	if len(r.buf) == 0 {
+		chunk, err := r.recv()
+		if len(chunk) == 0 {
+			return nil, err
+		}
+		r.buf = chunk
+	}
+	n := min(len(r.buf), r.passthroughRemaining)
+	out := r.buf[:n]
+	r.buf = r.buf[n:]
+	r.passthroughRemaining -= n
+	return out, nil
+}
+
+// readNextMessage reassembles the next message's 5-byte header, then either
+// returns the CopyData header plus whatever body bytes are already
+// buffered (deferring any remainder to readPassthrough as it arrives), or
+// fully buffers a control message's small body and classifies it.
+func (r *copyModeDownstreamReader) readNextMessage() ([]byte, error) {
+	if err := r.ensureBuffered(5); err != nil {
+		return nil, err
+	}
+	msgType, bodyLen, err := parsePgMessageHeader(r.buf[:5], "backend")
+	if err != nil {
+		return nil, err
+	}
+
+	if msgType == protocol.MsgCopyData {
+		// Forward the header plus however much of the body is already
+		// sitting in buf (possibly none, possibly all of it) in a single
+		// chunk — no reason to artificially split bytes we already have.
+		// Whatever's left (if any) is relayed via readPassthrough as
+		// later recv() calls deliver it.
+		bodyAvail := min(bodyLen, len(r.buf)-5)
+		total := 5 + bodyAvail
+		raw := append([]byte(nil), r.buf[:total]...)
+		r.buf = r.buf[total:]
+		r.passthroughRemaining = bodyLen - bodyAvail
+		return raw, nil
+	}
+
+	total := 5 + bodyLen
+	if err := r.ensureBuffered(total); err != nil {
+		return nil, err
+	}
+	raw := append([]byte(nil), r.buf[:total]...)
+	r.buf = r.buf[total:]
+	if msgType == protocol.MsgReadyForQuery {
+		return raw, errReplicationSessionResumed
+	}
+	return raw, nil
+}
+
+// ensureBuffered pulls chunks from recv() until r.buf holds at least n
+// bytes. See the package-level ensureBuffered for the byte-before-error
+// contract this honors.
+func (r *copyModeDownstreamReader) ensureBuffered(n int) error {
+	return ensureBuffered(&r.buf, r.recv, n)
+}
+
+// errReplicationSessionEndedByClient is returned by copyModeUpstreamReader
+// once a non-CopyData message (CopyDone, CopyFail, or — defensively —
+// anything else) has been fully relayed: the client is exiting the COPY
+// session. Multigres forwards that message (postgres needs to see it to end
+// its own WalSndLoop cleanly) but never relays anything the client sends
+// afterward, closing the pipelining loophole where a client sends a
+// follow-up command in the same write as CopyDone without waiting for a
+// reply.
+var errReplicationSessionEndedByClient = errors.New("client ended the replication COPY session; connection reuse is not supported")
+
+// copyModeUpstreamReader wraps the detached client socket and implements
+// io.Reader, forwarding CopyData/CopyDone/CopyFail messages to the pooler
+// stream during an active COPY-BOTH replication session. Client-sent
+// messages are always small (StandbyStatusUpdate, HotStandbyFeedback,
+// CopyDone, CopyFail — never large payloads), so unlike
+// copyModeDownstreamReader this always buffers a whole message before
+// returning it; no streaming passthrough is needed on this side.
+type copyModeUpstreamReader struct {
+	src     io.Reader
+	buf     []byte     // unread bytes from src, not yet classified into a message
+	pending []byte     // current message's bytes not yet copied out via Read
+	err     error      // sticky terminal error, delivered once pending is drained
+	scratch [4096]byte // reused read buffer for ensureBuffered; contents never need to survive past a single call
+}
+
+func newCopyModeUpstreamReader(src io.Reader) *copyModeUpstreamReader {
+	return &copyModeUpstreamReader{src: src}
+}
+
+// Read implements io.Reader. Once a non-CopyData message has been fully
+// delivered, every subsequent call returns errReplicationSessionEndedByClient
+// without reading anything further from src — so bytes already sitting in
+// src's buffer (a pipelined follow-up command) are never even inspected,
+// let alone forwarded.
+func (r *copyModeUpstreamReader) Read(p []byte) (int, error) {
+	if len(r.pending) == 0 {
+		if r.err != nil {
+			return 0, r.err
+		}
+		if err := r.fillPending(); err != nil {
+			return 0, err
+		}
+	}
+	n := copy(p, r.pending)
+	r.pending = r.pending[n:]
+	if len(r.pending) == 0 && r.err != nil {
+		return n, r.err
+	}
+	return n, nil
+}
+
+// fillPending reassembles exactly one complete frontend message into
+// r.pending, and sets r.err (delivered once r.pending is fully copied out)
+// if that message signals the end of the COPY session.
+func (r *copyModeUpstreamReader) fillPending() error {
+	if err := r.ensureBuffered(5); err != nil {
+		return err
+	}
+	msgType, bodyLen, err := parsePgMessageHeader(r.buf[:5], "frontend")
+	if err != nil {
+		return err
+	}
+	total := 5 + bodyLen
+	if err := r.ensureBuffered(total); err != nil {
+		return err
+	}
+	r.pending = append([]byte(nil), r.buf[:total]...)
+	r.buf = r.buf[total:]
+	if msgType != protocol.MsgCopyData {
+		r.err = errReplicationSessionEndedByClient
+	}
+	return nil
+}
+
+// ensureBuffered pulls from src until r.buf holds at least n bytes. See the
+// package-level ensureBuffered for the byte-before-error contract this
+// honors; src.Read is adapted to that shape via scratch, which is reused
+// across calls rather than allocated fresh each time.
+func (r *copyModeUpstreamReader) ensureBuffered(n int) error {
+	return ensureBuffered(&r.buf, func() ([]byte, error) {
+		rn, err := r.src.Read(r.scratch[:])
+		return r.scratch[:rn], err
+	}, n)
+}

--- a/go/services/multigateway/handler/replication_copy_relay_test.go
+++ b/go/services/multigateway/handler/replication_copy_relay_test.go
@@ -1,0 +1,327 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+)
+
+// chunkQueue is a recv-shaped fake: each call pops the next scripted chunk,
+// returning io.EOF once exhausted (unless overridden per-test).
+type chunkQueue struct {
+	chunks [][]byte
+	idx    int
+	atEnd  error // returned once chunks is exhausted; defaults to io.EOF
+}
+
+func (q *chunkQueue) recv() ([]byte, error) {
+	if q.idx >= len(q.chunks) {
+		if q.atEnd != nil {
+			return nil, q.atEnd
+		}
+		return nil, io.EOF
+	}
+	c := q.chunks[q.idx]
+	q.idx++
+	return c, nil
+}
+
+func TestCopyModeDownstreamReader_RelaysCopyDataIncrementally(t *testing.T) {
+	// A CopyData frame whose body arrives split across three chunks: the
+	// reader must return each chunk as soon as it's available, never
+	// buffering the whole body first.
+	body := []byte("0123456789") // 10 bytes
+	header := frameMessage(protocol.MsgCopyData, body)[:5]
+	q := &chunkQueue{chunks: [][]byte{
+		header,
+		body[:4],
+		body[4:7],
+		body[7:],
+	}}
+	r := &copyModeDownstreamReader{recv: q.recv}
+
+	got1, err := r.next()
+	require.NoError(t, err)
+	assert.Equal(t, header, got1, "header returned on its own, before any body bytes arrive")
+
+	got2, err := r.next()
+	require.NoError(t, err)
+	assert.Equal(t, body[:4], got2)
+
+	got3, err := r.next()
+	require.NoError(t, err)
+	assert.Equal(t, body[4:7], got3)
+
+	got4, err := r.next()
+	require.NoError(t, err)
+	assert.Equal(t, body[7:], got4)
+}
+
+func TestCopyModeDownstreamReader_RelaysCopyDataAcrossMultipleFrames(t *testing.T) {
+	frame1 := frameMessage(protocol.MsgCopyData, []byte("frame-one"))
+	frame2 := frameMessage(protocol.MsgCopyData, []byte("frame-two"))
+	q := &chunkQueue{chunks: [][]byte{append(append([]byte(nil), frame1...), frame2...)}}
+	r := &copyModeDownstreamReader{recv: q.recv}
+
+	got1, err := r.next()
+	require.NoError(t, err)
+	assert.Equal(t, frame1, got1, "first frame's header+full body returned in one call since both were already buffered")
+
+	got2, err := r.next()
+	require.NoError(t, err)
+	assert.Equal(t, frame2, got2)
+}
+
+func TestCopyModeDownstreamReader_PassesThroughSmallControlMessages(t *testing.T) {
+	commandComplete := frameMessage(protocol.MsgCommandComplete, []byte("COPY 0\x00"))
+	q := &chunkQueue{chunks: [][]byte{commandComplete}}
+	r := &copyModeDownstreamReader{recv: q.recv}
+
+	got, err := r.next()
+	require.NoError(t, err)
+	assert.Equal(t, commandComplete, got)
+}
+
+func TestCopyModeDownstreamReader_ReadyForQuerySignalsSessionResumed(t *testing.T) {
+	readyForQuery := frameMessage(protocol.MsgReadyForQuery, []byte{'I'})
+	q := &chunkQueue{chunks: [][]byte{readyForQuery}}
+	r := &copyModeDownstreamReader{recv: q.recv}
+
+	got, err := r.next()
+	assert.Equal(t, readyForQuery, got, "ReadyForQuery bytes must still be forwarded to the client")
+	require.ErrorIs(t, err, errReplicationSessionResumed)
+}
+
+func TestCopyModeDownstreamReader_HeaderSplitAcrossChunks(t *testing.T) {
+	readyForQuery := frameMessage(protocol.MsgReadyForQuery, []byte{'I'})
+	q := &chunkQueue{chunks: [][]byte{readyForQuery[:2], readyForQuery[2:4], readyForQuery[4:]}}
+	r := &copyModeDownstreamReader{recv: q.recv}
+
+	got, err := r.next()
+	assert.Equal(t, readyForQuery, got)
+	require.ErrorIs(t, err, errReplicationSessionResumed)
+}
+
+func TestCopyModeDownstreamReader_BytesDeliveredBeforeUnderlyingEOF(t *testing.T) {
+	// Regression: a recv() call can return (n>0 bytes, io.EOF) in the same
+	// call (matches io.Reader's documented contract for the underlying
+	// net.Conn/gRPC stream read). Those bytes must still be used/returned,
+	// not discarded because an error also came back.
+	readyForQuery := frameMessage(protocol.MsgReadyForQuery, []byte{'I'})
+	callCount := 0
+	recv := func() ([]byte, error) {
+		callCount++
+		if callCount == 1 {
+			return readyForQuery, io.EOF // whole message plus EOF in one call
+		}
+		return nil, io.EOF
+	}
+	r := &copyModeDownstreamReader{recv: recv}
+
+	got, err := r.next()
+	assert.Equal(t, readyForQuery, got, "the message bytes must be used even though EOF arrived alongside them")
+	require.ErrorIs(t, err, errReplicationSessionResumed)
+}
+
+func TestCopyModeDownstreamReader_PassthroughBytesDeliveredBeforeUnderlyingEOF(t *testing.T) {
+	// Same "bytes must be used even though an error arrived alongside them"
+	// contract as TestCopyModeDownstreamReader_BytesDeliveredBeforeUnderlyingEOF,
+	// but exercised mid-CopyData-body via readPassthrough rather than at a
+	// message boundary via ensureBuffered: readPassthrough is the path that
+	// handles large CopyData bodies, the whole reason this reader exists, so
+	// it needs its own coverage of a recv() call returning (n>0 bytes, io.EOF)
+	// together while more body is still expected.
+	body := []byte("0123456789") // 10 bytes; only 6 arrive before EOF
+	header := frameMessage(protocol.MsgCopyData, body)[:5]
+	callCount := 0
+	recv := func() ([]byte, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			return header, nil
+		case 2:
+			return body[:6], io.EOF // partial body plus EOF in one call
+		default:
+			return nil, io.EOF
+		}
+	}
+	r := &copyModeDownstreamReader{recv: recv}
+
+	got1, err := r.next()
+	require.NoError(t, err)
+	assert.Equal(t, header, got1, "header returned on its own, before any body bytes arrive")
+
+	got2, err := r.next()
+	require.NoError(t, err, "the partial body bytes must be used even though EOF arrived alongside them")
+	assert.Equal(t, body[:6], got2)
+
+	_, err = r.next()
+	assert.ErrorIs(t, err, io.EOF, "the EOF resurfaces once recv() is asked again with nothing left to deliver")
+}
+
+func TestCopyModeDownstreamReader_MalformedLengthRejected(t *testing.T) {
+	malformed := []byte{protocol.MsgReadyForQuery, 0x00, 0x00, 0x00, 0x02}
+	q := &chunkQueue{chunks: [][]byte{malformed}}
+	r := &copyModeDownstreamReader{recv: q.recv}
+
+	_, err := r.next()
+	assert.ErrorContains(t, err, "invalid backend message length")
+}
+
+func TestCopyModeDownstreamReader_UnderlyingRecvErrorPropagates(t *testing.T) {
+	wantErr := errors.New("stream broke")
+	q := &chunkQueue{atEnd: wantErr}
+	r := &copyModeDownstreamReader{recv: q.recv}
+
+	_, err := r.next()
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// fixedReader serves bytes from a queue of chunks via io.Reader, one chunk
+// per Read() call regardless of len(p) (so tests can force multi-call
+// reassembly), returning io.EOF once exhausted.
+type fixedReader struct {
+	chunks [][]byte
+	idx    int
+}
+
+func (f *fixedReader) Read(p []byte) (int, error) {
+	if f.idx >= len(f.chunks) {
+		return 0, io.EOF
+	}
+	c := f.chunks[f.idx]
+	f.idx++
+	n := copy(p, c)
+	if n < len(c) {
+		panic("fixedReader test fixture: p too small for chunk")
+	}
+	return n, nil
+}
+
+func TestCopyModeUpstreamReader_RelaysCopyDataUnchanged(t *testing.T) {
+	frame := frameMessage(protocol.MsgCopyData, []byte("standby-status-update"))
+	r := newCopyModeUpstreamReader(&fixedReader{chunks: [][]byte{frame}})
+
+	got := make([]byte, len(frame))
+	n, err := io.ReadFull(r, got)
+	require.NoError(t, err)
+	assert.Equal(t, frame, got[:n])
+}
+
+func TestCopyModeUpstreamReader_CopyDoneForwardedThenTerminates(t *testing.T) {
+	copyDone := frameMessage(protocol.MsgCopyDone, nil)
+	r := newCopyModeUpstreamReader(&fixedReader{chunks: [][]byte{copyDone}})
+
+	got := make([]byte, len(copyDone))
+	n, err := io.ReadFull(r, got)
+	require.NoError(t, err, "CopyDone bytes themselves must be delivered")
+	assert.Equal(t, copyDone, got[:n])
+
+	_, err = r.Read(make([]byte, 16))
+	require.ErrorIs(t, err, errReplicationSessionEndedByClient)
+}
+
+func TestCopyModeUpstreamReader_PipelinedMessageAfterCopyDoneNeverDelivered(t *testing.T) {
+	copyDone := frameMessage(protocol.MsgCopyDone, nil)
+	bogus := frameMessage(protocol.MsgQuery, append([]byte("CREATE_REPLICATION_SLOT s LOGICAL pgoutput"), 0))
+	// Both arrive in a single underlying chunk, simulating a client that
+	// pipelines a follow-up command immediately after CopyDone without
+	// waiting for any reply.
+	combined := append(append([]byte(nil), copyDone...), bogus...)
+	r := newCopyModeUpstreamReader(&fixedReader{chunks: [][]byte{combined}})
+
+	got := make([]byte, len(copyDone))
+	n, err := io.ReadFull(r, got)
+	require.NoError(t, err)
+	assert.Equal(t, copyDone, got[:n])
+
+	n2, err := r.Read(make([]byte, 4096))
+	assert.Equal(t, 0, n2, "the pipelined bogus message must never be delivered")
+	require.ErrorIs(t, err, errReplicationSessionEndedByClient)
+}
+
+func TestCopyModeUpstreamReader_CopyFailTerminates(t *testing.T) {
+	copyFail := frameMessage(protocol.MsgCopyFail, append([]byte("client gave up"), 0))
+	r := newCopyModeUpstreamReader(&fixedReader{chunks: [][]byte{copyFail}})
+
+	got := make([]byte, len(copyFail))
+	n, err := io.ReadFull(r, got)
+	require.NoError(t, err)
+	assert.Equal(t, copyFail, got[:n])
+
+	_, err = r.Read(make([]byte, 16))
+	require.ErrorIs(t, err, errReplicationSessionEndedByClient)
+}
+
+func TestCopyModeUpstreamReader_MessageSplitAcrossSmallReadBuffer(t *testing.T) {
+	frame := frameMessage(protocol.MsgCopyData, []byte("a somewhat longer standby status payload"))
+	r := newCopyModeUpstreamReader(&fixedReader{chunks: [][]byte{frame}})
+
+	var got []byte
+	small := make([]byte, 4) // force multiple Read() calls to drain one message
+	for len(got) < len(frame) {
+		n, err := r.Read(small)
+		got = append(got, small[:n]...)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, frame, got)
+}
+
+func TestCopyModeUpstreamReader_HeaderSplitAcrossUnderlyingReads(t *testing.T) {
+	copyDone := frameMessage(protocol.MsgCopyDone, nil) // 5 bytes, header only
+	r := newCopyModeUpstreamReader(&fixedReader{chunks: [][]byte{copyDone[:2], copyDone[2:4], copyDone[4:]}})
+
+	got := make([]byte, len(copyDone))
+	n, err := io.ReadFull(r, got)
+	require.NoError(t, err)
+	assert.Equal(t, copyDone, got[:n])
+
+	_, err = r.Read(make([]byte, 16))
+	require.ErrorIs(t, err, errReplicationSessionEndedByClient)
+}
+
+func TestCopyModeUpstreamReader_MalformedLengthRejected(t *testing.T) {
+	malformed := []byte{protocol.MsgQuery, 0x00, 0x00, 0x00, 0x02}
+	r := newCopyModeUpstreamReader(&fixedReader{chunks: [][]byte{malformed}})
+
+	_, err := r.Read(make([]byte, 16))
+	assert.ErrorContains(t, err, "invalid frontend message length")
+}
+
+// erroringReader is an io.Reader fake that always returns a fixed, non-EOF
+// error, mirroring chunkQueue's atEnd used by
+// TestCopyModeDownstreamReader_UnderlyingRecvErrorPropagates.
+type erroringReader struct {
+	err error
+}
+
+func (r *erroringReader) Read(p []byte) (int, error) {
+	return 0, r.err
+}
+
+func TestCopyModeUpstreamReader_UnderlyingReadErrorPropagates(t *testing.T) {
+	wantErr := errors.New("stream broke")
+	r := newCopyModeUpstreamReader(&erroringReader{err: wantErr})
+
+	_, err := r.Read(make([]byte, 16))
+	assert.ErrorIs(t, err, wantErr)
+}

--- a/go/services/multigateway/handler/replication_framing.go
+++ b/go/services/multigateway/handler/replication_framing.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// parsePgMessageHeader interprets a 5-byte PostgreSQL wire message header —
+// a 1-byte type plus a 4-byte big-endian length that includes itself but
+// excludes the type byte — returning the message type and body length.
+// label distinguishes "backend"/"frontend" in the returned error so callers
+// don't lose that context. Shared by pgMsgReader, copyModeDownstreamReader,
+// and copyModeUpstreamReader: all three frame the same wire format, just
+// from different sources (a gRPC recv func vs. a detached client socket).
+func parsePgMessageHeader(header []byte, label string) (msgType byte, bodyLen int, err error) {
+	length := binary.BigEndian.Uint32(header[1:5])
+	if length < 4 {
+		return 0, 0, fmt.Errorf("invalid %s message length: %d", label, length)
+	}
+	return header[0], int(length) - 4, nil
+}
+
+// ensureBuffered pulls chunks from recv into *buf until it holds at least n
+// bytes, or a terminal error occurs. Bytes returned alongside a non-nil
+// error are appended before the error is surfaced, matching io.Reader's
+// documented contract for the underlying stream (a final read can both
+// deliver data and signal EOF) — shared so every reader in this package
+// honors that contract the same way instead of each hand-rolling its own
+// accumulation loop.
+func ensureBuffered(buf *[]byte, recv func() ([]byte, error), n int) error {
+	for len(*buf) < n {
+		chunk, err := recv()
+		if len(chunk) > 0 {
+			*buf = append(*buf, chunk...)
+		}
+		if len(*buf) >= n {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/go/services/multigateway/handler/replication_preamble.go
+++ b/go/services/multigateway/handler/replication_preamble.go
@@ -1,0 +1,250 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
+	multipoolerservice "github.com/multigres/multigres/go/pb/multipoolerservice"
+)
+
+// pgMsgReader reassembles complete PostgreSQL protocol messages (frontend
+// or backend — both share the same 1-byte type + 4-byte length + body wire
+// framing) from the opaque byte chunks a chunk-returning source produces.
+// Those chunks are NOT message-aligned — a chunk can hold a partial
+// message, a whole message, or several.
+type pgMsgReader struct {
+	recv func() ([]byte, error)
+	buf  []byte // leftover bytes from prior recv() calls, not yet consumed
+}
+
+// next reads one complete backend message and returns its type byte and the
+// exact raw wire bytes (header + body), so the caller can forward them to
+// the client verbatim without re-serializing.
+func (r *pgMsgReader) next() (msgType byte, raw []byte, err error) {
+	if err := ensureBuffered(&r.buf, r.recv, 5); err != nil {
+		return 0, nil, err
+	}
+	msgType, bodyLen, err := parsePgMessageHeader(r.buf[:5], "backend")
+	if err != nil {
+		return 0, nil, err
+	}
+	total := 5 + bodyLen
+	if err := ensureBuffered(&r.buf, r.recv, total); err != nil {
+		return 0, nil, err
+	}
+	raw = append([]byte(nil), r.buf[:total]...)
+	r.buf = r.buf[total:]
+	return msgType, raw, nil
+}
+
+// rawClientMessage reconstructs the exact wire bytes (5-byte header + body)
+// of a frontend message whose type/length/body have already been read off
+// conn individually.
+func rawClientMessage(msgType byte, bodyLen int, body []byte) []byte {
+	raw := make([]byte, 5+bodyLen)
+	raw[0] = msgType
+	binary.BigEndian.PutUint32(raw[1:5], uint32(bodyLen+4))
+	copy(raw[5:], body)
+	return raw
+}
+
+// parseNullTerminatedString extracts a null-terminated string from a Query
+// message body, PostgreSQL wire-protocol convention. Returns false if body
+// is not null-terminated (malformed message — let the pooler/postgres reject
+// it rather than guessing).
+func parseNullTerminatedString(body []byte) (string, bool) {
+	if len(body) == 0 || body[len(body)-1] != 0 {
+		return "", false
+	}
+	return string(body[:len(body)-1]), true
+}
+
+// runReplicationPreamble relays the replication-protocol command/response
+// cycles (IDENTIFY_SYSTEM, CREATE_REPLICATION_SLOT, START_REPLICATION, ...)
+// message-by-message between the client and the pooler stream, inspecting
+// only CREATE_REPLICATION_SLOT to reject non-TEMPORARY slot requests before
+// they ever reach the pooler/postgres. Once streaming begins (a
+// CopyBothResponse is observed), it returns so the caller can hand off to the
+// byte-blind commonrepl.Tunnel for the remainder of the connection's life.
+//
+// Real replication clients block waiting for each command's reply before
+// deciding what to send next (e.g. IDENTIFY_SYSTEM before
+// CREATE_REPLICATION_SLOT), so this cannot just peek at the first message —
+// it must relay full request/response cycles until it affirmatively sees
+// streaming begin.
+//
+// Only the simple query protocol is supported here: a replication=database
+// connection technically allows arbitrary SQL in addition to the replication
+// commands, and such SQL could in principle use the extended query protocol
+// (Parse/Bind/Describe/Execute/Close/Flush/Sync). But a survey of the most
+// widely used open-source software that consumes PostgreSQL logical
+// replication — spanning independent implementations across several
+// languages — found none that use the extended query protocol on this
+// connection; several document this as a Postgres-imposed limitation, not
+// just their own choice. Supporting the extended protocol here would mean
+// mirroring postgres's own multi-message-per-command, ignore-till-sync state
+// machine for a case nothing in practice exercises. Anything other than
+// Query is rejected outright instead.
+func runReplicationPreamble(
+	ctx context.Context,
+	conn *server.Conn,
+	stream multipoolerservice.MultipoolerService_StreamReplicationClient,
+) (streaming bool, leftover []byte, err error) {
+	for {
+		// 1. Read one full frontend message off the still-attached client
+		// socket. EOF/Terminate here just means the client left before
+		// streaming started — not an error.
+		msgType, rerr := conn.ReadMessageType()
+		if rerr != nil {
+			if errors.Is(rerr, io.EOF) {
+				return false, nil, nil
+			}
+			return false, nil, rerr
+		}
+		if msgType == protocol.MsgTerminate {
+			return false, nil, nil
+		}
+
+		length, rerr := conn.ReadMessageLength()
+		if rerr != nil {
+			return false, nil, rerr
+		}
+		body, rerr := conn.ReadMessageBody(length)
+		if rerr != nil {
+			return false, nil, rerr
+		}
+
+		// 2. Gate: only simple Query is allowed here (see doc comment above).
+		if msgType != protocol.MsgQuery {
+			rejectErr := unsupportedPreambleMessageError(msgType)
+			if werr := conn.WriteError(rejectErr); werr != nil {
+				return false, nil, werr
+			}
+			return false, nil, rejectErr
+		}
+
+		// 3. Inspect the query text for a non-TEMPORARY CREATE_REPLICATION_SLOT
+		// and reject it before the pooler/postgres ever see it.
+		if cmd, ok := parseNullTerminatedString(body); ok {
+			if rejectErr := nonTemporaryCreateReplicationSlotError(cmd); rejectErr != nil {
+				// The pooler/postgres never see the rejected command.
+				if werr := conn.WriteError(rejectErr); werr != nil {
+					return false, nil, werr
+				}
+				return false, nil, rejectErr
+			}
+		}
+
+		// 4. Forward the (accepted) command to the pooler's replication stream
+		// verbatim.
+		raw := rawClientMessage(msgType, length, body)
+		if serr := stream.Send(&multipoolerservice.StreamReplicationRequest{
+			Msg: &multipoolerservice.StreamReplicationRequest_Data{Data: raw},
+		}); serr != nil {
+			return false, nil, serr
+		}
+
+		// 5. Relay the pooler's response(s) back to the client message-by-
+		// message until the command cycle resolves.
+		reader := &pgMsgReader{recv: func() ([]byte, error) {
+			resp, rerr := stream.Recv()
+			if rerr != nil {
+				return nil, rerr
+			}
+			if e := resp.GetError(); e != nil {
+				if diag := e.GetDiagnostic(); diag != nil {
+					return nil, mterrors.PgDiagnosticFromProto(diag)
+				}
+				return nil, mterrors.New(mtrpcpb.Code_INTERNAL, "replication stream returned an error without a diagnostic")
+			}
+			return resp.GetData(), nil
+		}}
+
+		for {
+			respType, respRaw, nerr := reader.next()
+			if nerr != nil {
+				return false, nil, nerr
+			}
+			if werr := conn.WriteRawMessage(respRaw); werr != nil {
+				return false, nil, werr
+			}
+			if werr := conn.Flush(); werr != nil {
+				return false, nil, werr
+			}
+			// 6a. Streaming has begun: hand off to the tunnel, carrying over
+			// any bytes already read past this response.
+			if respType == protocol.MsgCopyBothResponse {
+				return true, reader.buf, nil
+			}
+			// 6b. Command cycle done with no streaming yet: go back to step 1
+			// for the client's next command.
+			if respType == protocol.MsgReadyForQuery {
+				break
+			}
+		}
+	}
+}
+
+// unsupportedPreambleMessageError rejects any frontend message other than a
+// simple Query (Terminate is handled separately, unconditionally) arriving
+// before streaming begins. See runReplicationPreamble's doc comment for why
+// the extended query protocol isn't supported here.
+func unsupportedPreambleMessageError(msgType byte) error {
+	return mterrors.NewFeatureNotSupported(
+		fmt.Sprintf("message type %q is not supported on a replication connection before streaming begins: only the simple query protocol is supported here", string(msgType)))
+}
+
+// nonTemporaryCreateReplicationSlotError returns a rejection error if cmd is
+// a CREATE_REPLICATION_SLOT command that does not request a TEMPORARY slot,
+// or nil if cmd is anything else / already requests TEMPORARY. Multigres
+// cannot yet transition a replication slot's position across a primary
+// failover, so only ephemeral (client-lifetime) slots are safe.
+//
+// No grammar exists in this codebase for the replication protocol's command
+// language (see go/common/parser/ast/replication.go — the AST nodes exist
+// but nothing constructs them), so this is deliberately a lightweight
+// tokenizer, not a parser: CREATE_REPLICATION_SLOT slot_name [TEMPORARY]
+// {PHYSICAL|LOGICAL ...} — TEMPORARY, if present, appears between the slot
+// name and the PHYSICAL/LOGICAL keyword, so stop scanning there.
+func nonTemporaryCreateReplicationSlotError(cmd string) error {
+	fields := strings.Fields(cmd)
+	if len(fields) == 0 || !strings.EqualFold(fields[0], "CREATE_REPLICATION_SLOT") {
+		return nil
+	}
+	if len(fields) < 2 {
+		return mterrors.NewNonTemporaryReplicationSlotError("CREATE_REPLICATION_SLOT", "TEMPORARY")
+	}
+	// fields[1] is the slot name — skip it, or a client naming its slot
+	// "temporary" would have that name misread as the keyword.
+	for _, f := range fields[2:] {
+		if strings.EqualFold(f, "TEMPORARY") {
+			return nil
+		}
+		if strings.EqualFold(f, "PHYSICAL") || strings.EqualFold(f, "LOGICAL") {
+			break
+		}
+	}
+	return mterrors.NewNonTemporaryReplicationSlotError("CREATE_REPLICATION_SLOT", "TEMPORARY")
+}

--- a/go/services/multigateway/handler/replication_preamble.go
+++ b/go/services/multigateway/handler/replication_preamble.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 
 	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/parser"
+	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
@@ -146,10 +148,21 @@ func runReplicationPreamble(
 		}
 
 		// 3. Inspect the query text for a non-TEMPORARY CREATE_REPLICATION_SLOT
-		// and reject it before the pooler/postgres ever see it.
+		// (the replication-protocol command form) or a
+		// pg_create_*_replication_slot(...) call with temporary != true (the
+		// SQL form — postgres falls through to its normal SQL executor for
+		// any query on this connection that isn't a recognized replication
+		// command, so this connection can reach that function same as any
+		// other), and reject either before the pooler/postgres ever see it.
 		if cmd, ok := parseNullTerminatedString(body); ok {
 			if rejectErr := nonTemporaryCreateReplicationSlotError(cmd); rejectErr != nil {
 				// The pooler/postgres never see the rejected command.
+				if werr := conn.WriteError(rejectErr); werr != nil {
+					return false, nil, werr
+				}
+				return false, nil, rejectErr
+			}
+			if rejectErr := nonTemporaryReplicationSlotSQLFuncError(cmd); rejectErr != nil {
 				if werr := conn.WriteError(rejectErr); werr != nil {
 					return false, nil, werr
 				}
@@ -247,4 +260,34 @@ func nonTemporaryCreateReplicationSlotError(cmd string) error {
 		}
 	}
 	return mterrors.NewNonTemporaryReplicationSlotError("CREATE_REPLICATION_SLOT", "TEMPORARY")
+}
+
+// nonTemporaryReplicationSlotSQLFuncError returns a rejection error if cmd
+// parses as SQL containing a pg_create_physical_replication_slot/
+// pg_create_logical_replication_slot(...) call whose temporary argument
+// isn't a literal true, or nil otherwise (including when cmd isn't valid
+// SQL at all — e.g. a replication-protocol command like IDENTIFY_SYSTEM or
+// START_REPLICATION, which nonTemporaryCreateReplicationSlotError already
+// handles above and which never parses as SQL).
+//
+// This exists because postgres's walsender falls through to the normal SQL
+// executor for any query on a replication=database connection that isn't a
+// recognized replication command (exec_replication_command returning false
+// in walsender.c) — so a plain `SELECT pg_create_physical_replication_slot(...)`
+// reaches the same function the planner already guards on ordinary
+// connections (go/services/multigateway/planner/unsafe_funccall.go), and
+// must be guarded here too.
+func nonTemporaryReplicationSlotSQLFuncError(cmd string) error {
+	// A parse error means cmd isn't SQL at all — most likely one of the
+	// replication-protocol commands nonTemporaryCreateReplicationSlotError
+	// already handled above. Nothing to check.
+	stmts, err := parser.ParseSQL(cmd)
+	if err == nil {
+		for _, stmt := range stmts {
+			if name, found := ast.FindNonTemporaryReplicationSlotCall(stmt); found {
+				return mterrors.NewNonTemporaryReplicationSlotError(name, "temporary=true")
+			}
+		}
+	}
+	return nil
 }

--- a/go/services/multigateway/handler/replication_preamble_test.go
+++ b/go/services/multigateway/handler/replication_preamble_test.go
@@ -1,0 +1,381 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	multipoolerservice "github.com/multigres/multigres/go/pb/multipoolerservice"
+)
+
+// frameMessage builds a single pgwire message: type byte + 4-byte length
+// (includes itself) + body.
+func frameMessage(msgType byte, body []byte) []byte {
+	raw := make([]byte, 5+len(body))
+	raw[0] = msgType
+	binary.BigEndian.PutUint32(raw[1:5], uint32(4+len(body)))
+	copy(raw[5:], body)
+	return raw
+}
+
+func writeQueryMessage(buf *bytes.Buffer, query string) {
+	body := append([]byte(query), 0)
+	buf.Write(frameMessage(protocol.MsgQuery, body))
+}
+
+// scriptedReplStream is a stream fake that, for each client message the
+// preamble sends, hands back one scripted blob of raw backend-message bytes
+// via a single Recv call. Used to drive runReplicationPreamble through
+// canned command/response cycles without a real pooler.
+type scriptedReplStream struct {
+	ctx       context.Context
+	responses [][]byte
+	sendCount int
+	pending   [][]byte
+	sentRaw   [][]byte
+}
+
+func (s *scriptedReplStream) Send(req *multipoolerservice.StreamReplicationRequest) error {
+	s.sentRaw = append(s.sentRaw, append([]byte(nil), req.GetData()...))
+	if s.sendCount >= len(s.responses) {
+		return errors.New("scriptedReplStream: unexpected Send beyond scripted responses")
+	}
+	s.pending = [][]byte{s.responses[s.sendCount]}
+	s.sendCount++
+	return nil
+}
+
+func (s *scriptedReplStream) Recv() (*multipoolerservice.StreamReplicationResponse, error) {
+	if len(s.pending) == 0 {
+		return nil, io.EOF
+	}
+	chunk := s.pending[0]
+	s.pending = s.pending[1:]
+	return &multipoolerservice.StreamReplicationResponse{
+		Msg: &multipoolerservice.StreamReplicationResponse_Data{Data: chunk},
+	}, nil
+}
+
+func (s *scriptedReplStream) Context() context.Context     { return s.ctx }
+func (s *scriptedReplStream) Header() (metadata.MD, error) { return nil, nil }
+func (s *scriptedReplStream) Trailer() metadata.MD         { return nil }
+func (s *scriptedReplStream) CloseSend() error             { return nil }
+func (s *scriptedReplStream) SendMsg(m any) error          { return nil }
+func (s *scriptedReplStream) RecvMsg(m any) error          { return nil }
+
+// TestPgMsgReaderNext covers message reassembly from opaque byte chunks:
+// a message split across multiple chunks, multiple messages arriving in a
+// single chunk, and EOF interrupting a partial message.
+func TestPgMsgReaderNext(t *testing.T) {
+	t.Run("message split across multiple chunks", func(t *testing.T) {
+		full := frameMessage(protocol.MsgReadyForQuery, []byte{'I'})
+		chunks := [][]byte{full[:2], full[2:4], full[4:]}
+		idx := 0
+		r := &pgMsgReader{recv: func() ([]byte, error) {
+			if idx >= len(chunks) {
+				return nil, io.EOF
+			}
+			c := chunks[idx]
+			idx++
+			return c, nil
+		}}
+		msgType, raw, err := r.next()
+		require.NoError(t, err)
+		assert.Equal(t, byte(protocol.MsgReadyForQuery), msgType)
+		assert.Equal(t, full, raw)
+	})
+
+	t.Run("multiple messages in one chunk", func(t *testing.T) {
+		m1 := frameMessage(protocol.MsgCommandComplete, []byte("TAG\x00"))
+		m2 := frameMessage(protocol.MsgReadyForQuery, []byte{'I'})
+		combined := append(append([]byte(nil), m1...), m2...)
+		called := false
+		r := &pgMsgReader{recv: func() ([]byte, error) {
+			if called {
+				return nil, io.EOF
+			}
+			called = true
+			return combined, nil
+		}}
+
+		msgType1, raw1, err := r.next()
+		require.NoError(t, err)
+		assert.Equal(t, byte(protocol.MsgCommandComplete), msgType1)
+		assert.Equal(t, m1, raw1)
+
+		msgType2, raw2, err := r.next()
+		require.NoError(t, err)
+		assert.Equal(t, byte(protocol.MsgReadyForQuery), msgType2)
+		assert.Equal(t, m2, raw2)
+	})
+
+	t.Run("EOF mid-message", func(t *testing.T) {
+		full := frameMessage(protocol.MsgReadyForQuery, []byte{'I'})
+		partial := full[:3]
+		calls := 0
+		r := &pgMsgReader{recv: func() ([]byte, error) {
+			calls++
+			if calls == 1 {
+				return partial, nil
+			}
+			return nil, io.EOF
+		}}
+		_, _, err := r.next()
+		assert.ErrorIs(t, err, io.EOF)
+	})
+
+	t.Run("length field below the 4-byte minimum is rejected", func(t *testing.T) {
+		// A well-formed length field always includes itself, so the minimum
+		// valid value is 4 (type byte + zero-length body). A corrupt/malformed
+		// frame claiming a smaller length must be rejected rather than
+		// desynchronizing the reader by slicing off fewer bytes than the
+		// 5-byte header already buffered.
+		malformed := []byte{protocol.MsgReadyForQuery, 0x00, 0x00, 0x00, 0x02}
+		called := false
+		r := &pgMsgReader{recv: func() ([]byte, error) {
+			if called {
+				return nil, io.EOF
+			}
+			called = true
+			return malformed, nil
+		}}
+		_, _, err := r.next()
+		assert.ErrorContains(t, err, "invalid backend message length")
+	})
+}
+
+// TestNonTemporaryCreateReplicationSlotError pins the tokenizer's accept/
+// reject decisions: TEMPORARY present anywhere before PHYSICAL/LOGICAL is
+// accepted, absent is rejected, non-CREATE_REPLICATION_SLOT commands always
+// pass through, and TEMPORARY appearing only after the PHYSICAL/LOGICAL
+// boundary does not count.
+func TestNonTemporaryCreateReplicationSlotError(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmd     string
+		wantErr bool
+	}{
+		{"temporary logical accepted", "CREATE_REPLICATION_SLOT s1 TEMPORARY LOGICAL pgoutput", false},
+		{"temporary physical accepted", "CREATE_REPLICATION_SLOT s1 TEMPORARY PHYSICAL", false},
+		{"non-temporary logical rejected", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput", true},
+		{"non-temporary physical rejected", "CREATE_REPLICATION_SLOT s1 PHYSICAL", true},
+		{"case-insensitive command name", "create_replication_slot s1 temporary logical pgoutput", false},
+		{"case-insensitive temporary keyword", "CREATE_REPLICATION_SLOT s1 TEMPORARY logical pgoutput", false},
+		{"temporary after physical/logical boundary does not count", "CREATE_REPLICATION_SLOT s1 PHYSICAL TEMPORARY", true},
+		{"non-CREATE_REPLICATION_SLOT command passes through", "IDENTIFY_SYSTEM", false},
+		{"START_REPLICATION passes through", "START_REPLICATION SLOT s1 LOGICAL 0/0", false},
+		{"empty command", "", false},
+		// Regression: the slot name itself must never be mistaken for the
+		// TEMPORARY keyword — a non-temporary slot named "temporary" must
+		// still be rejected, and a genuinely temporary slot named "temporary"
+		// must still be accepted.
+		{"slot named 'temporary', non-temporary, rejected", "CREATE_REPLICATION_SLOT temporary PHYSICAL", true},
+		{"slot named 'temporary', actually temporary, accepted", "CREATE_REPLICATION_SLOT temporary TEMPORARY PHYSICAL", false},
+		{"slot named 'logical', non-temporary, rejected", "CREATE_REPLICATION_SLOT logical LOGICAL pgoutput", true},
+		{"slot named 'logical', actually temporary, accepted", "CREATE_REPLICATION_SLOT logical TEMPORARY LOGICAL pgoutput", false},
+		{"malformed: no slot name", "CREATE_REPLICATION_SLOT", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := nonTemporaryCreateReplicationSlotError(tt.cmd)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "requires TEMPORARY")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestRunReplicationPreamble_HappyPath drives IDENTIFY_SYSTEM ->
+// CREATE_REPLICATION_SLOT TEMPORARY -> START_REPLICATION through the
+// preamble and confirms every byte is relayed verbatim in both directions
+// until CopyBothResponse is observed, at which point the preamble reports
+// streaming=true.
+func TestRunReplicationPreamble_HappyPath(t *testing.T) {
+	var clientInput bytes.Buffer
+	writeQueryMessage(&clientInput, "IDENTIFY_SYSTEM")
+	writeQueryMessage(&clientInput, "CREATE_REPLICATION_SLOT s1 TEMPORARY LOGICAL pgoutput")
+	writeQueryMessage(&clientInput, "START_REPLICATION SLOT s1 LOGICAL 0/0")
+
+	identifyResp := bytes.Join([][]byte{
+		frameMessage(protocol.MsgRowDescription, []byte("rowdesc1")),
+		frameMessage(protocol.MsgDataRow, []byte("datarow1")),
+		frameMessage(protocol.MsgCommandComplete, []byte("IDENTIFY_SYSTEM\x00")),
+		frameMessage(protocol.MsgReadyForQuery, []byte{'I'}),
+	}, nil)
+	createSlotResp := bytes.Join([][]byte{
+		frameMessage(protocol.MsgRowDescription, []byte("rowdesc2")),
+		frameMessage(protocol.MsgDataRow, []byte("datarow2")),
+		frameMessage(protocol.MsgCommandComplete, []byte("CREATE_REPLICATION_SLOT\x00")),
+		frameMessage(protocol.MsgReadyForQuery, []byte{'I'}),
+	}, nil)
+	startReplResp := frameMessage(protocol.MsgCopyBothResponse, []byte{0, 0, 0})
+
+	stream := &scriptedReplStream{
+		ctx:       context.Background(),
+		responses: [][]byte{identifyResp, createSlotResp, startReplResp},
+	}
+
+	testConn := server.NewTestConn(&clientInput)
+	streaming, leftover, err := runReplicationPreamble(context.Background(), testConn.Conn, stream)
+	require.NoError(t, err)
+	assert.True(t, streaming)
+	assert.Empty(t, leftover)
+
+	wantClientOutput := bytes.Join([][]byte{identifyResp, createSlotResp, startReplResp}, nil)
+	assert.Equal(t, wantClientOutput, testConn.WriteBuf.Bytes())
+
+	require.Len(t, stream.sentRaw, 3)
+	assert.Equal(t, frameMessage(protocol.MsgQuery, append([]byte("IDENTIFY_SYSTEM"), 0)), stream.sentRaw[0])
+	assert.Equal(t, frameMessage(protocol.MsgQuery, append([]byte("CREATE_REPLICATION_SLOT s1 TEMPORARY LOGICAL pgoutput"), 0)), stream.sentRaw[1])
+	assert.Equal(t, frameMessage(protocol.MsgQuery, append([]byte("START_REPLICATION SLOT s1 LOGICAL 0/0"), 0)), stream.sentRaw[2])
+}
+
+// TestRunReplicationPreamble_ReturnsLeftoverAfterCopyBothResponse verifies
+// that bytes following the CopyBothResponse frame in the same backend chunk
+// (e.g. the start of XLogData streaming) are handed back as leftover rather
+// than relayed during the preamble or dropped.
+func TestRunReplicationPreamble_ReturnsLeftoverAfterCopyBothResponse(t *testing.T) {
+	var clientInput bytes.Buffer
+	writeQueryMessage(&clientInput, "START_REPLICATION SLOT s1 LOGICAL 0/0")
+
+	copyBoth := frameMessage(protocol.MsgCopyBothResponse, []byte{0, 0, 0})
+	extra := []byte("extra-xlogdata-bytes")
+	startReplResp := append(append([]byte(nil), copyBoth...), extra...)
+
+	stream := &scriptedReplStream{
+		ctx:       context.Background(),
+		responses: [][]byte{startReplResp},
+	}
+
+	testConn := server.NewTestConn(&clientInput)
+	streaming, leftover, err := runReplicationPreamble(context.Background(), testConn.Conn, stream)
+	require.NoError(t, err)
+	assert.True(t, streaming)
+	assert.Equal(t, extra, leftover)
+
+	// Only the CopyBothResponse frame itself was relayed to the client during
+	// the preamble; the leftover bytes are handed to the caller instead.
+	assert.Equal(t, copyBoth, testConn.WriteBuf.Bytes())
+}
+
+// TestRunReplicationPreamble_RejectsNonTemporarySlot verifies that a
+// CREATE_REPLICATION_SLOT without TEMPORARY is rejected before the pooler
+// ever sees it: the client gets an ErrorResponse, and stream.Send is never
+// called for that command.
+func TestRunReplicationPreamble_RejectsNonTemporarySlot(t *testing.T) {
+	var clientInput bytes.Buffer
+	writeQueryMessage(&clientInput, "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput")
+
+	stream := &scriptedReplStream{ctx: context.Background()}
+	testConn := server.NewTestConn(&clientInput)
+
+	streaming, leftover, err := runReplicationPreamble(context.Background(), testConn.Conn, stream)
+	require.Error(t, err)
+	assert.False(t, streaming)
+	assert.Nil(t, leftover)
+	assert.Contains(t, err.Error(), "requires TEMPORARY")
+
+	assert.Empty(t, stream.sentRaw, "the pooler must never see the rejected command")
+
+	require.NotEmpty(t, testConn.WriteBuf.Bytes())
+	assert.Equal(t, byte(protocol.MsgErrorResponse), testConn.WriteBuf.Bytes()[0])
+	assert.Contains(t, testConn.WriteBuf.String(), "requires TEMPORARY")
+}
+
+// TestRunReplicationPreamble_CleanEOF verifies a client that disconnects
+// before sending anything ends the preamble cleanly (no error, not
+// streaming).
+func TestRunReplicationPreamble_CleanEOF(t *testing.T) {
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	stream := &scriptedReplStream{ctx: context.Background()}
+
+	streaming, leftover, err := runReplicationPreamble(context.Background(), testConn.Conn, stream)
+	require.NoError(t, err)
+	assert.False(t, streaming)
+	assert.Nil(t, leftover)
+}
+
+// TestRunReplicationPreamble_ClientTerminate verifies a Terminate message
+// ends the preamble cleanly without ever reaching the pooler.
+func TestRunReplicationPreamble_ClientTerminate(t *testing.T) {
+	var clientInput bytes.Buffer
+	clientInput.Write(frameMessage(protocol.MsgTerminate, nil))
+
+	stream := &scriptedReplStream{ctx: context.Background()}
+	testConn := server.NewTestConn(&clientInput)
+
+	streaming, leftover, err := runReplicationPreamble(context.Background(), testConn.Conn, stream)
+	require.NoError(t, err)
+	assert.False(t, streaming)
+	assert.Nil(t, leftover)
+	assert.Empty(t, stream.sentRaw)
+}
+
+// TestRunReplicationPreamble_RejectsExtendedProtocol verifies that any
+// non-Query frontend message (the extended query protocol: Parse, Bind,
+// Describe, Execute, Close, Flush, Sync) is rejected outright before
+// streaming begins, rather than forwarded to the pooler. A survey of the
+// most widely used open-source software that consumes PostgreSQL logical
+// replication found none that use the extended query protocol on this
+// connection; supporting it here would mean mirroring postgres's own
+// multi-message-per-command, ignore-till-sync state machine for a case
+// nothing in practice exercises.
+func TestRunReplicationPreamble_RejectsExtendedProtocol(t *testing.T) {
+	tests := []struct {
+		name    string
+		msgType byte
+	}{
+		{"Parse", protocol.MsgParse},
+		{"Bind", protocol.MsgBind},
+		{"Describe", protocol.MsgDescribe},
+		{"Execute", protocol.MsgExecute},
+		{"Close", protocol.MsgClose},
+		{"Flush", protocol.MsgFlush},
+		{"Sync", protocol.MsgSync},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var clientInput bytes.Buffer
+			clientInput.Write(frameMessage(tt.msgType, []byte("body")))
+
+			stream := &scriptedReplStream{ctx: context.Background()}
+			testConn := server.NewTestConn(&clientInput)
+
+			streaming, leftover, err := runReplicationPreamble(context.Background(), testConn.Conn, stream)
+			require.Error(t, err)
+			assert.False(t, streaming)
+			assert.Nil(t, leftover)
+			assert.Contains(t, err.Error(), "not supported")
+
+			assert.Empty(t, stream.sentRaw, "the pooler must never see a rejected message")
+			require.NotEmpty(t, testConn.WriteBuf.Bytes())
+			assert.Equal(t, byte(protocol.MsgErrorResponse), testConn.WriteBuf.Bytes()[0])
+		})
+	}
+}

--- a/go/services/multigateway/handler/replication_preamble_test.go
+++ b/go/services/multigateway/handler/replication_preamble_test.go
@@ -308,6 +308,52 @@ func TestRunReplicationPreamble_RejectsNonTemporarySlot(t *testing.T) {
 	assert.Contains(t, testConn.WriteBuf.String(), "requires TEMPORARY")
 }
 
+// TestRunReplicationPreamble_RejectsSQLFunctionSlotCreation verifies that a
+// plain SQL query calling pg_create_physical_replication_slot/
+// pg_create_logical_replication_slot with a non-true temporary argument is
+// rejected before the pooler ever sees it — not just the
+// CREATE_REPLICATION_SLOT wire command form. Postgres's walsender falls
+// through to the normal SQL executor for any query that isn't a recognized
+// replication command, so this connection can reach these functions the
+// same as any ordinary connection.
+func TestRunReplicationPreamble_RejectsSQLFunctionSlotCreation(t *testing.T) {
+	tests := []struct {
+		name    string
+		sql     string
+		wantErr bool
+	}{
+		{"physical, non-temporary, rejected", "SELECT pg_create_physical_replication_slot('perm', false, false)", true},
+		{"physical, temporary omitted, rejected", "SELECT pg_create_physical_replication_slot('perm')", true},
+		{"logical, non-temporary, rejected", "SELECT pg_create_logical_replication_slot('perm', 'pgoutput', false)", true},
+		{"physical, temporary=true, accepted", "SELECT pg_create_physical_replication_slot('tmp', false, true)", false},
+		{"logical, temporary=true, accepted", "SELECT pg_create_logical_replication_slot('tmp', 'pgoutput', true)", false},
+		{"unrelated SQL is unaffected", "SELECT 1", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var clientInput bytes.Buffer
+			writeQueryMessage(&clientInput, tt.sql)
+			stream := &scriptedReplStream{ctx: context.Background()}
+			if !tt.wantErr {
+				stream.responses = [][]byte{frameMessage(protocol.MsgReadyForQuery, []byte{'I'})}
+			}
+			testConn := server.NewTestConn(&clientInput)
+
+			streaming, _, err := runReplicationPreamble(context.Background(), testConn.Conn, stream)
+			assert.False(t, streaming)
+			if !tt.wantErr {
+				require.NoError(t, err)
+				assert.NotEmpty(t, stream.sentRaw, "an accepted query must still reach the pooler")
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "requires temporary=true")
+			assert.Empty(t, stream.sentRaw, "the pooler must never see the rejected command")
+			assert.Contains(t, testConn.WriteBuf.String(), "requires temporary=true")
+		})
+	}
+}
+
 // TestRunReplicationPreamble_CleanEOF verifies a client that disconnects
 // before sending anything ends the preamble cleanly (no error, not
 // streaming).

--- a/go/services/multigateway/handler/replication_stream.go
+++ b/go/services/multigateway/handler/replication_stream.go
@@ -17,6 +17,7 @@ package handler
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 
 	"github.com/multigres/multigres/go/common/mterrors"
@@ -67,6 +68,21 @@ func (h *MultigatewayHandler) HandleReplicationStream(ctx context.Context, conn 
 		return err
 	}
 
+	// Relay IDENTIFY_SYSTEM/CREATE_REPLICATION_SLOT/START_REPLICATION
+	// message-by-message, rejecting a non-TEMPORARY CREATE_REPLICATION_SLOT
+	// before the pooler/postgres ever see it. Runs on the still-attached
+	// client socket — any rejection error has already been surfaced to the
+	// client as an ErrorResponse inside the preamble.
+	streaming, leftover, err := runReplicationPreamble(ctx, conn, stream)
+	if err != nil {
+		return err
+	}
+	if !streaming {
+		// The client disconnected (or terminated) during the preamble without
+		// ever reaching START_REPLICATION.
+		return nil
+	}
+
 	// Detach the authenticated client socket and carry over any read-ahead
 	// bytes the protocol reader already consumed.
 	raw, buffered, err := conn.DetachConn()
@@ -75,7 +91,7 @@ func (h *MultigatewayHandler) HandleReplicationStream(ctx context.Context, conn 
 	}
 
 	backend := clientBackend{
-		Reader: io.MultiReader(bytes.NewReader(buffered), raw),
+		Reader: newCopyModeUpstreamReader(io.MultiReader(bytes.NewReader(buffered), raw)),
 		Writer: raw,
 		Closer: raw,
 	}
@@ -85,7 +101,9 @@ func (h *MultigatewayHandler) HandleReplicationStream(ctx context.Context, conn 
 			Msg: &multipoolerservice.StreamReplicationRequest_Data{Data: append([]byte(nil), b...)},
 		})
 	}
-	recv := func() ([]byte, error) {
+
+	downstream := &copyModeDownstreamReader{buf: append([]byte(nil), leftover...)}
+	downstream.recv = func() ([]byte, error) {
 		resp, err := stream.Recv()
 		if err != nil {
 			return nil, err
@@ -101,8 +119,14 @@ func (h *MultigatewayHandler) HandleReplicationStream(ctx context.Context, conn 
 		}
 		return resp.GetData(), nil
 	}
+	recv := downstream.next
 
-	return commonrepl.NewTunnel(backend, h.metrics.NewReplicationStream(conn.User()), send, recv).Run(tunnelCtx)
+	err = commonrepl.NewTunnel(backend, h.metrics.NewReplicationStream(conn.User()), send, recv).Run(tunnelCtx)
+	if errors.Is(err, errReplicationSessionResumed) || errors.Is(err, errReplicationSessionEndedByClient) {
+		h.logger.InfoContext(ctx, "replication connection closed: session ended, resuming command mode on this connection is not supported",
+			"user", conn.User(), "reason", err)
+	}
+	return err
 }
 
 // clientBackend adapts the detached client socket (plus its read-ahead buffer)

--- a/go/services/multigateway/handler/replication_stream_test.go
+++ b/go/services/multigateway/handler/replication_stream_test.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	"github.com/multigres/multigres/go/common/callerid"
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	multipoolerservice "github.com/multigres/multigres/go/pb/multipoolerservice"
 	"github.com/multigres/multigres/go/pb/query"
@@ -45,6 +46,22 @@ type fakeReplStream struct {
 	cond   *sync.Cond
 	queue  [][]byte
 	closed bool
+
+	// preambleResponses, if set, are consumed in Send-call order: the Nth
+	// Send() (for N < len(preambleResponses)) enqueues preambleResponses[N]
+	// as the response instead of echoing the sent bytes. Once exhausted,
+	// Send falls back to the normal echo behavior. Models the real
+	// command/scripted-response handshake (e.g. START_REPLICATION ->
+	// CopyBothResponse) that the preamble drives before handing off to the
+	// byte-blind tunnel, which these tests exercise via plain echo.
+	preambleResponses [][]byte
+	sendCount         int
+
+	// sent records every chunk this stream's Send() has been given, in call
+	// order — i.e. everything the gateway has forwarded to the (fake)
+	// pooler, preamble responses aside. Used by tests to assert what did or
+	// did not reach the pooler.
+	sent [][]byte
 }
 
 func newFakeReplStream(ctx context.Context) *fakeReplStream {
@@ -72,11 +89,41 @@ func (s *fakeReplStream) Send(req *multipoolerservice.StreamReplicationRequest) 
 		return io.EOF
 	}
 	if data := req.GetData(); data != nil {
+		s.sent = append(s.sent, append([]byte(nil), data...))
+	}
+	if s.sendCount < len(s.preambleResponses) {
+		s.queue = append(s.queue, append([]byte(nil), s.preambleResponses[s.sendCount]...))
+		s.sendCount++
+		s.cond.Broadcast()
+		return nil
+	}
+	s.sendCount++
+	if data := req.GetData(); data != nil {
 		// Echo the client bytes back as a server Data response.
 		s.queue = append(s.queue, append([]byte(nil), data...))
 		s.cond.Broadcast()
 	}
 	return nil
+}
+
+// sentDataChunks returns every chunk recorded by Send so far, in call order.
+// Safe to call concurrently with an in-flight Send.
+func (s *fakeReplStream) sentDataChunks() [][]byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([][]byte, len(s.sent))
+	copy(out, s.sent)
+	return out
+}
+
+// queueDownstream pushes raw bytes directly onto the stream's response
+// queue, bypassing the echo-on-Send behavior, so a test can script an exact
+// downstream (pooler -> client) byte sequence for Recv to hand back.
+func (s *fakeReplStream) queueDownstream(raw []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.queue = append(s.queue, append([]byte(nil), raw...))
+	s.cond.Broadcast()
 }
 
 func (s *fakeReplStream) Recv() (*multipoolerservice.StreamReplicationResponse, error) {
@@ -127,6 +174,12 @@ type fakeReplExecutor struct {
 	// Used to hand back a stream type other than *fakeReplStream (e.g. one that
 	// returns a canned error response).
 	streamOverride multipoolerservice.MultipoolerService_StreamReplicationClient
+
+	// preambleResponses, when set, is applied to the lazily-created
+	// fakeReplStream so its scripted preamble handshake (see
+	// fakeReplStream.preambleResponses) is wired up with the real ctx
+	// StreamReplication receives.
+	preambleResponses [][]byte
 }
 
 func (e *fakeReplExecutor) StreamReplication(
@@ -145,6 +198,7 @@ func (e *fakeReplExecutor) StreamReplication(
 	}
 	if e.stream == nil {
 		e.stream = newFakeReplStream(ctx)
+		e.stream.preambleResponses = e.preambleResponses
 	}
 	return e.stream, nil
 }
@@ -181,7 +235,8 @@ func TestHandleReplicationStream_RoundTripsAndExitsOnClientEOF(t *testing.T) {
 	clientEnd, serverEnd := net.Pipe()
 	t.Cleanup(func() { _ = clientEnd.Close() })
 
-	fakeExec := &fakeReplExecutor{}
+	copyBothResp := frameMessage(protocol.MsgCopyBothResponse, []byte{0, 0, 0})
+	fakeExec := &fakeReplExecutor{preambleResponses: [][]byte{copyBothResp}}
 	h := NewMultigatewayHandler(fakeExec, slog.Default(), 0)
 
 	conn := server.NewReplicationTestConn(
@@ -196,8 +251,20 @@ func TestHandleReplicationStream_RoundTripsAndExitsOnClientEOF(t *testing.T) {
 		done <- h.HandleReplicationStream(context.Background(), conn.Conn)
 	}()
 
-	// Client -> gateway -> (fake) pooler -> echoed back -> client.
-	want := []byte("hello replication world")
+	// Drive the preamble first: a single START_REPLICATION whose scripted
+	// response is CopyBothResponse, handing off to the byte-blind tunnel.
+	startReplCmd := frameMessage(protocol.MsgQuery, append([]byte("START_REPLICATION SLOT s1 LOGICAL 0/0"), 0))
+	go func() { _, _ = clientEnd.Write(startReplCmd) }()
+
+	gotCopyBoth := make([]byte, len(copyBothResp))
+	_ = clientEnd.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, err := io.ReadFull(clientEnd, gotCopyBoth)
+	require.NoError(t, err)
+	assert.Equal(t, copyBothResp, gotCopyBoth)
+
+	// Client -> gateway -> (fake) pooler -> echoed back -> client. Framed as
+	// CopyData since the relay is frame-aware, not byte-blind, post-handoff.
+	want := frameMessage(protocol.MsgCopyData, []byte("hello replication world"))
 	go func() {
 		_, _ = clientEnd.Write(want)
 	}()
@@ -239,7 +306,8 @@ func TestHandleReplicationStream_SurvivesCtxCancelDuringDetach(t *testing.T) {
 	clientEnd, serverEnd := net.Pipe()
 	t.Cleanup(func() { _ = clientEnd.Close() })
 
-	fakeExec := &fakeReplExecutor{}
+	copyBothResp := frameMessage(protocol.MsgCopyBothResponse, []byte{0, 0, 0})
+	fakeExec := &fakeReplExecutor{preambleResponses: [][]byte{copyBothResp}}
 	h := NewMultigatewayHandler(fakeExec, slog.Default(), 0)
 
 	conn := server.NewReplicationTestConn(
@@ -257,7 +325,20 @@ func TestHandleReplicationStream_SurvivesCtxCancelDuringDetach(t *testing.T) {
 	// Simulate DetachConn cancelling the connection context.
 	cancel()
 
-	want := []byte("post-detach replication bytes")
+	// Drive the preamble first: a single START_REPLICATION whose scripted
+	// response is CopyBothResponse, handing off to the byte-blind tunnel.
+	startReplCmd := frameMessage(protocol.MsgQuery, append([]byte("START_REPLICATION SLOT s1 LOGICAL 0/0"), 0))
+	go func() { _, _ = clientEnd.Write(startReplCmd) }()
+
+	gotCopyBoth := make([]byte, len(copyBothResp))
+	_ = clientEnd.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, err := io.ReadFull(clientEnd, gotCopyBoth)
+	require.NoError(t, err)
+	assert.Equal(t, copyBothResp, gotCopyBoth)
+
+	// Framed as CopyData since the relay is frame-aware, not byte-blind,
+	// post-handoff.
+	want := frameMessage(protocol.MsgCopyData, []byte("post-detach replication bytes"))
 	go func() { _, _ = clientEnd.Write(want) }()
 
 	got := make([]byte, len(want))
@@ -322,11 +403,20 @@ func TestHandleReplicationStream_OpenErrorWriteAlsoFails(t *testing.T) {
 		"the original open error must still be returned even when WriteError fails")
 }
 
-// TestHandleReplicationStream_SurfacesDetachError verifies that a DetachConn
-// failure (the connection is already closed for protocol use) is surfaced
-// directly, after the pooler stream was already opened.
-func TestHandleReplicationStream_SurfacesDetachError(t *testing.T) {
+// TestHandleReplicationStream_SurfacesConnReadError verifies that a
+// connection already unusable when the preamble tries to read from it (e.g.
+// torn down by some other path) surfaces as an error from
+// HandleReplicationStream, after the pooler stream was already opened.
+//
+// The preamble now runs before DetachConn, so it is the first thing to touch
+// the connection — a preemptive conn.DetachConn() (the previous way this
+// test constructed "already closed") returns bufferedReader to the pool,
+// and reading from a nil bufferedReader panics rather than erroring. Closing
+// the raw socket directly reaches the same "connection is unusable" case
+// without that panic.
+func TestHandleReplicationStream_SurfacesConnReadError(t *testing.T) {
 	_, serverEnd := net.Pipe()
+	require.NoError(t, serverEnd.Close())
 
 	fakeExec := &fakeReplExecutor{}
 	h := NewMultigatewayHandler(fakeExec, slog.Default(), 0)
@@ -337,12 +427,7 @@ func TestHandleReplicationStream_SurfacesDetachError(t *testing.T) {
 		server.WithTestNetConn(serverEnd),
 	)
 
-	// Detach once up front so the handler's own DetachConn call fails.
-	raw, _, err := conn.Conn.DetachConn()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = raw.Close() })
-
-	err = h.HandleReplicationStream(context.Background(), conn.Conn)
+	err := h.HandleReplicationStream(context.Background(), conn.Conn)
 	require.Error(t, err)
 }
 
@@ -374,6 +459,12 @@ func TestHandleReplicationStream_PoolerErrorWithDiagnostic(t *testing.T) {
 		server.WithTestNetConn(serverEnd),
 	)
 
+	// The preamble now runs before the tunnel, so it must see a client
+	// command before errorReplStream's scripted error response is reached.
+	go func() {
+		_, _ = clientEnd.Write(frameMessage(protocol.MsgQuery, append([]byte("START_REPLICATION SLOT s1 LOGICAL 0/0"), 0)))
+	}()
+
 	err := h.HandleReplicationStream(context.Background(), conn.Conn)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "terminating connection")
@@ -404,6 +495,12 @@ func TestHandleReplicationStream_PoolerErrorWithoutDiagnostic(t *testing.T) {
 		server.WithTestUser("repl_user"),
 		server.WithTestNetConn(serverEnd),
 	)
+
+	// The preamble now runs before the tunnel, so it must see a client
+	// command before errorReplStream's scripted error response is reached.
+	go func() {
+		_, _ = clientEnd.Write(frameMessage(protocol.MsgQuery, append([]byte("START_REPLICATION SLOT s1 LOGICAL 0/0"), 0)))
+	}()
 
 	err := h.HandleReplicationStream(context.Background(), conn.Conn)
 	require.Error(t, err)
@@ -442,4 +539,109 @@ func TestHandleReplicationStream_PropagatesCallerIdentity(t *testing.T) {
 	cid := callerid.FromContext(fakeExec.gotCtx)
 	require.NotNil(t, cid, "caller identity must be attached to the context passed to the executor")
 	assert.Equal(t, "repl_user", cid.GetPrincipal())
+}
+
+// TestHandleReplicationStream_TerminatesOnClientCopyDone verifies that once
+// the client sends CopyDone, HandleReplicationStream stops relaying —
+// including a pipelined follow-up message sent immediately after, without
+// waiting for any reply — and returns a non-nil error rather than allowing
+// the connection to continue.
+func TestHandleReplicationStream_TerminatesOnClientCopyDone(t *testing.T) {
+	clientEnd, serverEnd := net.Pipe()
+	t.Cleanup(func() { _ = clientEnd.Close() })
+
+	copyBothResp := frameMessage(protocol.MsgCopyBothResponse, []byte{0, 0, 0})
+	fakeExec := &fakeReplExecutor{preambleResponses: [][]byte{copyBothResp}}
+	h := NewMultigatewayHandler(fakeExec, slog.Default(), 0)
+
+	conn := server.NewReplicationTestConn(
+		server.WithTestReplicationMode(server.ReplicationLogical),
+		server.WithTestUser("repl_user"),
+		server.WithTestNetConn(serverEnd),
+	)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.HandleReplicationStream(context.Background(), conn.Conn)
+	}()
+
+	startReplCmd := frameMessage(protocol.MsgQuery, append([]byte("START_REPLICATION SLOT s1 LOGICAL 0/0"), 0))
+	go func() { _, _ = clientEnd.Write(startReplCmd) }()
+
+	gotCopyBoth := make([]byte, len(copyBothResp))
+	_ = clientEnd.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, err := io.ReadFull(clientEnd, gotCopyBoth)
+	require.NoError(t, err)
+
+	// CopyDone immediately followed (pipelined, no wait for a reply) by a
+	// bogus command — must never reach the pooler.
+	copyDone := frameMessage(protocol.MsgCopyDone, nil)
+	bogus := frameMessage(protocol.MsgQuery, append([]byte("CREATE_REPLICATION_SLOT s2 LOGICAL pgoutput"), 0))
+	go func() { _, _ = clientEnd.Write(append(append([]byte(nil), copyDone...), bogus...)) }()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("HandleReplicationStream did not terminate after client CopyDone + pipelined command")
+	}
+
+	assert.Equal(t, startReplCmd, fakeExec.stream.sentDataChunks()[0], "the START_REPLICATION command was relayed")
+	assert.Equal(t, copyDone, fakeExec.stream.sentDataChunks()[len(fakeExec.stream.sentDataChunks())-1],
+		"the last thing forwarded to the pooler must be CopyDone itself, never the pipelined bogus command")
+}
+
+// TestHandleReplicationStream_TerminatesOnServerReadyForQuery verifies that
+// once postgres (via the pooler stream) sends ReadyForQuery — signalling it
+// has returned to command mode after the COPY session ended —
+// HandleReplicationStream relays that ReadyForQuery to the client, then
+// returns a non-nil error rather than allowing the connection to continue.
+func TestHandleReplicationStream_TerminatesOnServerReadyForQuery(t *testing.T) {
+	clientEnd, serverEnd := net.Pipe()
+	t.Cleanup(func() { _ = clientEnd.Close() })
+
+	xlogData := frameMessage(protocol.MsgCopyData, []byte("fake-xlogdata"))
+	commandComplete := frameMessage(protocol.MsgCommandComplete, []byte("COPY 0\x00"))
+	readyForQuery := frameMessage(protocol.MsgReadyForQuery, []byte{'I'})
+	copyBothResp := frameMessage(protocol.MsgCopyBothResponse, []byte{0, 0, 0})
+
+	fakeExec := &fakeReplExecutor{preambleResponses: [][]byte{copyBothResp}}
+	h := NewMultigatewayHandler(fakeExec, slog.Default(), 0)
+
+	conn := server.NewReplicationTestConn(
+		server.WithTestReplicationMode(server.ReplicationLogical),
+		server.WithTestUser("repl_user"),
+		server.WithTestNetConn(serverEnd),
+	)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.HandleReplicationStream(context.Background(), conn.Conn)
+	}()
+
+	startReplCmd := frameMessage(protocol.MsgQuery, append([]byte("START_REPLICATION SLOT s1 LOGICAL 0/0"), 0))
+	go func() { _, _ = clientEnd.Write(startReplCmd) }()
+
+	gotCopyBoth := make([]byte, len(copyBothResp))
+	_ = clientEnd.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, err := io.ReadFull(clientEnd, gotCopyBoth)
+	require.NoError(t, err)
+
+	// Script the pooler stream's post-handoff responses: some XLogData, then
+	// postgres ending the COPY session on its own.
+	fakeExec.stream.queueDownstream(append(append(append([]byte(nil), xlogData...), commandComplete...), readyForQuery...))
+
+	wantClientBytes := append(append(append([]byte(nil), xlogData...), commandComplete...), readyForQuery...)
+	gotClientBytes := make([]byte, len(wantClientBytes))
+	_ = clientEnd.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, err = io.ReadFull(clientEnd, gotClientBytes)
+	require.NoError(t, err)
+	assert.Equal(t, wantClientBytes, gotClientBytes, "the client must still see XLogData, CommandComplete, and ReadyForQuery")
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("HandleReplicationStream did not terminate after server ReadyForQuery")
+	}
 }

--- a/go/services/multigateway/planner/unsafe_funccall.go
+++ b/go/services/multigateway/planner/unsafe_funccall.go
@@ -72,6 +72,41 @@ var funcBlocklist = map[string]string{
 	"cursor_to_xmlschema":        "cursor_to_xmlschema is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler",
 }
 
+// replicationSlotFuncs lists the pg_create_*_replication_slot builtins and
+// the zero-based argument index of their `temporary` parameter. Multigres
+// cannot yet transition a replication slot's position across a primary
+// failover, so only TEMPORARY (session-scoped) slots are safe — see
+// rejectNonTemporaryReplicationSlot.
+var replicationSlotFuncs = map[string]int{
+	// pg_create_physical_replication_slot(slot_name, immediately_reserve DEFAULT false, temporary DEFAULT false)
+	"pg_create_physical_replication_slot": 2,
+	// pg_create_logical_replication_slot(slot_name, plugin, temporary DEFAULT false, twophase DEFAULT false)
+	"pg_create_logical_replication_slot": 2,
+}
+
+// rejectNonTemporaryReplicationSlot fails closed: if the temporary argument
+// is missing (the default is false) or isn't a literal boolean true, reject.
+// A non-literal/bound argument is rejected too — this is a safety
+// constraint, not a convenience one, so we don't guess.
+//
+// Known gap: this matches positional arguments only. Named-argument calls
+// (temporary => true) aren't handled — same class of limitation this file
+// already documents for advisory locks hidden in function bodies (see
+// AcquiresSessionAdvisoryLock's doc comment).
+func rejectNonTemporaryReplicationSlot(name string, temporaryArgIndex int, fc *ast.FuncCall) error {
+	if fc.Args == nil || fc.Args.Len() <= temporaryArgIndex {
+		return replicationSlotNotTemporaryError(name)
+	}
+	if isTemp, ok := constBoolArg(fc.Args.Items[temporaryArgIndex]); !ok || !isTemp {
+		return replicationSlotNotTemporaryError(name)
+	}
+	return nil
+}
+
+func replicationSlotNotTemporaryError(name string) error {
+	return mterrors.NewNonTemporaryReplicationSlotError(name, "temporary=true")
+}
+
 // setConfigCall is one `set_config(name, value, is_local)` call the planner
 // accepted as a tracked session-state update. The planner mints one per
 // allowed position and uses the list to build the execution plan.
@@ -338,6 +373,13 @@ func analyzeFunctionCalls(stmt ast.Stmt) (*statementAnalysis, error) {
 		if msg, blocked := funcBlocklist[name]; blocked {
 			walkErr = mterrors.NewFeatureNotSupported(msg)
 			return false
+		}
+		if temporaryArgIndex, isReplicationSlotFunc := replicationSlotFuncs[name]; isReplicationSlotFunc {
+			if err := rejectNonTemporaryReplicationSlot(name, temporaryArgIndex, fc); err != nil {
+				walkErr = err
+				return false
+			}
+			return true
 		}
 		if _, isAdvisory := sessionAdvisoryLockAcquireFuncs[name]; isAdvisory {
 			result.AcquiresSessionAdvisoryLock = true

--- a/go/services/multigateway/planner/unsafe_funccall.go
+++ b/go/services/multigateway/planner/unsafe_funccall.go
@@ -76,13 +76,15 @@ var funcBlocklist = map[string]string{
 // the zero-based argument index of their `temporary` parameter. Multigres
 // cannot yet transition a replication slot's position across a primary
 // failover, so only TEMPORARY (session-scoped) slots are safe — see
-// rejectNonTemporaryReplicationSlot.
-var replicationSlotFuncs = map[string]int{
-	// pg_create_physical_replication_slot(slot_name, immediately_reserve DEFAULT false, temporary DEFAULT false)
-	"pg_create_physical_replication_slot": 2,
-	// pg_create_logical_replication_slot(slot_name, plugin, temporary DEFAULT false, twophase DEFAULT false)
-	"pg_create_logical_replication_slot": 2,
-}
+// rejectNonTemporaryReplicationSlot. This is the same map
+// ast.FindNonTemporaryReplicationSlotCall uses for the equivalent check on
+// arbitrary SQL sent over a replication=database connection (see
+// go/services/multigateway/handler/replication_preamble.go) — kept as a
+// single shared definition in the ast package (this package can't import
+// handler's checks back, since planner already imports handler for
+// gateway-managed-variable lookups) so the two enforcement points can never
+// drift apart on which functions/argument index are covered.
+var replicationSlotFuncs = ast.ReplicationSlotFuncTemporaryArgIndex
 
 // rejectNonTemporaryReplicationSlot fails closed: if the temporary argument
 // is missing (the default is false) or isn't a literal boolean true, reject.

--- a/go/services/multigateway/planner/unsafe_funccall_test.go
+++ b/go/services/multigateway/planner/unsafe_funccall_test.go
@@ -131,6 +131,151 @@ func TestInspectExpressionFuncCalls_Blocklist(t *testing.T) {
 	}
 }
 
+// TestInspectExpressionFuncCalls_ReplicationSlots covers the
+// pg_create_physical_replication_slot / pg_create_logical_replication_slot
+// enforcement: only a literal temporary=true is accepted, since Multigres
+// cannot yet migrate a replication slot's position across a primary
+// failover.
+func TestInspectExpressionFuncCalls_ReplicationSlots(t *testing.T) {
+	tests := []struct {
+		name    string
+		sql     string
+		wantErr bool
+		wantMsg string
+	}{
+		{
+			name: "physical: temporary=true literal accepted",
+			sql:  "SELECT pg_create_physical_replication_slot('s1', false, true)",
+		},
+		{
+			name:    "physical: temporary=false literal rejected",
+			sql:     "SELECT pg_create_physical_replication_slot('s1', false, false)",
+			wantErr: true,
+			wantMsg: "pg_create_physical_replication_slot requires temporary=true",
+		},
+		{
+			name:    "physical: temporary omitted (2-arg call) rejected",
+			sql:     "SELECT pg_create_physical_replication_slot('s1', false)",
+			wantErr: true,
+			wantMsg: "pg_create_physical_replication_slot requires temporary=true",
+		},
+		{
+			name:    "physical: temporary omitted (1-arg call) rejected",
+			sql:     "SELECT pg_create_physical_replication_slot('s1')",
+			wantErr: true,
+			wantMsg: "pg_create_physical_replication_slot requires temporary=true",
+		},
+		{
+			name:    "physical: non-literal temporary (bound param) rejected",
+			sql:     "SELECT pg_create_physical_replication_slot('s1', false, $1)",
+			wantErr: true,
+			wantMsg: "pg_create_physical_replication_slot requires temporary=true",
+		},
+		{
+			name:    "physical: non-literal temporary (column ref) rejected",
+			sql:     "SELECT pg_create_physical_replication_slot('s1', false, col) FROM t",
+			wantErr: true,
+			wantMsg: "pg_create_physical_replication_slot requires temporary=true",
+		},
+		{
+			name: "physical: qualified pg_catalog form accepted with temporary=true",
+			sql:  "SELECT pg_catalog.pg_create_physical_replication_slot('s1', false, true)",
+		},
+		{
+			name:    "physical: qualified pg_catalog form rejected without temporary=true",
+			sql:     "SELECT pg_catalog.pg_create_physical_replication_slot('s1', false, false)",
+			wantErr: true,
+			wantMsg: "pg_create_physical_replication_slot requires temporary=true",
+		},
+		{
+			name: "logical: temporary=true literal accepted",
+			sql:  "SELECT pg_create_logical_replication_slot('s1', 'pgoutput', true)",
+		},
+		{
+			name:    "logical: temporary=false literal rejected",
+			sql:     "SELECT pg_create_logical_replication_slot('s1', 'pgoutput', false)",
+			wantErr: true,
+			wantMsg: "pg_create_logical_replication_slot requires temporary=true",
+		},
+		{
+			name:    "logical: temporary omitted rejected",
+			sql:     "SELECT pg_create_logical_replication_slot('s1', 'pgoutput')",
+			wantErr: true,
+			wantMsg: "pg_create_logical_replication_slot requires temporary=true",
+		},
+		{
+			name:    "logical: non-literal temporary (bound param) rejected",
+			sql:     "SELECT pg_create_logical_replication_slot('s1', 'pgoutput', $1)",
+			wantErr: true,
+			wantMsg: "pg_create_logical_replication_slot requires temporary=true",
+		},
+		{
+			name: "logical: qualified pg_catalog form accepted with temporary=true",
+			sql:  "SELECT pg_catalog.pg_create_logical_replication_slot('s1', 'pgoutput', true)",
+		},
+		{
+			name: "pg_drop_replication_slot is unaffected",
+			sql:  "SELECT pg_drop_replication_slot('s1')",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt := parseOne(t, tt.sql)
+			result, err := analyzeFunctionCalls(stmt)
+			if !tt.wantErr {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				return
+			}
+			require.Error(t, err)
+			assert.Nil(t, result)
+			var diag *mterrors.PgDiagnostic
+			require.True(t, errors.As(err, &diag))
+			assert.Equal(t, mterrors.PgSSFeatureNotSupported, diag.Code)
+			assert.Contains(t, diag.Message, tt.wantMsg)
+		})
+	}
+}
+
+// TestReplicationSlotAfterNormalization confirms the temporary=true check
+// survives literal normalization: the planner runs against the normalized
+// AST under the plan cache (see executor.go), and the normalizer must keep
+// the `temporary` argument literal precisely so this check can still see it
+// (see isPlannerLiteralFunc in normalizer.go). Calling analyzeFunctionCalls
+// directly on the un-normalized tree, as the table above does, would not
+// have caught a regression here.
+func TestReplicationSlotAfterNormalization(t *testing.T) {
+	accept := func(t *testing.T, sql string) {
+		t.Helper()
+		norm := ast.Normalize(parseOne(t, sql))
+		_, err := analyzeStatement(norm.NormalizedAST)
+		assert.NoError(t, err, "normalized SQL: %s", norm.NormalizedSQL)
+	}
+	reject := func(t *testing.T, sql string) {
+		t.Helper()
+		norm := ast.Normalize(parseOne(t, sql))
+		_, err := analyzeStatement(norm.NormalizedAST)
+		require.Error(t, err, "normalized SQL: %s", norm.NormalizedSQL)
+		var diag *mterrors.PgDiagnostic
+		require.True(t, errors.As(err, &diag))
+		assert.Contains(t, diag.Message, "requires temporary=true")
+	}
+
+	t.Run("physical: temporary=true literal survives normalization", func(t *testing.T) {
+		accept(t, "SELECT pg_create_physical_replication_slot('s1', false, true)")
+	})
+	t.Run("logical: temporary=true literal survives normalization", func(t *testing.T) {
+		accept(t, "SELECT pg_create_logical_replication_slot('s1', 'pgoutput', true)")
+	})
+	t.Run("physical: temporary=false literal still rejected after normalization", func(t *testing.T) {
+		reject(t, "SELECT pg_create_physical_replication_slot('s1', false, false)")
+	})
+	t.Run("logical: temporary=false literal still rejected after normalization", func(t *testing.T) {
+		reject(t, "SELECT pg_create_logical_replication_slot('s1', 'pgoutput', false)")
+	})
+}
+
 // TestInspectExpressionFuncCalls_SetConfigAccepted covers the allowed shapes
 // of set_config — directly as a top-level SELECT target-list entry. These
 // must be accepted and returned in result.SetConfigs for the planner to

--- a/go/test/endtoend/shardsetup/replication_stream_test.go
+++ b/go/test/endtoend/shardsetup/replication_stream_test.go
@@ -236,6 +236,31 @@ func TestGatewayReplicationStream_HappyPath(t *testing.T) {
 		"Standby Status Update must flow back through the gateway")
 }
 
+// TestGatewayReplicationStream_RejectsNonTemporarySlot verifies that
+// CREATE_REPLICATION_SLOT without TEMPORARY is rejected by the gateway's
+// replication preamble before it ever reaches the pooler/postgres: the
+// client sees a clear ErrorResponse, and pg_replication_slots (queried
+// directly over a normal multigateway connection) confirms the slot was
+// never actually created on postgres.
+func TestGatewayReplicationStream_RejectsNonTemporarySlot(t *testing.T) {
+	skipIfShort(t)
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+
+	sqlConn, _, _ := setupGatewayReplicationFixture(t, setup)
+	slot := fmt.Sprintf("slot_gw_reject_%d", replFixtureCounter.Add(1))
+
+	conn := dialGatewayReplicationConn(t, setup)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	_, err := conn.Query(ctx, fmt.Sprintf(
+		"CREATE_REPLICATION_SLOT %s LOGICAL pgoutput NOEXPORT_SNAPSHOT", slot))
+	require.Error(t, err, "CREATE_REPLICATION_SLOT without TEMPORARY must be rejected")
+	require.ErrorContains(t, err, "TEMPORARY")
+
+	requireGatewaySlotGone(t, sqlConn, slot)
+}
+
 // TestGatewayReplicationStream_LargePayload streams a row whose text value
 // exceeds 1 MiB and asserts the reassembled WAL bytes round-trip across 'w'
 // frames without frame-boundary corruption through the gateway + pooler
@@ -331,12 +356,16 @@ func TestGatewayReplicationStream_TempSlotDropped(t *testing.T) {
 
 // TestGatewayReplicationStream_DropReplicationSlot verifies an explicit
 // DROP_REPLICATION_SLOT command flows through the gateway tunnel and actually
-// drops the slot on postgres. This is distinct from
-// TestGatewayReplicationStream_TempSlotDropped's auto-drop-on-disconnect path:
-// a non-temporary slot survives disconnect, so only an explicit
-// DROP_REPLICATION_SLOT can remove it — a real client-usable path (e.g. a
-// client tearing down a slot it no longer needs) that had no coverage
-// anywhere in the tree before this test.
+// drops the slot on postgres, independent of auto-drop-on-disconnect (which
+// TestGatewayReplicationStream_TempSlotDropped already covers) — a real
+// client-usable path (e.g. a client tearing down a slot it no longer needs)
+// that had no coverage anywhere in the tree before this test. The slot must
+// be TEMPORARY: Multigres cannot yet migrate a slot's position across a
+// primary failover, so non-temporary slot creation is rejected (see
+// TestGatewayReplicationStream_RejectsNonTemporarySlot). The connection stays
+// open for the whole body, so the explicit drop below is asserted well before
+// disconnect would auto-drop it anyway — a temporary slot still fully
+// exercises the DROP_REPLICATION_SLOT wire path through gateway+pooler.
 func TestGatewayReplicationStream_DropReplicationSlot(t *testing.T) {
 	skipIfShort(t)
 	setup := getSharedSetup(t)
@@ -348,22 +377,83 @@ func TestGatewayReplicationStream_DropReplicationSlot(t *testing.T) {
 	conn := dialGatewayReplicationConn(t, setup)
 	ctx := utils.WithTimeout(t, 30*time.Second)
 
-	// Deliberately NOT TEMPORARY: a temporary slot would auto-drop on
-	// disconnect regardless of whether DROP_REPLICATION_SLOT works.
 	_, err := conn.Query(ctx, fmt.Sprintf(
-		"CREATE_REPLICATION_SLOT %s LOGICAL pgoutput NOEXPORT_SNAPSHOT", slot))
+		"CREATE_REPLICATION_SLOT %s TEMPORARY LOGICAL pgoutput NOEXPORT_SNAPSHOT", slot))
 	require.NoError(t, err, "CREATE_REPLICATION_SLOT through gateway")
-	// Safety net: this slot is non-temporary, so it survives disconnect and
-	// would otherwise leak on the shared postgres instance if a later
-	// assertion in this test fails before/during the explicit drop below.
-	// Idempotent — a no-op once the explicit DROP_REPLICATION_SLOT below has
-	// already removed it.
-	t.Cleanup(func() { dropGatewaySlotIfPresent(t, sqlConn, slot) })
 	requireGatewaySlotPresent(t, sqlConn, slot)
 
 	_, err = conn.Query(ctx, "DROP_REPLICATION_SLOT "+slot)
 	require.NoError(t, err, "DROP_REPLICATION_SLOT through gateway")
 	requireGatewaySlotGone(t, sqlConn, slot)
+}
+
+// TestGatewayReplicationStream_TerminatesAfterClientCopyDone proves the
+// connection-reuse bypass is closed against a real postgres: after stopping
+// an active replication stream with CopyDone, the gateway must not allow
+// the same connection to issue another command — it terminates the
+// connection instead of returning it to command mode.
+func TestGatewayReplicationStream_TerminatesAfterClientCopyDone(t *testing.T) {
+	skipIfShort(t)
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+
+	sqlConn, table, pub := setupGatewayReplicationFixture(t, setup)
+	slot := fmt.Sprintf("slot_gw_reuse_%d", replFixtureCounter.Add(1))
+
+	conn := dialGatewayReplicationConn(t, setup)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	_, err := conn.Query(ctx, fmt.Sprintf(
+		"CREATE_REPLICATION_SLOT %s TEMPORARY LOGICAL pgoutput NOEXPORT_SNAPSHOT", slot))
+	require.NoError(t, err)
+	_, err = conn.StartReplication(ctx, fmt.Sprintf(
+		"START_REPLICATION SLOT %s LOGICAL 0/0 (proto_version '2', publication_names '%s')",
+		slot, pub))
+	require.NoError(t, err)
+
+	// Generate at least one frame so the stream is genuinely live before
+	// stopping it.
+	insertGatewayRow(t, sqlConn, table, 1, "before-copydone")
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		rctx, cancel := context.WithDeadline(t.Context(), deadline)
+		msg, err := conn.ReadReplicationMessage(rctx)
+		cancel()
+		require.NoError(t, err)
+		if msg.Notice != nil {
+			continue
+		}
+		if len(msg.Data) > 0 && (msg.Data[0] == 'w' || msg.Data[0] == 'k') {
+			break
+		}
+	}
+
+	// Stop streaming.
+	require.NoError(t, conn.WriteCopyDone(), "client CopyDone must flow through the gateway")
+
+	// Attempting to reuse this connection for another command must fail —
+	// the gateway terminates the connection rather than returning it to
+	// command mode. Whether this surfaces as a read error, a write error, or
+	// the connection simply closing, some operation on this connection must
+	// fail; if every one of these unexpectedly succeeds, the bypass is back.
+	//
+	// conn.Query blocks on the underlying net.Conn via a plain blocking read
+	// that does not honor context cancellation (unlike ReadReplicationMessage),
+	// so read-after-peer-close semantics can vary; race it against the select
+	// below so a hang surfaces as a clear test failure instead of stalling
+	// until the outer test timeout. The passed-in context is long-lived by
+	// design here — it is not what bounds the call.
+	queryDone := make(chan error, 1)
+	go func() {
+		_, queryErr := conn.Query(t.Context(), "IDENTIFY_SYSTEM")
+		queryDone <- queryErr
+	}()
+	select {
+	case queryErr := <-queryDone:
+		require.Error(t, queryErr, "the gateway must not allow issuing a new command on a connection that already streamed and stopped")
+	case <-time.After(10 * time.Second):
+		t.Fatal("the gateway must not allow issuing a new command on a connection that already streamed and stopped: conn.Query neither errored nor returned within the bounded deadline")
+	}
 }
 
 // requireGatewaySlotPresent asserts the slot currently exists, via a normal
@@ -390,31 +480,4 @@ func requireGatewaySlotGone(t *testing.T, conn *sql.Conn, slot string) {
 			"SELECT EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)", slot).Scan(&present)
 		return err == nil && !present
 	}, 15*time.Second, 250*time.Millisecond, "temporary slot %s must disappear after disconnect", slot)
-}
-
-// dropGatewaySlotIfPresent is a best-effort, idempotent cleanup safety net for
-// non-temporary slots: it drops the named slot if pg_replication_slots still
-// shows it, and no-ops if it's already gone. Mirrors dropReplicationSlot in
-// go/test/endtoend/multipooler/logical_replication_stream_test.go. Needed
-// because getSharedSetup shares one postgres instance across the whole test
-// binary run — an orphaned non-temporary slot (one that survives connection
-// close by design) would otherwise leak into later tests.
-func dropGatewaySlotIfPresent(t *testing.T, conn *sql.Conn, slot string) {
-	t.Helper()
-	// t.Context() may already be canceled by cleanup time; use a fresh bounded
-	// context, matching setupGatewayReplicationFixture's cleanup above.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	var present bool
-	if err := conn.QueryRowContext(ctx,
-		"SELECT EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)", slot).Scan(&present); err != nil {
-		t.Logf("dropGatewaySlotIfPresent: could not check slot %s: %v", slot, err)
-		return
-	}
-	if !present {
-		return
-	}
-	if _, err := conn.ExecContext(ctx, "SELECT pg_drop_replication_slot($1)", slot); err != nil {
-		t.Logf("dropGatewaySlotIfPresent: could not drop slot %s: %v", slot, err)
-	}
 }

--- a/go/test/endtoend/shardsetup/replication_stream_test.go
+++ b/go/test/endtoend/shardsetup/replication_stream_test.go
@@ -261,6 +261,32 @@ func TestGatewayReplicationStream_RejectsNonTemporarySlot(t *testing.T) {
 	requireGatewaySlotGone(t, sqlConn, slot)
 }
 
+// TestGatewayReplicationStream_RejectsNonTemporarySlotViaSQLFunction proves
+// the same restriction holds for the SQL-function creation path issued as a
+// plain query over the replication connection, not just the
+// CREATE_REPLICATION_SLOT wire command: postgres's walsender falls through
+// to the normal SQL executor for any query that isn't a recognized
+// replication command, so `SELECT pg_create_physical_replication_slot(...)`
+// reaches the same function an ordinary connection would.
+func TestGatewayReplicationStream_RejectsNonTemporarySlotViaSQLFunction(t *testing.T) {
+	skipIfShort(t)
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+
+	sqlConn, _, _ := setupGatewayReplicationFixture(t, setup)
+	slot := fmt.Sprintf("slot_gw_reject_sqlfunc_%d", replFixtureCounter.Add(1))
+
+	conn := dialGatewayReplicationConn(t, setup)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	_, err := conn.Query(ctx, fmt.Sprintf(
+		"SELECT pg_create_physical_replication_slot('%s', false, false)", slot))
+	require.Error(t, err, "pg_create_physical_replication_slot(temporary=false) over the replication connection must be rejected")
+	require.ErrorContains(t, err, "requires temporary=true")
+
+	requireGatewaySlotGone(t, sqlConn, slot)
+}
+
 // TestGatewayReplicationStream_LargePayload streams a row whose text value
 // exceeds 1 MiB and asserts the reassembled WAL bytes round-trip across 'w'
 // frames without frame-boundary corruption through the gateway + pooler


### PR DESCRIPTION
## Summary

- Rejects every path that can create a non-temporary (permanent) replication slot: `pg_create_physical_replication_slot`/`pg_create_logical_replication_slot()` SQL calls, and the replication protocol's `CREATE_REPLICATION_SLOT` command over a `replication=database` connection.
- Adds a structured preamble in front of the gateway's previously byte-blind replication tunnel to inspect `CREATE_REPLICATION_SLOT` before handing off to a frame-aware relay once streaming begins (`CopyBothResponse`).
- Rejects the extended query protocol outright during the preamble — a survey of the most widely used open-source software that consumes PostgreSQL logical replication found none that use the extended query protocol on this connection, so a flat rejection is simpler and just as safe as fully modeling it.
- Closes a connection-reuse bypass: a client that stops an active replication stream (`CopyDone`) and postgres returning to command mode (`ReadyForQuery`) previously went unnoticed by the byte-blind tunnel, letting a client sneak a non-temporary `CREATE_REPLICATION_SLOT` past the restriction on the same connection. The relay now terminates the connection outright the moment either signal appears, rather than allowing command-mode reuse.

## Problem

Multigres cannot yet migrate a replication slot's position across a primary failover. A permanent slot that survives a failover would silently desync from postgres's real state and corrupt whatever consumes it (e.g. Realtime).

## Solution

Two independent enforcement points for the two independent creation paths, both failing closed (missing/non-literal/false `temporary` argument is rejected, not assumed safe).

For the replication-protocol path, the previously fully byte-blind tunnel is replaced with two small frame-aware readers plugged into the existing, unmodified `commonrepl.Tunnel`: a downstream reader relays `CopyData` bodies incrementally (never buffering a whole frame, since logical replication frames aren't size-bounded and a single large row change can be multi-megabyte) and watches for `ReadyForQuery`; an upstream reader watches for `CopyDone`/`CopyFail`, forwarding it but refusing to relay anything the client pipelines immediately afterward without waiting for a reply. Either signal tears the connection down.

Only the slot-rejection *policy* is temporary — it should be deleted once slot-position migration across failover exists. The surrounding infrastructure is not: the exported `ReadMessageBody`/`WriteRawMessage` primitives are general-purpose wire-protocol helpers, and the preamble/relay mechanism itself (the ability for the gateway to see replication-protocol commands and the stream's lifecycle before they reach postgres) is very likely what a future failover-migration feature builds on, since it will need the same visibility to register/track slots for migration.
