### PR TITLE
feat(multigateway): reserve connection for pg_create_logical_replication_slot()

### DIFF
--- a/go/common/protoutil/reservation.go
+++ b/go/common/protoutil/reservation.go
@@ -39,18 +39,13 @@ const (
 	// and must stay pinned to its current Postgres backend for the session's
 	// lifetime.
 	//
-	// Today this bit is set only at connection-open time, by the
-	// reserved.Pool.NewLogicalReplicationConn factory for connections that
-	// requested `replication=database` in the startup parameters.
-	//
-	// TODO: also set this bit mid-session when the planner observes
-	// pg_create_logical_replication_slot(...) on a plain SQL connection
-	// (polling / CDC-RLS path). This will mirror how ReasonTempTable is set
-	// when CREATE TEMP TABLE is observed (see
-	// go/services/multigateway/handler/connection_state.go for the
-	// PendingTempTableReservation precedent). Until that lands, polling
-	// consumers must cooperate by setting an application_name that
-	// multigateway recognizes (also future work).
+	// Set at connection-open time by the reserved.Pool.NewLogicalReplicationConn
+	// factory for connections that requested `replication=database` in the
+	// startup parameters, and mid-session by the multigateway planner when it
+	// observes pg_create_logical_replication_slot(...) on a plain SQL
+	// connection (the Postgres Changes / CDC-RLS polling path — see
+	// go/services/multigateway/planner/unsafe_funccall.go's
+	// logicalReplicationSlotCreateFuncs).
 	ReasonLogicalReplication = uint32(multipoolerpb.ReservationReason_RESERVATION_REASON_LOGICAL_REPLICATION) // 32
 
 	// ReasonSessionAdvisoryLock indicates the session holds one or more

--- a/go/services/multigateway/engine/engine.go
+++ b/go/services/multigateway/engine/engine.go
@@ -80,6 +80,15 @@ type PlanExecInfo struct {
 	// the statement.
 	PostQuerySessionSettings map[string]string
 
+	// LogicalReplicationSlot requests a reserved connection with
+	// ReasonLogicalReplication, pinning the backend for the session's
+	// lifetime. Set when the statement calls
+	// pg_create_logical_replication_slot(...) — the (often temporary) slot it
+	// creates only exists on that one backend. Unlike AdvisoryLock, there is no
+	// matching recheck/auto-release signal: this mirrors TempTable, not the
+	// advisory-lock pattern (see the plan that introduced this field for why).
+	LogicalReplicationSlot bool
+
 	// Exchange is a per-execution channel for handing runtime-computed data from
 	// one primitive in a Sequence to a later sibling (e.g. ValidateSetting →
 	// ApplySessionState). Sequence creates one per execution and threads the same

--- a/go/services/multigateway/engine/engine.go
+++ b/go/services/multigateway/engine/engine.go
@@ -84,9 +84,17 @@ type PlanExecInfo struct {
 	// ReasonLogicalReplication, pinning the backend for the session's
 	// lifetime. Set when the statement calls
 	// pg_create_logical_replication_slot(...) — the (often temporary) slot it
-	// creates only exists on that one backend. Unlike AdvisoryLock, there is no
-	// matching recheck/auto-release signal: this mirrors TempTable, not the
-	// advisory-lock pattern (see the plan that introduced this field for why).
+	// creates only exists on that one backend.
+	//
+	// Unlike AdvisoryLock, there is no matching recheck/auto-release signal:
+	// this mirrors TempTable, not the advisory-lock pattern. Advisory locks are
+	// commonly acquired and released within a session, so promptly unpinning
+	// once none remain frees the backend for other sessions. A logical
+	// replication slot's typical client (e.g. a CDC poller) holds one
+	// connection for its entire process lifetime regardless, so there is no
+	// backend to usefully free by reacting to pg_drop_replication_slot(...) —
+	// the reservation is released the same way TempTable's is: DISCARD ALL or
+	// session teardown.
 	LogicalReplicationSlot bool
 
 	// Exchange is a per-execution channel for handing runtime-computed data from

--- a/go/services/multigateway/engine/plan.go
+++ b/go/services/multigateway/engine/plan.go
@@ -27,21 +27,22 @@ import (
 
 // Plan type constants identify the root primitive for observability.
 const (
-	PlanTypeRoute                 = "Route"
-	PlanTypeTransaction           = "Transaction"
-	PlanTypeCopyStatement         = "CopyStatement"
-	PlanTypeApplySessionState     = "ApplySessionState"
-	PlanTypeResolveTrackSetConfig = "ResolveTrackSetConfig"
-	PlanTypeGatewaySessionState   = "GatewaySessionState"
-	PlanTypeGatewayShowVariable   = "GatewayShowVariable"
-	PlanTypeListenNotify          = "ListenNotify"
-	PlanTypeSequence              = "Sequence"
-	PlanTypeTempTableRoute        = "TempTableRoute"
-	PlanTypeAdvisoryLockRoute     = "AdvisoryLockRoute"
-	PlanTypeHoldCursorRoute       = "HoldCursorRoute"
-	PlanTypeCloseCursorRoute      = "CloseCursorRoute"
-	PlanTypeDiscardAll            = "DiscardAll"
-	PlanTypeUnknown               = "Unknown"
+	PlanTypeRoute                       = "Route"
+	PlanTypeTransaction                 = "Transaction"
+	PlanTypeCopyStatement               = "CopyStatement"
+	PlanTypeApplySessionState           = "ApplySessionState"
+	PlanTypeResolveTrackSetConfig       = "ResolveTrackSetConfig"
+	PlanTypeGatewaySessionState         = "GatewaySessionState"
+	PlanTypeGatewayShowVariable         = "GatewayShowVariable"
+	PlanTypeListenNotify                = "ListenNotify"
+	PlanTypeSequence                    = "Sequence"
+	PlanTypeTempTableRoute              = "TempTableRoute"
+	PlanTypeAdvisoryLockRoute           = "AdvisoryLockRoute"
+	PlanTypeLogicalReplicationSlotRoute = "LogicalReplicationSlotRoute"
+	PlanTypeHoldCursorRoute             = "HoldCursorRoute"
+	PlanTypeCloseCursorRoute            = "CloseCursorRoute"
+	PlanTypeDiscardAll                  = "DiscardAll"
+	PlanTypeUnknown                     = "Unknown"
 )
 
 // Plan represents a query execution plan.

--- a/go/services/multigateway/planner/planner.go
+++ b/go/services/multigateway/planner/planner.go
@@ -78,6 +78,12 @@ type PlanOptions struct {
 	// lifetime (AdvisoryLockRoute rather than a plain Route). Derived by Plan.
 	PinForAdvisoryLock bool
 
+	// PinForLogicalReplicationSlot indicates the statement creates a logical
+	// replication slot via pg_create_logical_replication_slot(...), so its
+	// route must keep the backend pinned for the session's lifetime. Derived
+	// by Plan.
+	PinForLogicalReplicationSlot bool
+
 	// RecheckForAdvisoryLock indicates the statement touches session-level
 	// advisory locks (an acquire or a release), so the multipooler should
 	// re-probe pg_locks afterward and unpin if none remain. It is a superset of
@@ -174,6 +180,7 @@ func (p *Planner) Plan(
 	// whatever plan they would otherwise produce.
 	opts.PinForAdvisoryLock = analysis.AcquiresSessionAdvisoryLock
 	opts.RecheckForAdvisoryLock = analysis.AcquiresSessionAdvisoryLock || analysis.ReleasesSessionAdvisoryLock
+	opts.PinForLogicalReplicationSlot = analysis.CreatesLogicalReplicationSlot
 	opts.RewriteCurrentSetting = analysis.NeedsCurrentSettingRewrite
 
 	// Dispatch to appropriate planner function based on statement type
@@ -373,16 +380,17 @@ func (p *Planner) planClosePortalStmt(sql string, stmt *ast.ClosePortalStmt) (*e
 }
 
 // planDefault creates a simple route plan for queries without special handling.
-// This is the fallback for most SQL statements. Advisory-lock pinning, when the
-// statement touches a session-level advisory lock, rides on the plan's ExecInfo
-// (see advisoryExecInfo) rather than a dedicated routing primitive.
+// This is the fallback for most SQL statements. Advisory-lock pinning and
+// logical-replication-slot pinning, when the statement touches either, ride on
+// the plan's ExecInfo (see execInfoFromOpts) rather than a dedicated routing
+// primitive.
 func (p *Planner) planDefault(sql string, stmt ast.Stmt, conn *server.Conn, opts PlanOptions) (*engine.Plan, error) {
 	prim, err := p.routePrimitive(sql, stmt, opts)
 	if err != nil {
 		return nil, err
 	}
 	plan := engine.NewPlan(sql, prim)
-	plan.ExecInfo = advisoryExecInfo(opts)
+	plan.ExecInfo = execInfoFromOpts(opts)
 
 	p.logger.Debug("created default route plan",
 		"plan", plan.String(),
@@ -411,15 +419,24 @@ func (p *Planner) routePrimitive(sql string, stmt ast.Stmt, opts PlanOptions) (e
 	return engine.NewRoute(p.defaultTableGroup, constants.DefaultShard, sql, stmt), nil
 }
 
-// advisoryExecInfo derives the plan-level reservation directives for a statement
-// that touches session-level advisory locks. We track on RecheckForAdvisoryLock
-// (the superset): an acquire wants both a pin and a recheck, a bare release
-// wants only the recheck — so the pin is carried separately and a release does
-// not reserve a connection. The zero value (no advisory) is the common case.
-func advisoryExecInfo(opts PlanOptions) engine.PlanExecInfo {
+// execInfoFromOpts derives the plan-level reservation directives for a
+// statement from the per-call PlanOptions the analysis pass already computed.
+//
+// Advisory locks: tracked on RecheckForAdvisoryLock (the superset): an
+// acquire wants both a pin and a recheck, a bare release wants only the
+// recheck — so the pin is carried separately and a release does not reserve a
+// connection.
+//
+// Logical replication slot creation: acquire-only, no recheck — mirrors
+// TempTable rather than the advisory-lock pattern (see
+// PlanExecInfo.LogicalReplicationSlot's doc comment for why).
+//
+// The zero value (no advisory, no slot creation) is the common case.
+func execInfoFromOpts(opts PlanOptions) engine.PlanExecInfo {
 	return engine.PlanExecInfo{
-		AdvisoryLock:         opts.PinForAdvisoryLock,
-		RecheckAdvisoryLocks: opts.RecheckForAdvisoryLock,
+		AdvisoryLock:           opts.PinForAdvisoryLock,
+		RecheckAdvisoryLocks:   opts.RecheckForAdvisoryLock,
+		LogicalReplicationSlot: opts.PinForLogicalReplicationSlot,
 	}
 }
 
@@ -445,6 +462,8 @@ func planType(p engine.Primitive, info engine.PlanExecInfo) string {
 		switch {
 		case info.TempTable:
 			return engine.PlanTypeTempTableRoute
+		case info.LogicalReplicationSlot:
+			return engine.PlanTypeLogicalReplicationSlotRoute
 		case info.AdvisoryLock || info.RecheckAdvisoryLocks:
 			return engine.PlanTypeAdvisoryLockRoute
 		}

--- a/go/services/multigateway/planner/select_stmt.go
+++ b/go/services/multigateway/planner/select_stmt.go
@@ -125,7 +125,7 @@ func (p *Planner) planSelectStmt(
 		}
 	}
 	plan := engine.NewPlan(sql, engine.NewSequence(primitives))
-	plan.ExecInfo = advisoryExecInfo(opts)
+	plan.ExecInfo = execInfoFromOpts(opts)
 	return plan, nil
 }
 
@@ -171,7 +171,7 @@ func (p *Planner) planResolveSetConfig(sql string, stmt *ast.SelectStmt, opts Pl
 
 	prim := engine.NewResolveTrackSetConfig(p.defaultTableGroup, constants.DefaultShard, sql, resolveRoute, unroll, aliases)
 	plan := engine.NewPlan(sql, prim)
-	plan.ExecInfo = advisoryExecInfo(opts)
+	plan.ExecInfo = execInfoFromOpts(opts)
 	return plan, nil
 }
 

--- a/go/services/multigateway/planner/unsafe_funccall.go
+++ b/go/services/multigateway/planner/unsafe_funccall.go
@@ -144,6 +144,19 @@ var sessionAdvisoryLockReleaseFuncs = map[string]struct{}{
 	"pg_advisory_unlock_all":    {},
 }
 
+// logicalReplicationSlotCreateFuncs is the set of built-in functions that
+// create a logical replication slot via plain SQL (as opposed to the
+// replication-protocol CREATE_REPLICATION_SLOT command, which is handled
+// separately at connection-open time — see protoutil.ReasonLogicalReplication).
+// Supabase Realtime's Postgres Changes / CDC-RLS polling extension creates a
+// TEMPORARY slot this way and then polls it repeatedly on the same client
+// session for the session's entire lifetime; a temporary slot only exists on
+// the backend that created it, so the gateway must keep routing the session
+// to that same backend from here on.
+var logicalReplicationSlotCreateFuncs = map[string]struct{}{
+	"pg_create_logical_replication_slot": {},
+}
+
 // statementAnalysis carries the result of analyzing a statement before
 // dispatch: the planning signals gathered from its expression tree (which
 // set_config calls to track, whether it acquires a session-level advisory
@@ -194,6 +207,17 @@ type statementAnalysis struct {
 	// (conservatively) until the next observed advisory statement, DISCARD ALL,
 	// or disconnect — never a leak.
 	ReleasesSessionAdvisoryLock bool
+
+	// CreatesLogicalReplicationSlot is true if any FuncCall in the statement is
+	// pg_create_logical_replication_slot(...) (see
+	// logicalReplicationSlotCreateFuncs). The planner uses this to route the
+	// statement through a reserved connection with ReasonLogicalReplication so
+	// the backend is pinned for the session's lifetime — a created slot (often
+	// temporary) only exists on that one backend. This is acquire-only: unlike
+	// AcquiresSessionAdvisoryLock, there is no matching "release" detection or
+	// recheck — the reservation persists until DISCARD ALL or session
+	// teardown, mirroring TempTable rather than the advisory-lock pattern.
+	CreatesLogicalReplicationSlot bool
 
 	// NeedsCurrentSettingRewrite is true when the statement is a value-evaluating
 	// DML statement (see stmtRewritableForCurrentSetting) that contains at least
@@ -347,6 +371,10 @@ func analyzeFunctionCalls(stmt ast.Stmt) (*statementAnalysis, error) {
 		}
 		if _, isUnlock := sessionAdvisoryLockReleaseFuncs[name]; isUnlock {
 			result.ReleasesSessionAdvisoryLock = true
+			return true
+		}
+		if _, isSlotCreate := logicalReplicationSlotCreateFuncs[name]; isSlotCreate {
+			result.CreatesLogicalReplicationSlot = true
 			return true
 		}
 		if name == "current_setting" {

--- a/go/services/multigateway/planner/unsafe_funccall.go
+++ b/go/services/multigateway/planner/unsafe_funccall.go
@@ -157,6 +157,30 @@ var logicalReplicationSlotCreateFuncs = map[string]struct{}{
 	"pg_create_logical_replication_slot": {},
 }
 
+// isTemporarySlotCreate reports whether fc's `temporary` argument (the third
+// positional argument to pg_create_logical_replication_slot) indicates the
+// slot being created is temporary — the case that needs backend pinning. A
+// persistent (non-temporary) slot is visible from any backend and survives
+// independently of the connection that created it, so it doesn't need one.
+//
+// `temporary` defaults to false when omitted, so a bare two-argument call is
+// definitively persistent. When the argument is present but isn't a literal
+// boolean (e.g. a bound parameter), its value can't be resolved at plan time;
+// this conservatively treats that case as temporary so a slot that turns out
+// temporary at execute time is never left unpinned — the cost of an
+// unnecessary pin is a held connection, not the data-unavailability bug this
+// detection exists to prevent.
+func isTemporarySlotCreate(fc *ast.FuncCall) bool {
+	if fc.Args == nil || fc.Args.Len() < 3 {
+		return false
+	}
+	isTemp, ok := constBoolArg(fc.Args.Items[2])
+	if !ok {
+		return true
+	}
+	return isTemp
+}
+
 // statementAnalysis carries the result of analyzing a statement before
 // dispatch: the planning signals gathered from its expression tree (which
 // set_config calls to track, whether it acquires a session-level advisory
@@ -209,11 +233,12 @@ type statementAnalysis struct {
 	ReleasesSessionAdvisoryLock bool
 
 	// CreatesLogicalReplicationSlot is true if any FuncCall in the statement is
-	// pg_create_logical_replication_slot(...) (see
-	// logicalReplicationSlotCreateFuncs). The planner uses this to route the
-	// statement through a reserved connection with ReasonLogicalReplication so
-	// the backend is pinned for the session's lifetime — a created slot (often
-	// temporary) only exists on that one backend. This is acquire-only: unlike
+	// pg_create_logical_replication_slot(...) with a temporary slot (see
+	// logicalReplicationSlotCreateFuncs and isTemporarySlotCreate). The planner
+	// uses this to route the statement through a reserved connection with
+	// ReasonLogicalReplication so the backend is pinned for the session's
+	// lifetime — a temporary slot only exists on that one backend, unlike a
+	// persistent slot, which needs no pinning. This is acquire-only: unlike
 	// AcquiresSessionAdvisoryLock, there is no matching "release" detection or
 	// recheck — the reservation persists until DISCARD ALL or session
 	// teardown, mirroring TempTable rather than the advisory-lock pattern.
@@ -374,7 +399,9 @@ func analyzeFunctionCalls(stmt ast.Stmt) (*statementAnalysis, error) {
 			return true
 		}
 		if _, isSlotCreate := logicalReplicationSlotCreateFuncs[name]; isSlotCreate {
-			result.CreatesLogicalReplicationSlot = true
+			if isTemporarySlotCreate(fc) {
+				result.CreatesLogicalReplicationSlot = true
+			}
 			return true
 		}
 		if name == "current_setting" {

--- a/go/services/multigateway/planner/unsafe_funccall_test.go
+++ b/go/services/multigateway/planner/unsafe_funccall_test.go
@@ -581,6 +581,64 @@ func TestInspectExpressionFuncCalls_Allowed(t *testing.T) {
 	}
 }
 
+// TestInspectExpressionFuncCalls_LogicalReplicationSlotCreation covers
+// detection of pg_create_logical_replication_slot(...), which must fire
+// regardless of how deeply the call is nested — Supabase Realtime's actual
+// call site (Extensions.PostgresCdcRls.Replications.prepare_replication/2)
+// buries it inside a CASE inside a scalar subquery, not a bare top-level
+// SELECT.
+func TestInspectExpressionFuncCalls_LogicalReplicationSlotCreation(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want bool
+	}{
+		{
+			"bare top-level call",
+			"SELECT pg_create_logical_replication_slot('s1', 'pgoutput')",
+			true,
+		},
+		{
+			"schema-qualified",
+			"SELECT pg_catalog.pg_create_logical_replication_slot('s1', 'pgoutput', true)",
+			true,
+		},
+		{
+			"Realtime's actual nested shape: CASE + scalar subquery",
+			`select
+			   case when not exists (
+			     select 1 from pg_replication_slots where slot_name = 's1'
+			   )
+			   then (
+			     select 1 from pg_create_logical_replication_slot('s1', 'wal2json', 'true')
+			   )
+			   else 1
+			   end`,
+			true,
+		},
+		{
+			"unrelated function call does not set the flag",
+			"SELECT pg_advisory_lock(1)",
+			false,
+		},
+		{
+			"no function call at all",
+			"SELECT 1",
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt := parseOne(t, tt.sql)
+			result, err := analyzeFunctionCalls(stmt)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.want, result.CreatesLogicalReplicationSlot)
+		})
+	}
+}
+
 // TestResolveFuncName checks the pg_catalog-qualification normalization.
 // A user writing `pg_catalog.dblink(...)` must hit the same blocklist entry
 // as bare `dblink(...)`.
@@ -663,6 +721,33 @@ func TestPlan_SetConfig_ProducesSequence(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPlan_LogicalReplicationSlotCreation_SetsExecInfo verifies that a
+// statement creating a logical replication slot — even nested inside a CASE +
+// scalar subquery, matching Supabase Realtime's real call site — produces a
+// plan whose ExecInfo.LogicalReplicationSlot is true, so the reservation
+// machinery in scatterconn picks it up.
+func TestPlan_LogicalReplicationSlotCreation_SetsExecInfo(t *testing.T) {
+	sql := `select
+	  case when not exists (
+	    select 1 from pg_replication_slots where slot_name = 's1'
+	  )
+	  then (
+	    select 1 from pg_create_logical_replication_slot('s1', 'wal2json', 'true')
+	  )
+	  else 1
+	  end`
+	stmt := parseOne(t, sql)
+
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	p := NewPlanner("default", logger, nil)
+	testConn := server.NewTestConn(&bytes.Buffer{})
+
+	plan, err := p.Plan(sql, stmt, testConn.Conn, PlanOptions{})
+	require.NoError(t, err)
+	assert.True(t, plan.ExecInfo.LogicalReplicationSlot)
+	assert.Equal(t, engine.PlanTypeLogicalReplicationSlotRoute, plan.Type)
 }
 
 // TestPlan_DynamicSetConfig_ProducesResolvePrimitive verifies that the pg_dump

--- a/go/services/multigateway/planner/unsafe_funccall_test.go
+++ b/go/services/multigateway/planner/unsafe_funccall_test.go
@@ -582,11 +582,12 @@ func TestInspectExpressionFuncCalls_Allowed(t *testing.T) {
 }
 
 // TestInspectExpressionFuncCalls_LogicalReplicationSlotCreation covers
-// detection of pg_create_logical_replication_slot(...), which must fire
-// regardless of how deeply the call is nested — Supabase Realtime's actual
-// call site (Extensions.PostgresCdcRls.Replications.prepare_replication/2)
+// detection of a TEMPORARY pg_create_logical_replication_slot(...), which
+// must fire regardless of how deeply the call is nested — Supabase Realtime's
+// actual call site (Extensions.PostgresCdcRls.Replications.prepare_replication/2)
 // buries it inside a CASE inside a scalar subquery, not a bare top-level
-// SELECT.
+// SELECT. A persistent (non-temporary) slot must NOT set the flag: it's
+// visible from any backend, so pinning would only waste a reservation.
 func TestInspectExpressionFuncCalls_LogicalReplicationSlotCreation(t *testing.T) {
 	tests := []struct {
 		name string
@@ -594,17 +595,27 @@ func TestInspectExpressionFuncCalls_LogicalReplicationSlotCreation(t *testing.T)
 		want bool
 	}{
 		{
-			"bare top-level call",
+			"bare two-argument call: temporary omitted, defaults to false (persistent)",
 			"SELECT pg_create_logical_replication_slot('s1', 'pgoutput')",
-			true,
+			false,
 		},
 		{
-			"schema-qualified",
+			"explicit temporary=false is persistent",
+			"SELECT pg_create_logical_replication_slot('s1', 'pgoutput', false)",
+			false,
+		},
+		{
+			"schema-qualified, explicit temporary=true",
 			"SELECT pg_catalog.pg_create_logical_replication_slot('s1', 'pgoutput', true)",
 			true,
 		},
 		{
-			"Realtime's actual nested shape: CASE + scalar subquery",
+			"bound temporary argument can't be resolved at plan time, conservatively treated as temporary",
+			"SELECT pg_create_logical_replication_slot('s1', 'pgoutput', $1)",
+			true,
+		},
+		{
+			"Realtime's actual nested shape: CASE + scalar subquery, temporary passed as literal string 'true'",
 			`select
 			   case when not exists (
 			     select 1 from pg_replication_slots where slot_name = 's1'

--- a/go/services/multigateway/scatterconn/scatter_conn.go
+++ b/go/services/multigateway/scatterconn/scatter_conn.go
@@ -170,6 +170,24 @@ func (sc *ScatterConn) applyReservedState(
 	}
 }
 
+// reservationReasonsForExecInfo ORs together the reservation reason bits
+// requested by info's boolean flags. PinPortals/ReleasePortals and the
+// transaction/BEGIN handling carry auxiliary data (names, query text) and are
+// composed separately by each call site.
+func reservationReasonsForExecInfo(info engine.PlanExecInfo) uint32 {
+	var reasons uint32
+	if info.TempTable {
+		reasons |= protoutil.ReasonTempTable
+	}
+	if info.AdvisoryLock {
+		reasons |= protoutil.ReasonSessionAdvisoryLock
+	}
+	if info.LogicalReplicationSlot {
+		reasons |= protoutil.ReasonLogicalReplication
+	}
+	return reasons
+}
+
 // StreamExecute executes a query on the specified tablegroup and streams results.
 // This is the implementation of engine.IExecute.StreamExecute().
 //
@@ -282,24 +300,15 @@ func (sc *ScatterConn) StreamExecute(
 			state.PendingBeginQuery = ""
 		}
 
-		// If this query creates a temp table, add the reason so the
-		// multipooler tracks it on the reserved connection.
-		if info.TempTable {
+		// If this query touches a temp table, a session-level advisory lock, or
+		// a logical replication slot, add the corresponding reason(s) so the
+		// multipooler keeps the backend pinned accordingly. Promotes an existing
+		// reservation (e.g. an open transaction) to also hold these reasons.
+		if reasons := reservationReasonsForExecInfo(info); reasons != 0 {
 			if reservationOpts == nil {
 				reservationOpts = &querypb.ReservationOptions{}
 			}
-			reservationOpts.Reasons |= protoutil.ReasonTempTable
-		}
-
-		// If this query acquires a session-level advisory lock, add the reason
-		// so the multipooler keeps the backend pinned until the lock is
-		// released. Promotes an existing reservation (e.g. an open transaction)
-		// to also hold the advisory-lock reason.
-		if info.AdvisoryLock {
-			if reservationOpts == nil {
-				reservationOpts = &querypb.ReservationOptions{}
-			}
-			reservationOpts.Reasons |= protoutil.ReasonSessionAdvisoryLock
+			reservationOpts.Reasons |= reasons
 		}
 
 		// If this query declares a `WITH HOLD` cursor, pin the cursor name on
@@ -375,21 +384,15 @@ func (sc *ScatterConn) StreamExecute(
 	// Case 2: Need a new reserved connection — for transaction, temp table,
 	// portal pin (DECLARE WITH HOLD), or any combination.
 	pinPortalNames := info.PinPortals
-	if conn.IsInTransaction() || info.TempTable || info.AdvisoryLock || len(pinPortalNames) > 0 {
-		reasons := uint32(0)
+	if conn.IsInTransaction() || info.TempTable || info.AdvisoryLock || info.LogicalReplicationSlot || len(pinPortalNames) > 0 {
+		reasons := reservationReasonsForExecInfo(info)
 		if conn.IsInTransaction() {
 			reasons |= protoutil.ReasonTransaction
-		}
-		if info.TempTable {
-			reasons |= protoutil.ReasonTempTable
 		}
 		// If the session already has a temp table reservation on another shard,
 		// include the temp table reason so the connection survives COMMIT.
 		if state.HasTempTableReservation() {
 			reasons |= protoutil.ReasonTempTable
-		}
-		if info.AdvisoryLock {
-			reasons |= protoutil.ReasonSessionAdvisoryLock
 		}
 		if len(pinPortalNames) > 0 {
 			reasons |= protoutil.ReasonPortal
@@ -532,32 +535,39 @@ func (sc *ScatterConn) PortalStreamExecute(
 		eo.ReservedConnectionId = ss.ReservedState.GetReservedConnectionId()
 		qs, err = sc.gateway.QueryServiceByID(ctx, ss.ReservedState.GetPoolerId(), target)
 
-		// If this portal acquires a session-level advisory lock, OR the reason
-		// onto the existing reservation so the lock keeps the backend pinned and
-		// survives the other reason ending (e.g. a COMMIT). The multipooler
-		// applies the reason atomically, before running the portal, so unlike a
-		// separate promotion step there's no window for the unpin probe to see
-		// no lock and tear the reservation down — see portalExecuteWithReserved.
+		// If this portal touches a session-level advisory lock or a logical
+		// replication slot, OR the reason(s) onto the existing reservation so
+		// the backend stays pinned and survives another reason ending (e.g. a
+		// COMMIT). The multipooler applies the reason atomically, before
+		// running the portal, so unlike a separate promotion step there's no
+		// window for the unpin probe to see no lock and tear the reservation
+		// down — see portalExecuteWithReserved.
+		//
+		// Deliberately narrower than reservationReasonsForExecInfo: unlike
+		// StreamExecute's Case 1, a temp table on an already-reserved portal
+		// connection does not promote the reservation here (pre-existing
+		// behavior, unrelated to this helper's introduction).
+		var reasons uint32
 		if info.AdvisoryLock {
-			reservationOpts = &querypb.ReservationOptions{Reasons: protoutil.ReasonSessionAdvisoryLock}
+			reasons |= protoutil.ReasonSessionAdvisoryLock
 		}
-	} else if conn.IsInTransaction() || info.TempTable || info.AdvisoryLock {
+		if info.LogicalReplicationSlot {
+			reasons |= protoutil.ReasonLogicalReplication
+		}
+		if reasons != 0 {
+			reservationOpts = &querypb.ReservationOptions{Reasons: reasons}
+		}
+	} else if conn.IsInTransaction() || info.TempTable || info.AdvisoryLock || info.LogicalReplicationSlot {
 		// Case 2: Need a new reserved connection — for transaction, temp table,
 		// advisory lock, or a combination. Build reservation options the same way
 		// the simple StreamExecute path does and pass them on the portal RPC; the
 		// multipooler reserves-and-runs atomically.
-		reasons := uint32(0)
+		reasons := reservationReasonsForExecInfo(info)
 		if conn.IsInTransaction() {
 			reasons |= protoutil.ReasonTransaction
 		}
-		if info.TempTable {
-			reasons |= protoutil.ReasonTempTable
-		}
 		if state.HasTempTableReservation() {
 			reasons |= protoutil.ReasonTempTable
-		}
-		if info.AdvisoryLock {
-			reasons |= protoutil.ReasonSessionAdvisoryLock
 		}
 
 		sc.logger.DebugContext(ctx, "reserving connection for portal via reservation options",

--- a/go/services/multigateway/scatterconn/scatter_conn_test.go
+++ b/go/services/multigateway/scatterconn/scatter_conn_test.go
@@ -265,6 +265,104 @@ func TestScatterConn_Case2_ReserveError(t *testing.T) {
 	require.Nil(t, state.GetMatchingShardState(target))
 }
 
+// TestScatterConn_Case1_LogicalReplicationSlotPromotesExistingReservation
+// verifies that a statement creating a logical replication slot on an
+// already-reserved connection (e.g. inside an open transaction) ORs the
+// logical-replication reason onto the existing reservation, exercising
+// reservationReasonsForExecInfo's LogicalReplicationSlot branch from Case 1.
+func TestScatterConn_Case1_LogicalReplicationSlotPromotesExistingReservation(t *testing.T) {
+	gw := &mockGateway{
+		callbackResult:           &sqltypes.Result{CommandTag: "SELECT 1"},
+		streamExecuteReturnState: &querypb.ReservedState{ReservedConnectionId: 42, ReservationReasons: protoutil.ReasonTransaction | protoutil.ReasonLogicalReplication},
+	}
+	sc := NewScatterConn(gw, slog.Default())
+	state := handler.NewMultigatewayConnectionState()
+	conn := newTestConn()
+	conn.SetTxnStatus(protocol.TxnStatusInBlock)
+
+	target := protoutil.NewTarget("", "tg1", "", querypb.Mode_MODE_WRITABLE)
+	state.SetReservedConnection(target, &querypb.ReservedState{
+		ReservedConnectionId: 42,
+		PoolerId:             &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"},
+		ReservationReasons:   protoutil.ReasonTransaction,
+	})
+
+	err := sc.StreamExecute(context.Background(), conn, "tg1", "", "SELECT pg_create_logical_replication_slot('s1', 'test_decoding', true)", nil, state,
+		engine.PlanExecInfo{LogicalReplicationSlot: true}, false,
+		func(_ context.Context, _ *sqltypes.Result) error { return nil })
+
+	require.NoError(t, err)
+	require.True(t, gw.queryServiceByIDCalled, "should use QueryServiceByID for existing reserved connection")
+	require.NotNil(t, gw.streamExecuteReservationOps, "should carry the promoted reservation reason")
+	require.True(t, protoutil.HasLogicalReplicationReason(gw.streamExecuteReservationOps.GetReasons()))
+}
+
+// TestScatterConn_Case2_LogicalReplicationSlotReservesNewConn verifies that a
+// statement creating a logical replication slot with no existing reservation
+// and no open transaction still reserves a new connection with
+// ReasonLogicalReplication.
+func TestScatterConn_Case2_LogicalReplicationSlotReservesNewConn(t *testing.T) {
+	gw := &mockGateway{
+		streamExecuteReturnState: &querypb.ReservedState{
+			ReservedConnectionId: 77,
+			PoolerId:             &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"},
+			ReservationReasons:   protoutil.ReasonLogicalReplication,
+		},
+		callbackResult: &sqltypes.Result{CommandTag: "SELECT 1"},
+	}
+	sc := NewScatterConn(gw, slog.Default())
+	state := handler.NewMultigatewayConnectionState()
+	conn := newTestConn() // not in a transaction
+
+	err := sc.StreamExecute(context.Background(), conn, "tg1", "", "SELECT pg_create_logical_replication_slot('s1', 'test_decoding', true)", nil, state,
+		engine.PlanExecInfo{LogicalReplicationSlot: true}, false,
+		func(_ context.Context, _ *sqltypes.Result) error { return nil })
+
+	require.NoError(t, err)
+	require.True(t, gw.streamExecuteCalled)
+	require.NotNil(t, gw.streamExecuteReservationOps)
+	require.True(t, protoutil.HasLogicalReplicationReason(gw.streamExecuteReservationOps.GetReasons()))
+
+	target := protoutil.NewTarget("", "tg1", "", querypb.Mode_MODE_WRITABLE)
+	ss := state.GetMatchingShardState(target)
+	require.NotNil(t, ss)
+	require.Equal(t, uint64(77), ss.ReservedState.GetReservedConnectionId())
+}
+
+// TestScatterConn_Case2_AdvisoryLockReservesNewConn verifies that a statement
+// acquiring a session-level advisory lock with no existing reservation and no
+// open transaction still reserves a new connection with
+// ReasonSessionAdvisoryLock, exercising reservationReasonsForExecInfo's
+// AdvisoryLock branch (otherwise only covered by the endtoend advisory-lock
+// suite, which doesn't count toward this package's own unit coverage).
+func TestScatterConn_Case2_AdvisoryLockReservesNewConn(t *testing.T) {
+	gw := &mockGateway{
+		streamExecuteReturnState: &querypb.ReservedState{
+			ReservedConnectionId: 88,
+			PoolerId:             &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"},
+			ReservationReasons:   protoutil.ReasonSessionAdvisoryLock,
+		},
+		callbackResult: &sqltypes.Result{CommandTag: "SELECT 1"},
+	}
+	sc := NewScatterConn(gw, slog.Default())
+	state := handler.NewMultigatewayConnectionState()
+	conn := newTestConn() // not in a transaction
+
+	err := sc.StreamExecute(context.Background(), conn, "tg1", "", "SELECT pg_advisory_lock(1)", nil, state,
+		engine.PlanExecInfo{AdvisoryLock: true}, false,
+		func(_ context.Context, _ *sqltypes.Result) error { return nil })
+
+	require.NoError(t, err)
+	require.True(t, gw.streamExecuteCalled)
+	require.NotNil(t, gw.streamExecuteReservationOps)
+	require.True(t, protoutil.HasSessionAdvisoryLockReason(gw.streamExecuteReservationOps.GetReasons()))
+
+	target := protoutil.NewTarget("", "tg1", "", querypb.Mode_MODE_WRITABLE)
+	ss := state.GetMatchingShardState(target)
+	require.NotNil(t, ss)
+	require.Equal(t, uint64(88), ss.ReservedState.GetReservedConnectionId())
+}
+
 // testPortalInfo builds a minimal PortalInfo for portal-path ScatterConn tests.
 func testPortalInfo() *preparedstatement.PortalInfo {
 	return &preparedstatement.PortalInfo{
@@ -377,6 +475,110 @@ func TestScatterConn_Portal_ExistingReservedConnNoReserveReasons(t *testing.T) {
 	require.False(t, gw.streamExecuteCalled)
 	require.Equal(t, uint64(42), gw.portalOpts.GetReservedConnectionId())
 	require.Nil(t, gw.portalReservationOps, "existing reservation needs no new reasons")
+}
+
+// TestScatterConn_Portal_LogicalReplicationSlotReservesViaPortalRPC verifies
+// the logical-replication reservation reason is carried on the portal RPC
+// when a portal creating a logical replication slot is the first statement
+// needing a reserved backend (Case 2, extended protocol).
+func TestScatterConn_Portal_LogicalReplicationSlotReservesViaPortalRPC(t *testing.T) {
+	gw := &mockGateway{
+		callbackResult: &sqltypes.Result{CommandTag: "SELECT 1"},
+		portalReturnState: &querypb.ReservedState{
+			ReservedConnectionId: 100,
+			PoolerId:             &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"},
+			ReservationReasons:   protoutil.ReasonLogicalReplication,
+		},
+	}
+	sc := NewScatterConn(gw, slog.Default())
+	state := handler.NewMultigatewayConnectionState()
+	conn := newTestConn() // not in a transaction
+
+	err := sc.PortalStreamExecute(context.Background(), "tg1", "", conn, state,
+		testPortalInfo(), 0, false,
+		engine.PlanExecInfo{LogicalReplicationSlot: true}, false,
+		func(_ context.Context, _ *sqltypes.Result) error { return nil })
+
+	require.NoError(t, err)
+	require.True(t, gw.portalCalled)
+	require.False(t, gw.streamExecuteCalled, "must NOT issue a no-op SELECT 1 reserve")
+	require.NotNil(t, gw.portalReservationOps)
+	require.True(t, protoutil.HasLogicalReplicationReason(gw.portalReservationOps.GetReasons()))
+}
+
+// TestScatterConn_Portal_LogicalReplicationSlotPromotesExistingReservation
+// verifies that a portal creating a logical replication slot on an
+// already-reserved connection ORs the logical-replication reason onto the
+// existing reservation (Case 1, extended protocol) — the narrower promotion
+// path that, unlike StreamExecute's Case 1, does not also promote TempTable.
+func TestScatterConn_Portal_LogicalReplicationSlotPromotesExistingReservation(t *testing.T) {
+	gw := &mockGateway{
+		callbackResult: &sqltypes.Result{CommandTag: "SELECT 1"},
+		portalReturnState: &querypb.ReservedState{
+			ReservedConnectionId: 42,
+			PoolerId:             &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"},
+			ReservationReasons:   protoutil.ReasonTransaction | protoutil.ReasonLogicalReplication,
+		},
+	}
+	sc := NewScatterConn(gw, slog.Default())
+	state := handler.NewMultigatewayConnectionState()
+	conn := newTestConn()
+	conn.SetTxnStatus(protocol.TxnStatusInBlock)
+
+	target := protoutil.NewTarget("", "tg1", "", querypb.Mode_MODE_WRITABLE)
+	state.SetReservedConnection(target, &querypb.ReservedState{
+		ReservedConnectionId: 42,
+		PoolerId:             &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"},
+		ReservationReasons:   protoutil.ReasonTransaction,
+	})
+
+	err := sc.PortalStreamExecute(context.Background(), "tg1", "", conn, state,
+		testPortalInfo(), 0, false,
+		engine.PlanExecInfo{LogicalReplicationSlot: true}, false,
+		func(_ context.Context, _ *sqltypes.Result) error { return nil })
+
+	require.NoError(t, err)
+	require.True(t, gw.portalCalled)
+	require.True(t, gw.queryServiceByIDCalled, "should route to the reserved connection's pooler")
+	require.NotNil(t, gw.portalReservationOps, "should carry the promoted reservation reason")
+	require.True(t, protoutil.HasLogicalReplicationReason(gw.portalReservationOps.GetReasons()))
+}
+
+// TestScatterConn_Portal_AdvisoryLockPromotesExistingReservation verifies that
+// a portal acquiring a session-level advisory lock on an already-reserved
+// connection ORs the advisory-lock reason onto the existing reservation
+// (Case 1, extended protocol).
+func TestScatterConn_Portal_AdvisoryLockPromotesExistingReservation(t *testing.T) {
+	gw := &mockGateway{
+		callbackResult: &sqltypes.Result{CommandTag: "SELECT 1"},
+		portalReturnState: &querypb.ReservedState{
+			ReservedConnectionId: 42,
+			PoolerId:             &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"},
+			ReservationReasons:   protoutil.ReasonTransaction | protoutil.ReasonSessionAdvisoryLock,
+		},
+	}
+	sc := NewScatterConn(gw, slog.Default())
+	state := handler.NewMultigatewayConnectionState()
+	conn := newTestConn()
+	conn.SetTxnStatus(protocol.TxnStatusInBlock)
+
+	target := protoutil.NewTarget("", "tg1", "", querypb.Mode_MODE_WRITABLE)
+	state.SetReservedConnection(target, &querypb.ReservedState{
+		ReservedConnectionId: 42,
+		PoolerId:             &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"},
+		ReservationReasons:   protoutil.ReasonTransaction,
+	})
+
+	err := sc.PortalStreamExecute(context.Background(), "tg1", "", conn, state,
+		testPortalInfo(), 0, false,
+		engine.PlanExecInfo{AdvisoryLock: true}, false,
+		func(_ context.Context, _ *sqltypes.Result) error { return nil })
+
+	require.NoError(t, err)
+	require.True(t, gw.portalCalled)
+	require.True(t, gw.queryServiceByIDCalled, "should route to the reserved connection's pooler")
+	require.NotNil(t, gw.portalReservationOps, "should carry the promoted reservation reason")
+	require.True(t, protoutil.HasSessionAdvisoryLockReason(gw.portalReservationOps.GetReasons()))
 }
 
 func TestScatterConn_Portal_ErrorAppliesReturnedReservedState(t *testing.T) {

--- a/go/test/endtoend/queryserving/pgbouncertests/logical_replication_slot_pinning_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/logical_replication_slot_pinning_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgbouncertests
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestMUL470LogicalReplicationSlotSurvivesPoolContention proves that a
+// TEMPORARY logical replication slot created via
+// pg_create_logical_replication_slot(...) on one client session's connection
+// stays reachable from later statements on that SAME connection, even under
+// heavy contention for a deliberately tiny connection pool. This is the
+// regression test for MUL-470: absent the reservation added by this plan, a
+// temporary slot's creating backend can be reassigned to a different client
+// mid-session, and later reads fail with "replication slot ... is active for
+// PID ..." or "does not exist" — see this plan's Background section for the
+// original 93/200 failure rate observed pre-fix.
+func TestMUL470LogicalReplicationSlotSurvivesPoolContention(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2), // primary + standby (bootstrap needs 2)
+		shardsetup.WithMultigateway(),
+		shardsetup.WithMultipoolerExtraArgs(connpoolGlobalCapacity, connpoolReservedRatio, connpoolRebalanceFast),
+	)
+	defer cleanup()
+	setup.WaitForMultigatewayQueryServing(t)
+
+	ctx := utils.WithTimeout(t, 120*time.Second)
+
+	gatewayDB := openGatewayDB(t, setup)
+	defer gatewayDB.Close()
+
+	settleConnpool(t, ctx, gatewayDB)
+
+	// One dedicated client connection, exactly like Realtime's long-lived
+	// ReplicationPoller connection: every statement below rides the SAME
+	// physical client->gateway TCP connection.
+	slotConn, err := gatewayDB.Conn(ctx)
+	require.NoError(t, err)
+	defer slotConn.Close()
+
+	slotName := "mul470_repro_slot"
+	_, err = slotConn.ExecContext(ctx,
+		"SELECT pg_create_logical_replication_slot($1, 'test_decoding', true)", slotName)
+	require.NoError(t, err, "slot creation must succeed")
+	t.Logf("created temporary logical replication slot %q", slotName)
+
+	// Noisy neighbors: hammer the SAME tiny shared pool concurrently so the
+	// gateway is forced to reassign backend connections for non-reserved
+	// statements (per executor.go: every unreserved statement does
+	// GetRegularConnWithSettings + recycle, from a shared per-role LIFO stack).
+	var stop atomic.Bool
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			for !stop.Load() {
+				_, _ = gatewayDB.ExecContext(ctx, "SELECT 1")
+			}
+		})
+	}
+	defer func() {
+		stop.Store(true)
+		wg.Wait()
+	}()
+
+	// Repeatedly read from the slot on the SAME slotConn, exactly like
+	// ReplicationPoller's list_changes poll loop. Without a reservation, this
+	// should eventually land on a different backend than the one that created
+	// the slot and fail with "replication slot ... does not exist".
+	var lastErr error
+	attempts := 200
+	failures := 0
+	for i := range attempts {
+		_, err := slotConn.ExecContext(ctx,
+			"SELECT * FROM pg_logical_slot_get_changes($1, NULL, NULL)", slotName)
+		if err != nil {
+			failures++
+			lastErr = err
+			t.Logf("iteration %d: read from slot failed: %v", i, err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if failures > 0 {
+		t.Logf("REPRODUCED: %d/%d slot reads failed under pool contention without a reservation; last error: %v",
+			failures, attempts, lastErr)
+	}
+	require.Zero(t, failures,
+		"every read from the temporary slot on the same client connection must succeed; "+
+			"a failure here means the backend was reassigned mid-session (MUL-470)")
+}


### PR DESCRIPTION
## Summary

- Detects `pg_create_logical_replication_slot(...)` anywhere in a statement's expression tree — including nested inside a `CASE` + scalar subquery, matching Supabase Realtime's actual Postgres Changes / CDC-RLS polling call site — by extending the existing session-level advisory-lock FuncCall walker.
- Reserves the client's backend connection with `ReasonLogicalReplication` on both the simple and extended query protocols, mirroring the existing `TempTable` reservation pattern, so later statements on the same session stay pinned to the backend that owns the (usually temporary) slot.
- Acquire-only, no auto-release recheck: the reservation persists for the session's lifetime and is released only by `DISCARD ALL` or session teardown, same as `TempTable`.
- Promotes the MUL-470 reproduction test into a permanent regression test and closes out the stale mid-session TODO on `protoutil.ReasonLogicalReplication`.

## Problem

Supabase Realtime's Postgres Changes / CDC-RLS polling extension creates a `TEMPORARY` logical replication slot on one long-lived client connection and repeatedly reads from it over that same connection for the lifetime of the poller (hours to days). A temporary slot only exists on the Postgres backend that created it. Without a connection reservation, multigateway could route later statements on that same client session to a different pooled backend, making the slot invisible and causing reads to fail with `replication slot "..." is active for PID ...` or `does not exist`. A deterministic endtoend repro under pool contention showed a 46.5% failure rate absent this fix.

## Solution

`ReasonLogicalReplication` already existed as a bit in the reservation bitmask (used today only for `replication=database` startup connections) with a TODO describing exactly this task. This change fulfills that TODO by mirroring the existing session-level advisory-lock detection/plumbing pipeline: fold the detection into `PlanExecInfo` via the existing fold-in point in the planner, then OR the reason bit into `ReservationOptions` at the same four call sites in `scatterconn` where `ReasonTempTable`/`ReasonSessionAdvisoryLock` are already added. No proto changes and no multipooler changes were needed — multipooler's reservation lifecycle already treats reasons as a generic bitmask.