### PR TITLE
test(backupfaults): harden TestPrimaryCrashWithUnarchivedWAL_NoDataLoss for coverage runs

### DIFF
--- a/go/test/endtoend/multipooler/backupfaults/backup_archive_lag_test.go
+++ b/go/test/endtoend/multipooler/backupfaults/backup_archive_lag_test.go
@@ -187,14 +187,14 @@ func TestPrimaryCrashWithUnarchivedWAL_NoDataLoss(t *testing.T) {
 	require.Eventually(t, func() bool {
 		s, _ := validator.Stats()
 		return s >= preSwitchCommits
-	}, 15*time.Second, 50*time.Millisecond,
+	}, 30*time.Second, 50*time.Millisecond,
 		"writer should accumulate >= %d successful commits before forcing WAL switch", preSwitchCommits)
 
 	// Force a WAL segment switch on the primary to trigger archive_command.
 	// Without this the writer's modest throughput (~50 commits/sec at small
 	// row sizes) will not fill a 16MB segment within the test budget, so no
 	// archive PUT would ever happen.
-	switchCtx, switchCancel := context.WithTimeout(t.Context(), 10*time.Second)
+	switchCtx, switchCancel := context.WithTimeout(t.Context(), 30*time.Second)
 	var switchedLSN string
 	require.NoError(t, primaryDB.QueryRowContext(switchCtx, "SELECT pg_switch_wal()::text").Scan(&switchedLSN))
 	switchCancel()
@@ -220,7 +220,7 @@ func TestPrimaryCrashWithUnarchivedWAL_NoDataLoss(t *testing.T) {
 	require.Eventually(t, func() bool {
 		s, _ := validator.Stats()
 		return s >= targetCommits
-	}, 30*time.Second, 100*time.Millisecond,
+	}, 60*time.Second, 100*time.Millisecond,
 		"writer should accumulate >= %d more commits after the archive was blocked (target=%d)", postBlockCommits, targetCommits)
 	preKillSuccess, preKillFailed := validator.Stats()
 	t.Logf("At kill: %d successful commits (%d after gate hit), %d failed",
@@ -252,7 +252,7 @@ func TestPrimaryCrashWithUnarchivedWAL_NoDataLoss(t *testing.T) {
 	validator.Stop()
 
 	// --- Wait for multiorch to elect a new primary.
-	newPrimaryName := shardsetup.WaitForNewPrimary(t, setup, originalPrimaryName, 30*time.Second)
+	newPrimaryName := shardsetup.WaitForNewPrimary(t, setup, originalPrimaryName, 60*time.Second)
 	require.NotEmpty(t, newPrimaryName, "no new primary elected within timeout")
 	t.Logf("New primary elected: %s", newPrimaryName)
 
@@ -306,7 +306,7 @@ func TestPrimaryCrashWithUnarchivedWAL_NoDataLoss(t *testing.T) {
 	t.Logf("New primary %s on term %d — verifying rejoined old primary", newPrimaryName, newPrimaryTerm)
 
 	verifyReplicasStreaming(t, setup, newPrimaryName, 60*time.Second)
-	verifyReplicasHaveAllIDs(t, setup, newPrimaryName, validator.TableName(), committedIDs, 30*time.Second)
+	verifyReplicasHaveAllIDs(t, setup, newPrimaryName, validator.TableName(), committedIDs, 60*time.Second)
 
 	// --- Provision a fresh standby (pooler-4) and let it bootstrap itself from
 	// the backup repo. The multipooler's MonitorPostgres detects an empty

--- a/go/test/endtoend/multipooler/backupfaults/helpers_test.go
+++ b/go/test/endtoend/multipooler/backupfaults/helpers_test.go
@@ -32,6 +32,15 @@ import (
 
 // connectToPostgresViaSocket opens a SQL connection to PostgreSQL over its
 // Unix socket. The caller is responsible for Close().
+//
+// The connection is not required to succeed on the first attempt: Ping is
+// polled with a generous budget. Under the coverage-instrumented CI jobs
+// (~2-3x slower, high concurrency) postgres can still be starting when this is
+// called — and, after a failover, a freshly promoted standby's socket may not
+// be accepting connections for a beat. Connecting immediately in those windows
+// yields the classic "connection to server on socket ... failed: No such file
+// or directory". The poll tolerates the slowdown; the bound follows the
+// project's ~30s+ convention for GitHub runners rather than a tight local one.
 func connectToPostgresViaSocket(t *testing.T, socketDir string, port int) *sql.DB {
 	t.Helper()
 
@@ -39,7 +48,14 @@ func connectToPostgresViaSocket(t *testing.T, socketDir string, port int) *sql.D
 		socketDir, port, shardsetup.TestPostgresPassword)
 	db, err := sql.Open("postgres", connStr)
 	require.NoError(t, err, "open postgres via socket")
-	require.NoError(t, db.Ping(), "ping postgres via socket")
+
+	require.Eventuallyf(t, func() bool {
+		pingCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		return db.PingContext(pingCtx) == nil
+	}, 60*time.Second, 200*time.Millisecond,
+		"postgres via socket %s (port %d) did not accept connections", socketDir, port)
+
 	return db
 }
 


### PR DESCRIPTION
## Problem

`TestPrimaryCrashWithUnarchivedWAL_NoDataLoss` is the single most-recurring flake in the **Code Coverage** CI workflow (the *Direct test coverage* and *Subprocess coverage* jobs), where the job retries and eventually gives up "after max_attempts". It is **not** a logic failure — it passes in the normal integration suite and locally. The coverage jobs run the full end-to-end suite with coverage-instrumented binaries (~2-3× slower) under high concurrency, and the test's tight waits time out.

The dominant symptom in the logs:

```
psql: error: connection to server on socket ".../.s.PGSQL.NNNN" failed: No such file or directory
```

i.e. the test connects/acts before postgres is actually accepting connections.

## Root cause

`connectToPostgresViaSocket` did a single `db.Ping()` and failed hard on the first attempt. That is fatal when postgres is still starting under coverage, or when the **freshly promoted new primary**'s socket isn't accepting connections for a beat — a window that the start-as-standby change (#1287) widens by turning a primary-postgres crash into a full failover rather than an in-place restart.

## Fix (target test only)

- `connectToPostgresViaSocket` now polls `PingContext` (up to 60s, 200ms interval) instead of a one-shot ping. This covers every direct-connect site, including the just-promoted new primary.
- Widen the tight poll bounds to the project's ~30s+ convention for slow GitHub runners under coverage:
  - pre-switch commits `15s → 30s`
  - `pg_switch_wal` context `10s → 30s`
  - post-block commits `30s → 60s`
  - `WaitForNewPrimary` `30s → 60s`
  - replica catch-up `30s → 60s`

No fixed `time.Sleep` remains — all waits are poll-based.

## Verification

Reproduced the exact CI slow path locally: coverage-instrumented binaries (`make build-coverage`, launched via `GOCOVERDIR` → `bin/cov/`, the *Subprocess coverage* path), run in isolation with `-count=10`:

```
ok  github.com/multigres/multigres/go/test/endtoend/multipooler/backupfaults  850.259s
```

**10/10 passing**, zero failures/panics (~85s/run under instrumentation).

## Scope

Focused fix for the one test that dominates the Code Coverage-job failures. Broader Code Coverage-job flakiness is tracked separately.