### PR TITLE
feat(consensus): pooler-driven divergence recovery + reconnect over-recruited followers

### DIFF
--- a/go/common/consensus/revocation.go
+++ b/go/common/consensus/revocation.go
@@ -138,6 +138,35 @@ func IsRuleRevoked(position *clustermetadatapb.RulePosition, revocation *cluster
 	return true
 }
 
+// IsSelfRevoked reports whether a node has no rule it can act on under the
+// revocation it has accepted: its highest known rule is still revoked by its own
+// promise (revoked_below_term with the recorded outgoing_rule). This is the
+// "recruited but not caught up and not yet re-ruled" state — after a Recruit
+// raises the promise floor, a node reports this until it accepts a rule at or
+// beyond that term.
+//
+// It keys on the highest known rule — the max of the node's own WAL position and
+// the rule last delivered via SetPrimary/Promote (ReplicationPrimary) — not just
+// the WAL position: a replica that has accepted a higher rule is following it and
+// is not stranded even while its WAL position lags behind. A rejected SetPrimary
+// never updates ReplicationPrimary, so a genuinely stranded node's highest known
+// rule stays at the revoked rule and this returns true.
+//
+// The revocation is a monotonic promise floor that ConsensusStatus keeps
+// reporting even after it is satisfied, so its mere presence does not mean the
+// node is still recruited; this predicate is the way to tell. Pure function of
+// the status message, delegating to IsRuleRevoked so it stays in lockstep with
+// the SetPrimary revocation gate.
+func IsSelfRevoked(status *clustermetadatapb.ConsensusStatus) bool {
+	current := status.GetCurrentPosition().GetPosition()
+	known := ReplicationPrimaryOrNil(status).GetPosition()
+	highest := current
+	if CompareRulePosition(known, current) > 0 {
+		highest = known
+	}
+	return IsRuleRevoked(highest, status.GetTermRevocation())
+}
+
 // ValidateRevocation reports whether the given revocation is safe for a node
 // with the provided status to honor. It returns nil if the revocation should be
 // accepted, or a descriptive error explaining why it was refused.

--- a/go/common/consensus/revocation_test.go
+++ b/go/common/consensus/revocation_test.go
@@ -317,6 +317,61 @@ func positionWithUndecidedProposal(decisionTerm, proposalTerm int64) *clustermet
 	}
 }
 
+func TestIsSelfRevoked(t *testing.T) {
+	// Recruited at term 2, transitioning away from the term-1 rule.
+	rev := &clustermetadatapb.TermRevocation{
+		RevokedBelowTerm: 2,
+		OutgoingRule:     &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
+	}
+	rule := func(term, subterm int64) *clustermetadatapb.RulePosition {
+		return &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
+			RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: term, LeaderSubterm: subterm},
+		}}
+	}
+
+	tests := []struct {
+		name   string
+		status *clustermetadatapb.ConsensusStatus
+		want   bool
+	}{
+		{
+			name:   "no revocation is never self-revoked",
+			status: &clustermetadatapb.ConsensusStatus{CurrentPosition: &clustermetadatapb.PoolerPosition{Position: rule(1, 0)}},
+			want:   false,
+		},
+		{
+			name: "recruited above own rule with no higher known rule is stranded",
+			status: &clustermetadatapb.ConsensusStatus{
+				CurrentPosition: &clustermetadatapb.PoolerPosition{Position: rule(1, 0)},
+				TermRevocation:  rev,
+			},
+			want: true,
+		},
+		{
+			name: "recruited but following a higher accepted rule while WAL lags is not stranded",
+			status: &clustermetadatapb.ConsensusStatus{
+				CurrentPosition:    &clustermetadatapb.PoolerPosition{Position: rule(1, 0)},
+				ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{Position: rule(1, 5)},
+				TermRevocation:     rev,
+			},
+			want: false,
+		},
+		{
+			name: "consumed recruit: own rule reached the revoked term",
+			status: &clustermetadatapb.ConsensusStatus{
+				CurrentPosition: &clustermetadatapb.PoolerPosition{Position: rule(2, 0)},
+				TermRevocation:  rev,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsSelfRevoked(tt.status))
+		})
+	}
+}
+
 func TestNewTermRevocation(t *testing.T) {
 	coord := &clustermetadatapb.ID{Name: "coord-1"}
 

--- a/go/common/rpcclient/client.go
+++ b/go/common/rpcclient/client.go
@@ -158,9 +158,6 @@ type MultipoolerClient interface {
 	// success without changes.
 	SetPrimary(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *consensusdatapb.SetPrimaryRequest) (*consensusdatapb.SetPrimaryResponse, error)
 
-	// RewindToSource performs pg_rewind to synchronize a replica with its source.
-	RewindToSource(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.RewindToSourceRequest) (*multipoolermanagerdatapb.RewindToSourceResponse, error)
-
 	//
 	// Manager Service Methods - Status and Monitoring
 	//

--- a/go/common/rpcclient/fake_client.go
+++ b/go/common/rpcclient/fake_client.go
@@ -73,7 +73,6 @@ type FakeClient struct {
 	BackupResponses                     map[topoclient.ComponentID]*multipoolermanagerdatapb.BackupResponse
 	GetBackupsResponses                 map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupsResponse
 	GetBackupByJobIdResponses           map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupByJobIdResponse
-	RewindToSourceResponses             map[topoclient.ComponentID]*multipoolermanagerdatapb.RewindToSourceResponse
 	SetPostgresRestartsEnabledResponses map[topoclient.ComponentID]*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse
 
 	// Errors to return - keyed by pooler ID
@@ -116,7 +115,6 @@ func NewFakeClient() *FakeClient {
 		BackupResponses:                     make(map[topoclient.ComponentID]*multipoolermanagerdatapb.BackupResponse),
 		GetBackupsResponses:                 make(map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupsResponse),
 		GetBackupByJobIdResponses:           make(map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupByJobIdResponse),
-		RewindToSourceResponses:             make(map[topoclient.ComponentID]*multipoolermanagerdatapb.RewindToSourceResponse),
 		SetPostgresRestartsEnabledResponses: make(map[topoclient.ComponentID]*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse),
 		Errors:                              make(map[topoclient.ComponentID]error),
 		RecruitDelays:                       make(map[topoclient.ComponentID]time.Duration),
@@ -463,26 +461,6 @@ func (f *FakeClient) VerifyBackups(ctx context.Context, pooler *clustermetadatap
 	}
 
 	return &multipoolermanagerdatapb.VerifyBackupsResponse{}, nil
-}
-
-//
-// Manager Service Methods - Timeline Repair
-//
-
-func (f *FakeClient) RewindToSource(ctx context.Context, pooler *clustermetadatapb.Multipooler, req *multipoolermanagerdatapb.RewindToSourceRequest) (*multipoolermanagerdatapb.RewindToSourceResponse, error) {
-	poolerID := f.getPoolerID(pooler)
-	f.logCall("RewindToSource", poolerID)
-
-	if err := f.checkError(poolerID); err != nil {
-		return nil, err
-	}
-
-	f.mu.RLock()
-	defer f.mu.RUnlock()
-	if resp, ok := f.RewindToSourceResponses[poolerID]; ok {
-		return resp, nil
-	}
-	return &multipoolermanagerdatapb.RewindToSourceResponse{}, nil
 }
 
 //

--- a/go/common/rpcclient/grpc_client.go
+++ b/go/common/rpcclient/grpc_client.go
@@ -121,19 +121,6 @@ func (c *Client) SetPrimary(ctx context.Context, pooler *clustermetadatapb.Multi
 	return conn.consensusClient.SetPrimary(ctx, request)
 }
 
-// RewindToSource performs pg_rewind to synchronize a replica with its source.
-func (c *Client) RewindToSource(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.RewindToSourceRequest) (*multipoolermanagerdatapb.RewindToSourceResponse, error) {
-	conn, closer, err := c.dialPersistent(ctx, pooler)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		_ = closer()
-	}()
-
-	return conn.consensusClient.RewindToSource(ctx, request)
-}
-
 //
 // Manager Service Methods - Status and Monitoring
 //

--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -2611,6 +2611,21 @@ func (x *ExternallyCertifiedRevocation) GetFrozenLsn() string {
 type ConsensusStatus struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// term_revocation records the highest coordinator term this pooler has revoked for.
+	//
+	// This is a monotonic promise floor: it is always reported here even after it
+	// has been satisfied (the pooler's own committed rule caught up to or past
+	// revoked_below_term), so its mere presence does NOT mean the pooler is still
+	// recruited. Consumers must check whether it still revokes the pooler's own
+	// position — see consensus.IsSelfRevoked.
+	//
+	// TODO: we could omit an obsolete revocation from this reported status (once
+	// the committed coordinator term reaches revoked_below_term) so that absence
+	// alone signals "not recruited". Deliberately not done yet: keeping the raw
+	// revocation visible aids debugging (a lingering self-revoking revocation is
+	// exactly the signal for a stranded pooler), and the omit condition is subtle
+	// — it must be the committed-term check, not IsSelfRevoked, or the
+	// runaway-recruit subterm-override case would drop term information that
+	// NewTermRevocation relies on and risk term reuse.
 	TermRevocation *TermRevocation `protobuf:"bytes,1,opt,name=term_revocation,json=termRevocation,proto3" json:"term_revocation,omitempty"`
 	// current_position is the highest rule this pooler has committed to local WAL
 	// and the latest WAL position.

--- a/go/pb/consensus/consensusconnect/consensusservice.connect.go
+++ b/go/pb/consensus/consensusconnect/consensusservice.connect.go
@@ -52,9 +52,6 @@ const (
 	// MultipoolerConsensusUpdateConsensusRuleProcedure is the fully-qualified name of the
 	// MultipoolerConsensus's UpdateConsensusRule RPC.
 	MultipoolerConsensusUpdateConsensusRuleProcedure = "/consensus.MultipoolerConsensus/UpdateConsensusRule"
-	// MultipoolerConsensusRewindToSourceProcedure is the fully-qualified name of the
-	// MultipoolerConsensus's RewindToSource RPC.
-	MultipoolerConsensusRewindToSourceProcedure = "/consensus.MultipoolerConsensus/RewindToSource"
 	// MultipoolerConsensusRecruitProcedure is the fully-qualified name of the MultipoolerConsensus's
 	// Recruit RPC.
 	MultipoolerConsensusRecruitProcedure = "/consensus.MultipoolerConsensus/Recruit"
@@ -72,9 +69,6 @@ type MultipoolerConsensusClient interface {
 	// primary handler updates synchronous_standby_names and records the cohort
 	// change in rule_history.
 	UpdateConsensusRule(context.Context, *connect.Request[multipoolermanagerdata.UpdateConsensusRuleRequest]) (*connect.Response[multipoolermanagerdata.UpdateConsensusRuleResponse], error)
-	// RewindToSource performs pg_rewind to synchronize this server with a source.
-	// This is used to repair diverged timelines after failover.
-	RewindToSource(context.Context, *connect.Request[multipoolermanagerdata.RewindToSourceRequest]) (*connect.Response[multipoolermanagerdata.RewindToSourceResponse], error)
 	// Recruit asks a pooler to revoke all terms below the one specified and
 	// record the coordinator's exclusive claim on that term.
 	Recruit(context.Context, *connect.Request[consensusdata.RecruitRequest]) (*connect.Response[consensusdata.RecruitResponse], error)
@@ -110,12 +104,6 @@ func NewMultipoolerConsensusClient(httpClient connect.HTTPClient, baseURL string
 			connect.WithSchema(multipoolerConsensusMethods.ByName("UpdateConsensusRule")),
 			connect.WithClientOptions(opts...),
 		),
-		rewindToSource: connect.NewClient[multipoolermanagerdata.RewindToSourceRequest, multipoolermanagerdata.RewindToSourceResponse](
-			httpClient,
-			baseURL+MultipoolerConsensusRewindToSourceProcedure,
-			connect.WithSchema(multipoolerConsensusMethods.ByName("RewindToSource")),
-			connect.WithClientOptions(opts...),
-		),
 		recruit: connect.NewClient[consensusdata.RecruitRequest, consensusdata.RecruitResponse](
 			httpClient,
 			baseURL+MultipoolerConsensusRecruitProcedure,
@@ -140,7 +128,6 @@ func NewMultipoolerConsensusClient(httpClient connect.HTTPClient, baseURL string
 // multipoolerConsensusClient implements MultipoolerConsensusClient.
 type multipoolerConsensusClient struct {
 	updateConsensusRule *connect.Client[multipoolermanagerdata.UpdateConsensusRuleRequest, multipoolermanagerdata.UpdateConsensusRuleResponse]
-	rewindToSource      *connect.Client[multipoolermanagerdata.RewindToSourceRequest, multipoolermanagerdata.RewindToSourceResponse]
 	recruit             *connect.Client[consensusdata.RecruitRequest, consensusdata.RecruitResponse]
 	promote             *connect.Client[consensusdata.PromoteRequest, consensusdata.PromoteResponse]
 	setPrimary          *connect.Client[consensusdata.SetPrimaryRequest, consensusdata.SetPrimaryResponse]
@@ -149,11 +136,6 @@ type multipoolerConsensusClient struct {
 // UpdateConsensusRule calls consensus.MultipoolerConsensus.UpdateConsensusRule.
 func (c *multipoolerConsensusClient) UpdateConsensusRule(ctx context.Context, req *connect.Request[multipoolermanagerdata.UpdateConsensusRuleRequest]) (*connect.Response[multipoolermanagerdata.UpdateConsensusRuleResponse], error) {
 	return c.updateConsensusRule.CallUnary(ctx, req)
-}
-
-// RewindToSource calls consensus.MultipoolerConsensus.RewindToSource.
-func (c *multipoolerConsensusClient) RewindToSource(ctx context.Context, req *connect.Request[multipoolermanagerdata.RewindToSourceRequest]) (*connect.Response[multipoolermanagerdata.RewindToSourceResponse], error) {
-	return c.rewindToSource.CallUnary(ctx, req)
 }
 
 // Recruit calls consensus.MultipoolerConsensus.Recruit.
@@ -177,9 +159,6 @@ type MultipoolerConsensusHandler interface {
 	// primary handler updates synchronous_standby_names and records the cohort
 	// change in rule_history.
 	UpdateConsensusRule(context.Context, *connect.Request[multipoolermanagerdata.UpdateConsensusRuleRequest]) (*connect.Response[multipoolermanagerdata.UpdateConsensusRuleResponse], error)
-	// RewindToSource performs pg_rewind to synchronize this server with a source.
-	// This is used to repair diverged timelines after failover.
-	RewindToSource(context.Context, *connect.Request[multipoolermanagerdata.RewindToSourceRequest]) (*connect.Response[multipoolermanagerdata.RewindToSourceResponse], error)
 	// Recruit asks a pooler to revoke all terms below the one specified and
 	// record the coordinator's exclusive claim on that term.
 	Recruit(context.Context, *connect.Request[consensusdata.RecruitRequest]) (*connect.Response[consensusdata.RecruitResponse], error)
@@ -211,12 +190,6 @@ func NewMultipoolerConsensusHandler(svc MultipoolerConsensusHandler, opts ...con
 		connect.WithSchema(multipoolerConsensusMethods.ByName("UpdateConsensusRule")),
 		connect.WithHandlerOptions(opts...),
 	)
-	multipoolerConsensusRewindToSourceHandler := connect.NewUnaryHandler(
-		MultipoolerConsensusRewindToSourceProcedure,
-		svc.RewindToSource,
-		connect.WithSchema(multipoolerConsensusMethods.ByName("RewindToSource")),
-		connect.WithHandlerOptions(opts...),
-	)
 	multipoolerConsensusRecruitHandler := connect.NewUnaryHandler(
 		MultipoolerConsensusRecruitProcedure,
 		svc.Recruit,
@@ -239,8 +212,6 @@ func NewMultipoolerConsensusHandler(svc MultipoolerConsensusHandler, opts ...con
 		switch r.URL.Path {
 		case MultipoolerConsensusUpdateConsensusRuleProcedure:
 			multipoolerConsensusUpdateConsensusRuleHandler.ServeHTTP(w, r)
-		case MultipoolerConsensusRewindToSourceProcedure:
-			multipoolerConsensusRewindToSourceHandler.ServeHTTP(w, r)
 		case MultipoolerConsensusRecruitProcedure:
 			multipoolerConsensusRecruitHandler.ServeHTTP(w, r)
 		case MultipoolerConsensusPromoteProcedure:
@@ -258,10 +229,6 @@ type UnimplementedMultipoolerConsensusHandler struct{}
 
 func (UnimplementedMultipoolerConsensusHandler) UpdateConsensusRule(context.Context, *connect.Request[multipoolermanagerdata.UpdateConsensusRuleRequest]) (*connect.Response[multipoolermanagerdata.UpdateConsensusRuleResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("consensus.MultipoolerConsensus.UpdateConsensusRule is not implemented"))
-}
-
-func (UnimplementedMultipoolerConsensusHandler) RewindToSource(context.Context, *connect.Request[multipoolermanagerdata.RewindToSourceRequest]) (*connect.Response[multipoolermanagerdata.RewindToSourceResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("consensus.MultipoolerConsensus.RewindToSource is not implemented"))
 }
 
 func (UnimplementedMultipoolerConsensusHandler) Recruit(context.Context, *connect.Request[consensusdata.RecruitRequest]) (*connect.Response[consensusdata.RecruitResponse], error) {

--- a/go/pb/consensus/consensusservice.pb.go
+++ b/go/pb/consensus/consensusservice.pb.go
@@ -40,10 +40,9 @@ var File_consensusservice_proto protoreflect.FileDescriptor
 
 const file_consensusservice_proto_rawDesc = "" +
 	"\n" +
-	"\x16consensusservice.proto\x12\tconsensus\x1a\x13consensusdata.proto\x1a\x1cmultipoolermanagerdata.proto2\xee\x03\n" +
+	"\x16consensusservice.proto\x12\tconsensus\x1a\x13consensusdata.proto\x1a\x1cmultipoolermanagerdata.proto2\xfd\x02\n" +
 	"\x14MultipoolerConsensus\x12~\n" +
-	"\x13UpdateConsensusRule\x122.multipoolermanagerdata.UpdateConsensusRuleRequest\x1a3.multipoolermanagerdata.UpdateConsensusRuleResponse\x12o\n" +
-	"\x0eRewindToSource\x12-.multipoolermanagerdata.RewindToSourceRequest\x1a..multipoolermanagerdata.RewindToSourceResponse\x12H\n" +
+	"\x13UpdateConsensusRule\x122.multipoolermanagerdata.UpdateConsensusRuleRequest\x1a3.multipoolermanagerdata.UpdateConsensusRuleResponse\x12H\n" +
 	"\aRecruit\x12\x1d.consensusdata.RecruitRequest\x1a\x1e.consensusdata.RecruitResponse\x12H\n" +
 	"\aPromote\x12\x1d.consensusdata.PromoteRequest\x1a\x1e.consensusdata.PromoteResponse\x12Q\n" +
 	"\n" +
@@ -51,29 +50,25 @@ const file_consensusservice_proto_rawDesc = "" +
 
 var file_consensusservice_proto_goTypes = []any{
 	(*multipoolermanagerdata.UpdateConsensusRuleRequest)(nil),  // 0: multipoolermanagerdata.UpdateConsensusRuleRequest
-	(*multipoolermanagerdata.RewindToSourceRequest)(nil),       // 1: multipoolermanagerdata.RewindToSourceRequest
-	(*consensusdata.RecruitRequest)(nil),                       // 2: consensusdata.RecruitRequest
-	(*consensusdata.PromoteRequest)(nil),                       // 3: consensusdata.PromoteRequest
-	(*consensusdata.SetPrimaryRequest)(nil),                    // 4: consensusdata.SetPrimaryRequest
-	(*multipoolermanagerdata.UpdateConsensusRuleResponse)(nil), // 5: multipoolermanagerdata.UpdateConsensusRuleResponse
-	(*multipoolermanagerdata.RewindToSourceResponse)(nil),      // 6: multipoolermanagerdata.RewindToSourceResponse
-	(*consensusdata.RecruitResponse)(nil),                      // 7: consensusdata.RecruitResponse
-	(*consensusdata.PromoteResponse)(nil),                      // 8: consensusdata.PromoteResponse
-	(*consensusdata.SetPrimaryResponse)(nil),                   // 9: consensusdata.SetPrimaryResponse
+	(*consensusdata.RecruitRequest)(nil),                       // 1: consensusdata.RecruitRequest
+	(*consensusdata.PromoteRequest)(nil),                       // 2: consensusdata.PromoteRequest
+	(*consensusdata.SetPrimaryRequest)(nil),                    // 3: consensusdata.SetPrimaryRequest
+	(*multipoolermanagerdata.UpdateConsensusRuleResponse)(nil), // 4: multipoolermanagerdata.UpdateConsensusRuleResponse
+	(*consensusdata.RecruitResponse)(nil),                      // 5: consensusdata.RecruitResponse
+	(*consensusdata.PromoteResponse)(nil),                      // 6: consensusdata.PromoteResponse
+	(*consensusdata.SetPrimaryResponse)(nil),                   // 7: consensusdata.SetPrimaryResponse
 }
 var file_consensusservice_proto_depIdxs = []int32{
 	0, // 0: consensus.MultipoolerConsensus.UpdateConsensusRule:input_type -> multipoolermanagerdata.UpdateConsensusRuleRequest
-	1, // 1: consensus.MultipoolerConsensus.RewindToSource:input_type -> multipoolermanagerdata.RewindToSourceRequest
-	2, // 2: consensus.MultipoolerConsensus.Recruit:input_type -> consensusdata.RecruitRequest
-	3, // 3: consensus.MultipoolerConsensus.Promote:input_type -> consensusdata.PromoteRequest
-	4, // 4: consensus.MultipoolerConsensus.SetPrimary:input_type -> consensusdata.SetPrimaryRequest
-	5, // 5: consensus.MultipoolerConsensus.UpdateConsensusRule:output_type -> multipoolermanagerdata.UpdateConsensusRuleResponse
-	6, // 6: consensus.MultipoolerConsensus.RewindToSource:output_type -> multipoolermanagerdata.RewindToSourceResponse
-	7, // 7: consensus.MultipoolerConsensus.Recruit:output_type -> consensusdata.RecruitResponse
-	8, // 8: consensus.MultipoolerConsensus.Promote:output_type -> consensusdata.PromoteResponse
-	9, // 9: consensus.MultipoolerConsensus.SetPrimary:output_type -> consensusdata.SetPrimaryResponse
-	5, // [5:10] is the sub-list for method output_type
-	0, // [0:5] is the sub-list for method input_type
+	1, // 1: consensus.MultipoolerConsensus.Recruit:input_type -> consensusdata.RecruitRequest
+	2, // 2: consensus.MultipoolerConsensus.Promote:input_type -> consensusdata.PromoteRequest
+	3, // 3: consensus.MultipoolerConsensus.SetPrimary:input_type -> consensusdata.SetPrimaryRequest
+	4, // 4: consensus.MultipoolerConsensus.UpdateConsensusRule:output_type -> multipoolermanagerdata.UpdateConsensusRuleResponse
+	5, // 5: consensus.MultipoolerConsensus.Recruit:output_type -> consensusdata.RecruitResponse
+	6, // 6: consensus.MultipoolerConsensus.Promote:output_type -> consensusdata.PromoteResponse
+	7, // 7: consensus.MultipoolerConsensus.SetPrimary:output_type -> consensusdata.SetPrimaryResponse
+	4, // [4:8] is the sub-list for method output_type
+	0, // [0:4] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
 	0, // [0:0] is the sub-list for extension extendee
 	0, // [0:0] is the sub-list for field type_name

--- a/go/pb/consensus/consensusservice.pb.gw.go
+++ b/go/pb/consensus/consensusservice.pb.gw.go
@@ -64,33 +64,6 @@ func local_request_MultipoolerConsensus_UpdateConsensusRule_0(ctx context.Contex
 	return msg, metadata, err
 }
 
-func request_MultipoolerConsensus_RewindToSource_0(ctx context.Context, marshaler runtime.Marshaler, client MultipoolerConsensusClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var (
-		protoReq multipoolermanagerdata.RewindToSourceRequest
-		metadata runtime.ServerMetadata
-	)
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-	if req.Body != nil {
-		_, _ = io.Copy(io.Discard, req.Body)
-	}
-	msg, err := client.RewindToSource(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
-	return msg, metadata, err
-}
-
-func local_request_MultipoolerConsensus_RewindToSource_0(ctx context.Context, marshaler runtime.Marshaler, server MultipoolerConsensusServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var (
-		protoReq multipoolermanagerdata.RewindToSourceRequest
-		metadata runtime.ServerMetadata
-	)
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-	msg, err := server.RewindToSource(ctx, &protoReq)
-	return msg, metadata, err
-}
-
 func request_MultipoolerConsensus_Recruit_0(ctx context.Context, marshaler runtime.Marshaler, client MultipoolerConsensusClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq consensusdata.RecruitRequest
@@ -197,26 +170,6 @@ func RegisterMultipoolerConsensusHandlerServer(ctx context.Context, mux *runtime
 			return
 		}
 		forward_MultipoolerConsensus_UpdateConsensusRule_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-	})
-	mux.Handle(http.MethodPost, pattern_MultipoolerConsensus_RewindToSource_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		var stream runtime.ServerTransportStream
-		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/consensus.MultipoolerConsensus/RewindToSource", runtime.WithHTTPPathPattern("/consensus.MultipoolerConsensus/RewindToSource"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := local_request_MultipoolerConsensus_RewindToSource_0(annotatedContext, inboundMarshaler, server, req, pathParams)
-		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		forward_MultipoolerConsensus_RewindToSource_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodPost, pattern_MultipoolerConsensus_Recruit_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -335,23 +288,6 @@ func RegisterMultipoolerConsensusHandlerClient(ctx context.Context, mux *runtime
 		}
 		forward_MultipoolerConsensus_UpdateConsensusRule_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPost, pattern_MultipoolerConsensus_RewindToSource_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/consensus.MultipoolerConsensus/RewindToSource", runtime.WithHTTPPathPattern("/consensus.MultipoolerConsensus/RewindToSource"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := request_MultipoolerConsensus_RewindToSource_0(annotatedContext, inboundMarshaler, client, req, pathParams)
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		forward_MultipoolerConsensus_RewindToSource_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-	})
 	mux.Handle(http.MethodPost, pattern_MultipoolerConsensus_Recruit_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -408,7 +344,6 @@ func RegisterMultipoolerConsensusHandlerClient(ctx context.Context, mux *runtime
 
 var (
 	pattern_MultipoolerConsensus_UpdateConsensusRule_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"consensus.MultipoolerConsensus", "UpdateConsensusRule"}, ""))
-	pattern_MultipoolerConsensus_RewindToSource_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"consensus.MultipoolerConsensus", "RewindToSource"}, ""))
 	pattern_MultipoolerConsensus_Recruit_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"consensus.MultipoolerConsensus", "Recruit"}, ""))
 	pattern_MultipoolerConsensus_Promote_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"consensus.MultipoolerConsensus", "Promote"}, ""))
 	pattern_MultipoolerConsensus_SetPrimary_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"consensus.MultipoolerConsensus", "SetPrimary"}, ""))
@@ -416,7 +351,6 @@ var (
 
 var (
 	forward_MultipoolerConsensus_UpdateConsensusRule_0 = runtime.ForwardResponseMessage
-	forward_MultipoolerConsensus_RewindToSource_0      = runtime.ForwardResponseMessage
 	forward_MultipoolerConsensus_Recruit_0             = runtime.ForwardResponseMessage
 	forward_MultipoolerConsensus_Promote_0             = runtime.ForwardResponseMessage
 	forward_MultipoolerConsensus_SetPrimary_0          = runtime.ForwardResponseMessage

--- a/go/pb/consensus/consensusservice_grpc.pb.go
+++ b/go/pb/consensus/consensusservice_grpc.pb.go
@@ -36,7 +36,6 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	MultipoolerConsensus_UpdateConsensusRule_FullMethodName = "/consensus.MultipoolerConsensus/UpdateConsensusRule"
-	MultipoolerConsensus_RewindToSource_FullMethodName      = "/consensus.MultipoolerConsensus/RewindToSource"
 	MultipoolerConsensus_Recruit_FullMethodName             = "/consensus.MultipoolerConsensus/Recruit"
 	MultipoolerConsensus_Promote_FullMethodName             = "/consensus.MultipoolerConsensus/Promote"
 	MultipoolerConsensus_SetPrimary_FullMethodName          = "/consensus.MultipoolerConsensus/SetPrimary"
@@ -52,9 +51,6 @@ type MultipoolerConsensusClient interface {
 	// primary handler updates synchronous_standby_names and records the cohort
 	// change in rule_history.
 	UpdateConsensusRule(ctx context.Context, in *multipoolermanagerdata.UpdateConsensusRuleRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.UpdateConsensusRuleResponse, error)
-	// RewindToSource performs pg_rewind to synchronize this server with a source.
-	// This is used to repair diverged timelines after failover.
-	RewindToSource(ctx context.Context, in *multipoolermanagerdata.RewindToSourceRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.RewindToSourceResponse, error)
 	// Recruit asks a pooler to revoke all terms below the one specified and
 	// record the coordinator's exclusive claim on that term.
 	Recruit(ctx context.Context, in *consensusdata.RecruitRequest, opts ...grpc.CallOption) (*consensusdata.RecruitResponse, error)
@@ -85,16 +81,6 @@ func (c *multipoolerConsensusClient) UpdateConsensusRule(ctx context.Context, in
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(multipoolermanagerdata.UpdateConsensusRuleResponse)
 	err := c.cc.Invoke(ctx, MultipoolerConsensus_UpdateConsensusRule_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *multipoolerConsensusClient) RewindToSource(ctx context.Context, in *multipoolermanagerdata.RewindToSourceRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.RewindToSourceResponse, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(multipoolermanagerdata.RewindToSourceResponse)
-	err := c.cc.Invoke(ctx, MultipoolerConsensus_RewindToSource_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -141,9 +127,6 @@ type MultipoolerConsensusServer interface {
 	// primary handler updates synchronous_standby_names and records the cohort
 	// change in rule_history.
 	UpdateConsensusRule(context.Context, *multipoolermanagerdata.UpdateConsensusRuleRequest) (*multipoolermanagerdata.UpdateConsensusRuleResponse, error)
-	// RewindToSource performs pg_rewind to synchronize this server with a source.
-	// This is used to repair diverged timelines after failover.
-	RewindToSource(context.Context, *multipoolermanagerdata.RewindToSourceRequest) (*multipoolermanagerdata.RewindToSourceResponse, error)
 	// Recruit asks a pooler to revoke all terms below the one specified and
 	// record the coordinator's exclusive claim on that term.
 	Recruit(context.Context, *consensusdata.RecruitRequest) (*consensusdata.RecruitResponse, error)
@@ -172,9 +155,6 @@ type UnimplementedMultipoolerConsensusServer struct{}
 
 func (UnimplementedMultipoolerConsensusServer) UpdateConsensusRule(context.Context, *multipoolermanagerdata.UpdateConsensusRuleRequest) (*multipoolermanagerdata.UpdateConsensusRuleResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateConsensusRule not implemented")
-}
-func (UnimplementedMultipoolerConsensusServer) RewindToSource(context.Context, *multipoolermanagerdata.RewindToSourceRequest) (*multipoolermanagerdata.RewindToSourceResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method RewindToSource not implemented")
 }
 func (UnimplementedMultipoolerConsensusServer) Recruit(context.Context, *consensusdata.RecruitRequest) (*consensusdata.RecruitResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Recruit not implemented")
@@ -220,24 +200,6 @@ func _MultipoolerConsensus_UpdateConsensusRule_Handler(srv interface{}, ctx cont
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(MultipoolerConsensusServer).UpdateConsensusRule(ctx, req.(*multipoolermanagerdata.UpdateConsensusRuleRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _MultipoolerConsensus_RewindToSource_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(multipoolermanagerdata.RewindToSourceRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(MultipoolerConsensusServer).RewindToSource(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: MultipoolerConsensus_RewindToSource_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MultipoolerConsensusServer).RewindToSource(ctx, req.(*multipoolermanagerdata.RewindToSourceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -306,10 +268,6 @@ var MultipoolerConsensus_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UpdateConsensusRule",
 			Handler:    _MultipoolerConsensus_UpdateConsensusRule_Handler,
-		},
-		{
-			MethodName: "RewindToSource",
-			Handler:    _MultipoolerConsensus_RewindToSource_Handler,
 		},
 		{
 			MethodName: "Recruit",

--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -2617,121 +2617,6 @@ func (x *BackupMetadata) GetPgVersion() string {
 	return ""
 }
 
-// RewindToSourceRequest requests pg_rewind to synchronize with a source server.
-// This operation:
-// 1. Stops PostgreSQL
-// 2. Runs pg_rewind --dry-run to check if rewind is needed
-// 3. If needed, runs actual pg_rewind
-// 4. Starts PostgreSQL
-type RewindToSourceRequest struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Source multipooler (the primary) to rewind to
-	Source        *clustermetadata.Multipooler `protobuf:"bytes,1,opt,name=source,proto3" json:"source,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *RewindToSourceRequest) Reset() {
-	*x = RewindToSourceRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *RewindToSourceRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*RewindToSourceRequest) ProtoMessage() {}
-
-func (x *RewindToSourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use RewindToSourceRequest.ProtoReflect.Descriptor instead.
-func (*RewindToSourceRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{32}
-}
-
-func (x *RewindToSourceRequest) GetSource() *clustermetadata.Multipooler {
-	if x != nil {
-		return x.Source
-	}
-	return nil
-}
-
-type RewindToSourceResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True if the operation completed successfully
-	Success bool `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
-	// Error message if operation failed
-	ErrorMessage string `protobuf:"bytes,2,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
-	// True if servers had diverged and pg_rewind was performed
-	// False if timelines were compatible and no rewind was needed
-	RewindPerformed bool `protobuf:"varint,3,opt,name=rewind_performed,json=rewindPerformed,proto3" json:"rewind_performed,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
-}
-
-func (x *RewindToSourceResponse) Reset() {
-	*x = RewindToSourceResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *RewindToSourceResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*RewindToSourceResponse) ProtoMessage() {}
-
-func (x *RewindToSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use RewindToSourceResponse.ProtoReflect.Descriptor instead.
-func (*RewindToSourceResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{33}
-}
-
-func (x *RewindToSourceResponse) GetSuccess() bool {
-	if x != nil {
-		return x.Success
-	}
-	return false
-}
-
-func (x *RewindToSourceResponse) GetErrorMessage() string {
-	if x != nil {
-		return x.ErrorMessage
-	}
-	return ""
-}
-
-func (x *RewindToSourceResponse) GetRewindPerformed() bool {
-	if x != nil {
-		return x.RewindPerformed
-	}
-	return false
-}
-
 // SetPostgresRestartsEnabledRequest enables or disables automatic PostgreSQL restarts
 // by the postgres monitor. When disabled, the monitor will still run and detect problems,
 // but will not automatically restart a stopped PostgreSQL instance.
@@ -2745,7 +2630,7 @@ type SetPostgresRestartsEnabledRequest struct {
 
 func (x *SetPostgresRestartsEnabledRequest) Reset() {
 	*x = SetPostgresRestartsEnabledRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2757,7 +2642,7 @@ func (x *SetPostgresRestartsEnabledRequest) String() string {
 func (*SetPostgresRestartsEnabledRequest) ProtoMessage() {}
 
 func (x *SetPostgresRestartsEnabledRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2770,7 +2655,7 @@ func (x *SetPostgresRestartsEnabledRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use SetPostgresRestartsEnabledRequest.ProtoReflect.Descriptor instead.
 func (*SetPostgresRestartsEnabledRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{34}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *SetPostgresRestartsEnabledRequest) GetEnabled() bool {
@@ -2790,7 +2675,7 @@ type SetPostgresRestartsEnabledResponse struct {
 
 func (x *SetPostgresRestartsEnabledResponse) Reset() {
 	*x = SetPostgresRestartsEnabledResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2802,7 +2687,7 @@ func (x *SetPostgresRestartsEnabledResponse) String() string {
 func (*SetPostgresRestartsEnabledResponse) ProtoMessage() {}
 
 func (x *SetPostgresRestartsEnabledResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2815,7 +2700,7 @@ func (x *SetPostgresRestartsEnabledResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use SetPostgresRestartsEnabledResponse.ProtoReflect.Descriptor instead.
 func (*SetPostgresRestartsEnabledResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{35}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{33}
 }
 
 var File_multipoolermanagerdata_proto protoreflect.FileDescriptor
@@ -2968,13 +2853,7 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\aUNKNOWN\x10\x00\x12\x0e\n" +
 	"\n" +
 	"INCOMPLETE\x10\x01\x12\f\n" +
-	"\bCOMPLETE\x10\x02\"M\n" +
-	"\x15RewindToSourceRequest\x124\n" +
-	"\x06source\x18\x01 \x01(\v2\x1c.clustermetadata.MultipoolerR\x06source\"\x82\x01\n" +
-	"\x16RewindToSourceResponse\x12\x18\n" +
-	"\asuccess\x18\x01 \x01(\bR\asuccess\x12#\n" +
-	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\x12)\n" +
-	"\x10rewind_performed\x18\x03 \x01(\bR\x0frewindPerformed\"=\n" +
+	"\bCOMPLETE\x10\x02\"=\n" +
 	"!SetPostgresRestartsEnabledRequest\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\"$\n" +
 	"\"SetPostgresRestartsEnabledResponse*\xa4\x01\n" +
@@ -3029,7 +2908,7 @@ func file_multipoolermanagerdata_proto_rawDescGZIP() []byte {
 }
 
 var file_multipoolermanagerdata_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
+var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
 var file_multipoolermanagerdata_proto_goTypes = []any{
 	(PostgresStatus)(0),                         // 0: multipoolermanagerdata.PostgresStatus
 	(PostgresAction)(0),                         // 1: multipoolermanagerdata.PostgresAction
@@ -3071,76 +2950,72 @@ var file_multipoolermanagerdata_proto_goTypes = []any{
 	(*VerifyBackupsRequest)(nil),                // 37: multipoolermanagerdata.VerifyBackupsRequest
 	(*VerifyBackupsResponse)(nil),               // 38: multipoolermanagerdata.VerifyBackupsResponse
 	(*BackupMetadata)(nil),                      // 39: multipoolermanagerdata.BackupMetadata
-	(*RewindToSourceRequest)(nil),               // 40: multipoolermanagerdata.RewindToSourceRequest
-	(*RewindToSourceResponse)(nil),              // 41: multipoolermanagerdata.RewindToSourceResponse
-	(*SetPostgresRestartsEnabledRequest)(nil),   // 42: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	(*SetPostgresRestartsEnabledResponse)(nil),  // 43: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	nil,                             // 44: multipoolermanagerdata.BackupRequest.OverridesEntry
-	nil,                             // 45: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	(*durationpb.Duration)(nil),     // 46: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),   // 47: google.protobuf.Timestamp
-	(*clustermetadata.ID)(nil),      // 48: clustermetadata.ID
-	(clustermetadata.PoolerType)(0), // 49: clustermetadata.PoolerType
-	(*clustermetadata.AvailabilityStatus)(nil), // 50: clustermetadata.AvailabilityStatus
-	(*clustermetadata.ConsensusStatus)(nil),    // 51: clustermetadata.ConsensusStatus
-	(*clustermetadata.RuleNumber)(nil),         // 52: clustermetadata.RuleNumber
-	(clustermetadata.RoutingRole)(0),           // 53: clustermetadata.RoutingRole
-	(*clustermetadata.Multipooler)(nil),        // 54: clustermetadata.Multipooler
+	(*SetPostgresRestartsEnabledRequest)(nil),   // 40: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
+	(*SetPostgresRestartsEnabledResponse)(nil),  // 41: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	nil,                             // 42: multipoolermanagerdata.BackupRequest.OverridesEntry
+	nil,                             // 43: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	(*durationpb.Duration)(nil),     // 44: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),   // 45: google.protobuf.Timestamp
+	(*clustermetadata.ID)(nil),      // 46: clustermetadata.ID
+	(clustermetadata.PoolerType)(0), // 47: clustermetadata.PoolerType
+	(*clustermetadata.AvailabilityStatus)(nil), // 48: clustermetadata.AvailabilityStatus
+	(*clustermetadata.ConsensusStatus)(nil),    // 49: clustermetadata.ConsensusStatus
+	(*clustermetadata.RuleNumber)(nil),         // 50: clustermetadata.RuleNumber
+	(clustermetadata.RoutingRole)(0),           // 51: clustermetadata.RoutingRole
 }
 var file_multipoolermanagerdata_proto_depIdxs = []int32{
-	46, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
+	44, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
 	8,  // 1: multipoolermanagerdata.StandbyReplicationStatus.primary_conn_info:type_name -> multipoolermanagerdata.PrimaryConnInfo
-	47, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
-	46, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
-	46, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
-	46, // 5: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
+	45, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
+	44, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
+	44, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
+	44, // 5: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
 	3,  // 6: multipoolermanagerdata.StopReplicationRequest.mode:type_name -> multipoolermanagerdata.ReplicationPauseMode
 	9,  // 7: multipoolermanagerdata.StopReplicationResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
 	6,  // 8: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
 	4,  // 9: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
-	48, // 10: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
-	48, // 11: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
+	46, // 10: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
+	46, // 11: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
 	16, // 12: multipoolermanagerdata.PrimaryStatus.sync_replication_config:type_name -> multipoolermanagerdata.SynchronousReplicationConfiguration
-	49, // 13: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
+	47, // 13: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
 	17, // 14: multipoolermanagerdata.Status.primary_status:type_name -> multipoolermanagerdata.PrimaryStatus
 	9,  // 15: multipoolermanagerdata.Status.replication_status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
 	0,  // 16: multipoolermanagerdata.Status.postgres_status:type_name -> multipoolermanagerdata.PostgresStatus
 	1,  // 17: multipoolermanagerdata.Status.postgres_action:type_name -> multipoolermanagerdata.PostgresAction
-	46, // 18: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
+	44, // 18: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
 	18, // 19: multipoolermanagerdata.StatusResponse.status:type_name -> multipoolermanagerdata.Status
-	50, // 20: multipoolermanagerdata.StatusResponse.availability_status:type_name -> clustermetadata.AvailabilityStatus
-	51, // 21: multipoolermanagerdata.StatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	48, // 20: multipoolermanagerdata.StatusResponse.availability_status:type_name -> clustermetadata.AvailabilityStatus
+	49, // 21: multipoolermanagerdata.StatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
 	22, // 22: multipoolermanagerdata.ManagerHealthStreamClientMessage.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartRequest
 	23, // 23: multipoolermanagerdata.ManagerHealthStreamClientMessage.poll:type_name -> multipoolermanagerdata.ManagerHealthStreamPollRequest
-	46, // 24: multipoolermanagerdata.ManagerHealthStreamStartRequest.snapshot_interval:type_name -> google.protobuf.Duration
-	46, // 25: multipoolermanagerdata.ManagerHealthStreamStartRequest.staleness_timeout:type_name -> google.protobuf.Duration
-	46, // 26: multipoolermanagerdata.ManagerHealthStreamStartResponse.snapshot_interval:type_name -> google.protobuf.Duration
-	46, // 27: multipoolermanagerdata.ManagerHealthStreamStartResponse.staleness_timeout:type_name -> google.protobuf.Duration
+	44, // 24: multipoolermanagerdata.ManagerHealthStreamStartRequest.snapshot_interval:type_name -> google.protobuf.Duration
+	44, // 25: multipoolermanagerdata.ManagerHealthStreamStartRequest.staleness_timeout:type_name -> google.protobuf.Duration
+	44, // 26: multipoolermanagerdata.ManagerHealthStreamStartResponse.snapshot_interval:type_name -> google.protobuf.Duration
+	44, // 27: multipoolermanagerdata.ManagerHealthStreamStartResponse.staleness_timeout:type_name -> google.protobuf.Duration
 	24, // 28: multipoolermanagerdata.ManagerHealthStreamResponse.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartResponse
 	26, // 29: multipoolermanagerdata.ManagerHealthStreamResponse.snapshot:type_name -> multipoolermanagerdata.ManagerHealthSnapshot
 	20, // 30: multipoolermanagerdata.ManagerHealthSnapshot.status:type_name -> multipoolermanagerdata.StatusResponse
-	46, // 31: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
+	44, // 31: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
 	2,  // 32: multipoolermanagerdata.ManagerHealthSnapshot.trigger:type_name -> multipoolermanagerdata.SnapshotTrigger
-	47, // 33: multipoolermanagerdata.ManagerHealthSnapshot.captured_at:type_name -> google.protobuf.Timestamp
+	45, // 33: multipoolermanagerdata.ManagerHealthSnapshot.captured_at:type_name -> google.protobuf.Timestamp
 	5,  // 34: multipoolermanagerdata.UpdateConsensusRuleRequest.operation:type_name -> multipoolermanagerdata.RuleOperation
-	48, // 35: multipoolermanagerdata.UpdateConsensusRuleRequest.standby_ids:type_name -> clustermetadata.ID
-	52, // 36: multipoolermanagerdata.UpdateConsensusRuleRequest.expected_outgoing_rule:type_name -> clustermetadata.RuleNumber
-	48, // 37: multipoolermanagerdata.UpdateConsensusRuleRequest.coordinator_id:type_name -> clustermetadata.ID
-	44, // 38: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
+	46, // 35: multipoolermanagerdata.UpdateConsensusRuleRequest.standby_ids:type_name -> clustermetadata.ID
+	50, // 36: multipoolermanagerdata.UpdateConsensusRuleRequest.expected_outgoing_rule:type_name -> clustermetadata.RuleNumber
+	46, // 37: multipoolermanagerdata.UpdateConsensusRuleRequest.coordinator_id:type_name -> clustermetadata.ID
+	42, // 38: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
 	39, // 39: multipoolermanagerdata.GetBackupsResponse.backups:type_name -> multipoolermanagerdata.BackupMetadata
 	39, // 40: multipoolermanagerdata.GetBackupByJobIdResponse.backup:type_name -> multipoolermanagerdata.BackupMetadata
-	45, // 41: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	46, // 42: multipoolermanagerdata.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
+	43, // 41: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	44, // 42: multipoolermanagerdata.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
 	7,  // 43: multipoolermanagerdata.BackupMetadata.status:type_name -> multipoolermanagerdata.BackupMetadata.Status
-	53, // 44: multipoolermanagerdata.BackupMetadata.routing_role:type_name -> clustermetadata.RoutingRole
-	47, // 45: multipoolermanagerdata.BackupMetadata.start_timestamp:type_name -> google.protobuf.Timestamp
-	47, // 46: multipoolermanagerdata.BackupMetadata.stop_timestamp:type_name -> google.protobuf.Timestamp
-	54, // 47: multipoolermanagerdata.RewindToSourceRequest.source:type_name -> clustermetadata.Multipooler
-	48, // [48:48] is the sub-list for method output_type
-	48, // [48:48] is the sub-list for method input_type
-	48, // [48:48] is the sub-list for extension type_name
-	48, // [48:48] is the sub-list for extension extendee
-	0,  // [0:48] is the sub-list for field type_name
+	51, // 44: multipoolermanagerdata.BackupMetadata.routing_role:type_name -> clustermetadata.RoutingRole
+	45, // 45: multipoolermanagerdata.BackupMetadata.start_timestamp:type_name -> google.protobuf.Timestamp
+	45, // 46: multipoolermanagerdata.BackupMetadata.stop_timestamp:type_name -> google.protobuf.Timestamp
+	47, // [47:47] is the sub-list for method output_type
+	47, // [47:47] is the sub-list for method input_type
+	47, // [47:47] is the sub-list for extension type_name
+	47, // [47:47] is the sub-list for extension extendee
+	0,  // [0:47] is the sub-list for field type_name
 }
 
 func init() { file_multipoolermanagerdata_proto_init() }
@@ -3162,7 +3037,7 @@ func file_multipoolermanagerdata_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_multipoolermanagerdata_proto_rawDesc), len(file_multipoolermanagerdata_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   38,
+			NumMessages:   36,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -332,53 +332,64 @@ func (SynchronousMethod) EnumDescriptor() ([]byte, []int) {
 	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{4}
 }
 
-// Enum representing the type of cohort membership change
-type CohortUpdateOperation int32
+// RuleOperation is the kind of change UpdateConsensusRule applies to the
+// leader's consensus rule.
+type RuleOperation int32
 
 const (
-	CohortUpdateOperation_COHORT_UPDATE_OPERATION_UNSPECIFIED CohortUpdateOperation = 0
-	CohortUpdateOperation_COHORT_UPDATE_OPERATION_ADD         CohortUpdateOperation = 1
-	CohortUpdateOperation_COHORT_UPDATE_OPERATION_REMOVE      CohortUpdateOperation = 2
+	RuleOperation_RULE_OPERATION_UNSPECIFIED RuleOperation = 0
+	// Cohort-membership changes: add or remove a synchronous standby.
+	RuleOperation_RULE_OPERATION_COHORT_ADD    RuleOperation = 1
+	RuleOperation_RULE_OPERATION_COHORT_REMOVE RuleOperation = 2
+	// ADVANCE makes no cohort change: it re-writes the current rule with the same
+	// leader and cohort at a fresh leader_subterm. Used to reconnect a follower
+	// stranded by an abandoned recruit — advancing the committed decision past the
+	// rule the stray revocation was authored to transition away from
+	// (outgoing_rule) defeats that revocation via the runaway-recruit override in
+	// IsRuleRevoked, without changing the coordinator term or any revocation.
+	RuleOperation_RULE_OPERATION_ADVANCE RuleOperation = 3
 )
 
-// Enum value maps for CohortUpdateOperation.
+// Enum value maps for RuleOperation.
 var (
-	CohortUpdateOperation_name = map[int32]string{
-		0: "COHORT_UPDATE_OPERATION_UNSPECIFIED",
-		1: "COHORT_UPDATE_OPERATION_ADD",
-		2: "COHORT_UPDATE_OPERATION_REMOVE",
+	RuleOperation_name = map[int32]string{
+		0: "RULE_OPERATION_UNSPECIFIED",
+		1: "RULE_OPERATION_COHORT_ADD",
+		2: "RULE_OPERATION_COHORT_REMOVE",
+		3: "RULE_OPERATION_ADVANCE",
 	}
-	CohortUpdateOperation_value = map[string]int32{
-		"COHORT_UPDATE_OPERATION_UNSPECIFIED": 0,
-		"COHORT_UPDATE_OPERATION_ADD":         1,
-		"COHORT_UPDATE_OPERATION_REMOVE":      2,
+	RuleOperation_value = map[string]int32{
+		"RULE_OPERATION_UNSPECIFIED":   0,
+		"RULE_OPERATION_COHORT_ADD":    1,
+		"RULE_OPERATION_COHORT_REMOVE": 2,
+		"RULE_OPERATION_ADVANCE":       3,
 	}
 )
 
-func (x CohortUpdateOperation) Enum() *CohortUpdateOperation {
-	p := new(CohortUpdateOperation)
+func (x RuleOperation) Enum() *RuleOperation {
+	p := new(RuleOperation)
 	*p = x
 	return p
 }
 
-func (x CohortUpdateOperation) String() string {
+func (x RuleOperation) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (CohortUpdateOperation) Descriptor() protoreflect.EnumDescriptor {
+func (RuleOperation) Descriptor() protoreflect.EnumDescriptor {
 	return file_multipoolermanagerdata_proto_enumTypes[5].Descriptor()
 }
 
-func (CohortUpdateOperation) Type() protoreflect.EnumType {
+func (RuleOperation) Type() protoreflect.EnumType {
 	return &file_multipoolermanagerdata_proto_enumTypes[5]
 }
 
-func (x CohortUpdateOperation) Number() protoreflect.EnumNumber {
+func (x RuleOperation) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use CohortUpdateOperation.Descriptor instead.
-func (CohortUpdateOperation) EnumDescriptor() ([]byte, []int) {
+// Deprecated: Use RuleOperation.Descriptor instead.
+func (RuleOperation) EnumDescriptor() ([]byte, []int) {
 	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{5}
 }
 
@@ -1834,13 +1845,13 @@ func (x *ManagerHealthSnapshot) GetCapturedAt() *timestamppb.Timestamp {
 	return nil
 }
 
-// UpdateConsensusRule applies a cohort-membership change on the primary.
-// Internally this updates synchronous_standby_names and records the cohort
-// change in rule_history.
+// UpdateConsensusRule applies a rule change on the primary: a cohort-membership
+// change (which also updates synchronous_standby_names) or a no-op ADVANCE.
+// Either way it records a new rule in rule_history.
 type UpdateConsensusRuleRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Operation to perform (add, remove)
-	Operation CohortUpdateOperation `protobuf:"varint,1,opt,name=operation,proto3,enum=multipoolermanagerdata.CohortUpdateOperation" json:"operation,omitempty"`
+	// Operation to perform (cohort add/remove, or advance).
+	Operation RuleOperation `protobuf:"varint,1,opt,name=operation,proto3,enum=multipoolermanagerdata.RuleOperation" json:"operation,omitempty"`
 	// List of multipooler IDs to add to or remove from the cohort.
 	// The application names will be generated as {cell}_{name} from these IDs.
 	StandbyIds []*clustermetadata.ID `protobuf:"bytes,2,rep,name=standby_ids,json=standbyIds,proto3" json:"standby_ids,omitempty"`
@@ -1888,11 +1899,11 @@ func (*UpdateConsensusRuleRequest) Descriptor() ([]byte, []int) {
 	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{19}
 }
 
-func (x *UpdateConsensusRuleRequest) GetOperation() CohortUpdateOperation {
+func (x *UpdateConsensusRuleRequest) GetOperation() RuleOperation {
 	if x != nil {
 		return x.Operation
 	}
-	return CohortUpdateOperation_COHORT_UPDATE_OPERATION_UNSPECIFIED
+	return RuleOperation_RULE_OPERATION_UNSPECIFIED
 }
 
 func (x *UpdateConsensusRuleRequest) GetStandbyIds() []*clustermetadata.ID {
@@ -2896,9 +2907,9 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\atimeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\atimeout\x12A\n" +
 	"\atrigger\x18\x03 \x01(\x0e2'.multipoolermanagerdata.SnapshotTriggerR\atrigger\x12;\n" +
 	"\vcaptured_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
-	"capturedAt\"\xae\x02\n" +
-	"\x1aUpdateConsensusRuleRequest\x12K\n" +
-	"\toperation\x18\x01 \x01(\x0e2-.multipoolermanagerdata.CohortUpdateOperationR\toperation\x124\n" +
+	"capturedAt\"\xa6\x02\n" +
+	"\x1aUpdateConsensusRuleRequest\x12C\n" +
+	"\toperation\x18\x01 \x01(\x0e2%.multipoolermanagerdata.RuleOperationR\toperation\x124\n" +
 	"\vstandby_ids\x18\x02 \x03(\v2\x13.clustermetadata.IDR\n" +
 	"standbyIds\x12Q\n" +
 	"\x16expected_outgoing_rule\x18\x04 \x01(\v2\x1b.clustermetadata.RuleNumberR\x14expectedOutgoingRule\x12:\n" +
@@ -2992,11 +3003,12 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\x11SynchronousMethod\x12\"\n" +
 	"\x1eSYNCHRONOUS_METHOD_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18SYNCHRONOUS_METHOD_FIRST\x10\x01\x12\x1a\n" +
-	"\x16SYNCHRONOUS_METHOD_ANY\x10\x02*\x85\x01\n" +
-	"\x15CohortUpdateOperation\x12'\n" +
-	"#COHORT_UPDATE_OPERATION_UNSPECIFIED\x10\x00\x12\x1f\n" +
-	"\x1bCOHORT_UPDATE_OPERATION_ADD\x10\x01\x12\"\n" +
-	"\x1eCOHORT_UPDATE_OPERATION_REMOVE\x10\x02*\xb7\x01\n" +
+	"\x16SYNCHRONOUS_METHOD_ANY\x10\x02*\x8c\x01\n" +
+	"\rRuleOperation\x12\x1e\n" +
+	"\x1aRULE_OPERATION_UNSPECIFIED\x10\x00\x12\x1d\n" +
+	"\x19RULE_OPERATION_COHORT_ADD\x10\x01\x12 \n" +
+	"\x1cRULE_OPERATION_COHORT_REMOVE\x10\x02\x12\x1a\n" +
+	"\x16RULE_OPERATION_ADVANCE\x10\x03*\xb7\x01\n" +
 	"\x16SynchronousCommitLevel\x12\x1a\n" +
 	"\x16SYNCHRONOUS_COMMIT_OFF\x10\x00\x12\x1c\n" +
 	"\x18SYNCHRONOUS_COMMIT_LOCAL\x10\x01\x12#\n" +
@@ -3024,7 +3036,7 @@ var file_multipoolermanagerdata_proto_goTypes = []any{
 	(SnapshotTrigger)(0),                        // 2: multipoolermanagerdata.SnapshotTrigger
 	(ReplicationPauseMode)(0),                   // 3: multipoolermanagerdata.ReplicationPauseMode
 	(SynchronousMethod)(0),                      // 4: multipoolermanagerdata.SynchronousMethod
-	(CohortUpdateOperation)(0),                  // 5: multipoolermanagerdata.CohortUpdateOperation
+	(RuleOperation)(0),                          // 5: multipoolermanagerdata.RuleOperation
 	(SynchronousCommitLevel)(0),                 // 6: multipoolermanagerdata.SynchronousCommitLevel
 	(BackupMetadata_Status)(0),                  // 7: multipoolermanagerdata.BackupMetadata.Status
 	(*PrimaryConnInfo)(nil),                     // 8: multipoolermanagerdata.PrimaryConnInfo
@@ -3110,7 +3122,7 @@ var file_multipoolermanagerdata_proto_depIdxs = []int32{
 	46, // 31: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
 	2,  // 32: multipoolermanagerdata.ManagerHealthSnapshot.trigger:type_name -> multipoolermanagerdata.SnapshotTrigger
 	47, // 33: multipoolermanagerdata.ManagerHealthSnapshot.captured_at:type_name -> google.protobuf.Timestamp
-	5,  // 34: multipoolermanagerdata.UpdateConsensusRuleRequest.operation:type_name -> multipoolermanagerdata.CohortUpdateOperation
+	5,  // 34: multipoolermanagerdata.UpdateConsensusRuleRequest.operation:type_name -> multipoolermanagerdata.RuleOperation
 	48, // 35: multipoolermanagerdata.UpdateConsensusRuleRequest.standby_ids:type_name -> clustermetadata.ID
 	52, // 36: multipoolermanagerdata.UpdateConsensusRuleRequest.expected_outgoing_rule:type_name -> clustermetadata.RuleNumber
 	48, // 37: multipoolermanagerdata.UpdateConsensusRuleRequest.coordinator_id:type_name -> clustermetadata.ID

--- a/go/services/multiorch/recovery/actions/fix_replication.go
+++ b/go/services/multiorch/recovery/actions/fix_replication.go
@@ -203,113 +203,16 @@ func (a *FixReplicationAction) fixNotReplicating(
 		return mterrors.Wrap(err, "SetPrimary RPC failed")
 	}
 
-	// Verify replication started
-	err := a.verifyReplicationStarted(ctx, replica)
-	if err != nil {
-		a.logger.WarnContext(ctx, "replication did not start after configuration",
-			"replica", replica.Health().Multipooler.Id.Name,
-			"primary", leader.Health().Multipooler.Id.Name)
-
-		// Re-check the primary's latest health-stream state before running pg_rewind.
-		// pg_rewind stops the replica's postgres before contacting the source; if the
-		// primary postgres is no longer running the stop will leave two nodes down.
-		// Return an error for retry — the next cycle will detect PrimaryIsDead.
-		primaryKey := topoclient.ComponentIDString(leader.Health().Multipooler.Id)
-		latest, ok := a.poolerStore.GetRider(primaryKey)
-		if !ok || !latest.Health().GetStatus().GetPostgresReady() {
-			return mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
-				"primary postgres not running, skipping pg_rewind to avoid leaving two nodes down")
-		}
-
-		// Defer pg_rewind until the leader has checkpointed onto its current
-		// timeline. Rewinding from a leader whose control file still advertises a
-		// stale checkpoint timeline stamps that stale timeline into this replica's
-		// minRecoveryPoint and FATALs on startup. The leader self-reports readiness
-		// in its published ReplicationPrimary (auto-cleared on any new term, so a
-		// true value is current). Return for retry; the next cycle re-checks once
-		// the leader's post-promotion checkpoint completes.
-		if !commonconsensus.ReplicationPrimaryOrNil(latest.Health().GetConsensusStatus()).GetRewindReady() {
-			return mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
-				"leader %s not yet rewind-ready (checkpoint pending on its current timeline); deferring pg_rewind",
-				leader.Health().Multipooler.Id.Name)
-		}
-
-		if rewindErr := a.tryPgRewind(ctx, leader, replica); rewindErr != nil {
-			return mterrors.Wrap(rewindErr, "pg_rewind failed")
-		}
-		// Re-verify replication after rewind. RewindToSource restarts
-		// PostgreSQL as a standby and re-establishes primary_conninfo,
-		// which pg_rewind may have cleared by syncing postgresql.auto.conf
-		// from the source.
-		if verifyErr := a.verifyReplicationStarted(ctx, replica); verifyErr != nil {
-			return mterrors.Wrap(verifyErr, "replication did not start after pg_rewind")
-		}
+	// Verify replication started.
+	if err := a.verifyReplicationStarted(ctx, replica); err != nil {
+		return mterrors.Wrapf(err,
+			"replication did not start after configuring primary_conninfo toward %s; leaving divergence recovery to the pooler",
+			leader.Health().Multipooler.Id.Name)
 	}
-
-	// Cohort membership (adding the replica to synchronous_standby_names) is
-	// managed by ReconcileCohortAction separately. By the time this action
-	// returns, the replica is replicating; the cohort analyzer will pick it up
-	// on the next cycle and promote adding it to the cohort.
 
 	a.logger.InfoContext(ctx, "fix replication action completed successfully",
 		"replica", replica.Health().Multipooler.Id.Name,
 		"primary", leader.Health().Multipooler.Id.Name)
-
-	return nil
-}
-
-// tryPgRewind attempts to repair a replica using pg_rewind.
-// RewindToSource will:
-// 1. Stop postgres
-// 2. Check if rewind is needed (dry-run)
-// 3. Run actual rewind if needed
-// 4. Start postgres
-// If pg_rewind is not feasible (missing WAL), it marks the pooler as DRAINED.
-func (a *FixReplicationAction) tryPgRewind(
-	ctx context.Context,
-	primary *store.Pooler,
-	replica *store.Pooler,
-) error {
-	a.logger.InfoContext(ctx, "attempting pg_rewind",
-		"replica", replica.Health().Multipooler.Id.Name,
-		"primary", primary.Health().Multipooler.Id.Name)
-
-	// Call RewindToSource - it handles the entire flow atomically
-	rewindReq := &multipoolermanagerdatapb.RewindToSourceRequest{
-		Source: primary.Health().Multipooler,
-	}
-	rewindResp, err := a.rpcClient.RewindToSource(ctx, replica.Health().Multipooler, rewindReq)
-	if err != nil {
-		// RPC failure (e.g. primary postgres unreachable) is transient — do not
-		// drain the pooler. Return an error so the next recovery cycle retries.
-		a.logger.WarnContext(ctx, "pg_rewind RPC failed, will retry next cycle",
-			"replica", replica.Health().Multipooler.Id.Name,
-			"error", err)
-		return mterrors.Wrap(err, "pg_rewind RPC failed")
-	}
-	if !rewindResp.Success {
-		// pg_rewind is not feasible (e.g. the required WAL has been recycled): the
-		// replica cannot rejoin and needs replacement.
-		//
-		// TODO: signal this durably via the pooler's lifecycle stage so the
-		// provisioner and orch treat the pooler as broken/needs-replacement. Orch
-		// must not write the pooler's topology Type — the pooler owns its own record
-		// and would clobber an external write. For now we surface an error so the
-		// failure is visible; the next recovery cycle will retry.
-		a.logger.WarnContext(ctx, "pg_rewind not feasible; pooler needs replacement",
-			"replica", replica.Health().Multipooler.Id.Name,
-			"error", rewindResp.ErrorMessage)
-		return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
-			"pg_rewind not feasible for %s: %s", replica.Health().Multipooler.Id.Name, rewindResp.ErrorMessage)
-	}
-
-	if rewindResp.RewindPerformed {
-		a.logger.InfoContext(ctx, "pg_rewind completed successfully - servers were diverged",
-			"replica", replica.Health().Multipooler.Id.Name)
-	} else {
-		a.logger.InfoContext(ctx, "pg_rewind not needed - timelines are compatible",
-			"replica", replica.Health().Multipooler.Id.Name)
-	}
 
 	return nil
 }

--- a/go/services/multiorch/recovery/actions/fix_replication_test.go
+++ b/go/services/multiorch/recovery/actions/fix_replication_test.go
@@ -760,186 +760,11 @@ func (c *replicationStatusClient) Status(
 	}, nil
 }
 
-// streamingAfterRewindClient wraps FakeClient to simulate the full pg_rewind
-// success path: the replica has no primary_conninfo initially, the WAL receiver
-// stays idle through the first verifyReplicationStarted window (exhausting all
-// attempts), then streams after RewindToSource restores primary_conninfo.
-//
-// Call sequence (with verifyMaxAttempts = N):
-//  1. verifyProblemExists        → no PrimaryConnInfo (triggers fix)
-//     2..N+1. verifyReplicationStarted after SetPrimary  → not streaming (all fail)
-//     N+2+.  verifyReplicationStarted after RewindToSource → streaming
-type streamingAfterRewindClient struct {
-	*rpcclient.FakeClient
-	replicaCallCount  int
-	nonStreamingCalls int // number of non-streaming calls after call 1 before transitioning
-}
-
-func (c *streamingAfterRewindClient) Status(
-	ctx context.Context,
-	pooler *clustermetadatapb.Multipooler,
-	request *multipoolermanagerdatapb.StatusRequest,
-) (*multipoolermanagerdatapb.StatusResponse, error) {
-	if pooler == nil || pooler.Id == nil || pooler.Id.Name != "replica1" {
-		return c.FakeClient.Status(ctx, pooler, request)
-	}
-	c.replicaCallCount++
-	switch {
-	case c.replicaCallCount == 1:
-		// verifyProblemExists: no primary_conninfo → triggers fix
-		return &multipoolermanagerdatapb.StatusResponse{
-			Status: &multipoolermanagerdatapb.Status{
-				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{},
-			},
-		}, nil
-	case c.replicaCallCount <= 1+c.nonStreamingCalls:
-		// verifyReplicationStarted after SetPrimary: WAL receiver idle
-		return &multipoolermanagerdatapb.StatusResponse{
-			Status: &multipoolermanagerdatapb.Status{
-				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-					WalReceiverStatus: "",
-				},
-			},
-		}, nil
-	default:
-		// verifyReplicationStarted after RewindToSource: streaming
-		return &multipoolermanagerdatapb.StatusResponse{
-			Status: &multipoolermanagerdatapb.Status{
-				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-					WalReceiverStatus: "streaming",
-					LastReceiveLsn:    "0/5000100",
-				},
-			},
-		}, nil
-	}
-}
-
-// TestFixReplicationAction_SucceedsViaRewind is a regression test for the bug where
-// RewindToSource did not restore primary_conninfo after pg_rewind, leaving the WAL
-// receiver with no primary to connect to. The full path under test:
-//
-//  1. SetPrimary is called but the WAL receiver never starts streaming.
-//  2. tryPgRewind → RewindToSource runs (which now restores primary_conninfo).
-//  3. verifyReplicationStarted sees "streaming" and the action succeeds.
-func TestFixReplicationAction_SucceedsViaRewind(t *testing.T) {
-	ctx := context.Background()
-	ts, _ := memorytopo.NewServerAndFactory(ctx, "cell1")
-	defer ts.Close()
-
-	const verifyAttempts = 3 // override default to keep test fast
-
-	baseFakeClient := rpcclient.NewFakeClient()
-	baseFakeClient.SetStatusResponse("multipooler-cell1-primary", &multipoolermanagerdatapb.StatusResponse{
-		Status: &multipoolermanagerdatapb.Status{
-			IsInitialized: true,
-			PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
-		},
-		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
-			Id:              fixReplPrimaryID,
-			TermRevocation:  &clustermetadatapb.TermRevocation{RevokedBelowTerm: 1},
-			CurrentPosition: leaderCurrentPosition(1),
-		},
-	})
-	baseFakeClient.SetStatusResponse("multipooler-cell1-replica1", &multipoolermanagerdatapb.StatusResponse{
-		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
-			TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 1},
-		},
-	})
-	baseFakeClient.UpdateConsensusRuleResponses = map[topoclient.ComponentID]*multipoolermanagerdatapb.UpdateConsensusRuleResponse{
-		"multipooler-cell1-primary": {},
-	}
-	// RewindToSource succeeds, simulating pg_rewind running and primary_conninfo
-	// being restored by the fix in rpc_manager.go.
-	baseFakeClient.RewindToSourceResponses = map[topoclient.ComponentID]*multipoolermanagerdatapb.RewindToSourceResponse{
-		"multipooler-cell1-replica1": {
-			Success:         true,
-			RewindPerformed: true,
-		},
-	}
-
-	fakeClient := &streamingAfterRewindClient{
-		FakeClient:        baseFakeClient,
-		nonStreamingCalls: verifyAttempts,
-	}
-	poolerStore := store.NewTestCache(t)
-
-	replicaID := &clustermetadatapb.ID{
-		Component: clustermetadatapb.ID_MULTIPOOLER,
-		Cell:      "cell1",
-		Name:      "replica1",
-	}
-	replica := &clustermetadatapb.Multipooler{
-		Id: replicaID,
-		ShardKey: &clustermetadatapb.ShardKey{
-			Database:   "testdb",
-			TableGroup: "default",
-			Shard:      "0",
-		},
-		Type: clustermetadatapb.PoolerType_REPLICA,
-	}
-	primary := &clustermetadatapb.Multipooler{
-		Id: &clustermetadatapb.ID{
-			Component: clustermetadatapb.ID_MULTIPOOLER,
-			Cell:      "cell1",
-			Name:      "primary",
-		},
-		ShardKey: &clustermetadatapb.ShardKey{
-			Database:   "testdb",
-			TableGroup: "default",
-			Shard:      "0",
-		},
-		Type:     clustermetadatapb.PoolerType_PRIMARY,
-		Hostname: "primary.example.com",
-		PortMap:  map[string]int32{"postgres": 5432},
-	}
-
-	require.NoError(t, ts.CreateMultipooler(ctx, replica))
-	require.NoError(t, ts.CreateMultipooler(ctx, primary))
-
-	store.SeedCache(t, poolerStore, store.NewPooler(&multiorchdatapb.PoolerHealthState{
-		Multipooler: replica,
-	}, nil))
-	store.SeedCache(t, poolerStore, store.NewPooler(&multiorchdatapb.PoolerHealthState{
-		Multipooler: primary,
-		Status:      &multipoolermanagerdatapb.Status{PostgresReady: true},
-		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
-			Id:             fixReplPrimaryID,
-			TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 1},
-			CurrentPosition: &clustermetadatapb.PoolerPosition{
-				Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
-					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
-					LeaderId:   fixReplPrimaryID,
-				}},
-			},
-			// Leader is rewind-ready, so fix_replication's tryPgRewind gate proceeds.
-			ReplicationPrimary: rewindReadyPrimary(1),
-		},
-	}, nil))
-
-	action := NewFixReplicationAction(config.NewTestConfig(), fakeClient, poolerStore, slog.Default())
-	action.verifyPollInterval = 10 * time.Millisecond
-	action.verifyMaxAttempts = verifyAttempts
-
-	problem := types.Problem{
-		Code: types.ProblemReplicaNotReplicating,
-		ShardKey: &clustermetadatapb.ShardKey{
-			Database:   "testdb",
-			TableGroup: "default",
-			Shard:      "0",
-		},
-		PoolerID: replicaID,
-	}
-
-	err := action.Execute(ctx, problem)
-	require.NoError(t, err, "fixNotReplicating must succeed via pg_rewind path")
-
-	// Verify the expected call sequence.
-	assert.Contains(t, fakeClient.CallLog, "SetPrimary(multipooler-cell1-replica1)",
-		"SetPrimary must be called first")
-	assert.Contains(t, fakeClient.CallLog, "RewindToSource(multipooler-cell1-replica1)",
-		"RewindToSource must be called when SetPrimary doesn't start streaming")
-}
-
+// TestFixReplicationAction_FailsWhenReplicationDoesNotStart verifies that when
+// SetPrimary does not bring the WAL receiver up to streaming, fixNotReplicating
+// fails and leaves divergence recovery to the pooler. Orch no longer drives
+// pg_rewind (RewindToSource) itself — a diverged standby self-heals via its own
+// revocation-gated rewind — so the action must NOT call RewindToSource here.
 func TestFixReplicationAction_FailsWhenReplicationDoesNotStart(t *testing.T) {
 	ctx := context.Background()
 	ts, _ := memorytopo.NewServerAndFactory(ctx, "cell1")
@@ -966,13 +791,6 @@ func TestFixReplicationAction_FailsWhenReplicationDoesNotStart(t *testing.T) {
 	})
 	baseFakeClient.UpdateConsensusRuleResponses = map[topoclient.ComponentID]*multipoolermanagerdatapb.UpdateConsensusRuleResponse{
 		"multipooler-cell1-primary": {},
-	}
-	// pg_rewind dry-run fails, so it marks the pooler as DRAINED
-	baseFakeClient.RewindToSourceResponses = map[topoclient.ComponentID]*multipoolermanagerdatapb.RewindToSourceResponse{
-		"multipooler-cell1-replica1": {
-			Success:      false,
-			ErrorMessage: "pg_rewind not feasible: source timeline diverged before target's last checkpoint",
-		},
 	}
 
 	fakeClient := &replicationStatusClient{FakeClient: baseFakeClient, walReceiverStatus: "stopping"}
@@ -1009,7 +827,6 @@ func TestFixReplicationAction_FailsWhenReplicationDoesNotStart(t *testing.T) {
 		PortMap:  map[string]int32{"postgres": 5432},
 	}
 
-	// Create in topology for markPoolerDrained to work
 	require.NoError(t, ts.CreateMultipooler(ctx, replica))
 	require.NoError(t, ts.CreateMultipooler(ctx, primary))
 
@@ -1022,7 +839,8 @@ func TestFixReplicationAction_FailsWhenReplicationDoesNotStart(t *testing.T) {
 		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
 			Id:              fixReplPrimaryID,
 			CurrentPosition: leaderCurrentPosition(1),
-			// Leader is rewind-ready, so fix_replication's tryPgRewind gate proceeds.
+			// Leader is rewind-ready; SetPrimary relays this to the replica so its
+			// own self-heal may rewind. Orch itself does not act on it here.
 			ReplicationPrimary: rewindReadyPrimary(1),
 		},
 	}, nil))
@@ -1042,16 +860,17 @@ func TestFixReplicationAction_FailsWhenReplicationDoesNotStart(t *testing.T) {
 
 	err := action.Execute(ctx, problem)
 
-	// pg_rewind was not feasible, so the action fails with FAILED_PRECONDITION.
-	// Orch no longer drains the pooler itself; surfacing the broken pooler to the
-	// provisioner via its lifecycle stage is future work (see fix_replication.go).
+	// Replication never reached streaming, so verifyReplicationStarted fails
+	// (INTERNAL) and fixNotReplicating surfaces it, leaving divergence recovery to
+	// the pooler.
 	require.Error(t, err)
-	assert.Equal(t, mtrpcpb.Code_FAILED_PRECONDITION, mterrors.Code(err))
+	assert.Equal(t, mtrpcpb.Code_INTERNAL, mterrors.Code(err))
+	assert.ErrorContains(t, err, "leaving divergence recovery to the pooler")
 
 	// Verify SetPrimary was called (configuration was attempted)
 	assert.Contains(t, fakeClient.CallLog, "SetPrimary(multipooler-cell1-replica1)")
-	// Verify pg_rewind was tried after replication failed to start
-	assert.Contains(t, fakeClient.CallLog, "RewindToSource(multipooler-cell1-replica1)")
+	// Orch must NOT drive pg_rewind: the pooler owns divergence recovery now.
+	assert.NotContains(t, fakeClient.CallLog, "RewindToSource(multipooler-cell1-replica1)")
 
 	// The pooler's topology Type must be left untouched: orch no longer writes a
 	// pooler's record to mark it broken. Surfacing the broken pooler durably to the

--- a/go/services/multiorch/recovery/actions/fix_replication_test.go
+++ b/go/services/multiorch/recovery/actions/fix_replication_test.go
@@ -763,8 +763,8 @@ func (c *replicationStatusClient) Status(
 // TestFixReplicationAction_FailsWhenReplicationDoesNotStart verifies that when
 // SetPrimary does not bring the WAL receiver up to streaming, fixNotReplicating
 // fails and leaves divergence recovery to the pooler. Orch no longer drives
-// pg_rewind (RewindToSource) itself — a diverged standby self-heals via its own
-// revocation-gated rewind — so the action must NOT call RewindToSource here.
+// pg_rewind itself — a diverged standby self-heals via its own revocation-gated
+// rewind.
 func TestFixReplicationAction_FailsWhenReplicationDoesNotStart(t *testing.T) {
 	ctx := context.Background()
 	ts, _ := memorytopo.NewServerAndFactory(ctx, "cell1")
@@ -867,10 +867,9 @@ func TestFixReplicationAction_FailsWhenReplicationDoesNotStart(t *testing.T) {
 	assert.Equal(t, mtrpcpb.Code_INTERNAL, mterrors.Code(err))
 	assert.ErrorContains(t, err, "leaving divergence recovery to the pooler")
 
-	// Verify SetPrimary was called (configuration was attempted)
+	// Verify SetPrimary was called (configuration was attempted). Orch has no way
+	// to drive pg_rewind — the pooler owns divergence recovery now.
 	assert.Contains(t, fakeClient.CallLog, "SetPrimary(multipooler-cell1-replica1)")
-	// Orch must NOT drive pg_rewind: the pooler owns divergence recovery now.
-	assert.NotContains(t, fakeClient.CallLog, "RewindToSource(multipooler-cell1-replica1)")
 
 	// The pooler's topology Type must be left untouched: orch no longer writes a
 	// pooler's record to mark it broken. Surfacing the broken pooler durably to the

--- a/go/services/multiorch/recovery/actions/reconcile_cohort.go
+++ b/go/services/multiorch/recovery/actions/reconcile_cohort.go
@@ -81,12 +81,12 @@ func (a *ReconcileCohortAction) Execute(ctx context.Context, problem types.Probl
 		"pooler", problem.PoolerID.Name,
 		"problem_code", string(problem.Code))
 
-	var op multipoolermanagerdatapb.CohortUpdateOperation
+	var op multipoolermanagerdatapb.RuleOperation
 	switch problem.Code {
 	case types.ProblemPoolerNotInCohort:
-		op = multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_ADD
+		op = multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_ADD
 	case types.ProblemCohortMemberIneligible:
-		op = multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_REMOVE
+		op = multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_REMOVE
 	default:
 		return mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
 			"unsupported problem code for reconcile cohort: %s", problem.Code)
@@ -97,7 +97,7 @@ func (a *ReconcileCohortAction) Execute(ctx context.Context, problem types.Probl
 	// be gone from the cache (the whole point of "cohort member is no longer
 	// tracked"), so we operate on the problem's raw ID directly.
 	var targetID *clustermetadatapb.ID
-	if op == multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_ADD {
+	if op == multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_ADD {
 		target, err := store.FindPoolerByID(a.poolerStore, problem.PoolerID)
 		if err != nil {
 			return mterrors.Wrap(err, "failed to find target pooler")

--- a/go/services/multiorch/recovery/actions/reconcile_cohort_test.go
+++ b/go/services/multiorch/recovery/actions/reconcile_cohort_test.go
@@ -110,7 +110,7 @@ func TestReconcileCohortAction_Execute(t *testing.T) {
 		assert.Contains(t, fakeClient.CallLog, "UpdateConsensusRule(multipooler-cell1-primary)")
 		req := fakeClient.LastUpdateConsensusRuleRequest
 		require.NotNil(t, req)
-		assert.Equal(t, multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_ADD, req.Operation)
+		assert.Equal(t, multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_ADD, req.Operation)
 		require.Len(t, req.StandbyIds, 1)
 		assert.Equal(t, replicaID.Name, req.StandbyIds[0].Name)
 		require.NotNil(t, req.ExpectedOutgoingRule, "CAS guard must be set")
@@ -144,7 +144,7 @@ func TestReconcileCohortAction_Execute(t *testing.T) {
 		assert.Contains(t, fakeClient.CallLog, "UpdateConsensusRule(multipooler-cell1-primary)")
 		req := fakeClient.LastUpdateConsensusRuleRequest
 		require.NotNil(t, req)
-		assert.Equal(t, multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_REMOVE, req.Operation)
+		assert.Equal(t, multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_REMOVE, req.Operation)
 	})
 
 	t.Run("returns error when target pooler is not in store", func(t *testing.T) {

--- a/go/services/multiorch/recovery/actions/reconnect_recruit_abandoned.go
+++ b/go/services/multiorch/recovery/actions/reconnect_recruit_abandoned.go
@@ -1,0 +1,218 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/rpcclient"
+	"github.com/multigres/multigres/go/common/topoclient"
+	"github.com/multigres/multigres/go/services/multiorch/config"
+	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
+	"github.com/multigres/multigres/go/services/multiorch/store"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
+	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+)
+
+// Compile-time assertion that ReconnectRecruitAbandonedAction implements types.RecoveryAction.
+var _ types.RecoveryAction = (*ReconnectRecruitAbandonedAction)(nil)
+
+// ReconnectRecruitAbandonedAction reconnects a follower stranded by an abandoned
+// recruit (ProblemReplicaRecruitAbandoned).
+//
+// The follower's TermRevocation revokes the leader's committed rule — a failover
+// was started at a higher term, reached this follower, then never committed — so
+// the follower rejects a plain SetPrimary at the current rule. The fix is a
+// leader-led no-op rule advance: UpdateConsensusRule(ADVANCE) rewrites the rule
+// with the same leader and cohort at a fresh leader_subterm, committed by the
+// rest of the cohort. That moves the committed decision past the rule the
+// revocation was authored to transition away from (its outgoing_rule), which
+// defeats the revocation via the runaway-recruit override in IsRuleRevoked
+// without changing the coordinator term or any pooler's revocation. The action
+// then relays the advanced decision via SetPrimary, which the follower now
+// accepts, and it rejoins as a streaming standby.
+//
+// Idempotency: UpdateConsensusRule is compare-and-swap guarded on the expected
+// outgoing rule, so concurrent orchestrators cannot double-advance; a loser sees
+// the rule already advanced and its later SetPrimary is harmless.
+type ReconnectRecruitAbandonedAction struct {
+	config      *config.Config
+	rpcClient   rpcclient.MultipoolerClient
+	poolerStore *store.PoolerCache
+	logger      *slog.Logger
+
+	// Polling parameters for waiting on the advanced rule to be decided.
+	verifyMaxAttempts  int
+	verifyPollInterval time.Duration
+}
+
+// NewReconnectRecruitAbandonedAction creates a new reconnect action.
+func NewReconnectRecruitAbandonedAction(
+	cfg *config.Config,
+	rpcClient rpcclient.MultipoolerClient,
+	poolerStore *store.PoolerCache,
+	logger *slog.Logger,
+) *ReconnectRecruitAbandonedAction {
+	maxAttempts := DefaultVerifyMaxAttempts
+	pollInterval := DefaultVerifyPollInterval
+	if cfg != nil {
+		if timeout := cfg.GetVerifyReplicationTimeout(); timeout > 0 {
+			maxAttempts = max(int(timeout/DefaultVerifyPollInterval), 1)
+		}
+	}
+	return &ReconnectRecruitAbandonedAction{
+		config:             cfg,
+		rpcClient:          rpcClient,
+		poolerStore:        poolerStore,
+		logger:             logger,
+		verifyMaxAttempts:  maxAttempts,
+		verifyPollInterval: pollInterval,
+	}
+}
+
+// Execute advances the leader's rule and reconnects the stranded follower.
+func (a *ReconnectRecruitAbandonedAction) Execute(ctx context.Context, problem types.Problem) error {
+	a.logger.InfoContext(ctx, "executing reconnect recruit-abandoned action",
+		"shard_key", problem.ShardKey.String(),
+		"pooler", problem.PoolerID.Name,
+		"problem_code", string(problem.Code))
+
+	follower, err := store.FindPoolerByID(a.poolerStore, problem.PoolerID)
+	if err != nil {
+		return mterrors.Wrap(err, "failed to find stranded follower")
+	}
+
+	members := store.FindShardMembers(a.poolerStore, problem.ShardKey)
+	leader := members.Leader
+	if leader == nil || members.HighestKnownPosition == nil {
+		return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
+			"no consensus leader known for shard %s", problem.ShardKey)
+	}
+
+	revocation := follower.Health().GetConsensusStatus().GetTermRevocation()
+
+	// Advance the rule only if the follower is still stranded — the highest known
+	// rule may already outrank the revocation (its decision is high enough, even
+	// mid-transition with an outstanding proposal, or a prior cycle / racing
+	// orchestrator already advanced it), in which case SetPrimary is safe to send
+	// as-is and no advance is needed.
+	advanced := members.HighestKnownPosition
+	if commonconsensus.IsRuleRevoked(advanced, revocation) {
+		// Advancing rewrites the rule; the leader refuses that while a proposal is
+		// undecided (it CAS-guards on the decided outgoing rule), so defer to a
+		// later cycle rather than erroring.
+		if !commonconsensus.IsRuleDecided(advanced) {
+			return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
+				"shard %s has an undecided proposal; cannot advance rule yet", problem.ShardKey)
+		}
+		req := &multipoolermanagerdatapb.UpdateConsensusRuleRequest{
+			Operation:            multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_ADVANCE,
+			ExpectedOutgoingRule: members.HighestKnownPosition.GetDecision().GetRuleNumber(),
+		}
+		if _, err := a.rpcClient.UpdateConsensusRule(ctx, leader.Health().Multipooler, req); err != nil {
+			return mterrors.Wrap(err, "leader-led rule advance failed")
+		}
+		a.logger.InfoContext(ctx, "advanced leader rule to reconnect stranded follower",
+			"leader", leader.Health().Multipooler.Id.Name,
+			"follower", follower.Health().Multipooler.Id.Name)
+
+		advanced, err = a.waitForRulePastRevocation(ctx, leader, revocation)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Relay the advanced decision to the follower. It no longer revokes this rule,
+	// so it accepts SetPrimary and rejoins. RewindReady is relayed so a follower
+	// that also needs a rewind defers it until the leader is checkpointed.
+	setReq := &consensusdatapb.SetPrimaryRequest{
+		ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
+			Position:    advanced,
+			Primary:     topoclient.PoolerAddressFor(leader.Health().Multipooler),
+			RewindReady: commonconsensus.ReplicationPrimaryOrNil(leader.Health().GetConsensusStatus()).GetRewindReady(),
+		},
+	}
+	if _, err := a.rpcClient.SetPrimary(ctx, follower.Health().Multipooler, setReq); err != nil {
+		return mterrors.Wrap(err, "SetPrimary to reconnect stranded follower failed")
+	}
+
+	a.logger.InfoContext(ctx, "reconnect recruit-abandoned action completed",
+		"leader", leader.Health().Multipooler.Id.Name,
+		"follower", follower.Health().Multipooler.Id.Name)
+	return nil
+}
+
+// waitForRulePastRevocation polls the leader until its committed decision has
+// advanced past the follower's revocation (the ADVANCE is decided by the
+// cohort), returning that decided position for the reconnect SetPrimary. Until
+// the advance is decided, the follower would still reject SetPrimary, so this
+// avoids a silently-ignored reconnect.
+func (a *ReconnectRecruitAbandonedAction) waitForRulePastRevocation(
+	ctx context.Context,
+	leader *store.Pooler,
+	revocation *clustermetadatapb.TermRevocation,
+) (*clustermetadatapb.RulePosition, error) {
+	ticker := time.NewTicker(a.verifyPollInterval)
+	defer ticker.Stop()
+
+	var lastPos *clustermetadatapb.RulePosition
+	for attempt := 1; attempt <= a.verifyMaxAttempts; attempt++ {
+		select {
+		case <-ctx.Done():
+			return nil, mterrors.Wrap(ctx.Err(), "context cancelled while waiting for rule advance")
+		case <-ticker.C:
+		}
+
+		resp, err := a.rpcClient.Status(ctx, leader.Health().Multipooler, &multipoolermanagerdatapb.StatusRequest{})
+		if err != nil {
+			return nil, mterrors.Wrap(err, "failed to read leader status while waiting for rule advance")
+		}
+		pos := resp.GetConsensusStatus().GetCurrentPosition().GetPosition()
+		lastPos = pos
+		if commonconsensus.IsRuleDecided(pos) && !commonconsensus.IsRuleRevoked(pos, revocation) {
+			return pos, nil
+		}
+	}
+	return nil, mterrors.Errorf(mtrpcpb.Code_DEADLINE_EXCEEDED,
+		"leader rule did not advance past the follower's revocation after %d attempts (last position %s)",
+		a.verifyMaxAttempts, commonconsensus.FormatRulePosition(lastPos))
+}
+
+// RequiresHealthyLeader reports that this action needs a healthy leader: it runs
+// UpdateConsensusRule on the leader.
+func (a *ReconnectRecruitAbandonedAction) RequiresHealthyLeader() bool {
+	return true
+}
+
+func (a *ReconnectRecruitAbandonedAction) Metadata() types.RecoveryMetadata {
+	return types.RecoveryMetadata{
+		Name:        "ReconnectRecruitAbandoned",
+		Description: "Advance the leader rule to reconnect a follower stranded by an abandoned recruit",
+		Timeout:     30 * time.Second,
+		LockTimeout: 15 * time.Second,
+		Retryable:   true,
+	}
+}
+
+func (a *ReconnectRecruitAbandonedAction) GracePeriod() *types.GracePeriodConfig {
+	return nil
+}

--- a/go/services/multiorch/recovery/actions/reconnect_recruit_abandoned_test.go
+++ b/go/services/multiorch/recovery/actions/reconnect_recruit_abandoned_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/rpcclient"
+	"github.com/multigres/multigres/go/services/multiorch/config"
+	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
+	"github.com/multigres/multigres/go/services/multiorch/store"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+)
+
+func TestReconnectRecruitAbandonedAction(t *testing.T) {
+	ctx := context.Background()
+	shardKey := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: "default", Shard: "0"}
+	replicaID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "replica1"}
+
+	leaderMP := &clustermetadatapb.Multipooler{
+		Id: fixReplPrimaryID, ShardKey: shardKey, Type: clustermetadatapb.PoolerType_PRIMARY,
+		Hostname: "primary.example.com", PortMap: map[string]int32{"postgres": 5432},
+	}
+	replicaMP := &clustermetadatapb.Multipooler{Id: replicaID, ShardKey: shardKey, Type: clustermetadatapb.PoolerType_REPLICA}
+
+	// followerRevocation revokes the term-1 rule (recruited at term 2, transitioning
+	// away from the term-1 rule the leader still holds).
+	followerRevocation := &clustermetadatapb.TermRevocation{
+		RevokedBelowTerm: 2,
+		OutgoingRule:     &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
+	}
+	ruleAt := func(term, subterm int64) *clustermetadatapb.RulePosition {
+		return &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
+			RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: term, LeaderSubterm: subterm},
+			LeaderId:   fixReplPrimaryID,
+		}}
+	}
+
+	// seed builds a cache with the leader at leaderTerm and the stranded follower.
+	seed := func(t *testing.T, leaderPos *clustermetadatapb.PoolerPosition) *store.PoolerCache {
+		cache := store.NewTestCache(t)
+		store.SeedCache(t, cache, store.NewPooler(&multiorchdatapb.PoolerHealthState{
+			Multipooler:      leaderMP,
+			IsLastCheckValid: true,
+			Status:           &multipoolermanagerdatapb.Status{PostgresReady: true},
+			ConsensusStatus:  &clustermetadatapb.ConsensusStatus{Id: fixReplPrimaryID, CurrentPosition: leaderPos},
+		}, nil))
+		store.SeedCache(t, cache, store.NewPooler(&multiorchdatapb.PoolerHealthState{
+			Multipooler:      replicaMP,
+			IsLastCheckValid: true,
+			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+				Id:              replicaID,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{Position: ruleAt(1, 0)},
+				TermRevocation:  followerRevocation,
+			},
+		}, nil))
+		return cache
+	}
+
+	problem := types.Problem{
+		Code:     types.ProblemReplicaRecruitAbandoned,
+		ShardKey: shardKey,
+		PoolerID: replicaID,
+	}
+
+	t.Run("advances the rule then reconnects the follower", func(t *testing.T) {
+		fake := rpcclient.NewFakeClient()
+		// After the advance, the leader reports its committed rule at a fresh
+		// subterm (1.1), which outranks the follower's revocation outgoing_rule.
+		fake.SetStatusResponse("multipooler-cell1-primary", &multipoolermanagerdatapb.StatusResponse{
+			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+				Id:              fixReplPrimaryID,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{Position: ruleAt(1, 1)},
+			},
+		})
+
+		action := NewReconnectRecruitAbandonedAction(config.NewTestConfig(), fake, seed(t, leaderCurrentPosition(1)), slog.Default())
+		action.verifyPollInterval = 10 * time.Millisecond
+
+		require.NoError(t, action.Execute(ctx, problem))
+		assert.Contains(t, fake.CallLog, "UpdateConsensusRule(multipooler-cell1-primary)",
+			"must advance the rule on the leader")
+		assert.Contains(t, fake.CallLog, "SetPrimary(multipooler-cell1-replica1)",
+			"must reconnect the follower after advancing")
+	})
+
+	t.Run("skips the advance when the rule already outranks the revocation", func(t *testing.T) {
+		fake := rpcclient.NewFakeClient()
+		// Leader already at term 2: the highest known rule is not revoked by the
+		// follower's revocation, so no advance is needed — just reconnect.
+		action := NewReconnectRecruitAbandonedAction(config.NewTestConfig(), fake, seed(t, leaderCurrentPosition(2)), slog.Default())
+		action.verifyPollInterval = 10 * time.Millisecond
+
+		require.NoError(t, action.Execute(ctx, problem))
+		assert.NotContains(t, fake.CallLog, "UpdateConsensusRule(multipooler-cell1-primary)",
+			"must not advance when the rule already outranks the revocation")
+		assert.Contains(t, fake.CallLog, "SetPrimary(multipooler-cell1-replica1)",
+			"must still reconnect the follower")
+	})
+}

--- a/go/services/multiorch/recovery/analysis/action_factory.go
+++ b/go/services/multiorch/recovery/analysis/action_factory.go
@@ -83,6 +83,12 @@ func (f *RecoveryActionFactory) NewReconcileCohortAction() types.RecoveryAction 
 	return actions.NewReconcileCohortAction(f.config, f.rpcClient, f.poolerStore, f.topoStore, f.logger)
 }
 
+// NewReconnectRecruitAbandonedAction creates an action to reconnect a follower
+// stranded by an abandoned recruit via a leader-led no-op rule advance.
+func (f *RecoveryActionFactory) NewReconnectRecruitAbandonedAction() types.RecoveryAction {
+	return actions.NewReconnectRecruitAbandonedAction(f.config, f.rpcClient, f.poolerStore, f.logger)
+}
+
 // Logger returns the factory's logger for use by analyzers.
 func (f *RecoveryActionFactory) Logger() *slog.Logger {
 	return f.logger

--- a/go/services/multiorch/recovery/analysis/analyzer.go
+++ b/go/services/multiorch/recovery/analysis/analyzer.go
@@ -43,6 +43,7 @@ func DefaultAnalyzers(factory *RecoveryActionFactory) []Analyzer {
 			&ShardNeedsInitializationAnalyzer{factory: factory},
 			&StaleLeaderAnalyzer{factory: factory},
 			&LeaderNeedsReplacementAnalyzer{factory: factory},
+			&RecruitAbandonedAnalyzer{factory: factory},
 			&ReplicaNotReplicatingAnalyzer{factory: factory},
 			&CohortMismatchAnalyzer{factory: factory},
 		}

--- a/go/services/multiorch/recovery/analysis/recruit_abandoned_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/recruit_abandoned_analyzer.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
+	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
+	"github.com/multigres/multigres/go/services/multiorch/store"
+)
+
+// RecruitAbandonedAnalyzer detects a follower stranded by an abandoned recruit:
+// its TermRevocation revokes the shard's committed rule, so it rejects the
+// leader's SetPrimary and cannot rejoin. The remedy is a leader-led no-op rule
+// advance (see ReconnectRecruitAbandonedAction), not FixReplication — a
+// SetPrimary at the current rule would just be ignored.
+type RecruitAbandonedAnalyzer struct {
+	factory *RecoveryActionFactory
+}
+
+func (a *RecruitAbandonedAnalyzer) Name() types.CheckName {
+	return "ReplicaRecruitAbandoned"
+}
+
+func (a *RecruitAbandonedAnalyzer) RecoveryAction() types.RecoveryAction {
+	return a.factory.NewReconnectRecruitAbandonedAction()
+}
+
+func (a *RecruitAbandonedAnalyzer) Analyze(sa *ShardAnalysis) ([]types.Problem, error) {
+	return analyzeAllPoolers(sa, a.analyzePooler)
+}
+
+// revocationStrandsFollower reports whether the leader's rule — the very rule
+// orch would relay to this follower via SetPrimary — would be rejected by the
+// follower's recorded TermRevocation, leaving it stranded. This is the signature
+// of an abandoned recruit: a failover started at a higher term reached this
+// follower but never committed a rule at that term.
+//
+// It is a faithful pre-check of SetPrimary's own gate, which ignores an incoming
+// rule when IsRuleRevoked(rule, revocation) holds (see the pooler's
+// SetPrimary). We mirror that exact predicate against the position orch would
+// send (HighestPosition) so detection cannot drift from enforcement — rather
+// than ValidateRevocation, which layers on checks SetPrimary does not apply (LSN
+// parse, recruit floor, stored-revocation consistency). A legitimate failover
+// that has since committed a rule at the revocation's term makes HighestPosition
+// outrank the revocation, so this returns false and the follower is no longer
+// considered stranded. Returns false when no rule is known.
+//
+// ReplicaNotReplicatingAnalyzer also consults this to hand such a follower off
+// to this analyzer rather than firing a SetPrimary the follower would ignore.
+func revocationStrandsFollower(sa *ShardAnalysis, p *store.Pooler) bool {
+	if sa.HighestPosition == nil {
+		return false
+	}
+	revocation := p.Health().GetConsensusStatus().GetTermRevocation()
+	return commonconsensus.IsRuleRevoked(sa.HighestPosition, revocation)
+}
+
+// revocationAgedPastFailoverGrace reports whether the follower's revocation was
+// issued longer ago than the failover grace window (base + max jitter), the
+// bound within which a live failover completes. Only then do we treat the
+// recruit as abandoned. A revocation with no coordinator_initiated_at (which a
+// valid one always carries) is treated as not-yet-aged, erring toward waiting.
+func revocationAgedPastFailoverGrace(factory *RecoveryActionFactory, sa *ShardAnalysis, p *store.Pooler) bool {
+	initiatedAt := p.Health().GetConsensusStatus().GetTermRevocation().GetCoordinatorInitiatedAt()
+	if initiatedAt == nil {
+		return false
+	}
+	var grace time.Duration
+	if cfg := factory.Config(); cfg != nil {
+		grace = cfg.GetLeaderFailoverGracePeriodBase() + cfg.GetLeaderFailoverGracePeriodMaxJitter()
+	}
+	return sa.Now.Sub(initiatedAt.AsTime()) >= grace
+}
+
+func (a *RecruitAbandonedAnalyzer) analyzePooler(sa *ShardAnalysis, pa *store.Pooler) (*types.Problem, error) {
+	if a.factory == nil {
+		return nil, errors.New("recovery action factory not initialized")
+	}
+
+	// Only followers can be stranded; the leader defines the rule.
+	if commonconsensus.SelfConsensusRole(pa.Health().GetConsensusStatus()) == commonconsensus.ConsensusRoleLeader {
+		return nil, nil
+	}
+	if !pa.IsInitialized() {
+		return nil, nil
+	}
+
+	// We need a serving, known leader with an address: the fix drives an
+	// UpdateConsensusRule on the leader and then a SetPrimary toward the follower.
+	if !leaderServing(sa) || sa.Leader.Health().GetMultipooler().GetHostname() == "" {
+		return nil, nil
+	}
+
+	// Only a follower that is actually recruited can be stranded: its accepted
+	// revocation must still revoke its own committed position (self-revoked). The
+	// revocation is a monotonic promise floor that ConsensusStatus keeps reporting
+	// even after the follower's rule catches up, so its mere presence is not
+	// enough.
+	if !commonconsensus.IsSelfRevoked(pa.Health().GetConsensusStatus()) {
+		return nil, nil
+	}
+
+	// The stranding signature: the follower's revocation revokes the committed rule.
+	if !revocationStrandsFollower(sa, pa) {
+		return nil, nil
+	}
+
+	// Give an in-flight recruit time to finish before concluding it was
+	// abandoned. Another orchestrator with fresher information may still be
+	// completing a legitimate failover at this term (e.g. the current leader is
+	// resigning but still writable). Advancing the rule out from under such a
+	// failover would fight it, so we wait until the revocation has aged past the
+	// failover grace window — the bound within which a live failover acts. Once
+	// that failover commits a rule at the higher term the follower is no longer
+	// stranded (its revocation no longer outranks the committed decision) and this
+	// analyzer stops firing on its own.
+	if !revocationAgedPastFailoverGrace(a.factory, sa, pa) {
+		return nil, nil
+	}
+
+	return &types.Problem{
+		Code:           types.ProblemReplicaRecruitAbandoned,
+		CheckName:      a.Name(),
+		PoolerID:       poolerID(pa),
+		ShardKey:       sa.ShardKey,
+		Description:    fmt.Sprintf("Follower %s is stranded by an abandoned recruit (revocation outranks the committed rule)", poolerID(pa).Name),
+		Priority:       types.PriorityHigh,
+		Scope:          types.ScopePooler,
+		DetectedAt:     time.Now(),
+		RecoveryAction: a.factory.NewReconnectRecruitAbandonedAction(),
+	}, nil
+}

--- a/go/services/multiorch/recovery/analysis/recruit_abandoned_analyzer_test.go
+++ b/go/services/multiorch/recovery/analysis/recruit_abandoned_analyzer_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/multigres/multigres/go/common/rpcclient"
+	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	"github.com/multigres/multigres/go/services/multiorch/config"
+	"github.com/multigres/multigres/go/services/multiorch/consensus"
+	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
+	"github.com/multigres/multigres/go/services/multiorch/store"
+)
+
+func TestRecruitAbandonedAnalyzer_Analyze(t *testing.T) {
+	ctx := context.Background()
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "cell1")
+	defer ts.Close()
+	rpcClient := &rpcclient.FakeClient{}
+	coordID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIORCH, Cell: "cell1", Name: "test-coord"}
+	coord := consensus.NewCoordinator(coordID, ts, rpcClient, slog.Default())
+
+	primaryID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "primary1"}
+	replicaID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "replica1"}
+	shardKey := &clustermetadatapb.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"}
+
+	now := time.Now()
+
+	// ruleLedBy is the leader's committed rule at term 1 — the rule orch would
+	// relay to the follower.
+	ruleLedBy := func(term, subterm int64) *clustermetadatapb.RulePosition {
+		return &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
+			RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: term, LeaderSubterm: subterm},
+			LeaderId:   primaryID,
+		}}
+	}
+	highestPosition := ruleLedBy(1, 0)
+
+	leaderHealth := func() *store.Pooler {
+		return store.NewPooler(&multiorchdatapb.PoolerHealthState{
+			Multipooler:      &clustermetadatapb.Multipooler{Id: primaryID, ShardKey: shardKey, Hostname: "primary.example.com"},
+			IsLastCheckValid: true,
+			LastSeen:         timestamppb.New(now),
+			Status:           &multipoolermanagerdatapb.Status{PostgresReady: true},
+			ConsensusStatus:  &clustermetadatapb.ConsensusStatus{Id: primaryID, CurrentPosition: &clustermetadatapb.PoolerPosition{Position: ruleLedBy(1, 0)}},
+		}, nil)
+	}
+
+	// strandedFollower builds a follower recruited at term 2 (revocation revokes
+	// the term-1 rule) whose own WAL rule is still at term 1 — the abandoned
+	// recruit. initiatedAt controls the revocation's age for the grace gate.
+	strandedFollower := func(initiatedAt time.Time, ownRule *clustermetadatapb.RulePosition, initialized bool) *store.Pooler {
+		return newRider(&multiorchdatapb.PoolerHealthState{
+			Multipooler:      &clustermetadatapb.Multipooler{Id: replicaID, ShardKey: shardKey},
+			IsLastCheckValid: true,
+			LastSeen:         timestamppb.New(now),
+			Status:           &multipoolermanagerdatapb.Status{IsInitialized: initialized},
+			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+				Id:              replicaID,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{Position: ownRule},
+				TermRevocation: &clustermetadatapb.TermRevocation{
+					RevokedBelowTerm:       2,
+					OutgoingRule:           &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
+					AcceptedCoordinatorId:  coordID,
+					CoordinatorInitiatedAt: timestamppb.New(initiatedAt),
+				},
+			},
+		})
+	}
+
+	// newSA builds a ShardAnalysis with the given analyses, a serving leader, and
+	// the shard's committed rule at term 1.
+	newSA := func(analyses ...*store.Pooler) *ShardAnalysis {
+		return &ShardAnalysis{
+			ShardKey:        shardKey,
+			Analyses:        analyses,
+			Leader:          leaderHealth(),
+			HighestPosition: highestPosition,
+			Now:             now,
+			Policy:          DefaultAvailabilityPolicy(),
+		}
+	}
+
+	// noGraceFactory treats a revocation as abandoned immediately (grace 0).
+	noGraceFactory := NewRecoveryActionFactory(config.NewTestConfig(), store.NewTestCache(t), rpcClient, ts, coord, slog.Default())
+
+	t.Run("detects a stranded over-recruited follower", func(t *testing.T) {
+		analyzer := &RecruitAbandonedAnalyzer{factory: noGraceFactory}
+		problems, err := analyzer.Analyze(newSA(strandedFollower(now.Add(-time.Minute), ruleLedBy(1, 0), true)))
+		require.NoError(t, err)
+		require.Len(t, problems, 1)
+		require.Equal(t, types.ProblemReplicaRecruitAbandoned, problems[0].Code)
+		require.Equal(t, types.ScopePooler, problems[0].Scope)
+		require.Equal(t, types.PriorityHigh, problems[0].Priority)
+		require.NotNil(t, problems[0].RecoveryAction)
+	})
+
+	t.Run("ignores follower that already caught up to the revoked term", func(t *testing.T) {
+		analyzer := &RecruitAbandonedAnalyzer{factory: noGraceFactory}
+		// Own rule reached term 2: no longer self-revoked.
+		problems, err := analyzer.Analyze(newSA(strandedFollower(now.Add(-time.Minute), ruleLedBy(2, 0), true)))
+		require.NoError(t, err)
+		require.Empty(t, problems)
+	})
+
+	t.Run("ignores follower within the failover grace window", func(t *testing.T) {
+		graceFactory := NewRecoveryActionFactory(
+			config.NewTestConfig(config.WithLeaderFailoverGracePeriodBase(10*time.Second)),
+			store.NewTestCache(t), rpcClient, ts, coord, slog.Default())
+		analyzer := &RecruitAbandonedAnalyzer{factory: graceFactory}
+		// Revocation issued just now, well inside the 10s grace: a legit failover
+		// may still be completing.
+		problems, err := analyzer.Analyze(newSA(strandedFollower(now, ruleLedBy(1, 0), true)))
+		require.NoError(t, err)
+		require.Empty(t, problems)
+	})
+
+	t.Run("ignores uninitialized follower", func(t *testing.T) {
+		analyzer := &RecruitAbandonedAnalyzer{factory: noGraceFactory}
+		problems, err := analyzer.Analyze(newSA(strandedFollower(now.Add(-time.Minute), ruleLedBy(1, 0), false)))
+		require.NoError(t, err)
+		require.Empty(t, problems)
+	})
+
+	t.Run("ignores when no serving leader is known", func(t *testing.T) {
+		analyzer := &RecruitAbandonedAnalyzer{factory: noGraceFactory}
+		sa := newSA(strandedFollower(now.Add(-time.Minute), ruleLedBy(1, 0), true))
+		sa.Leader = nil
+		problems, err := analyzer.Analyze(sa)
+		require.NoError(t, err)
+		require.Empty(t, problems)
+	})
+
+	t.Run("returns error when factory is nil", func(t *testing.T) {
+		analyzer := &RecruitAbandonedAnalyzer{factory: nil}
+		problems, err := analyzer.Analyze(newSA(strandedFollower(now.Add(-time.Minute), ruleLedBy(1, 0), true)))
+		require.Error(t, err)
+		require.Nil(t, problems)
+	})
+
+	// A stranded follower also looks "not replicating" (no primary_conninfo), but
+	// ReplicaNotReplicating must defer it to this analyzer rather than firing a
+	// SetPrimary the follower would ignore.
+	t.Run("ReplicaNotReplicating skips a stranded follower", func(t *testing.T) {
+		rnr := &ReplicaNotReplicatingAnalyzer{factory: noGraceFactory}
+		problems, err := rnr.Analyze(newSA(strandedFollower(now.Add(-time.Minute), ruleLedBy(1, 0), true)))
+		require.NoError(t, err)
+		require.Empty(t, problems)
+	})
+}

--- a/go/services/multiorch/recovery/analysis/replica_not_replicating_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/replica_not_replicating_analyzer.go
@@ -71,6 +71,14 @@ func (a *ReplicaNotReplicatingAnalyzer) analyzePooler(sa *ShardAnalysis, pa *sto
 		return nil, nil
 	}
 
+	// A follower whose revocation revokes the committed rule is stranded by an
+	// abandoned recruit: a plain SetPrimary would be silently ignored (the rule is
+	// revoked), so this is not a replication fix. RecruitAbandonedAnalyzer owns it
+	// — it advances the rule first. Leave that pooler to it.
+	if revocationStrandsFollower(sa, pa) {
+		return nil, nil
+	}
+
 	// Check if replication is not configured or stopped
 	if !a.needsReplicationFix(pa) {
 		return nil, nil

--- a/go/services/multiorch/recovery/types/types.go
+++ b/go/services/multiorch/recovery/types/types.go
@@ -50,10 +50,18 @@ const (
 
 	// Replica problems (require healthy leader).
 	ProblemReplicaNotReplicating ProblemCode = "ReplicaNotReplicating"
-	ProblemReplicaWrongPrimary   ProblemCode = "ReplicaWrongPrimary"
-	ProblemReplicaLagging        ProblemCode = "ReplicaLagging"
-	ProblemReplicaMisconfigured  ProblemCode = "ReplicaMisconfigured"
-	ProblemReplicaIsWritable     ProblemCode = "ReplicaIsWritable"
+	// ProblemReplicaRecruitAbandoned is a follower stranded by an abandoned
+	// recruit: its TermRevocation revokes the leader's committed rule (a failover
+	// was started at a higher term, reached this follower, then never committed),
+	// so it rejects the leader's SetPrimary and cannot rejoin. The remedy is a
+	// leader-led no-op rule advance (same leader/cohort/term, fresh subterm) that
+	// moves the committed decision past the revocation's outgoing_rule, defeating
+	// it via the runaway-recruit override in IsRuleRevoked.
+	ProblemReplicaRecruitAbandoned ProblemCode = "ReplicaRecruitAbandoned"
+	ProblemReplicaWrongPrimary     ProblemCode = "ReplicaWrongPrimary"
+	ProblemReplicaLagging          ProblemCode = "ReplicaLagging"
+	ProblemReplicaMisconfigured    ProblemCode = "ReplicaMisconfigured"
+	ProblemReplicaIsWritable       ProblemCode = "ReplicaIsWritable"
 
 	// Cohort drift problems (require healthy leader; not service-impacting on
 	// their own, but durability degrades if left unaddressed).

--- a/go/services/multipooler/internal/grpcconsensusservice/service.go
+++ b/go/services/multipooler/internal/grpcconsensusservice/service.go
@@ -84,12 +84,3 @@ func (s *consensusService) SetPrimary(ctx context.Context, req *consensusdata.Se
 	}
 	return resp, nil
 }
-
-// RewindToSource performs pg_rewind to synchronize this server with a source
-func (s *consensusService) RewindToSource(ctx context.Context, req *multipoolermanagerdatapb.RewindToSourceRequest) (*multipoolermanagerdatapb.RewindToSourceResponse, error) {
-	resp, err := s.manager.RewindToSource(ctx, req.Source)
-	if err != nil {
-		return nil, mterrors.ToGRPC(err)
-	}
-	return resp, nil
-}

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -180,6 +180,13 @@ type MultipoolerManager struct {
 	// pgMonitorLastLoggedReason tracks the last logged reason in the monitor to avoid duplicate logs.
 	pgMonitorLastLoggedReason string
 
+	// replicationStuckSince is when the monitor first observed this standby up with
+	// a correct primary_conninfo but no active WAL streaming. Zero when not stuck.
+	// The monitor waits this out (replicationStuckThreshold) before suspecting WAL
+	// divergence, since a diverged standby's receiver can't connect at all and so
+	// has no last-message timestamp to age out. Monitor-goroutine-only; no lock.
+	replicationStuckSince time.Time
+
 	// stateManager coordinates serving state transitions across components
 	// (query service, heartbeat tracker) and updates the multipooler record.
 	stateManager *StateManager

--- a/go/services/multipooler/internal/manager/pg_replication.go
+++ b/go/services/multipooler/internal/manager/pg_replication.go
@@ -1171,13 +1171,15 @@ func (pm *MultipoolerManager) clearSyncReplicationForDemotion(ctx context.Contex
 }
 
 // ----------------------------------------------------------------------------
-// standbyUpdateOperationName maps a CohortUpdateOperation enum to a short string for logging/history.
-func standbyUpdateOperationName(op multipoolermanagerdatapb.CohortUpdateOperation) string {
+// standbyUpdateOperationName maps a RuleOperation enum to a short string for logging/history.
+func standbyUpdateOperationName(op multipoolermanagerdatapb.RuleOperation) string {
 	switch op {
-	case multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_ADD:
+	case multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_ADD:
 		return "add"
-	case multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_REMOVE:
+	case multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_REMOVE:
 		return "remove"
+	case multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_ADVANCE:
+		return "advance"
 	default:
 		return "unknown"
 	}

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -509,14 +509,10 @@ func (pm *MultipoolerManager) primaryConnInfoDiffersFromRecorded(ctx context.Con
 // call sites (the periodic monitor tick vs. an in-line SetPrimary reconcile)
 // in logs.
 //
-// TODO: when suspectedDivergence=true (an unexpected demotion happened
-// without a follow-up pg_rewind), just setting primary_conninfo is not
-// enough — the WAL receiver will fail to start due to timeline divergence.
-// Route through demoteStalePrimaryLocked instead, which runs pg_rewind
-// dry-run (cheap when there's no divergence) before re-establishing
-// replication. This would let both callers self-heal a stuck-replica
-// scenario without waiting for orch's FixReplicationAction to issue a
-// RewindToSource RPC.
+// Note: when suspectedDivergence=true, primary_conninfo reconciliation does not
+// run — determineReplicationSettingsAction routes a held, divergence-suspected
+// standby through the rewind path (shouldRewindForDivergence) instead, so this
+// helper only ever fires for a trusted-WAL standby whose conninfo has drifted.
 func (pm *MultipoolerManager) reconcilePrimaryConnInfoToRecorded(ctx context.Context, logPrefix string) {
 	target := pm.consensusMgr.GetReplicationPrimary().GetPrimary()
 	pm.logger.InfoContext(ctx, logPrefix+": primary_conninfo drift detected; rewriting to recorded primary",
@@ -1055,9 +1051,9 @@ func (pm *MultipoolerManager) hasCompleteBackups(ctx context.Context) (bool, err
 // SetPrimary/Promote/standby-conninfo path routes through demoteStalePrimaryLocked
 // (which runs pg_rewind dry-run; cheap when there's no divergence) before
 // trusting local WAL. This bears on the broader self-rewind plan:
-//   - replicas with phantom transactions: orch sends an explicit
-//     RewindToSource RPC today; a future change should let the local monitor
-//     detect stuck replication and self-heal without needing orch in the loop.
+//   - replicas with phantom transactions: the monitor now self-detects stuck
+//     replication (determineReplicationSettingsAction) and self-heals via
+//     shouldRewindForDivergence, without orch in the loop.
 //   - primaries demoted unexpectedly (crash, SIGKILL, external pg_demote):
 //     the restart-as-standby helper should require callers to declare
 //     "clean" vs "unexpected" so an unexpected transition can set

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -117,6 +117,12 @@ type postgresState struct {
 	// from. False on standbys and on a freshly promoted primary that has not yet
 	// checkpointed onto its new timeline.
 	rewindSourceReady bool
+	// walReceiverStreaming is true when this pooler is a standby whose WAL receiver
+	// is actively streaming (pg_stat_wal_receiver.status == "streaming"). Only
+	// meaningful in recovery; false on primaries and on a standby that cannot
+	// connect at all (e.g. a timeline divergence the receiver can't get past —
+	// which is why divergence is timed rather than read from a message timestamp).
+	walReceiverStreaming bool
 }
 
 // postgresStateEqual reports whether two postgresState values are identical.
@@ -127,7 +133,8 @@ func postgresStateEqual(a, b postgresState) bool {
 		a.backupsAvailable == b.backupsAvailable &&
 		a.pgMode == b.pgMode &&
 		a.bootstrapSentinelPresent == b.bootstrapSentinelPresent &&
-		a.rewindSourceReady == b.rewindSourceReady
+		a.rewindSourceReady == b.rewindSourceReady &&
+		a.walReceiverStreaming == b.walReceiverStreaming
 }
 
 // remedialAction represents actions the postgres monitor can take
@@ -193,7 +200,34 @@ const (
 	// is restore-from-backup leaving it enabled for a freshly-restored
 	// observer (see WrapRestoreCommand).
 	remedialActionDisableRestoreCommand
+
+	// remedialActionMarkSuspectedDivergence means this pooler is a standby whose
+	// primary_conninfo already points at the recorded (non-revoked) leader, yet its
+	// WAL receiver has not been streaming for longer than replicationStuckThreshold.
+	// The likeliest cause is WAL divergence (a diverged receiver can't connect at
+	// all), so mark suspectedDivergence; the next tick's shouldRewindForDivergence
+	// then runs a rate-limited pg_rewind (dry-run — a no-op when the timelines are
+	// actually compatible). Marking is idempotent, side-effect-only on consensus state.
+	remedialActionMarkSuspectedDivergence
+
+	// remedialActionClearSuspectedDivergence means this standby is actively
+	// streaming from its primary, so it is by definition not diverged — clear any
+	// lingering suspectedDivergence rather than rewinding a healthy standby. This
+	// is both the "only rewind when not streaming" guard and the loop backstop: a
+	// rewind that reconnects clears divergence, and any spurious mark is undone as
+	// soon as streaming is observed. Side-effect-only on consensus state.
+	remedialActionClearSuspectedDivergence
 )
+
+// replicationStuckThreshold is how long a standby may be up with a correct
+// primary_conninfo but no active WAL streaming before the monitor suspects WAL
+// divergence. With a 5s monitor tick this is one confirmation tick past the
+// first stuck observation — long enough not to mistake a receiver mid-reconnect
+// for divergence, short enough that recovery is no slower than the old
+// orch-driven rewind. Acting spuriously is cheap and self-correcting: the rewind
+// dry-runs (a no-op on compatible timelines) and suspectedDivergence is cleared
+// the moment we observe streaming again (see determineReplicationSettingsAction).
+const replicationStuckThreshold = 10 * time.Second
 
 // monitorPostgresIteration performs one iteration of PostgreSQL monitoring.
 // Returns the discovered postgres state on success, or an error if the state
@@ -337,6 +371,22 @@ func (pm *MultipoolerManager) discoverPostgresState(ctx context.Context) (postgr
 				state.rewindSourceReady = ready
 			}
 		}
+		// On a standby, capture whether the WAL receiver is actively streaming. A
+		// standby that is up with a correct primary_conninfo but cannot stream is
+		// the signal for suspected WAL divergence: its receiver can't connect, so
+		// there is no last-message timestamp to age out — the stall is timed
+		// instead. That makes a read failure unsafe to treat as "not streaming":
+		// defaulting to false accrues stuck time and pushes toward a destructive
+		// rewind. So surface the error and skip this tick, matching the recovery-mode
+		// and consensus-position probes above.
+		if !state.pgMode.OutOfRecovery() {
+			rs, rsErr := pm.queryReplicationStatus(ctx)
+			if rsErr != nil {
+				return state, fmt.Errorf("read WAL receiver status: %w", rsErr)
+			}
+			state.walReceiverStreaming = rs.GetWalReceiverStatus() == "streaming"
+		}
+
 		// Refresh the cached consensus position from postgres so this iteration's
 		// role decisions (highestKnownRule / SelfConsensusRole read the cache)
 		// converge on current state rather than lagging the periodic Status RPC that
@@ -554,6 +604,14 @@ func (pm *MultipoolerManager) determineReplicationSettingsAction(ctx context.Con
 	// ReplicationPrimary when it has drifted from what we've been told via
 	// SetPrimary/Promote.
 	if !state.pgMode.OutOfRecovery() {
+		// An actively streaming standby is, by definition, not diverged: never
+		// rewind it, and clear any lingering suspicion. This is checked before
+		// shouldRewindForDivergence so a spurious mark can't rewind a healthy
+		// standby, and it is what breaks any rewind loop — once a rewind reconnects
+		// and streaming resumes, the suspicion is cleared here.
+		if pm.consensusMgr.SuspectedDivergence() && state.walReceiverStreaming {
+			return remedialActionClearSuspectedDivergence
+		}
 		// A standby that suspects its WAL diverged must be rewound against the
 		// recorded leader before it can safely follow it. Now that postgres is up,
 		// its position is readable, so once the leader is rewind-ready we rewind
@@ -567,22 +625,25 @@ func (pm *MultipoolerManager) determineReplicationSettingsAction(ctx context.Con
 		// primary_conninfo, so don't re-point at a leader we haven't rewound to.
 		// Fall through to the restore_command backstop below (a held node must not
 		// archive-replay either). Otherwise reconcile primary_conninfo drift.
-		if !pm.consensusMgr.SuspectedDivergence() && pm.primaryConnInfoDiffersFromRecorded(ctx) {
-			return remedialActionFixPrimaryConnInfo
+		if !pm.consensusMgr.SuspectedDivergence() {
+			if pm.primaryConnInfoDiffersFromRecorded(ctx) {
+				return remedialActionFixPrimaryConnInfo
+			}
+			// Self-rewind detection. primary_conninfo already points at the recorded
+			// (non-revoked) leader — fix-primary-conninfo above would have fired
+			// otherwise — yet the WAL receiver isn't streaming. If that persists past
+			// replicationStuckThreshold, the likeliest cause is WAL divergence: a
+			// diverged receiver can't connect at all, so there's no last-message
+			// timestamp to age out — replicationStuckLongEnough times the stall from
+			// the first stuck observation instead. RewindTarget confirms a recorded,
+			// different, non-revoked leader to rewind toward. Suspecting divergence
+			// routes the next tick through shouldRewindForDivergence -> pg_rewind
+			// (dry-run: a no-op when the timelines are actually compatible).
+			_, _, haveRewindTarget := pm.consensusMgr.RewindTarget()
+			if pm.replicationStuckLongEnough(haveRewindTarget && !state.walReceiverStreaming) {
+				return remedialActionMarkSuspectedDivergence
+			}
 		}
-		// TODO: self-rewind detection. A replica may need pg_rewind even
-		// when it was never primary — phantom transactions can leak in
-		// (e.g. via a brief sync-replication ack that got rolled back on
-		// the primary). The old consensus flow let orch re-issue an
-		// explicit rewind whenever it suspected one; the new flow's
-		// SetPrimary is idempotent and won't repeat work, so the monitor
-		// needs to self-detect stuck replication. Check
-		// pg_stat_wal_receiver.status: if not "streaming" for
-		// >stuckThreshold AND we have a recorded primary, treat as
-		// suspected divergence — set suspectedDivergence=true so the next
-		// remedialActionFixPrimaryConnInfo iteration runs
-		// pg_rewind dry-run before re-establishing replication. Cheap
-		// when no divergence, conclusive when there is.
 	}
 
 	// restore_command is a standby concern: a cohort member must only ever
@@ -677,6 +738,27 @@ func (pm *MultipoolerManager) shouldRewindForDivergence() bool {
 		return false
 	}
 	return pm.consensusMgr.RewindBackoffElapsed()
+}
+
+// replicationStuckLongEnough tracks how long the standby has been continuously
+// "stuck" (up, primary_conninfo pointing at a valid rewind target, but the WAL
+// receiver not streaming) and reports whether that has now exceeded
+// replicationStuckThreshold. A diverged receiver never connects, so there is no
+// last-message timestamp to age out; we time the stall from the first stuck
+// observation instead. Any non-stuck tick (streaming resumed, or no rewind
+// target) resets the timer, so only an uninterrupted stall trips the threshold.
+//
+// Monitor-goroutine-only: mutates replicationStuckSince without a lock.
+func (pm *MultipoolerManager) replicationStuckLongEnough(stuck bool) bool {
+	if !stuck {
+		pm.replicationStuckSince = time.Time{}
+		return false
+	}
+	if pm.replicationStuckSince.IsZero() {
+		pm.replicationStuckSince = time.Now()
+		return false
+	}
+	return time.Since(pm.replicationStuckSince) >= replicationStuckThreshold
 }
 
 // shouldMarkRewindReady reports whether this pooler should advertise rewind
@@ -917,6 +999,24 @@ func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action rem
 		if pm.consensusMgr.MarkSelfRewindReady(pm.serviceID, expectedPosition) {
 			pm.logger.InfoContext(ctx, "MonitorPostgres: checkpointed onto current timeline; advertising rewind-ready")
 			pm.broadcastHealth()
+		}
+
+	case remedialActionMarkSuspectedDivergence:
+		// A standby has been up with a valid primary_conninfo but no WAL streaming
+		// for longer than replicationStuckThreshold. Its receiver can't connect, so
+		// the most likely cause is a WAL timeline divergence. Mark divergence so the
+		// next tick routes through shouldRewindForDivergence -> pg_rewind, which
+		// dry-runs first and is a no-op if the timelines turn out compatible.
+		pm.logger.InfoContext(ctx, "MonitorPostgres: standby up but WAL receiver not streaming past threshold; marking suspected divergence")
+		if _, err := pm.consensusMgr.SetSuspectedDivergence(ctx, true); err != nil {
+			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to mark suspected divergence for stuck standby", "error", err)
+		}
+
+	case remedialActionClearSuspectedDivergence:
+		// Streaming resumed, so this standby is not diverged; clear the suspicion.
+		pm.logger.InfoContext(ctx, "MonitorPostgres: standby streaming from primary; clearing suspected divergence")
+		if _, err := pm.consensusMgr.SetSuspectedDivergence(ctx, false); err != nil {
+			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to clear suspected divergence for streaming standby", "error", err)
 		}
 	}
 }

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -128,6 +128,11 @@ func newRunningStandbyManagerForTest(t *testing.T, rs consensus.RuleStorer) *Mul
 	}
 	mockQueryService := mock.NewQueryService()
 	mockQueryService.AddQueryPattern("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
+	// A standby's state discovery reads pg_stat_wal_receiver to detect whether it
+	// is actively streaming (for divergence detection). Report a streaming
+	// receiver so these tests exercise the healthy-standby path.
+	replCols := []string{"replay_lsn", "receive_lsn", "is_paused", "pause_state", "last_xact_replay_ts", "primary_conninfo", "status", "last_msg_receive_time", "wal_receiver_status_interval", "wal_receiver_timeout"}
+	mockQueryService.AddQueryPattern("pg_last_wal_replay_lsn", mock.MakeQueryResult(replCols, [][]any{{nil, nil, false, "not paused", nil, "", "streaming", nil, nil, nil}}))
 	pm.qsc = &mockPoolerController{queryService: mockQueryService}
 	return pm
 }
@@ -756,6 +761,67 @@ func TestShouldRewindForDivergence(t *testing.T) {
 			require.Equal(t, tt.want, pm.shouldRewindForDivergence())
 		})
 	}
+}
+
+// TestDetermineReplicationSettingsAction_ClearsSuspectedDivergenceWhenStreaming
+// verifies the streaming-based safety valve: an actively streaming standby is by
+// definition not diverged, so any lingering suspicion is cleared rather than
+// driving a needless rewind. This is what breaks a rewind loop once a rewind
+// reconnects.
+func TestDetermineReplicationSettingsAction_ClearsSuspectedDivergenceWhenStreaming(t *testing.T) {
+	selfID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "test-cell", Name: "self"}
+	otherID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "test-cell", Name: "other"}
+	otherAddr := &clustermetadatapb.PoolerAddress{Id: otherID, Host: "other-host", PostgresPort: 5432}
+
+	// A different, rewind-ready leader is recorded (a valid rewind target) so the
+	// only reason we do not rewind is that we observe active streaming.
+	pm := newTestManager(t, withServiceID(selfID), withReplicationPrimary(&clustermetadatapb.ReplicationPrimary{
+		Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
+			RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
+			LeaderId:   otherID,
+		}},
+		Primary:     otherAddr,
+		RewindReady: true,
+	}))
+	lockCtx, err := pm.actionLock.Acquire(t.Context(), "test-seed")
+	require.NoError(t, err)
+	_, err = pm.consensusMgr.SetSuspectedDivergence(lockCtx, true)
+	require.NoError(t, err)
+	pm.actionLock.Release(lockCtx)
+
+	state := postgresState{
+		pgctldAvailable:      true,
+		dirInitialized:       true,
+		postgresRunning:      true,
+		pgMode:               pgmode.InRecovery,
+		walReceiverStreaming: true,
+	}
+	require.Equal(t, remedialActionClearSuspectedDivergence,
+		pm.determineReplicationSettingsAction(t.Context(), state))
+}
+
+// TestReplicationStuckLongEnough verifies the stuck-timer helper: a non-stuck
+// tick clears the timer, the first stuck tick starts it (not yet long enough),
+// and the threshold trips only after an uninterrupted stall.
+func TestReplicationStuckLongEnough(t *testing.T) {
+	pm := newTestManager(t)
+
+	// A non-stuck observation clears any prior timer and never trips.
+	pm.replicationStuckSince = time.Now().Add(-time.Hour)
+	require.False(t, pm.replicationStuckLongEnough(false))
+	require.True(t, pm.replicationStuckSince.IsZero(), "non-stuck tick must reset the timer")
+
+	// The first stuck observation starts the timer but does not trip immediately.
+	require.False(t, pm.replicationStuckLongEnough(true))
+	require.False(t, pm.replicationStuckSince.IsZero(), "first stuck tick must start the timer")
+
+	// Once the stall has lasted past the threshold, it trips.
+	pm.replicationStuckSince = time.Now().Add(-replicationStuckThreshold - time.Second)
+	require.True(t, pm.replicationStuckLongEnough(true))
+
+	// Recovery (a non-stuck tick) clears the timer again.
+	require.False(t, pm.replicationStuckLongEnough(false))
+	require.True(t, pm.replicationStuckSince.IsZero())
 }
 
 // TestStaleStandbyDemoteTarget verifies the gating for monitor-driven

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -368,13 +368,13 @@ func (pm *MultipoolerManager) Status(ctx context.Context) (*multipoolermanagerda
 // proceeds only if this pooler's current recorded rule matches the given
 // RuleNumber. If they differ (the caller's view is stale), the operation
 // fails — the caller should re-read state and retry.
-func (pm *MultipoolerManager) UpdateConsensusRule(ctx context.Context, operation multipoolermanagerdatapb.CohortUpdateOperation, standbyIDs []*clustermetadatapb.ID, expectedOutgoingRule *clustermetadatapb.RuleNumber, coordinatorID *clustermetadatapb.ID) error {
+func (pm *MultipoolerManager) UpdateConsensusRule(ctx context.Context, operation multipoolermanagerdatapb.RuleOperation, standbyIDs []*clustermetadatapb.ID, expectedOutgoingRule *clustermetadatapb.RuleNumber, coordinatorID *clustermetadatapb.ID) error {
 	if err := pm.checkReady(); err != nil {
 		return err
 	}
 
 	// Validate operation
-	if operation == multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_UNSPECIFIED {
+	if operation == multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_UNSPECIFIED {
 		return mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "operation must be specified")
 	}
 
@@ -383,10 +383,17 @@ func (pm *MultipoolerManager) UpdateConsensusRule(ctx context.Context, operation
 			"expected_outgoing_rule is required (compare-and-swap guard)")
 	}
 
-	// Validate standby IDs using the shared validation function
-	requestedApplicationNames, err := consensus.ValidateStandbyIDs(standbyIDs)
-	if err != nil {
-		return err
+	// Validate standby IDs using the shared validation function. ADVANCE makes no
+	// cohort change and carries no standby IDs, so it skips this check.
+	var (
+		requestedApplicationNames []consensus.ReplicaID
+		err                       error
+	)
+	if operation != multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_ADVANCE {
+		requestedApplicationNames, err = consensus.ValidateStandbyIDs(standbyIDs)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Pre-compute history fields before acquiring the lock.
@@ -436,11 +443,16 @@ func (pm *MultipoolerManager) UpdateConsensusRule(ctx context.Context, operation
 
 	var updatedStandbys []consensus.ReplicaID
 	switch operation {
-	case multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_ADD:
+	case multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_ADD:
 		updatedStandbys = consensus.ApplyAddOperation(currentApplicationNames, requestedApplicationNames)
 
-	case multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_REMOVE:
+	case multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_REMOVE:
 		updatedStandbys = consensus.ApplyRemoveOperation(currentApplicationNames, requestedApplicationNames)
+
+	case multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_ADVANCE:
+		// No cohort change: keep the current membership and let the rule store
+		// assign a fresh leader_subterm below. Any standby_ids passed are ignored.
+		updatedStandbys = currentApplicationNames
 
 	default:
 		return mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT,
@@ -453,8 +465,11 @@ func (pm *MultipoolerManager) UpdateConsensusRule(ctx context.Context, operation
 			"resulting standby list cannot be empty after operation")
 	}
 
-	// Check if there are any changes (idempotent).
-	if poolerIDSetEqual(currentApplicationNames, updatedStandbys) {
+	// Check if there are any changes (idempotent). ADVANCE is intentionally
+	// exempt: it re-writes the rule at a fresh subterm precisely because the
+	// cohort is unchanged, to move the committed decision forward.
+	if operation != multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_ADVANCE &&
+		poolerIDSetEqual(currentApplicationNames, updatedStandbys) {
 		return nil
 	}
 

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -756,9 +756,8 @@ func (pm *MultipoolerManager) demoteToStandbyLocked(ctx context.Context, consens
 		return err
 	}
 
-	// Mark the WAL as rewind-suspect: this node was just demoted, so the next
-	// restart-as-standby (the coordinator's RewindToSource, or the monitor's own
-	// demote path) must run pg_rewind before trusting local WAL.
+	// Mark the WAL as rewind-suspect: this node was just demoted, so the monitor's
+	// next self-heal restart-as-standby must run pg_rewind before trusting local WAL.
 	if _, err := pm.consensusMgr.SetSuspectedDivergence(ctx, true); err != nil {
 		pm.logger.ErrorContext(ctx, "failed to set suspected divergence on emergency demote", "error", err)
 	}
@@ -784,57 +783,6 @@ func (pm *MultipoolerManager) demoteToStandbyLocked(ctx context.Context, consens
 		"connections_terminated", connectionsTerminated)
 
 	return nil
-}
-
-// RewindToSource pg_rewinds this server against source and brings it back as a
-// standby. The heavy lifting (stop, rewind, restart-as-standby, resume) is
-// shared with the stale-primary demote path via stopRewindRestartAsStandbyLocked.
-func (pm *MultipoolerManager) RewindToSource(ctx context.Context, source *clustermetadatapb.Multipooler) (*multipoolermanagerdatapb.RewindToSourceResponse, error) {
-	if err := pm.checkReady(); err != nil {
-		return nil, mterrors.Wrap(err, "multipooler not ready")
-	}
-
-	if source == nil || source.PortMap == nil {
-		return nil, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT, "source pooler or port_map is nil")
-	}
-	if source.Hostname == "" {
-		return nil, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT, "source hostname is required")
-	}
-	port, ok := source.PortMap["postgres"]
-	if !ok {
-		return nil, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT, "postgres port not found in source pooler's port map")
-	}
-
-	pm.logger.InfoContext(ctx, "RewindToSource RPC called", "source", source.Id.Name)
-
-	ctx, err := pm.actionLock.Acquire(ctx, "RewindToSource")
-	if err != nil {
-		return nil, mterrors.Wrap(err, "failed to acquire action lock")
-	}
-	defer pm.actionLock.Release(ctx)
-
-	if err := pm.actionLock.SetAction(ctx, multipoolermanagerdatapb.PostgresAction_POSTGRES_ACTION_REWIND); err != nil {
-		pm.logger.ErrorContext(ctx, "RewindToSource: failed to set action", "error", err)
-	}
-
-	// RewindToSource is an explicit "this WAL is suspect, rewind it" request from
-	// the caller; raise suspectedDivergence so restartAsStandbyLocked runs the
-	// pg_rewind dry-run. The caller (orch's FixReplicationAction) has already
-	// confirmed the source is rewind-ready before issuing this RPC.
-	if _, err := pm.consensusMgr.SetSuspectedDivergence(ctx, true); err != nil {
-		pm.logger.ErrorContext(ctx, "failed to set suspected divergence in RewindToSource", "error", err)
-	}
-	rewindPerformed, err := pm.restartAsStandbyLocked(ctx, source.Hostname, port)
-	if err != nil {
-		return nil, err
-	}
-
-	pm.logger.InfoContext(ctx, "RewindToSource completed successfully",
-		"rewind_performed", rewindPerformed)
-	return &multipoolermanagerdatapb.RewindToSourceResponse{
-		Success:         true,
-		RewindPerformed: rewindPerformed,
-	}, nil
 }
 
 // SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts by the monitor.
@@ -889,17 +837,17 @@ func (pm *MultipoolerManager) pgctldStopWithEscalation(ctx context.Context) erro
 	return mterrors.Wrap(lastErr, "failed to stop postgres after fast/immediate escalation")
 }
 
-// restartAsStandbyLocked is the shared core of RewindToSource and the
-// stale-primary branch of SetPrimary: it pauses the manager, stops
-// postgres, runs pg_rewind against source iff suspectedDivergence is set
+// restartAsStandbyLocked is the shared core of the monitor's divergence
+// self-heal and the stale-primary branch of SetPrimary: it pauses the manager,
+// stops postgres, runs pg_rewind against source iff suspectedDivergence is set
 // (patching pgbackrest paths in postgresql.auto.conf after the rewind
 // copies them from source), then restarts postgres as standby and
 // resumes the manager.
 //
 // Gating on suspectedDivergence: callers raise the flag when this node's WAL may
 // have diverged from the cluster's chosen history (demoteToStandbyLocked
-// sets it after an emergency demote; SetPrimary's stale-primary branch
-// and RewindToSource set it before calling here). When the flag is clear we
+// sets it after an emergency demote; SetPrimary's stale-primary branch and the
+// monitor's self-heal set it before calling here). When the flag is clear we
 // skip even the pg_rewind dry-run — the WAL is trusted and we just need to
 // come back as a standby. The flag is cleared only after postgres restarts and
 // is verified in recovery mode below, NOT as soon as pg_rewind returns: an early

--- a/go/services/multipooler/internal/manager/rpc_manager_test.go
+++ b/go/services/multipooler/internal/manager/rpc_manager_test.go
@@ -945,11 +945,25 @@ func TestUpdateConsensusRule_HistoryFailurePreventsGUCUpdate(t *testing.T) {
 		"If this fails, it means SetPolicy was called despite history insert failure")
 }
 
-// TestRewindToSource_ManagerReopenedOnError is a regression test for a bug where
-// RewindToSource would leave the manager closed if an error occurred after pausing.
-// The fix uses the Pause()/resume() pattern with defer to guarantee the manager
-// is always reopened, even on error paths.
-func TestRewindToSource_ManagerReopenedOnError(t *testing.T) {
+// rewindViaSelfHeal drives restartAsStandbyLocked exactly as the monitor's
+// divergence self-heal does: under the action lock, with suspectedDivergence set
+// so the pg_rewind dry-run runs. Returns whether an actual rewind was performed.
+func rewindViaSelfHeal(t *testing.T, manager *MultipoolerManager, source *clustermetadatapb.Multipooler) (bool, error) {
+	t.Helper()
+	lockCtx, err := manager.actionLock.Acquire(context.Background(), "test-self-heal-rewind")
+	require.NoError(t, err)
+	defer manager.actionLock.Release(lockCtx)
+	if _, err := manager.consensusMgr.SetSuspectedDivergence(lockCtx, true); err != nil {
+		return false, err
+	}
+	return manager.restartAsStandbyLocked(lockCtx, source.Hostname, source.PortMap["postgres"])
+}
+
+// TestRestartAsStandbyLocked_ManagerReopenedOnError is a regression test for a
+// bug where the rewind path would leave the manager closed if an error occurred
+// after pausing. The fix uses the Pause()/resume() pattern with defer to
+// guarantee the manager is always reopened, even on error paths.
+func TestRestartAsStandbyLocked_ManagerReopenedOnError(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	ctx := context.Background()
 
@@ -1029,29 +1043,29 @@ func TestRewindToSource_ManagerReopenedOnError(t *testing.T) {
 		},
 	}
 
-	// Call RewindToSource - this should fail during the Stop call
-	_, err = manager.RewindToSource(ctx, source)
+	// Drive the self-heal rewind - this should fail during the Stop call
+	_, err = rewindViaSelfHeal(t, manager, source)
 
 	// Verify the call failed as expected
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "PostgreSQL stop failed")
 
 	// CRITICAL REGRESSION TEST: Verify the manager was reopened despite the error.
-	// This is the bug we're testing for: if RewindToSource fails, the manager must
+	// This is the bug we're testing for: if the rewind fails, the manager must
 	// still be reopened so the node can continue operating.
 	require.Eventually(t, func() bool {
 		manager.mu.Lock()
 		defer manager.mu.Unlock()
 		return manager.isOpen
-	}, 2*time.Second, 50*time.Millisecond, "REGRESSION: Manager should be reopened even when RewindToSource fails")
+	}, 2*time.Second, 50*time.Millisecond, "REGRESSION: Manager should be reopened even when the rewind fails")
 }
 
-// TestRewindToSource_RestoresPrimaryConnInfo is a regression test for the bug where
-// RewindToSource did not call setPrimaryConnInfoLocked after pg_rewind. When actual
-// pg_rewind runs it syncs postgresql.auto.conf from the source (which has no
-// primary_conninfo), wiping the value set by the earlier SetPrimary call and
+// TestRestartAsStandbyLocked_RestoresPrimaryConnInfo is a regression test for the
+// bug where the rewind path did not call setPrimaryConnInfoLocked after pg_rewind.
+// When actual pg_rewind runs it syncs postgresql.auto.conf from the source (which
+// has no primary_conninfo), wiping the value set by the earlier SetPrimary call and
 // leaving the WAL receiver with no primary to connect to.
-func TestRewindToSource_RestoresPrimaryConnInfo(t *testing.T) {
+func TestRestartAsStandbyLocked_RestoresPrimaryConnInfo(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	ctx := context.Background()
 
@@ -1148,9 +1162,9 @@ func TestRewindToSource_RestoresPrimaryConnInfo(t *testing.T) {
 		PortMap:  map[string]int32{"postgres": 5433},
 	}
 
-	resp, err := manager.RewindToSource(ctx, source)
+	rewindPerformed, err := rewindViaSelfHeal(t, manager, source)
 	require.NoError(t, err)
-	assert.True(t, resp.RewindPerformed, "actual pg_rewind should have run (divergence detected)")
+	assert.True(t, rewindPerformed, "actual pg_rewind should have run (divergence detected)")
 
 	// Verify both actual rewind calls were made (dry-run + actual).
 	rewindCalls := mockPgctld.PgRewindCalls
@@ -1166,16 +1180,16 @@ func TestRewindToSource_RestoresPrimaryConnInfo(t *testing.T) {
 	assert.Contains(t, primaryConnInfoSet, "5433", "primary_conninfo must reference the source postgres port")
 }
 
-// TestRewindToSource_NoDivergence_StillSetsPrimaryConnInfo guards the helper
-// contract introduced in the unified-rewind refactor: restartAsStandbyLocked
-// sets primary_conninfo on success regardless of whether pg_rewind actually
-// ran. The dry-run reports no divergence here, so runPgRewind returns
-// rewindPerformed=false and skips the actual rewind — but the helper must
-// still point primary_conninfo at source. Without this test, a regression
-// that gates the conninfo call on rewindPerformed would pass the divergence
-// test (TestRewindToSource_RestoresPrimaryConnInfo) and silently break
+// TestRestartAsStandbyLocked_NoDivergence_StillSetsPrimaryConnInfo guards the
+// helper contract: restartAsStandbyLocked sets primary_conninfo on success
+// regardless of whether pg_rewind actually ran. The dry-run reports no
+// divergence here, so runPgRewind returns rewindPerformed=false and skips the
+// actual rewind — but the helper must still point primary_conninfo at source.
+// Without this test, a regression that gates the conninfo call on
+// rewindPerformed would pass the divergence test
+// (TestRestartAsStandbyLocked_RestoresPrimaryConnInfo) and silently break
 // callers that arrive via this path.
-func TestRewindToSource_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
+func TestRestartAsStandbyLocked_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	ctx := context.Background()
 
@@ -1266,9 +1280,9 @@ func TestRewindToSource_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
 		PortMap:  map[string]int32{"postgres": 5433},
 	}
 
-	resp, err := manager.RewindToSource(ctx, source)
+	rewindPerformed, err := rewindViaSelfHeal(t, manager, source)
 	require.NoError(t, err)
-	assert.False(t, resp.RewindPerformed, "no divergence reported, so actual pg_rewind should not have run")
+	assert.False(t, rewindPerformed, "no divergence reported, so actual pg_rewind should not have run")
 
 	// Only the dry-run should have fired; no actual rewind.
 	rewindCalls := mockPgctld.PgRewindCalls
@@ -1279,90 +1293,6 @@ func TestRewindToSource_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
 	assert.NotEmpty(t, primaryConnInfoSet, "primary_conninfo must be set even when no rewind runs")
 	assert.Contains(t, primaryConnInfoSet, "source-host", "primary_conninfo must reference the source host")
 	assert.Contains(t, primaryConnInfoSet, "5433", "primary_conninfo must reference the source postgres port")
-}
-
-// TestRewindToSource_InvalidArgs verifies the four input-validation branches
-// at the top of RewindToSource return INVALID_ARGUMENT without touching
-// postgres. The manager is constructed but never reaches setInitialized; the
-// validation happens before checkReady, so this is enough.
-func TestRewindToSource_InvalidArgs(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	ctx := context.Background()
-
-	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
-	defer ts.Close()
-
-	poolerDir := t.TempDir()
-	serviceID := &clustermetadatapb.ID{
-		Component: clustermetadatapb.ID_MULTIPOOLER,
-		Cell:      "zone1",
-		Name:      "test-pooler",
-	}
-	multipooler := &clustermetadatapb.Multipooler{
-		Id:        serviceID,
-		PoolerDir: poolerDir,
-		Type:      clustermetadatapb.PoolerType_REPLICA,
-		PortMap:   map[string]int32{"postgres": 5432},
-		ShardKey: &clustermetadatapb.ShardKey{
-			Database:   "postgres",
-			TableGroup: constants.DefaultTableGroup,
-			Shard:      constants.DefaultShard,
-		},
-	}
-
-	manager, err := NewMultipoolerManager(logger, multipooler, &Config{TopoClient: ts})
-	require.NoError(t, err)
-	defer manager.ShutdownForTest(t.Context())
-
-	createPgDataDir(t, poolerDir)
-	require.NoError(t, manager.setInitialized())
-	manager.mu.Lock()
-	manager.isOpen = true
-	manager.state = ManagerStateReady
-	manager.ctx, manager.cancel = context.WithCancel(ctx)
-	manager.mu.Unlock()
-
-	cases := []struct {
-		name   string
-		source *clustermetadatapb.Multipooler
-	}{
-		{
-			name:   "nil source",
-			source: nil,
-		},
-		{
-			name: "nil port map",
-			source: &clustermetadatapb.Multipooler{
-				Id:       &clustermetadatapb.ID{Name: "src"},
-				Hostname: "src-host",
-			},
-		},
-		{
-			name: "empty hostname",
-			source: &clustermetadatapb.Multipooler{
-				Id:      &clustermetadatapb.ID{Name: "src"},
-				PortMap: map[string]int32{"postgres": 5433},
-			},
-		},
-		{
-			name: "missing postgres port",
-			source: &clustermetadatapb.Multipooler{
-				Id:       &clustermetadatapb.ID{Name: "src"},
-				Hostname: "src-host",
-				PortMap:  map[string]int32{"grpc": 8080},
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			resp, err := manager.RewindToSource(ctx, tc.source)
-			require.Error(t, err)
-			assert.Nil(t, resp)
-			assert.Equal(t, mtrpcpb.Code_INVALID_ARGUMENT, mterrors.Code(err),
-				"expected INVALID_ARGUMENT, got %v: %v", mterrors.Code(err), err)
-		})
-	}
 }
 
 func TestSetPostgresRestartsEnabledRPC(t *testing.T) {

--- a/go/services/multipooler/internal/manager/rpc_manager_test.go
+++ b/go/services/multipooler/internal/manager/rpc_manager_test.go
@@ -353,7 +353,7 @@ func TestActionLock_MutationMethodsTimeout(t *testing.T) {
 			name:       "UpdateConsensusRule times out when lock is held",
 			poolerType: clustermetadatapb.PoolerType_PRIMARY,
 			callMethod: func(ctx context.Context) error {
-				return manager.UpdateConsensusRule(ctx, multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_ADD, []*clustermetadatapb.ID{serviceID}, &clustermetadatapb.RuleNumber{}, nil)
+				return manager.UpdateConsensusRule(ctx, multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_ADD, []*clustermetadatapb.ID{serviceID}, &clustermetadatapb.RuleNumber{}, nil)
 			},
 		},
 	}
@@ -930,7 +930,7 @@ func TestUpdateConsensusRule_HistoryFailurePreventsGUCUpdate(t *testing.T) {
 
 	err = manager.UpdateConsensusRule(
 		ctx,
-		multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_ADD,
+		multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_ADD,
 		[]*clustermetadatapb.ID{newStandby},
 		&clustermetadatapb.RuleNumber{CoordinatorTerm: 5}, // expectedOutgoingRule
 		nil, // coordinatorID

--- a/go/test/endtoend/multiorch/fix_replication_test.go
+++ b/go/test/endtoend/multiorch/fix_replication_test.go
@@ -376,7 +376,7 @@ func removeReplicaFromStandbyList(t *testing.T, primaryClient *shardsetup.Multip
 	// Use UpdateConsensusRule to remove the replica
 	// In shardsetup, the ID uses Cell="test-cell" and Name=replicaName
 	_, err = primaryClient.Consensus.UpdateConsensusRule(ctx, &multipoolermanagerdatapb.UpdateConsensusRuleRequest{
-		Operation: multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_REMOVE,
+		Operation: multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_REMOVE,
 		StandbyIds: []*clustermetadatapb.ID{{
 			Component: clustermetadatapb.ID_MULTIPOOLER,
 			Cell:      "test-cell",

--- a/go/test/endtoend/multiorch/over_recruited_replica_reconnect_test.go
+++ b/go/test/endtoend/multiorch/over_recruited_replica_reconnect_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiorch
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	consensuspb "github.com/multigres/multigres/go/pb/consensus"
+	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
+	multipoolermanagerpb "github.com/multigres/multigres/go/pb/multipoolermanager"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+)
+
+// TestOverRecruitedReplicaReconnect covers a spurious partial failover that does
+// NOT depose the leader: a single follower is Recruit()'d at a new term, which
+// bumps that follower's per-pooler revocation above the current leader's rule.
+// The follower now refuses to follow the leader (it will reject a SetPrimary for
+// a rule whose term is below its revocation), so it sits disconnected while the
+// leader and the rest of the cohort keep serving.
+//
+// multiorch must notice the stranded follower and reconnect it. Because plain
+// SetPrimary cannot reattach a follower whose revocation is ahead of the rule,
+// the expected remedy is a no-op leader-led rule change (same leader, same
+// cohort, same quorum) that lifts the rule term past the stray revocation,
+// after which the follower accepts SetPrimary and rejoins as a streaming standby.
+//
+// NOTE: this encodes the DESIRED end state and may fail against current code if
+// that reconnect path is not yet implemented — it is a regression/spec test for
+// the gap, not (yet) a guarantee.
+func TestOverRecruitedReplicaReconnect(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping over-recruited replica reconnect test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("Skipping end-to-end over-recruited replica reconnect test (no postgres binaries)")
+	}
+
+	// Three poolers under AT_LEAST_2: a majority (2 of 3) remains after one
+	// follower is over-recruited, so the leader keeps serving and there is
+	// headroom to fix the stray follower without a full failover.
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultiorchCount(1),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+		shardsetup.WithDurabilityPolicy("AT_LEAST_2"),
+		shardsetup.WithMultigateway(),
+	)
+	defer cleanup()
+
+	setup.StartMultiorchs(t.Context(), t)
+
+	primaryName := waitForShardReady(t, setup, 2 /*expectedStandbyCount*/, 60*time.Second)
+	t.Logf("Bootstrap complete; primary=%s (3-member cohort)", primaryName)
+
+	// Pick one follower to over-recruit — any pooler that is not the primary.
+	var targetReplica string
+	for name := range setup.Multipoolers {
+		if name != primaryName {
+			targetReplica = name
+			break
+		}
+	}
+	require.NotEmpty(t, targetReplica, "expected at least one non-primary pooler")
+	t.Logf("Over-recruiting single follower: %s", targetReplica)
+
+	// Quiet multiorch while we bump the target's term, so it does not race our
+	// manual Recruit. We re-enable below and let it drive the reconnect.
+	resumeRecovery := setup.DisableRecovery(t, "multiorch")
+
+	// Open per-pooler clients: consensus for Recruit, manager for Status snapshots.
+	type poolerClient struct {
+		name      string
+		consensus consensuspb.MultipoolerConsensusClient
+		manager   multipoolermanagerpb.MultipoolerManagerClient
+	}
+	poolerClients := make(map[string]*poolerClient, len(setup.Multipoolers))
+	for name, inst := range setup.Multipoolers {
+		conn, err := grpc.NewClient(
+			fmt.Sprintf("localhost:%d", inst.Multipooler.GrpcPort),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		require.NoError(t, err, "dial multipooler %s", name)
+		t.Cleanup(func() { conn.Close() })
+		poolerClients[name] = &poolerClient{
+			name:      name,
+			consensus: consensuspb.NewMultipoolerConsensusClient(conn),
+			manager:   multipoolermanagerpb.NewMultipoolerManagerClient(conn),
+		}
+	}
+
+	// Snapshot current consensus statuses so we can build a revocation at the next
+	// term (the same helper multiorch uses during AppointLeader).
+	statuses := make([]*clustermetadatapb.ConsensusStatus, 0, len(poolerClients))
+	// Baseline each pooler's revocation term. Healing must leave every pooler other
+	// than the target exactly here — a failover or coordinator-led rule change would
+	// re-recruit the cohort and bump these.
+	baseRevoke := make(map[string]int64, len(poolerClients))
+	for _, pc := range poolerClients {
+		resp, err := pc.manager.Status(utils.WithShortDeadline(t), &multipoolermanagerdatapb.StatusRequest{})
+		require.NoError(t, err, "Status on %s", pc.name)
+		require.NotNil(t, resp.GetConsensusStatus(), "ConsensusStatus from %s", pc.name)
+		statuses = append(statuses, resp.GetConsensusStatus())
+		baseRevoke[pc.name] = resp.GetConsensusStatus().GetTermRevocation().GetRevokedBelowTerm()
+	}
+
+	testCoordinatorID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIORCH,
+		Cell:      "test-cell",
+		Name:      "test-coordinator",
+	}
+	revocation, err := commonconsensus.NewTermRevocation(statuses, testCoordinatorID, timestamppb.Now())
+	require.NoError(t, err, "build term revocation")
+	t.Logf("Recruiting only %s at new term %d (leader %s stays in place)", targetReplica, revocation.GetRevokedBelowTerm(), primaryName)
+
+	// Recruit ONLY the target follower — do not touch the leader or the other
+	// follower. This strands the target ahead of the leader's rule.
+	_, err = poolerClients[targetReplica].consensus.Recruit(utils.WithTimeout(t, 30*time.Second), &consensusdatapb.RecruitRequest{
+		TermRevocation: revocation,
+	})
+	require.NoError(t, err, "Recruit on %s", targetReplica)
+
+	// Diagnostic: capture the target's state immediately after Recruit, before
+	// recovery runs — this shows whether Recruit actually stranded it (replication
+	// stopped, primary_conninfo cleared, revoked above the leader's rule).
+	{
+		resp, err := poolerClients[targetReplica].manager.Status(utils.WithShortDeadline(t), &multipoolermanagerdatapb.StatusRequest{})
+		require.NoError(t, err, "post-Recruit Status on %s", targetReplica)
+		rs := resp.GetStatus().GetReplicationStatus()
+		t.Logf("post-Recruit %s: pooler_type=%v wal_receiver=%q primary_conninfo_host=%q last_receive_lsn=%q revoked_below_term=%d",
+			targetReplica, resp.GetStatus().GetPoolerType(), rs.GetWalReceiverStatus(), rs.GetPrimaryConnInfo().GetHost(),
+			rs.GetLastReceiveLsn(), resp.GetConsensusStatus().GetTermRevocation().GetRevokedBelowTerm())
+	}
+
+	// Hand control back to multiorch and require it to reconnect the stranded
+	// follower and settle to a problem-free state.
+	resumeRecovery()
+	waitForNodeToRejoinAsStandby(t, setup, targetReplica, primaryName, revocation.GetRevokedBelowTerm(), 30*time.Second)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioFixReplication)
+
+	// Healing must be purely replication-level: no failover, no coordinator-led
+	// rule change, and no re-recruitment of the untouched poolers. The leader stays
+	// put and every OTHER pooler's revocation is exactly what it was before — a
+	// failover or coordinator rule change would re-recruit the cohort and bump these.
+	for _, pc := range poolerClients {
+		resp, err := pc.manager.Status(utils.WithShortDeadline(t), &multipoolermanagerdatapb.StatusRequest{})
+		require.NoError(t, err, "post-heal Status on %s", pc.name)
+		finalRevoke := resp.GetConsensusStatus().GetTermRevocation().GetRevokedBelowTerm()
+		t.Logf("post-heal %s: type=%v revoked_below_term=%d (baseline %d)",
+			pc.name, resp.GetStatus().GetPoolerType(), finalRevoke, baseRevoke[pc.name])
+		if pc.name == targetReplica {
+			continue
+		}
+		require.Equal(t, baseRevoke[pc.name], finalRevoke,
+			"%s revocation changed: healing must not recruit other poolers or run a coordinator-led rule change", pc.name)
+		if pc.name == primaryName {
+			require.Equal(t, clustermetadatapb.PoolerType_PRIMARY, resp.GetStatus().GetPoolerType(),
+				"leader %s must still be primary — healing must not trigger failover", primaryName)
+		}
+	}
+}

--- a/go/test/endtoend/multiorch/rewind_diverged_replica_test.go
+++ b/go/test/endtoend/multiorch/rewind_diverged_replica_test.go
@@ -42,8 +42,9 @@ import (
 //  4. Write a diverging row to R1 (exists on the new timeline only)
 //  5. Restart R1 as a standby — WAL receiver starts, immediately FAILs due to
 //     timeline conflict (R1's timeline > P's), enters retry-wait state
-//  6. Re-enable orch — detects WAL receiver not streaming, verifyReplicationStarted
-//     times out → tryPgRewind → RewindToSource RPC → pg_rewind runs
+//  6. Re-enable orch — its SetPrimary can't start streaming, so it leaves recovery
+//     to the pooler, whose monitor detects the stuck WAL receiver, suspects
+//     divergence, and self-rewinds against the recorded leader
 //  7. Verify R1 rejoins P with the diverged row absent and baseline data present
 func TestRewindDivergedReplica(t *testing.T) {
 	if testing.Short() {

--- a/go/test/endtoend/multiorch/stuck_proposal_test.go
+++ b/go/test/endtoend/multiorch/stuck_proposal_test.go
@@ -142,7 +142,7 @@ func TestCohortChangeRejectedWithStuckProposal(t *testing.T) {
 	// undecided: it has no independent safety backing (no cert, no verified
 	// quorum) to know whether overwriting it would discard durable work.
 	_, err = primaryClient.Consensus.UpdateConsensusRule(ctx, &multipoolermanagerdatapb.UpdateConsensusRuleRequest{
-		Operation: multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_REMOVE,
+		Operation: multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_REMOVE,
 		StandbyIds: []*clustermetadatapb.ID{{
 			Component: clustermetadatapb.ID_MULTIPOOLER,
 			Cell:      "test-cell",

--- a/go/test/endtoend/multipooler/rpc_consensus_test.go
+++ b/go/test/endtoend/multipooler/rpc_consensus_test.go
@@ -108,7 +108,7 @@ func TestUpdateConsensusRule(t *testing.T) {
 		// ADD all desired standbys first (keeps list non-empty throughout).
 		_, err := primaryConsensusClient.UpdateConsensusRule(addCtx,
 			&multipoolermanagerdatapb.UpdateConsensusRuleRequest{
-				Operation:            multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_ADD,
+				Operation:            multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_ADD,
 				StandbyIds:           desired,
 				ExpectedOutgoingRule: currentRuleNumberFromClient(t, ctx, primaryManagerClient),
 			})
@@ -143,7 +143,7 @@ func TestUpdateConsensusRule(t *testing.T) {
 			removeCtx, removeCancel := context.WithTimeout(ctx, 10*time.Second)
 			_, err = primaryConsensusClient.UpdateConsensusRule(removeCtx,
 				&multipoolermanagerdatapb.UpdateConsensusRuleRequest{
-					Operation:            multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_REMOVE,
+					Operation:            multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_REMOVE,
 					StandbyIds:           toRemove,
 					ExpectedOutgoingRule: currentRuleNumberFromClient(t, ctx, primaryManagerClient),
 				})
@@ -178,7 +178,7 @@ func TestUpdateConsensusRule(t *testing.T) {
 
 		_, err := primaryConsensusClient.UpdateConsensusRule(utils.WithTimeout(t, 10*time.Second),
 			&multipoolermanagerdatapb.UpdateConsensusRuleRequest{
-				Operation:            multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_ADD,
+				Operation:            multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_ADD,
 				StandbyIds:           []*clustermetadatapb.ID{makeMultipoolerID("test-cell", "standby2")},
 				ExpectedOutgoingRule: currentRuleNumberFromClient(t, t.Context(), primaryManagerClient),
 			})
@@ -216,7 +216,7 @@ func TestUpdateConsensusRule(t *testing.T) {
 		// ADD a standby that already exists
 		_, err := primaryConsensusClient.UpdateConsensusRule(utils.WithTimeout(t, 10*time.Second),
 			&multipoolermanagerdatapb.UpdateConsensusRuleRequest{
-				Operation:            multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_ADD,
+				Operation:            multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_ADD,
 				StandbyIds:           []*clustermetadatapb.ID{makeMultipoolerID("test-cell", "standby1")},
 				ExpectedOutgoingRule: currentRuleNumberFromClient(t, t.Context(), primaryManagerClient),
 			})
@@ -239,7 +239,7 @@ func TestUpdateConsensusRule(t *testing.T) {
 
 		_, err := primaryConsensusClient.UpdateConsensusRule(utils.WithTimeout(t, 10*time.Second),
 			&multipoolermanagerdatapb.UpdateConsensusRuleRequest{
-				Operation:            multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_REMOVE,
+				Operation:            multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_REMOVE,
 				StandbyIds:           []*clustermetadatapb.ID{makeMultipoolerID("test-cell", "standby2")},
 				ExpectedOutgoingRule: currentRuleNumberFromClient(t, t.Context(), primaryManagerClient),
 			})
@@ -276,7 +276,7 @@ func TestUpdateConsensusRule(t *testing.T) {
 
 		_, err := primaryConsensusClient.UpdateConsensusRule(utils.WithTimeout(t, 10*time.Second),
 			&multipoolermanagerdatapb.UpdateConsensusRuleRequest{
-				Operation: multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_REMOVE,
+				Operation: multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_REMOVE,
 				StandbyIds: []*clustermetadatapb.ID{
 					makeMultipoolerID("test-cell", "does-not-exist"),
 				},
@@ -301,7 +301,7 @@ func TestUpdateConsensusRule(t *testing.T) {
 		// ADD two more
 		_, err := primaryConsensusClient.UpdateConsensusRule(utils.WithTimeout(t, 10*time.Second),
 			&multipoolermanagerdatapb.UpdateConsensusRuleRequest{
-				Operation: multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_ADD,
+				Operation: multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_ADD,
 				StandbyIds: []*clustermetadatapb.ID{
 					makeMultipoolerID("test-cell", "standby3"),
 					makeMultipoolerID("test-cell", "standby4"),
@@ -318,7 +318,7 @@ func TestUpdateConsensusRule(t *testing.T) {
 		// REMOVE two
 		_, err = primaryConsensusClient.UpdateConsensusRule(utils.WithTimeout(t, 10*time.Second),
 			&multipoolermanagerdatapb.UpdateConsensusRuleRequest{
-				Operation: multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_REMOVE,
+				Operation: multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_REMOVE,
 				StandbyIds: []*clustermetadatapb.ID{
 					makeMultipoolerID("test-cell", "standby2"),
 					makeMultipoolerID("test-cell", "standby4"),
@@ -360,7 +360,7 @@ func TestUpdateConsensusRule(t *testing.T) {
 
 		_, err := primaryConsensusClient.UpdateConsensusRule(utils.WithTimeout(t, 10*time.Second),
 			&multipoolermanagerdatapb.UpdateConsensusRuleRequest{
-				Operation:            multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_REMOVE,
+				Operation:            multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_REMOVE,
 				StandbyIds:           []*clustermetadatapb.ID{realStandbyID},
 				ExpectedOutgoingRule: currentRuleNumberFromClient(t, t.Context(), primaryManagerClient),
 			})
@@ -375,7 +375,7 @@ func TestUpdateConsensusRule(t *testing.T) {
 
 		_, err := standbyConsensusClient.UpdateConsensusRule(utils.WithTimeout(t, 1*time.Second),
 			&multipoolermanagerdatapb.UpdateConsensusRuleRequest{
-				Operation:  multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_ADD,
+				Operation:  multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_ADD,
 				StandbyIds: []*clustermetadatapb.ID{makeMultipoolerID("test-cell", "standby1")},
 				// Expected rule is a placeholder; the call should fail at the
 				// REPLICA guardrail before the CAS check would matter.

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -759,6 +759,21 @@ message ExternallyCertifiedRevocation {
 //     current_position; not persisted and may be stale after restarts.
 message ConsensusStatus {
   // term_revocation records the highest coordinator term this pooler has revoked for.
+  //
+  // This is a monotonic promise floor: it is always reported here even after it
+  // has been satisfied (the pooler's own committed rule caught up to or past
+  // revoked_below_term), so its mere presence does NOT mean the pooler is still
+  // recruited. Consumers must check whether it still revokes the pooler's own
+  // position — see consensus.IsSelfRevoked.
+  //
+  // TODO: we could omit an obsolete revocation from this reported status (once
+  // the committed coordinator term reaches revoked_below_term) so that absence
+  // alone signals "not recruited". Deliberately not done yet: keeping the raw
+  // revocation visible aids debugging (a lingering self-revoking revocation is
+  // exactly the signal for a stranded pooler), and the omit condition is subtle
+  // — it must be the committed-term check, not IsSelfRevoked, or the
+  // runaway-recruit subterm-override case would drop term information that
+  // NewTermRevocation relies on and risk term reuse.
   TermRevocation term_revocation = 1;
 
   // current_position is the highest rule this pooler has committed to local WAL

--- a/proto/consensusservice.proto
+++ b/proto/consensusservice.proto
@@ -31,11 +31,6 @@ service MultipoolerConsensus {
   rpc UpdateConsensusRule(multipoolermanagerdata.UpdateConsensusRuleRequest)
     returns (multipoolermanagerdata.UpdateConsensusRuleResponse);
 
-  // RewindToSource performs pg_rewind to synchronize this server with a source.
-  // This is used to repair diverged timelines after failover.
-  rpc RewindToSource(multipoolermanagerdata.RewindToSourceRequest)
-    returns (multipoolermanagerdata.RewindToSourceResponse);
-
   // Appointment protocol: Recruit, then concurrent Promote (to the leader) and
   // SetPrimary (to the other cohort members).
 

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -579,33 +579,6 @@ message BackupMetadata {
 }
 
 // =============================================================================
-// PgRewind APIs
-// =============================================================================
-
-// RewindToSourceRequest requests pg_rewind to synchronize with a source server.
-// This operation:
-// 1. Stops PostgreSQL
-// 2. Runs pg_rewind --dry-run to check if rewind is needed
-// 3. If needed, runs actual pg_rewind
-// 4. Starts PostgreSQL
-message RewindToSourceRequest {
-  // Source multipooler (the primary) to rewind to
-  clustermetadata.Multipooler source = 1;
-}
-
-message RewindToSourceResponse {
-  // True if the operation completed successfully
-  bool success = 1;
-
-  // Error message if operation failed
-  string error_message = 2;
-
-  // True if servers had diverged and pg_rewind was performed
-  // False if timelines were compatible and no rewind was needed
-  bool rewind_performed = 3;
-}
-
-// =============================================================================
 // PostgreSQL Monitoring Control APIs
 // =============================================================================
 

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -390,11 +390,22 @@ enum SynchronousMethod {
   SYNCHRONOUS_METHOD_ANY = 2;
 }
 
-// Enum representing the type of cohort membership change
-enum CohortUpdateOperation {
-  COHORT_UPDATE_OPERATION_UNSPECIFIED = 0;
-  COHORT_UPDATE_OPERATION_ADD = 1;
-  COHORT_UPDATE_OPERATION_REMOVE = 2;
+// RuleOperation is the kind of change UpdateConsensusRule applies to the
+// leader's consensus rule.
+enum RuleOperation {
+  RULE_OPERATION_UNSPECIFIED = 0;
+
+  // Cohort-membership changes: add or remove a synchronous standby.
+  RULE_OPERATION_COHORT_ADD = 1;
+  RULE_OPERATION_COHORT_REMOVE = 2;
+
+  // ADVANCE makes no cohort change: it re-writes the current rule with the same
+  // leader and cohort at a fresh leader_subterm. Used to reconnect a follower
+  // stranded by an abandoned recruit — advancing the committed decision past the
+  // rule the stray revocation was authored to transition away from
+  // (outgoing_rule) defeats that revocation via the runaway-recruit override in
+  // IsRuleRevoked, without changing the coordinator term or any revocation.
+  RULE_OPERATION_ADVANCE = 3;
 }
 
 // Synchronous commit level
@@ -415,12 +426,12 @@ enum SynchronousCommitLevel {
   SYNCHRONOUS_COMMIT_REMOTE_APPLY = 4;
 }
 
-// UpdateConsensusRule applies a cohort-membership change on the primary.
-// Internally this updates synchronous_standby_names and records the cohort
-// change in rule_history.
+// UpdateConsensusRule applies a rule change on the primary: a cohort-membership
+// change (which also updates synchronous_standby_names) or a no-op ADVANCE.
+// Either way it records a new rule in rule_history.
 message UpdateConsensusRuleRequest {
-  // Operation to perform (add, remove)
-  CohortUpdateOperation operation = 1;
+  // Operation to perform (cohort add/remove, or advance).
+  RuleOperation operation = 1;
 
   // List of multipooler IDs to add to or remove from the cohort.
   // The application names will be generated as {cell}_{name} from these IDs.

--- a/web/multiadmin/lib/api/generated/clustermetadata_pb.ts
+++ b/web/multiadmin/lib/api/generated/clustermetadata_pb.ts
@@ -2232,6 +2232,21 @@ export class ConsensusStatus extends Message<ConsensusStatus> {
   /**
    * term_revocation records the highest coordinator term this pooler has revoked for.
    *
+   * This is a monotonic promise floor: it is always reported here even after it
+   * has been satisfied (the pooler's own committed rule caught up to or past
+   * revoked_below_term), so its mere presence does NOT mean the pooler is still
+   * recruited. Consumers must check whether it still revokes the pooler's own
+   * position — see consensus.IsSelfRevoked.
+   *
+   * TODO: we could omit an obsolete revocation from this reported status (once
+   * the committed coordinator term reaches revoked_below_term) so that absence
+   * alone signals "not recruited". Deliberately not done yet: keeping the raw
+   * revocation visible aids debugging (a lingering self-revoking revocation is
+   * exactly the signal for a stranded pooler), and the omit condition is subtle
+   * — it must be the committed-term check, not IsSelfRevoked, or the
+   * runaway-recruit subterm-override case would drop term information that
+   * NewTermRevocation relies on and risk term reuse.
+   *
    * @generated from field: clustermetadata.TermRevocation term_revocation = 1;
    */
   termRevocation?: TermRevocation;

--- a/web/multiadmin/lib/api/generated/multipoolermanagerdata_pb.ts
+++ b/web/multiadmin/lib/api/generated/multipoolermanagerdata_pb.ts
@@ -245,31 +245,47 @@ proto3.util.setEnumType(SynchronousMethod, "multipoolermanagerdata.SynchronousMe
 ]);
 
 /**
- * Enum representing the type of cohort membership change
+ * RuleOperation is the kind of change UpdateConsensusRule applies to the
+ * leader's consensus rule.
  *
- * @generated from enum multipoolermanagerdata.CohortUpdateOperation
+ * @generated from enum multipoolermanagerdata.RuleOperation
  */
-export enum CohortUpdateOperation {
+export enum RuleOperation {
   /**
-   * @generated from enum value: COHORT_UPDATE_OPERATION_UNSPECIFIED = 0;
+   * @generated from enum value: RULE_OPERATION_UNSPECIFIED = 0;
    */
   UNSPECIFIED = 0,
 
   /**
-   * @generated from enum value: COHORT_UPDATE_OPERATION_ADD = 1;
+   * Cohort-membership changes: add or remove a synchronous standby.
+   *
+   * @generated from enum value: RULE_OPERATION_COHORT_ADD = 1;
    */
-  ADD = 1,
+  COHORT_ADD = 1,
 
   /**
-   * @generated from enum value: COHORT_UPDATE_OPERATION_REMOVE = 2;
+   * @generated from enum value: RULE_OPERATION_COHORT_REMOVE = 2;
    */
-  REMOVE = 2,
+  COHORT_REMOVE = 2,
+
+  /**
+   * ADVANCE makes no cohort change: it re-writes the current rule with the same
+   * leader and cohort at a fresh leader_subterm. Used to reconnect a follower
+   * stranded by an abandoned recruit — advancing the committed decision past the
+   * rule the stray revocation was authored to transition away from
+   * (outgoing_rule) defeats that revocation via the runaway-recruit override in
+   * IsRuleRevoked, without changing the coordinator term or any revocation.
+   *
+   * @generated from enum value: RULE_OPERATION_ADVANCE = 3;
+   */
+  ADVANCE = 3,
 }
-// Retrieve enum metadata with: proto3.getEnumType(CohortUpdateOperation)
-proto3.util.setEnumType(CohortUpdateOperation, "multipoolermanagerdata.CohortUpdateOperation", [
-  { no: 0, name: "COHORT_UPDATE_OPERATION_UNSPECIFIED" },
-  { no: 1, name: "COHORT_UPDATE_OPERATION_ADD" },
-  { no: 2, name: "COHORT_UPDATE_OPERATION_REMOVE" },
+// Retrieve enum metadata with: proto3.getEnumType(RuleOperation)
+proto3.util.setEnumType(RuleOperation, "multipoolermanagerdata.RuleOperation", [
+  { no: 0, name: "RULE_OPERATION_UNSPECIFIED" },
+  { no: 1, name: "RULE_OPERATION_COHORT_ADD" },
+  { no: 2, name: "RULE_OPERATION_COHORT_REMOVE" },
+  { no: 3, name: "RULE_OPERATION_ADVANCE" },
 ]);
 
 /**
@@ -1479,19 +1495,19 @@ export class ManagerHealthSnapshot extends Message<ManagerHealthSnapshot> {
 }
 
 /**
- * UpdateConsensusRule applies a cohort-membership change on the primary.
- * Internally this updates synchronous_standby_names and records the cohort
- * change in rule_history.
+ * UpdateConsensusRule applies a rule change on the primary: a cohort-membership
+ * change (which also updates synchronous_standby_names) or a no-op ADVANCE.
+ * Either way it records a new rule in rule_history.
  *
  * @generated from message multipoolermanagerdata.UpdateConsensusRuleRequest
  */
 export class UpdateConsensusRuleRequest extends Message<UpdateConsensusRuleRequest> {
   /**
-   * Operation to perform (add, remove)
+   * Operation to perform (cohort add/remove, or advance).
    *
-   * @generated from field: multipoolermanagerdata.CohortUpdateOperation operation = 1;
+   * @generated from field: multipoolermanagerdata.RuleOperation operation = 1;
    */
-  operation = CohortUpdateOperation.UNSPECIFIED;
+  operation = RuleOperation.UNSPECIFIED;
 
   /**
    * List of multipooler IDs to add to or remove from the cohort.
@@ -1529,7 +1545,7 @@ export class UpdateConsensusRuleRequest extends Message<UpdateConsensusRuleReque
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "multipoolermanagerdata.UpdateConsensusRuleRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "operation", kind: "enum", T: proto3.getEnumType(CohortUpdateOperation) },
+    { no: 1, name: "operation", kind: "enum", T: proto3.getEnumType(RuleOperation) },
     { no: 2, name: "standby_ids", kind: "message", T: ID, repeated: true },
     { no: 4, name: "expected_outgoing_rule", kind: "message", T: RuleNumber },
     { no: 6, name: "coordinator_id", kind: "message", T: ID },

--- a/web/multiadmin/lib/api/generated/multipoolermanagerdata_pb.ts
+++ b/web/multiadmin/lib/api/generated/multipoolermanagerdata_pb.ts
@@ -19,7 +19,7 @@
 
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
 import { Duration, Message, proto3, protoInt64, Timestamp } from "@bufbuild/protobuf";
-import { AvailabilityStatus, ConsensusStatus, ID, Multipooler, PoolerType, RoutingRole, RuleNumber } from "./clustermetadata_pb";
+import { AvailabilityStatus, ConsensusStatus, ID, PoolerType, RoutingRole, RuleNumber } from "./clustermetadata_pb";
 
 /**
  * PostgresStatus is the observed state of the PostgreSQL server process.
@@ -2205,108 +2205,6 @@ proto3.util.setEnumType(BackupMetadata_Status, "multipoolermanagerdata.BackupMet
   { no: 1, name: "INCOMPLETE" },
   { no: 2, name: "COMPLETE" },
 ]);
-
-/**
- * RewindToSourceRequest requests pg_rewind to synchronize with a source server.
- * This operation:
- * 1. Stops PostgreSQL
- * 2. Runs pg_rewind --dry-run to check if rewind is needed
- * 3. If needed, runs actual pg_rewind
- * 4. Starts PostgreSQL
- *
- * @generated from message multipoolermanagerdata.RewindToSourceRequest
- */
-export class RewindToSourceRequest extends Message<RewindToSourceRequest> {
-  /**
-   * Source multipooler (the primary) to rewind to
-   *
-   * @generated from field: clustermetadata.Multipooler source = 1;
-   */
-  source?: Multipooler;
-
-  constructor(data?: PartialMessage<RewindToSourceRequest>) {
-    super();
-    proto3.util.initPartial(data, this);
-  }
-
-  static readonly runtime: typeof proto3 = proto3;
-  static readonly typeName = "multipoolermanagerdata.RewindToSourceRequest";
-  static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "source", kind: "message", T: Multipooler },
-  ]);
-
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RewindToSourceRequest {
-    return new RewindToSourceRequest().fromBinary(bytes, options);
-  }
-
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): RewindToSourceRequest {
-    return new RewindToSourceRequest().fromJson(jsonValue, options);
-  }
-
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): RewindToSourceRequest {
-    return new RewindToSourceRequest().fromJsonString(jsonString, options);
-  }
-
-  static equals(a: RewindToSourceRequest | PlainMessage<RewindToSourceRequest> | undefined, b: RewindToSourceRequest | PlainMessage<RewindToSourceRequest> | undefined): boolean {
-    return proto3.util.equals(RewindToSourceRequest, a, b);
-  }
-}
-
-/**
- * @generated from message multipoolermanagerdata.RewindToSourceResponse
- */
-export class RewindToSourceResponse extends Message<RewindToSourceResponse> {
-  /**
-   * True if the operation completed successfully
-   *
-   * @generated from field: bool success = 1;
-   */
-  success = false;
-
-  /**
-   * Error message if operation failed
-   *
-   * @generated from field: string error_message = 2;
-   */
-  errorMessage = "";
-
-  /**
-   * True if servers had diverged and pg_rewind was performed
-   * False if timelines were compatible and no rewind was needed
-   *
-   * @generated from field: bool rewind_performed = 3;
-   */
-  rewindPerformed = false;
-
-  constructor(data?: PartialMessage<RewindToSourceResponse>) {
-    super();
-    proto3.util.initPartial(data, this);
-  }
-
-  static readonly runtime: typeof proto3 = proto3;
-  static readonly typeName = "multipoolermanagerdata.RewindToSourceResponse";
-  static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "success", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-    { no: 2, name: "error_message", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "rewind_performed", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-  ]);
-
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RewindToSourceResponse {
-    return new RewindToSourceResponse().fromBinary(bytes, options);
-  }
-
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): RewindToSourceResponse {
-    return new RewindToSourceResponse().fromJson(jsonValue, options);
-  }
-
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): RewindToSourceResponse {
-    return new RewindToSourceResponse().fromJsonString(jsonString, options);
-  }
-
-  static equals(a: RewindToSourceResponse | PlainMessage<RewindToSourceResponse> | undefined, b: RewindToSourceResponse | PlainMessage<RewindToSourceResponse> | undefined): boolean {
-    return proto3.util.equals(RewindToSourceResponse, a, b);
-  }
-}
 
 /**
  * SetPostgresRestartsEnabledRequest enables or disables automatic PostgreSQL restarts


### PR DESCRIPTION
## Summary

Two related consensus-recovery changes: multiorch no longer drives destructive `pg_rewind` on replicas, and a spuriously over-recruited follower can rejoin without a failover.

### Pooler-driven divergence recovery
`FixReplication` no longer escalates to an orch-driven `pg_rewind`. When `SetPrimary` doesn't bring a standby to streaming, it leaves divergence recovery to the pooler. The multipooler monitor detects a standby that is up with a correct `primary_conninfo` but not streaming past a short threshold, marks suspected divergence, and self-rewinds against the recorded leader (revocation-gated). An actively streaming standby clears any lingering suspicion, which also breaks any rewind loop. `discoverPostgresState` now surfaces a WAL-receiver read failure instead of defaulting to "not streaming".

### Reconnect an over-recruited follower
A follower `Recruit()`'d at a higher term raises its `TermRevocation` above the leader's committed rule, so it rejects the leader's `SetPrimary` and sits disconnected while the leader keeps serving — an abandoned partial failover.

multiorch now detects this (a self-revoked follower whose revocation still revokes the highest-known rule, once past the failover grace window so a legit in-flight failover is left to finish) and repairs it with a leader-led no-op rule advance: `UpdateConsensusRule(RULE_OPERATION_ADVANCE)` rewrites the rule with the same leader and cohort at a fresh `leader_subterm`, moving the committed decision past the rule the revocation was authored to transition away from. That defeats the revocation via the runaway-recruit override in `IsRuleRevoked`, without changing the coordinator term or any pooler's revocation. The action then relays the advanced rule via `SetPrimary` and the follower rejoins.

### Supporting changes
- `consensus.IsSelfRevoked`, keyed on the highest-known rule so a replica streaming toward a higher accepted rule while its WAL lags is not misread as stranded.
- `RULE_OPERATION_ADVANCE` on `UpdateConsensusRule`; renamed `CohortUpdateOperation` → `RuleOperation` now that it carries a non-cohort operation.
- `ReplicaNotReplicating` defers a stranded follower to the new analyzer instead of firing a `SetPrimary` it would ignore.
