### PR TITLE
fix(multipooler): detect unreadable pgbackrest repos via status code

### DIFF
--- a/go/services/multipooler/internal/manager/backup/backup_health.go
+++ b/go/services/multipooler/internal/manager/backup/backup_health.go
@@ -334,6 +334,16 @@ func (e *Engine) refreshFromRepo(ctx context.Context) (reachable bool, reason st
 		e.logger.DebugContext(ctx, "backup health: failed to parse pgbackrest info; keeping cached age/count", "error", err)
 		return false, ReadyReasonRepoUnreachable
 	}
+	// `info` always exits 0 and always attaches the correct status code, even
+	// when a repository can't be evaluated (e.g. a cipher-key mismatch) — but
+	// getting here means the JSON above happened to decode (see decodeInfo for
+	// when it doesn't). The failure still shows up as backup:[] with no decode
+	// error, so it must not be read as "zero backups" — that would report
+	// readiness as reachable for a repo we actually can't read.
+	if err := repoStatusError(infoData); err != nil {
+		e.logger.DebugContext(ctx, "backup health: repo status error; keeping cached age/count", "error", err)
+		return false, ReadyReasonRepoUnreachable
+	}
 
 	var completeCount int64
 	var lastSuccessStop time.Time

--- a/go/services/multipooler/internal/manager/backup/backup_health_test.go
+++ b/go/services/multipooler/internal/manager/backup/backup_health_test.go
@@ -449,6 +449,29 @@ func TestRefreshFromRepo_MalformedJSONRetainsCache(t *testing.T) {
 	assert.Equal(t, int64(7), e.Health().Snapshot().CompleteCount, "cached count retained on parse error")
 }
 
+func TestRefreshFromRepo_UnreadableRepoStatusRetainsCache(t *testing.T) {
+	// info exits 0 with well-formed JSON, but repo[].status.code reports a
+	// repository pgbackrest could not evaluate (e.g. a cipher-key mismatch).
+	// backup:[] here must not be read as "zero backups, reachable" -- the
+	// cached age/count must be retained and readiness must report unreachable.
+	json := `[{"archive":[],"backup":[],"cipher":"aes-256-cbc","db":[],"name":"multigres",` +
+		`"repo":[{"cipher":"aes-256-cbc","key":1,"status":{"code":99,"message":"[FormatError] unable to load info file: repo is unreadable"}}],` +
+		`"status":{"code":99,"lock":{"backup":{"held":false},"restore":{"held":false}},"message":"other"}}]`
+	stubPgbackrest(t, pgbackrestInfoStub(json))
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+	primed := time.Unix(1735984860, 0)
+	e.Health().applyRepoInfo(primed, 7)
+
+	reachable, reason := e.refreshFromRepo(t.Context())
+	assert.False(t, reachable)
+	assert.Equal(t, ReadyReasonRepoUnreachable, reason)
+	snap := e.Health().Snapshot()
+	assert.Equal(t, int64(7), snap.CompleteCount, "cached count retained on repo status error")
+	assert.Equal(t, primed.Unix(), snap.LastSuccessStop.Unix())
+}
+
 func TestResolveRole(t *testing.T) {
 	e, _ := newTestEngine(t, t.TempDir(), "tg1", "0", "/tmp/backups")
 	assert.Equal(t, pgmode.Primary, e.resolveRole(t.Context()), "nil provider defaults to primary")

--- a/go/services/multipooler/internal/manager/backup/list.go
+++ b/go/services/multipooler/internal/manager/backup/list.go
@@ -88,7 +88,8 @@ func repoStatusError(infoData []pgBackRestInfo) error {
 	for _, stanza := range infoData {
 		for _, repo := range stanza.Repo {
 			switch repo.Status.Code {
-			case pgBackRestRepoStatusOK, pgBackRestRepoStatusMissingStanzaPath, pgBackRestRepoStatusNoValidBackups:
+			case pgBackRestRepoStatusOK, pgBackRestRepoStatusMissingStanzaPath, pgBackRestRepoStatusNoValidBackups,
+				pgBackRestRepoStatusMissingStanzaData:
 				continue
 			default:
 				return mterrors.New(mtrpcpb.Code_INTERNAL,

--- a/go/services/multipooler/internal/manager/backup/list.go
+++ b/go/services/multipooler/internal/manager/backup/list.go
@@ -70,7 +70,33 @@ func (e *Engine) ListBackups(ctx context.Context) ([]*multipoolermanagerdata.Bac
 	if err != nil {
 		return nil, err
 	}
+	if err := repoStatusError(infoData); err != nil {
+		return nil, err
+	}
 	return e.parseBackups(ctx, infoData), nil
+}
+
+// repoStatusError inspects the per-repository status pgbackrest reports and
+// returns an error if any repository could not be evaluated. `pgbackrest
+// info` always exits 0 and always attaches the correct status code (e.g. 99
+// "other" for a cipher-key mismatch) — decodeInfo above covers the case where
+// that status arrives in JSON that fails to decode. When it decodes fine,
+// "backup" is simply empty, so backup:[] alone must not be read as "no
+// backups yet": check the status code too, or a caller could bootstrap a
+// fresh stanza over a repo it cannot actually read.
+func repoStatusError(infoData []pgBackRestInfo) error {
+	for _, stanza := range infoData {
+		for _, repo := range stanza.Repo {
+			switch repo.Status.Code {
+			case pgBackRestRepoStatusOK, pgBackRestRepoStatusMissingStanzaPath, pgBackRestRepoStatusNoValidBackups:
+				continue
+			default:
+				return mterrors.New(mtrpcpb.Code_INTERNAL,
+					fmt.Sprintf("pgbackrest repo %d status: %s", repo.Key, repo.Status.Message))
+			}
+		}
+	}
+	return nil
 }
 
 // runInfoCmd runs `pgbackrest info --output=json` with the given config path and
@@ -97,7 +123,15 @@ func isStanzaMissing(output string) bool {
 		strings.Contains(output, "unable to open missing file")
 }
 
-// decodeInfo unmarshals `pgbackrest info` JSON output.
+// decodeInfo unmarshals `pgbackrest info` JSON output. This can fail even
+// though pgbackrest exited 0: when a repo can't be decrypted (e.g. a
+// cipher-key mismatch), some of pgbackrest's own error messages splice a raw,
+// unescaped snippet of the repo's undecrypted bytes directly into the JSON
+// message string. Those bytes can contain characters (control bytes, invalid
+// UTF-8) that are illegal inside a JSON string, which breaks decoding of the
+// whole document. Callers must treat that as a real error — see
+// repoStatusError for the same underlying failure when the JSON happens to
+// decode fine instead.
 func decodeInfo(output string) ([]pgBackRestInfo, error) {
 	var infoData []pgBackRestInfo
 	if err := json.Unmarshal([]byte(output), &infoData); err != nil {
@@ -230,6 +264,9 @@ func (e *Engine) FindByJobID(
 
 	infoData, err := decodeInfo(output)
 	if err != nil {
+		return "", err
+	}
+	if err := repoStatusError(infoData); err != nil {
 		return "", err
 	}
 

--- a/go/services/multipooler/internal/manager/backup/list_test.go
+++ b/go/services/multipooler/internal/manager/backup/list_test.go
@@ -169,6 +169,24 @@ func TestListBackups_ErrorOnUnreadableRepoStatus(t *testing.T) {
 	assert.Contains(t, err.Error(), "unable to load info file")
 }
 
+func TestListBackups_MissingStanzaDataIsBenign(t *testing.T) {
+	// Status code 3 (INFO_STANZA_STATUS_CODE_MISSING_STANZA_DATA) means the
+	// stanza path exists but backup.info is simply absent -- a FileMissingError,
+	// not a decrypt failure -- so it's the same "nothing here yet" state as
+	// codes 1/2 and must not be treated as an error.
+	json := `[{"archive":[],"backup":[],"cipher":"aes-256-cbc","db":[],"name":"multigres",` +
+		`"repo":[{"cipher":"aes-256-cbc","key":1,"status":{"code":3,"message":"missing stanza data"}}],` +
+		`"status":{"code":3,"lock":{"backup":{"held":false},"restore":{"held":false}},"message":"missing stanza data"}}]`
+	stubPgbackrest(t, pgbackrestInfoStub(json))
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+
+	backups, err := e.ListBackups(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, backups)
+}
+
 func TestListBackups_ErrorOnMalformedJSON(t *testing.T) {
 	stubPgbackrest(t, "#!/bin/bash\nif [[ \"$*\" == *info* ]]; then echo \"garbage not json\"; exit 0; fi\nexit 0\n")
 	poolerDir := t.TempDir()

--- a/go/services/multipooler/internal/manager/backup/list_test.go
+++ b/go/services/multipooler/internal/manager/backup/list_test.go
@@ -149,6 +149,26 @@ func TestListBackups_EmptyWhenStanzaMissing(t *testing.T) {
 	assert.Empty(t, backups)
 }
 
+func TestListBackups_ErrorOnUnreadableRepoStatus(t *testing.T) {
+	// pgbackrest info always exits 0 and always emits well-formed top-level
+	// JSON, even when it cannot decrypt/read a repo (e.g. wrong cipher key):
+	// the failure is reported via repo[].status.code inside the JSON body,
+	// not via a nonzero process exit or a JSON decode error. backup:[] here
+	// must not be read as "no backups yet" -- that would let the caller
+	// bootstrap a fresh stanza over a repo it actually cannot read.
+	json := `[{"archive":[],"backup":[],"cipher":"aes-256-cbc","db":[],"name":"multigres",` +
+		`"repo":[{"cipher":"aes-256-cbc","key":1,"status":{"code":99,"message":"[FormatError] unable to load info file: repo is unreadable"}}],` +
+		`"status":{"code":99,"lock":{"backup":{"held":false},"restore":{"held":false}},"message":"other"}}]`
+	stubPgbackrest(t, pgbackrestInfoStub(json))
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+
+	_, err := e.ListBackups(t.Context())
+	require.Error(t, err, "a repo status error must not be silently treated as an empty backup list")
+	assert.Contains(t, err.Error(), "unable to load info file")
+}
+
 func TestListBackups_ErrorOnMalformedJSON(t *testing.T) {
 	stubPgbackrest(t, "#!/bin/bash\nif [[ \"$*\" == *info* ]]; then echo \"garbage not json\"; exit 0; fi\nexit 0\n")
 	poolerDir := t.TempDir()

--- a/go/services/multipooler/internal/manager/backup/types.go
+++ b/go/services/multipooler/internal/manager/backup/types.go
@@ -16,9 +16,40 @@ package backup
 
 // pgBackRestInfo represents the structure of pgbackrest info JSON output
 type pgBackRestInfo struct {
-	Name   string             `json:"name"`
-	Backup []pgBackRestBackup `json:"backup"`
+	Name   string                 `json:"name"`
+	Backup []pgBackRestBackup     `json:"backup"`
+	Repo   []pgBackRestRepoStatus `json:"repo"`
 }
+
+// pgBackRestRepoStatus represents the per-repository status pgbackrest
+// reports for a stanza. `info` always exits 0 and reports its best-effort
+// view even when a repository cannot be evaluated at all (e.g. a cipher-key
+// mismatch): that failure only shows up here, never as a nonzero exit code.
+type pgBackRestRepoStatus struct {
+	Key    int                 `json:"key"`
+	Status pgBackRestRepoState `json:"status"`
+}
+
+// pgBackRestRepoState is the status code/message pgbackrest assigns to a
+// repository. Per `pgbackrest help info`: known conditions get a specific
+// code (ok, missing stanza path, no valid backups); anything else pgbackrest
+// can't classify is reported as code 99 ("other") with the full error detail
+// in Message.
+type pgBackRestRepoState struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// Known-benign pgbackrest repo status codes: the repository was evaluated
+// successfully and either has usable backup data or is simply not bootstrapped
+// yet. Any other code (including the 99 "other" catch-all) means pgbackrest
+// could not properly evaluate the repository and must not be read as "no
+// backups".
+const (
+	pgBackRestRepoStatusOK                = 0 // stanza/repo is healthy
+	pgBackRestRepoStatusMissingStanzaPath = 1 // stanza never created (fresh repo)
+	pgBackRestRepoStatusNoValidBackups    = 2 // stanza exists but has no backups yet
+)
 
 // pgBackRestBackup represents a single backup in the info output
 type pgBackRestBackup struct {

--- a/go/services/multipooler/internal/manager/backup/types.go
+++ b/go/services/multipooler/internal/manager/backup/types.go
@@ -45,10 +45,14 @@ type pgBackRestRepoState struct {
 // yet. Any other code (including the 99 "other" catch-all) means pgbackrest
 // could not properly evaluate the repository and must not be read as "no
 // backups".
+//
+// Source of truth for these codes (INFO_STANZA_STATUS_CODE_*):
+// https://github.com/pgbackrest/pgbackrest/blob/main/src/command/info/info.c
 const (
 	pgBackRestRepoStatusOK                = 0 // stanza/repo is healthy
 	pgBackRestRepoStatusMissingStanzaPath = 1 // stanza never created (fresh repo)
 	pgBackRestRepoStatusNoValidBackups    = 2 // stanza exists but has no backups yet
+	pgBackRestRepoStatusMissingStanzaData = 3 // stanza path exists but backup.info is simply absent (not a decrypt failure)
 )
 
 // pgBackRestBackup represents a single backup in the info output


### PR DESCRIPTION
## Summary

- `ListBackups`, `FindByJobID`, and the backup health poller's `refreshFromRepo` silently misread an unreadable pgBackRest repository (e.g. a cipher-key mismatch) as "zero backups" instead of surfacing an error.
- Added `repoStatusError`, which checks pgBackRest's own `repo[].status.code` and treats any code other than the known-benign ones (ok, missing stanza path, no valid backups) as an error.
- Added regression tests for `ListBackups` and `refreshFromRepo` covering this case directly, without depending on real pgbackrest binaries.
- After this change, this test passes consistently in my local:  `TestJoin_FailsWithWrongCipherKey`. I was able to repro the failure before the change.


## Problem

`pgbackrest info` always exits 0, even when it cannot decrypt/read a repository — the failure is reported via `repo[].status.code` inside the JSON body, not through a nonzero exit code or command error. The Go struct decoding that output never captured `repo[].status`, so an unreadable repo decoded as an empty `backup: []` list, which was read as "no backups yet" rather than "repo unreadable."

Whether this got masked depended on an unrelated coincidence: some of pgbackrest's own error messages for this case splice a raw, unescaped snippet of the repo's undecrypted ciphertext directly into the JSON message string. That snippet sometimes contains bytes illegal inside a JSON string, which breaks decoding of the whole document — in that case the pre-existing decode-error path happened to surface an error anyway. This made `TestJoin_FailsWithWrongCipherKey` flaky: it passed most of the time by accident (the decode happened to fail), and occasionally failed when the decode happened to succeed, letting the monitor read the unreadable repo as empty and attempt to bootstrap over it.

## Solution

Added `pgBackRestRepoStatus`/`pgBackRestRepoState` to actually capture `repo[].status`, and `repoStatusError` to treat any status code other than the known-benign set (0 ok, 1 missing stanza path, 2 no valid backups) as a real error. Wired into `ListBackups`, `FindByJobID`, and `refreshFromRepo`, so an unreadable repo is never silently treated as an empty one, regardless of whether pgbackrest's diagnostic message happens to decode as JSON.

## Test
* Added a few more tests to capture this.
*  I validated this change by running:
```
MULTIGRES_PORT_POOL_ADDR=/tmp/multigres-port-pool.sock go test -run TestJoin_FailsWithWrongCipherKey -count=10 -v -timeout=15m ./go/test/endtoend/multipooler/backupfaults/...
```
