### PR TITLE
refactor(multipooler): remove RewindToSource RPC; self-heal diverged standbys locally

### DIFF
--- a/go/common/rpcclient/client.go
+++ b/go/common/rpcclient/client.go
@@ -158,9 +158,6 @@ type MultipoolerClient interface {
 	// success without changes.
 	SetPrimary(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *consensusdatapb.SetPrimaryRequest) (*consensusdatapb.SetPrimaryResponse, error)
 
-	// RewindToSource performs pg_rewind to synchronize a replica with its source.
-	RewindToSource(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.RewindToSourceRequest) (*multipoolermanagerdatapb.RewindToSourceResponse, error)
-
 	//
 	// Manager Service Methods - Status and Monitoring
 	//

--- a/go/common/rpcclient/fake_client.go
+++ b/go/common/rpcclient/fake_client.go
@@ -73,7 +73,6 @@ type FakeClient struct {
 	BackupResponses                     map[topoclient.ComponentID]*multipoolermanagerdatapb.BackupResponse
 	GetBackupsResponses                 map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupsResponse
 	GetBackupByJobIdResponses           map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupByJobIdResponse
-	RewindToSourceResponses             map[topoclient.ComponentID]*multipoolermanagerdatapb.RewindToSourceResponse
 	SetPostgresRestartsEnabledResponses map[topoclient.ComponentID]*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse
 
 	// Errors to return - keyed by pooler ID
@@ -116,7 +115,6 @@ func NewFakeClient() *FakeClient {
 		BackupResponses:                     make(map[topoclient.ComponentID]*multipoolermanagerdatapb.BackupResponse),
 		GetBackupsResponses:                 make(map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupsResponse),
 		GetBackupByJobIdResponses:           make(map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupByJobIdResponse),
-		RewindToSourceResponses:             make(map[topoclient.ComponentID]*multipoolermanagerdatapb.RewindToSourceResponse),
 		SetPostgresRestartsEnabledResponses: make(map[topoclient.ComponentID]*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse),
 		Errors:                              make(map[topoclient.ComponentID]error),
 		RecruitDelays:                       make(map[topoclient.ComponentID]time.Duration),
@@ -463,26 +461,6 @@ func (f *FakeClient) VerifyBackups(ctx context.Context, pooler *clustermetadatap
 	}
 
 	return &multipoolermanagerdatapb.VerifyBackupsResponse{}, nil
-}
-
-//
-// Manager Service Methods - Timeline Repair
-//
-
-func (f *FakeClient) RewindToSource(ctx context.Context, pooler *clustermetadatapb.Multipooler, req *multipoolermanagerdatapb.RewindToSourceRequest) (*multipoolermanagerdatapb.RewindToSourceResponse, error) {
-	poolerID := f.getPoolerID(pooler)
-	f.logCall("RewindToSource", poolerID)
-
-	if err := f.checkError(poolerID); err != nil {
-		return nil, err
-	}
-
-	f.mu.RLock()
-	defer f.mu.RUnlock()
-	if resp, ok := f.RewindToSourceResponses[poolerID]; ok {
-		return resp, nil
-	}
-	return &multipoolermanagerdatapb.RewindToSourceResponse{}, nil
 }
 
 //

--- a/go/common/rpcclient/grpc_client.go
+++ b/go/common/rpcclient/grpc_client.go
@@ -121,19 +121,6 @@ func (c *Client) SetPrimary(ctx context.Context, pooler *clustermetadatapb.Multi
 	return conn.consensusClient.SetPrimary(ctx, request)
 }
 
-// RewindToSource performs pg_rewind to synchronize a replica with its source.
-func (c *Client) RewindToSource(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.RewindToSourceRequest) (*multipoolermanagerdatapb.RewindToSourceResponse, error) {
-	conn, closer, err := c.dialPersistent(ctx, pooler)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		_ = closer()
-	}()
-
-	return conn.consensusClient.RewindToSource(ctx, request)
-}
-
 //
 // Manager Service Methods - Status and Monitoring
 //

--- a/go/pb/consensus/consensusconnect/consensusservice.connect.go
+++ b/go/pb/consensus/consensusconnect/consensusservice.connect.go
@@ -52,9 +52,6 @@ const (
 	// MultipoolerConsensusUpdateConsensusRuleProcedure is the fully-qualified name of the
 	// MultipoolerConsensus's UpdateConsensusRule RPC.
 	MultipoolerConsensusUpdateConsensusRuleProcedure = "/consensus.MultipoolerConsensus/UpdateConsensusRule"
-	// MultipoolerConsensusRewindToSourceProcedure is the fully-qualified name of the
-	// MultipoolerConsensus's RewindToSource RPC.
-	MultipoolerConsensusRewindToSourceProcedure = "/consensus.MultipoolerConsensus/RewindToSource"
 	// MultipoolerConsensusRecruitProcedure is the fully-qualified name of the MultipoolerConsensus's
 	// Recruit RPC.
 	MultipoolerConsensusRecruitProcedure = "/consensus.MultipoolerConsensus/Recruit"
@@ -72,9 +69,6 @@ type MultipoolerConsensusClient interface {
 	// primary handler updates synchronous_standby_names and records the cohort
 	// change in rule_history.
 	UpdateConsensusRule(context.Context, *connect.Request[multipoolermanagerdata.UpdateConsensusRuleRequest]) (*connect.Response[multipoolermanagerdata.UpdateConsensusRuleResponse], error)
-	// RewindToSource performs pg_rewind to synchronize this server with a source.
-	// This is used to repair diverged timelines after failover.
-	RewindToSource(context.Context, *connect.Request[multipoolermanagerdata.RewindToSourceRequest]) (*connect.Response[multipoolermanagerdata.RewindToSourceResponse], error)
 	// Recruit asks a pooler to revoke all terms below the one specified and
 	// record the coordinator's exclusive claim on that term.
 	Recruit(context.Context, *connect.Request[consensusdata.RecruitRequest]) (*connect.Response[consensusdata.RecruitResponse], error)
@@ -110,12 +104,6 @@ func NewMultipoolerConsensusClient(httpClient connect.HTTPClient, baseURL string
 			connect.WithSchema(multipoolerConsensusMethods.ByName("UpdateConsensusRule")),
 			connect.WithClientOptions(opts...),
 		),
-		rewindToSource: connect.NewClient[multipoolermanagerdata.RewindToSourceRequest, multipoolermanagerdata.RewindToSourceResponse](
-			httpClient,
-			baseURL+MultipoolerConsensusRewindToSourceProcedure,
-			connect.WithSchema(multipoolerConsensusMethods.ByName("RewindToSource")),
-			connect.WithClientOptions(opts...),
-		),
 		recruit: connect.NewClient[consensusdata.RecruitRequest, consensusdata.RecruitResponse](
 			httpClient,
 			baseURL+MultipoolerConsensusRecruitProcedure,
@@ -140,7 +128,6 @@ func NewMultipoolerConsensusClient(httpClient connect.HTTPClient, baseURL string
 // multipoolerConsensusClient implements MultipoolerConsensusClient.
 type multipoolerConsensusClient struct {
 	updateConsensusRule *connect.Client[multipoolermanagerdata.UpdateConsensusRuleRequest, multipoolermanagerdata.UpdateConsensusRuleResponse]
-	rewindToSource      *connect.Client[multipoolermanagerdata.RewindToSourceRequest, multipoolermanagerdata.RewindToSourceResponse]
 	recruit             *connect.Client[consensusdata.RecruitRequest, consensusdata.RecruitResponse]
 	promote             *connect.Client[consensusdata.PromoteRequest, consensusdata.PromoteResponse]
 	setPrimary          *connect.Client[consensusdata.SetPrimaryRequest, consensusdata.SetPrimaryResponse]
@@ -149,11 +136,6 @@ type multipoolerConsensusClient struct {
 // UpdateConsensusRule calls consensus.MultipoolerConsensus.UpdateConsensusRule.
 func (c *multipoolerConsensusClient) UpdateConsensusRule(ctx context.Context, req *connect.Request[multipoolermanagerdata.UpdateConsensusRuleRequest]) (*connect.Response[multipoolermanagerdata.UpdateConsensusRuleResponse], error) {
 	return c.updateConsensusRule.CallUnary(ctx, req)
-}
-
-// RewindToSource calls consensus.MultipoolerConsensus.RewindToSource.
-func (c *multipoolerConsensusClient) RewindToSource(ctx context.Context, req *connect.Request[multipoolermanagerdata.RewindToSourceRequest]) (*connect.Response[multipoolermanagerdata.RewindToSourceResponse], error) {
-	return c.rewindToSource.CallUnary(ctx, req)
 }
 
 // Recruit calls consensus.MultipoolerConsensus.Recruit.
@@ -177,9 +159,6 @@ type MultipoolerConsensusHandler interface {
 	// primary handler updates synchronous_standby_names and records the cohort
 	// change in rule_history.
 	UpdateConsensusRule(context.Context, *connect.Request[multipoolermanagerdata.UpdateConsensusRuleRequest]) (*connect.Response[multipoolermanagerdata.UpdateConsensusRuleResponse], error)
-	// RewindToSource performs pg_rewind to synchronize this server with a source.
-	// This is used to repair diverged timelines after failover.
-	RewindToSource(context.Context, *connect.Request[multipoolermanagerdata.RewindToSourceRequest]) (*connect.Response[multipoolermanagerdata.RewindToSourceResponse], error)
 	// Recruit asks a pooler to revoke all terms below the one specified and
 	// record the coordinator's exclusive claim on that term.
 	Recruit(context.Context, *connect.Request[consensusdata.RecruitRequest]) (*connect.Response[consensusdata.RecruitResponse], error)
@@ -211,12 +190,6 @@ func NewMultipoolerConsensusHandler(svc MultipoolerConsensusHandler, opts ...con
 		connect.WithSchema(multipoolerConsensusMethods.ByName("UpdateConsensusRule")),
 		connect.WithHandlerOptions(opts...),
 	)
-	multipoolerConsensusRewindToSourceHandler := connect.NewUnaryHandler(
-		MultipoolerConsensusRewindToSourceProcedure,
-		svc.RewindToSource,
-		connect.WithSchema(multipoolerConsensusMethods.ByName("RewindToSource")),
-		connect.WithHandlerOptions(opts...),
-	)
 	multipoolerConsensusRecruitHandler := connect.NewUnaryHandler(
 		MultipoolerConsensusRecruitProcedure,
 		svc.Recruit,
@@ -239,8 +212,6 @@ func NewMultipoolerConsensusHandler(svc MultipoolerConsensusHandler, opts ...con
 		switch r.URL.Path {
 		case MultipoolerConsensusUpdateConsensusRuleProcedure:
 			multipoolerConsensusUpdateConsensusRuleHandler.ServeHTTP(w, r)
-		case MultipoolerConsensusRewindToSourceProcedure:
-			multipoolerConsensusRewindToSourceHandler.ServeHTTP(w, r)
 		case MultipoolerConsensusRecruitProcedure:
 			multipoolerConsensusRecruitHandler.ServeHTTP(w, r)
 		case MultipoolerConsensusPromoteProcedure:
@@ -258,10 +229,6 @@ type UnimplementedMultipoolerConsensusHandler struct{}
 
 func (UnimplementedMultipoolerConsensusHandler) UpdateConsensusRule(context.Context, *connect.Request[multipoolermanagerdata.UpdateConsensusRuleRequest]) (*connect.Response[multipoolermanagerdata.UpdateConsensusRuleResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("consensus.MultipoolerConsensus.UpdateConsensusRule is not implemented"))
-}
-
-func (UnimplementedMultipoolerConsensusHandler) RewindToSource(context.Context, *connect.Request[multipoolermanagerdata.RewindToSourceRequest]) (*connect.Response[multipoolermanagerdata.RewindToSourceResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("consensus.MultipoolerConsensus.RewindToSource is not implemented"))
 }
 
 func (UnimplementedMultipoolerConsensusHandler) Recruit(context.Context, *connect.Request[consensusdata.RecruitRequest]) (*connect.Response[consensusdata.RecruitResponse], error) {

--- a/go/pb/consensus/consensusservice.pb.go
+++ b/go/pb/consensus/consensusservice.pb.go
@@ -40,10 +40,9 @@ var File_consensusservice_proto protoreflect.FileDescriptor
 
 const file_consensusservice_proto_rawDesc = "" +
 	"\n" +
-	"\x16consensusservice.proto\x12\tconsensus\x1a\x13consensusdata.proto\x1a\x1cmultipoolermanagerdata.proto2\xee\x03\n" +
+	"\x16consensusservice.proto\x12\tconsensus\x1a\x13consensusdata.proto\x1a\x1cmultipoolermanagerdata.proto2\xfd\x02\n" +
 	"\x14MultipoolerConsensus\x12~\n" +
-	"\x13UpdateConsensusRule\x122.multipoolermanagerdata.UpdateConsensusRuleRequest\x1a3.multipoolermanagerdata.UpdateConsensusRuleResponse\x12o\n" +
-	"\x0eRewindToSource\x12-.multipoolermanagerdata.RewindToSourceRequest\x1a..multipoolermanagerdata.RewindToSourceResponse\x12H\n" +
+	"\x13UpdateConsensusRule\x122.multipoolermanagerdata.UpdateConsensusRuleRequest\x1a3.multipoolermanagerdata.UpdateConsensusRuleResponse\x12H\n" +
 	"\aRecruit\x12\x1d.consensusdata.RecruitRequest\x1a\x1e.consensusdata.RecruitResponse\x12H\n" +
 	"\aPromote\x12\x1d.consensusdata.PromoteRequest\x1a\x1e.consensusdata.PromoteResponse\x12Q\n" +
 	"\n" +
@@ -51,29 +50,25 @@ const file_consensusservice_proto_rawDesc = "" +
 
 var file_consensusservice_proto_goTypes = []any{
 	(*multipoolermanagerdata.UpdateConsensusRuleRequest)(nil),  // 0: multipoolermanagerdata.UpdateConsensusRuleRequest
-	(*multipoolermanagerdata.RewindToSourceRequest)(nil),       // 1: multipoolermanagerdata.RewindToSourceRequest
-	(*consensusdata.RecruitRequest)(nil),                       // 2: consensusdata.RecruitRequest
-	(*consensusdata.PromoteRequest)(nil),                       // 3: consensusdata.PromoteRequest
-	(*consensusdata.SetPrimaryRequest)(nil),                    // 4: consensusdata.SetPrimaryRequest
-	(*multipoolermanagerdata.UpdateConsensusRuleResponse)(nil), // 5: multipoolermanagerdata.UpdateConsensusRuleResponse
-	(*multipoolermanagerdata.RewindToSourceResponse)(nil),      // 6: multipoolermanagerdata.RewindToSourceResponse
-	(*consensusdata.RecruitResponse)(nil),                      // 7: consensusdata.RecruitResponse
-	(*consensusdata.PromoteResponse)(nil),                      // 8: consensusdata.PromoteResponse
-	(*consensusdata.SetPrimaryResponse)(nil),                   // 9: consensusdata.SetPrimaryResponse
+	(*consensusdata.RecruitRequest)(nil),                       // 1: consensusdata.RecruitRequest
+	(*consensusdata.PromoteRequest)(nil),                       // 2: consensusdata.PromoteRequest
+	(*consensusdata.SetPrimaryRequest)(nil),                    // 3: consensusdata.SetPrimaryRequest
+	(*multipoolermanagerdata.UpdateConsensusRuleResponse)(nil), // 4: multipoolermanagerdata.UpdateConsensusRuleResponse
+	(*consensusdata.RecruitResponse)(nil),                      // 5: consensusdata.RecruitResponse
+	(*consensusdata.PromoteResponse)(nil),                      // 6: consensusdata.PromoteResponse
+	(*consensusdata.SetPrimaryResponse)(nil),                   // 7: consensusdata.SetPrimaryResponse
 }
 var file_consensusservice_proto_depIdxs = []int32{
 	0, // 0: consensus.MultipoolerConsensus.UpdateConsensusRule:input_type -> multipoolermanagerdata.UpdateConsensusRuleRequest
-	1, // 1: consensus.MultipoolerConsensus.RewindToSource:input_type -> multipoolermanagerdata.RewindToSourceRequest
-	2, // 2: consensus.MultipoolerConsensus.Recruit:input_type -> consensusdata.RecruitRequest
-	3, // 3: consensus.MultipoolerConsensus.Promote:input_type -> consensusdata.PromoteRequest
-	4, // 4: consensus.MultipoolerConsensus.SetPrimary:input_type -> consensusdata.SetPrimaryRequest
-	5, // 5: consensus.MultipoolerConsensus.UpdateConsensusRule:output_type -> multipoolermanagerdata.UpdateConsensusRuleResponse
-	6, // 6: consensus.MultipoolerConsensus.RewindToSource:output_type -> multipoolermanagerdata.RewindToSourceResponse
-	7, // 7: consensus.MultipoolerConsensus.Recruit:output_type -> consensusdata.RecruitResponse
-	8, // 8: consensus.MultipoolerConsensus.Promote:output_type -> consensusdata.PromoteResponse
-	9, // 9: consensus.MultipoolerConsensus.SetPrimary:output_type -> consensusdata.SetPrimaryResponse
-	5, // [5:10] is the sub-list for method output_type
-	0, // [0:5] is the sub-list for method input_type
+	1, // 1: consensus.MultipoolerConsensus.Recruit:input_type -> consensusdata.RecruitRequest
+	2, // 2: consensus.MultipoolerConsensus.Promote:input_type -> consensusdata.PromoteRequest
+	3, // 3: consensus.MultipoolerConsensus.SetPrimary:input_type -> consensusdata.SetPrimaryRequest
+	4, // 4: consensus.MultipoolerConsensus.UpdateConsensusRule:output_type -> multipoolermanagerdata.UpdateConsensusRuleResponse
+	5, // 5: consensus.MultipoolerConsensus.Recruit:output_type -> consensusdata.RecruitResponse
+	6, // 6: consensus.MultipoolerConsensus.Promote:output_type -> consensusdata.PromoteResponse
+	7, // 7: consensus.MultipoolerConsensus.SetPrimary:output_type -> consensusdata.SetPrimaryResponse
+	4, // [4:8] is the sub-list for method output_type
+	0, // [0:4] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
 	0, // [0:0] is the sub-list for extension extendee
 	0, // [0:0] is the sub-list for field type_name

--- a/go/pb/consensus/consensusservice.pb.gw.go
+++ b/go/pb/consensus/consensusservice.pb.gw.go
@@ -64,33 +64,6 @@ func local_request_MultipoolerConsensus_UpdateConsensusRule_0(ctx context.Contex
 	return msg, metadata, err
 }
 
-func request_MultipoolerConsensus_RewindToSource_0(ctx context.Context, marshaler runtime.Marshaler, client MultipoolerConsensusClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var (
-		protoReq multipoolermanagerdata.RewindToSourceRequest
-		metadata runtime.ServerMetadata
-	)
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-	if req.Body != nil {
-		_, _ = io.Copy(io.Discard, req.Body)
-	}
-	msg, err := client.RewindToSource(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
-	return msg, metadata, err
-}
-
-func local_request_MultipoolerConsensus_RewindToSource_0(ctx context.Context, marshaler runtime.Marshaler, server MultipoolerConsensusServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var (
-		protoReq multipoolermanagerdata.RewindToSourceRequest
-		metadata runtime.ServerMetadata
-	)
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-	msg, err := server.RewindToSource(ctx, &protoReq)
-	return msg, metadata, err
-}
-
 func request_MultipoolerConsensus_Recruit_0(ctx context.Context, marshaler runtime.Marshaler, client MultipoolerConsensusClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq consensusdata.RecruitRequest
@@ -197,26 +170,6 @@ func RegisterMultipoolerConsensusHandlerServer(ctx context.Context, mux *runtime
 			return
 		}
 		forward_MultipoolerConsensus_UpdateConsensusRule_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-	})
-	mux.Handle(http.MethodPost, pattern_MultipoolerConsensus_RewindToSource_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		var stream runtime.ServerTransportStream
-		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/consensus.MultipoolerConsensus/RewindToSource", runtime.WithHTTPPathPattern("/consensus.MultipoolerConsensus/RewindToSource"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := local_request_MultipoolerConsensus_RewindToSource_0(annotatedContext, inboundMarshaler, server, req, pathParams)
-		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		forward_MultipoolerConsensus_RewindToSource_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodPost, pattern_MultipoolerConsensus_Recruit_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -335,23 +288,6 @@ func RegisterMultipoolerConsensusHandlerClient(ctx context.Context, mux *runtime
 		}
 		forward_MultipoolerConsensus_UpdateConsensusRule_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPost, pattern_MultipoolerConsensus_RewindToSource_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/consensus.MultipoolerConsensus/RewindToSource", runtime.WithHTTPPathPattern("/consensus.MultipoolerConsensus/RewindToSource"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := request_MultipoolerConsensus_RewindToSource_0(annotatedContext, inboundMarshaler, client, req, pathParams)
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		forward_MultipoolerConsensus_RewindToSource_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-	})
 	mux.Handle(http.MethodPost, pattern_MultipoolerConsensus_Recruit_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -408,7 +344,6 @@ func RegisterMultipoolerConsensusHandlerClient(ctx context.Context, mux *runtime
 
 var (
 	pattern_MultipoolerConsensus_UpdateConsensusRule_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"consensus.MultipoolerConsensus", "UpdateConsensusRule"}, ""))
-	pattern_MultipoolerConsensus_RewindToSource_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"consensus.MultipoolerConsensus", "RewindToSource"}, ""))
 	pattern_MultipoolerConsensus_Recruit_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"consensus.MultipoolerConsensus", "Recruit"}, ""))
 	pattern_MultipoolerConsensus_Promote_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"consensus.MultipoolerConsensus", "Promote"}, ""))
 	pattern_MultipoolerConsensus_SetPrimary_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"consensus.MultipoolerConsensus", "SetPrimary"}, ""))
@@ -416,7 +351,6 @@ var (
 
 var (
 	forward_MultipoolerConsensus_UpdateConsensusRule_0 = runtime.ForwardResponseMessage
-	forward_MultipoolerConsensus_RewindToSource_0      = runtime.ForwardResponseMessage
 	forward_MultipoolerConsensus_Recruit_0             = runtime.ForwardResponseMessage
 	forward_MultipoolerConsensus_Promote_0             = runtime.ForwardResponseMessage
 	forward_MultipoolerConsensus_SetPrimary_0          = runtime.ForwardResponseMessage

--- a/go/pb/consensus/consensusservice_grpc.pb.go
+++ b/go/pb/consensus/consensusservice_grpc.pb.go
@@ -36,7 +36,6 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	MultipoolerConsensus_UpdateConsensusRule_FullMethodName = "/consensus.MultipoolerConsensus/UpdateConsensusRule"
-	MultipoolerConsensus_RewindToSource_FullMethodName      = "/consensus.MultipoolerConsensus/RewindToSource"
 	MultipoolerConsensus_Recruit_FullMethodName             = "/consensus.MultipoolerConsensus/Recruit"
 	MultipoolerConsensus_Promote_FullMethodName             = "/consensus.MultipoolerConsensus/Promote"
 	MultipoolerConsensus_SetPrimary_FullMethodName          = "/consensus.MultipoolerConsensus/SetPrimary"
@@ -52,9 +51,6 @@ type MultipoolerConsensusClient interface {
 	// primary handler updates synchronous_standby_names and records the cohort
 	// change in rule_history.
 	UpdateConsensusRule(ctx context.Context, in *multipoolermanagerdata.UpdateConsensusRuleRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.UpdateConsensusRuleResponse, error)
-	// RewindToSource performs pg_rewind to synchronize this server with a source.
-	// This is used to repair diverged timelines after failover.
-	RewindToSource(ctx context.Context, in *multipoolermanagerdata.RewindToSourceRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.RewindToSourceResponse, error)
 	// Recruit asks a pooler to revoke all terms below the one specified and
 	// record the coordinator's exclusive claim on that term.
 	Recruit(ctx context.Context, in *consensusdata.RecruitRequest, opts ...grpc.CallOption) (*consensusdata.RecruitResponse, error)
@@ -85,16 +81,6 @@ func (c *multipoolerConsensusClient) UpdateConsensusRule(ctx context.Context, in
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(multipoolermanagerdata.UpdateConsensusRuleResponse)
 	err := c.cc.Invoke(ctx, MultipoolerConsensus_UpdateConsensusRule_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *multipoolerConsensusClient) RewindToSource(ctx context.Context, in *multipoolermanagerdata.RewindToSourceRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.RewindToSourceResponse, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(multipoolermanagerdata.RewindToSourceResponse)
-	err := c.cc.Invoke(ctx, MultipoolerConsensus_RewindToSource_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -141,9 +127,6 @@ type MultipoolerConsensusServer interface {
 	// primary handler updates synchronous_standby_names and records the cohort
 	// change in rule_history.
 	UpdateConsensusRule(context.Context, *multipoolermanagerdata.UpdateConsensusRuleRequest) (*multipoolermanagerdata.UpdateConsensusRuleResponse, error)
-	// RewindToSource performs pg_rewind to synchronize this server with a source.
-	// This is used to repair diverged timelines after failover.
-	RewindToSource(context.Context, *multipoolermanagerdata.RewindToSourceRequest) (*multipoolermanagerdata.RewindToSourceResponse, error)
 	// Recruit asks a pooler to revoke all terms below the one specified and
 	// record the coordinator's exclusive claim on that term.
 	Recruit(context.Context, *consensusdata.RecruitRequest) (*consensusdata.RecruitResponse, error)
@@ -172,9 +155,6 @@ type UnimplementedMultipoolerConsensusServer struct{}
 
 func (UnimplementedMultipoolerConsensusServer) UpdateConsensusRule(context.Context, *multipoolermanagerdata.UpdateConsensusRuleRequest) (*multipoolermanagerdata.UpdateConsensusRuleResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateConsensusRule not implemented")
-}
-func (UnimplementedMultipoolerConsensusServer) RewindToSource(context.Context, *multipoolermanagerdata.RewindToSourceRequest) (*multipoolermanagerdata.RewindToSourceResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method RewindToSource not implemented")
 }
 func (UnimplementedMultipoolerConsensusServer) Recruit(context.Context, *consensusdata.RecruitRequest) (*consensusdata.RecruitResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Recruit not implemented")
@@ -220,24 +200,6 @@ func _MultipoolerConsensus_UpdateConsensusRule_Handler(srv interface{}, ctx cont
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(MultipoolerConsensusServer).UpdateConsensusRule(ctx, req.(*multipoolermanagerdata.UpdateConsensusRuleRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _MultipoolerConsensus_RewindToSource_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(multipoolermanagerdata.RewindToSourceRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(MultipoolerConsensusServer).RewindToSource(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: MultipoolerConsensus_RewindToSource_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MultipoolerConsensusServer).RewindToSource(ctx, req.(*multipoolermanagerdata.RewindToSourceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -306,10 +268,6 @@ var MultipoolerConsensus_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "UpdateConsensusRule",
 			Handler:    _MultipoolerConsensus_UpdateConsensusRule_Handler,
-		},
-		{
-			MethodName: "RewindToSource",
-			Handler:    _MultipoolerConsensus_RewindToSource_Handler,
 		},
 		{
 			MethodName: "Recruit",

--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -113,8 +113,6 @@ const (
 	PostgresAction_POSTGRES_ACTION_RESTORING_FROM_BACKUP PostgresAction = 2
 	// No backup exists yet; running initdb and creating the first pgBackRest backup.
 	PostgresAction_POSTGRES_ACTION_CREATING_FIRST_BACKUP PostgresAction = 3
-	// A pg_rewind operation is running to re-sync this server with the primary.
-	PostgresAction_POSTGRES_ACTION_REWIND PostgresAction = 4
 )
 
 // Enum value maps for PostgresAction.
@@ -124,14 +122,12 @@ var (
 		1: "POSTGRES_ACTION_STARTING",
 		2: "POSTGRES_ACTION_RESTORING_FROM_BACKUP",
 		3: "POSTGRES_ACTION_CREATING_FIRST_BACKUP",
-		4: "POSTGRES_ACTION_REWIND",
 	}
 	PostgresAction_value = map[string]int32{
 		"POSTGRES_ACTION_UNSPECIFIED":           0,
 		"POSTGRES_ACTION_STARTING":              1,
 		"POSTGRES_ACTION_RESTORING_FROM_BACKUP": 2,
 		"POSTGRES_ACTION_CREATING_FIRST_BACKUP": 3,
-		"POSTGRES_ACTION_REWIND":                4,
 	}
 )
 
@@ -2621,121 +2617,6 @@ func (x *BackupMetadata) GetPgVersion() string {
 	return ""
 }
 
-// RewindToSourceRequest requests pg_rewind to synchronize with a source server.
-// This operation:
-// 1. Stops PostgreSQL
-// 2. Runs pg_rewind --dry-run to check if rewind is needed
-// 3. If needed, runs actual pg_rewind
-// 4. Starts PostgreSQL
-type RewindToSourceRequest struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Source multipooler (the primary) to rewind to
-	Source        *clustermetadata.Multipooler `protobuf:"bytes,1,opt,name=source,proto3" json:"source,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *RewindToSourceRequest) Reset() {
-	*x = RewindToSourceRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *RewindToSourceRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*RewindToSourceRequest) ProtoMessage() {}
-
-func (x *RewindToSourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use RewindToSourceRequest.ProtoReflect.Descriptor instead.
-func (*RewindToSourceRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{32}
-}
-
-func (x *RewindToSourceRequest) GetSource() *clustermetadata.Multipooler {
-	if x != nil {
-		return x.Source
-	}
-	return nil
-}
-
-type RewindToSourceResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True if the operation completed successfully
-	Success bool `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
-	// Error message if operation failed
-	ErrorMessage string `protobuf:"bytes,2,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
-	// True if servers had diverged and pg_rewind was performed
-	// False if timelines were compatible and no rewind was needed
-	RewindPerformed bool `protobuf:"varint,3,opt,name=rewind_performed,json=rewindPerformed,proto3" json:"rewind_performed,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
-}
-
-func (x *RewindToSourceResponse) Reset() {
-	*x = RewindToSourceResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *RewindToSourceResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*RewindToSourceResponse) ProtoMessage() {}
-
-func (x *RewindToSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use RewindToSourceResponse.ProtoReflect.Descriptor instead.
-func (*RewindToSourceResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{33}
-}
-
-func (x *RewindToSourceResponse) GetSuccess() bool {
-	if x != nil {
-		return x.Success
-	}
-	return false
-}
-
-func (x *RewindToSourceResponse) GetErrorMessage() string {
-	if x != nil {
-		return x.ErrorMessage
-	}
-	return ""
-}
-
-func (x *RewindToSourceResponse) GetRewindPerformed() bool {
-	if x != nil {
-		return x.RewindPerformed
-	}
-	return false
-}
-
 // SetPostgresRestartsEnabledRequest enables or disables automatic PostgreSQL restarts
 // by the postgres monitor. When disabled, the monitor will still run and detect problems,
 // but will not automatically restart a stopped PostgreSQL instance.
@@ -2749,7 +2630,7 @@ type SetPostgresRestartsEnabledRequest struct {
 
 func (x *SetPostgresRestartsEnabledRequest) Reset() {
 	*x = SetPostgresRestartsEnabledRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2761,7 +2642,7 @@ func (x *SetPostgresRestartsEnabledRequest) String() string {
 func (*SetPostgresRestartsEnabledRequest) ProtoMessage() {}
 
 func (x *SetPostgresRestartsEnabledRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2774,7 +2655,7 @@ func (x *SetPostgresRestartsEnabledRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use SetPostgresRestartsEnabledRequest.ProtoReflect.Descriptor instead.
 func (*SetPostgresRestartsEnabledRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{34}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *SetPostgresRestartsEnabledRequest) GetEnabled() bool {
@@ -2794,7 +2675,7 @@ type SetPostgresRestartsEnabledResponse struct {
 
 func (x *SetPostgresRestartsEnabledResponse) Reset() {
 	*x = SetPostgresRestartsEnabledResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2806,7 +2687,7 @@ func (x *SetPostgresRestartsEnabledResponse) String() string {
 func (*SetPostgresRestartsEnabledResponse) ProtoMessage() {}
 
 func (x *SetPostgresRestartsEnabledResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2819,7 +2700,7 @@ func (x *SetPostgresRestartsEnabledResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use SetPostgresRestartsEnabledResponse.ProtoReflect.Descriptor instead.
 func (*SetPostgresRestartsEnabledResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{35}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{33}
 }
 
 var File_multipoolermanagerdata_proto protoreflect.FileDescriptor
@@ -2973,13 +2854,7 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\aUNKNOWN\x10\x00\x12\x0e\n" +
 	"\n" +
 	"INCOMPLETE\x10\x01\x12\f\n" +
-	"\bCOMPLETE\x10\x02\"M\n" +
-	"\x15RewindToSourceRequest\x124\n" +
-	"\x06source\x18\x01 \x01(\v2\x1c.clustermetadata.MultipoolerR\x06source\"\x82\x01\n" +
-	"\x16RewindToSourceResponse\x12\x18\n" +
-	"\asuccess\x18\x01 \x01(\bR\asuccess\x12#\n" +
-	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\x12)\n" +
-	"\x10rewind_performed\x18\x03 \x01(\bR\x0frewindPerformed\"=\n" +
+	"\bCOMPLETE\x10\x02\"=\n" +
 	"!SetPostgresRestartsEnabledRequest\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\"$\n" +
 	"\"SetPostgresRestartsEnabledResponse*\xa4\x01\n" +
@@ -2988,13 +2863,12 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\x18POSTGRES_STATUS_STARTING\x10\x01\x12\x1b\n" +
 	"\x17POSTGRES_STATUS_STANDBY\x10\x02\x12\x1d\n" +
 	"\x19POSTGRES_STATUS_PROMOTING\x10\x03\x12\x1b\n" +
-	"\x17POSTGRES_STATUS_PRIMARY\x10\x04*\xc1\x01\n" +
+	"\x17POSTGRES_STATUS_PRIMARY\x10\x04*\xa5\x01\n" +
 	"\x0ePostgresAction\x12\x1f\n" +
 	"\x1bPOSTGRES_ACTION_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18POSTGRES_ACTION_STARTING\x10\x01\x12)\n" +
 	"%POSTGRES_ACTION_RESTORING_FROM_BACKUP\x10\x02\x12)\n" +
-	"%POSTGRES_ACTION_CREATING_FIRST_BACKUP\x10\x03\x12\x1a\n" +
-	"\x16POSTGRES_ACTION_REWIND\x10\x04*\xac\x01\n" +
+	"%POSTGRES_ACTION_CREATING_FIRST_BACKUP\x10\x03*\xac\x01\n" +
 	"\x0fSnapshotTrigger\x12 \n" +
 	"\x1cSNAPSHOT_TRIGGER_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18SNAPSHOT_TRIGGER_INITIAL\x10\x01\x12\x1e\n" +
@@ -3033,7 +2907,7 @@ func file_multipoolermanagerdata_proto_rawDescGZIP() []byte {
 }
 
 var file_multipoolermanagerdata_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
+var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
 var file_multipoolermanagerdata_proto_goTypes = []any{
 	(PostgresStatus)(0),                         // 0: multipoolermanagerdata.PostgresStatus
 	(PostgresAction)(0),                         // 1: multipoolermanagerdata.PostgresAction
@@ -3075,77 +2949,73 @@ var file_multipoolermanagerdata_proto_goTypes = []any{
 	(*VerifyBackupsRequest)(nil),                // 37: multipoolermanagerdata.VerifyBackupsRequest
 	(*VerifyBackupsResponse)(nil),               // 38: multipoolermanagerdata.VerifyBackupsResponse
 	(*BackupMetadata)(nil),                      // 39: multipoolermanagerdata.BackupMetadata
-	(*RewindToSourceRequest)(nil),               // 40: multipoolermanagerdata.RewindToSourceRequest
-	(*RewindToSourceResponse)(nil),              // 41: multipoolermanagerdata.RewindToSourceResponse
-	(*SetPostgresRestartsEnabledRequest)(nil),   // 42: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	(*SetPostgresRestartsEnabledResponse)(nil),  // 43: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	nil,                             // 44: multipoolermanagerdata.BackupRequest.OverridesEntry
-	nil,                             // 45: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	(*durationpb.Duration)(nil),     // 46: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),   // 47: google.protobuf.Timestamp
-	(*clustermetadata.ID)(nil),      // 48: clustermetadata.ID
-	(clustermetadata.PoolerType)(0), // 49: clustermetadata.PoolerType
-	(*clustermetadata.AvailabilityStatus)(nil), // 50: clustermetadata.AvailabilityStatus
-	(*clustermetadata.ConsensusStatus)(nil),    // 51: clustermetadata.ConsensusStatus
-	(*clustermetadata.RuleNumber)(nil),         // 52: clustermetadata.RuleNumber
-	(clustermetadata.RoutingRole)(0),           // 53: clustermetadata.RoutingRole
-	(*clustermetadata.Multipooler)(nil),        // 54: clustermetadata.Multipooler
+	(*SetPostgresRestartsEnabledRequest)(nil),   // 40: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
+	(*SetPostgresRestartsEnabledResponse)(nil),  // 41: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	nil,                             // 42: multipoolermanagerdata.BackupRequest.OverridesEntry
+	nil,                             // 43: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	(*durationpb.Duration)(nil),     // 44: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),   // 45: google.protobuf.Timestamp
+	(*clustermetadata.ID)(nil),      // 46: clustermetadata.ID
+	(clustermetadata.PoolerType)(0), // 47: clustermetadata.PoolerType
+	(*clustermetadata.AvailabilityStatus)(nil), // 48: clustermetadata.AvailabilityStatus
+	(*clustermetadata.ConsensusStatus)(nil),    // 49: clustermetadata.ConsensusStatus
+	(*clustermetadata.RuleNumber)(nil),         // 50: clustermetadata.RuleNumber
+	(clustermetadata.RoutingRole)(0),           // 51: clustermetadata.RoutingRole
 }
 var file_multipoolermanagerdata_proto_depIdxs = []int32{
-	46, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
+	44, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
 	8,  // 1: multipoolermanagerdata.StandbyReplicationStatus.primary_conn_info:type_name -> multipoolermanagerdata.PrimaryConnInfo
-	47, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
-	46, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
-	46, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
-	47, // 5: multipoolermanagerdata.StandbyReplicationStatus.last_receive_lsn_advance_time:type_name -> google.protobuf.Timestamp
-	46, // 6: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
+	45, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
+	44, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
+	44, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
+	45, // 5: multipoolermanagerdata.StandbyReplicationStatus.last_receive_lsn_advance_time:type_name -> google.protobuf.Timestamp
+	44, // 6: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
 	3,  // 7: multipoolermanagerdata.StopReplicationRequest.mode:type_name -> multipoolermanagerdata.ReplicationPauseMode
 	9,  // 8: multipoolermanagerdata.StopReplicationResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
 	6,  // 9: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
 	4,  // 10: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
-	48, // 11: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
-	48, // 12: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
+	46, // 11: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
+	46, // 12: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
 	16, // 13: multipoolermanagerdata.PrimaryStatus.sync_replication_config:type_name -> multipoolermanagerdata.SynchronousReplicationConfiguration
-	49, // 14: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
+	47, // 14: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
 	17, // 15: multipoolermanagerdata.Status.primary_status:type_name -> multipoolermanagerdata.PrimaryStatus
 	9,  // 16: multipoolermanagerdata.Status.replication_status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
 	0,  // 17: multipoolermanagerdata.Status.postgres_status:type_name -> multipoolermanagerdata.PostgresStatus
 	1,  // 18: multipoolermanagerdata.Status.postgres_action:type_name -> multipoolermanagerdata.PostgresAction
-	46, // 19: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
+	44, // 19: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
 	18, // 20: multipoolermanagerdata.StatusResponse.status:type_name -> multipoolermanagerdata.Status
-	50, // 21: multipoolermanagerdata.StatusResponse.availability_status:type_name -> clustermetadata.AvailabilityStatus
-	51, // 22: multipoolermanagerdata.StatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	48, // 21: multipoolermanagerdata.StatusResponse.availability_status:type_name -> clustermetadata.AvailabilityStatus
+	49, // 22: multipoolermanagerdata.StatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
 	22, // 23: multipoolermanagerdata.ManagerHealthStreamClientMessage.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartRequest
 	23, // 24: multipoolermanagerdata.ManagerHealthStreamClientMessage.poll:type_name -> multipoolermanagerdata.ManagerHealthStreamPollRequest
-	46, // 25: multipoolermanagerdata.ManagerHealthStreamStartRequest.snapshot_interval:type_name -> google.protobuf.Duration
-	46, // 26: multipoolermanagerdata.ManagerHealthStreamStartRequest.staleness_timeout:type_name -> google.protobuf.Duration
-	46, // 27: multipoolermanagerdata.ManagerHealthStreamStartResponse.snapshot_interval:type_name -> google.protobuf.Duration
-	46, // 28: multipoolermanagerdata.ManagerHealthStreamStartResponse.staleness_timeout:type_name -> google.protobuf.Duration
+	44, // 25: multipoolermanagerdata.ManagerHealthStreamStartRequest.snapshot_interval:type_name -> google.protobuf.Duration
+	44, // 26: multipoolermanagerdata.ManagerHealthStreamStartRequest.staleness_timeout:type_name -> google.protobuf.Duration
+	44, // 27: multipoolermanagerdata.ManagerHealthStreamStartResponse.snapshot_interval:type_name -> google.protobuf.Duration
+	44, // 28: multipoolermanagerdata.ManagerHealthStreamStartResponse.staleness_timeout:type_name -> google.protobuf.Duration
 	24, // 29: multipoolermanagerdata.ManagerHealthStreamResponse.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartResponse
 	26, // 30: multipoolermanagerdata.ManagerHealthStreamResponse.snapshot:type_name -> multipoolermanagerdata.ManagerHealthSnapshot
 	20, // 31: multipoolermanagerdata.ManagerHealthSnapshot.status:type_name -> multipoolermanagerdata.StatusResponse
-	46, // 32: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
+	44, // 32: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
 	2,  // 33: multipoolermanagerdata.ManagerHealthSnapshot.trigger:type_name -> multipoolermanagerdata.SnapshotTrigger
-	47, // 34: multipoolermanagerdata.ManagerHealthSnapshot.captured_at:type_name -> google.protobuf.Timestamp
+	45, // 34: multipoolermanagerdata.ManagerHealthSnapshot.captured_at:type_name -> google.protobuf.Timestamp
 	5,  // 35: multipoolermanagerdata.UpdateConsensusRuleRequest.operation:type_name -> multipoolermanagerdata.CohortUpdateOperation
-	48, // 36: multipoolermanagerdata.UpdateConsensusRuleRequest.standby_ids:type_name -> clustermetadata.ID
-	52, // 37: multipoolermanagerdata.UpdateConsensusRuleRequest.expected_outgoing_rule:type_name -> clustermetadata.RuleNumber
-	48, // 38: multipoolermanagerdata.UpdateConsensusRuleRequest.coordinator_id:type_name -> clustermetadata.ID
-	44, // 39: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
+	46, // 36: multipoolermanagerdata.UpdateConsensusRuleRequest.standby_ids:type_name -> clustermetadata.ID
+	50, // 37: multipoolermanagerdata.UpdateConsensusRuleRequest.expected_outgoing_rule:type_name -> clustermetadata.RuleNumber
+	46, // 38: multipoolermanagerdata.UpdateConsensusRuleRequest.coordinator_id:type_name -> clustermetadata.ID
+	42, // 39: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
 	39, // 40: multipoolermanagerdata.GetBackupsResponse.backups:type_name -> multipoolermanagerdata.BackupMetadata
 	39, // 41: multipoolermanagerdata.GetBackupByJobIdResponse.backup:type_name -> multipoolermanagerdata.BackupMetadata
-	45, // 42: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	46, // 43: multipoolermanagerdata.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
+	43, // 42: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	44, // 43: multipoolermanagerdata.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
 	7,  // 44: multipoolermanagerdata.BackupMetadata.status:type_name -> multipoolermanagerdata.BackupMetadata.Status
-	53, // 45: multipoolermanagerdata.BackupMetadata.routing_role:type_name -> clustermetadata.RoutingRole
-	47, // 46: multipoolermanagerdata.BackupMetadata.start_timestamp:type_name -> google.protobuf.Timestamp
-	47, // 47: multipoolermanagerdata.BackupMetadata.stop_timestamp:type_name -> google.protobuf.Timestamp
-	54, // 48: multipoolermanagerdata.RewindToSourceRequest.source:type_name -> clustermetadata.Multipooler
-	49, // [49:49] is the sub-list for method output_type
-	49, // [49:49] is the sub-list for method input_type
-	49, // [49:49] is the sub-list for extension type_name
-	49, // [49:49] is the sub-list for extension extendee
-	0,  // [0:49] is the sub-list for field type_name
+	51, // 45: multipoolermanagerdata.BackupMetadata.routing_role:type_name -> clustermetadata.RoutingRole
+	45, // 46: multipoolermanagerdata.BackupMetadata.start_timestamp:type_name -> google.protobuf.Timestamp
+	45, // 47: multipoolermanagerdata.BackupMetadata.stop_timestamp:type_name -> google.protobuf.Timestamp
+	48, // [48:48] is the sub-list for method output_type
+	48, // [48:48] is the sub-list for method input_type
+	48, // [48:48] is the sub-list for extension type_name
+	48, // [48:48] is the sub-list for extension extendee
+	0,  // [0:48] is the sub-list for field type_name
 }
 
 func init() { file_multipoolermanagerdata_proto_init() }
@@ -3167,7 +3037,7 @@ func file_multipoolermanagerdata_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_multipoolermanagerdata_proto_rawDesc), len(file_multipoolermanagerdata_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   38,
+			NumMessages:   36,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/services/multiorch/recovery/actions/fix_replication.go
+++ b/go/services/multiorch/recovery/actions/fix_replication.go
@@ -204,46 +204,18 @@ func (a *FixReplicationAction) fixNotReplicating(
 	}
 
 	// Verify replication started
-	err := a.verifyReplicationStarted(ctx, replica)
-	if err != nil {
-		a.logger.WarnContext(ctx, "replication did not start after configuration",
-			"replica", replica.Health().Multipooler.Id.Name,
-			"primary", leader.Health().Multipooler.Id.Name)
-
-		// Re-check the primary's latest health-stream state before running pg_rewind.
-		// pg_rewind stops the replica's postgres before contacting the source; if the
-		// primary postgres is no longer running the stop will leave two nodes down.
-		// Return an error for retry — the next cycle will detect PrimaryIsDead.
-		primaryKey := topoclient.ComponentIDString(leader.Health().Multipooler.Id)
-		latest, ok := a.poolerStore.GetRider(primaryKey)
-		if !ok || !latest.Health().GetStatus().GetPostgresReady() {
-			return mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
-				"primary postgres not running, skipping pg_rewind to avoid leaving two nodes down")
-		}
-
-		// Defer pg_rewind until the leader has checkpointed onto its current
-		// timeline. Rewinding from a leader whose control file still advertises a
-		// stale checkpoint timeline stamps that stale timeline into this replica's
-		// minRecoveryPoint and FATALs on startup. The leader self-reports readiness
-		// in its published ReplicationPrimary (auto-cleared on any new term, so a
-		// true value is current). Return for retry; the next cycle re-checks once
-		// the leader's post-promotion checkpoint completes.
-		if !commonconsensus.ReplicationPrimaryOrNil(latest.Health().GetConsensusStatus()).GetRewindReady() {
-			return mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
-				"leader %s not yet rewind-ready (checkpoint pending on its current timeline); deferring pg_rewind",
-				leader.Health().Multipooler.Id.Name)
-		}
-
-		if rewindErr := a.tryPgRewind(ctx, leader, replica); rewindErr != nil {
-			return mterrors.Wrap(rewindErr, "pg_rewind failed")
-		}
-		// Re-verify replication after rewind. RewindToSource restarts
-		// PostgreSQL as a standby and re-establishes primary_conninfo,
-		// which pg_rewind may have cleared by syncing postgresql.auto.conf
-		// from the source.
-		if verifyErr := a.verifyReplicationStarted(ctx, replica); verifyErr != nil {
-			return mterrors.Wrap(verifyErr, "replication did not start after pg_rewind")
-		}
+	if err := a.verifyReplicationStarted(ctx, replica); err != nil {
+		// primary_conninfo is now recorded on the replica, but it is not yet
+		// streaming. The most common cause is timeline divergence: the WAL
+		// receiver connects, gets FATAL, and exits. Healing that is the pooler's
+		// own responsibility now — its monitor detects a stuck standby whose WAL
+		// diverged, sets suspectedDivergence, and re-runs pg_rewind against the
+		// recorded leader (gated on the leader being rewind-ready, rate-limited
+		// with backoff) until the standby rejoins. Orch's job is done once the
+		// leader identity has been delivered via SetPrimary above; return an
+		// error so this problem is re-checked next cycle and clears once the
+		// replica is streaming.
+		return mterrors.Wrap(err, "replication did not start after configuration; pooler will self-heal via pg_rewind if diverged")
 	}
 
 	// Cohort membership (adding the replica to synchronous_standby_names) is
@@ -254,62 +226,6 @@ func (a *FixReplicationAction) fixNotReplicating(
 	a.logger.InfoContext(ctx, "fix replication action completed successfully",
 		"replica", replica.Health().Multipooler.Id.Name,
 		"primary", leader.Health().Multipooler.Id.Name)
-
-	return nil
-}
-
-// tryPgRewind attempts to repair a replica using pg_rewind.
-// RewindToSource will:
-// 1. Stop postgres
-// 2. Check if rewind is needed (dry-run)
-// 3. Run actual rewind if needed
-// 4. Start postgres
-// If pg_rewind is not feasible (missing WAL), it marks the pooler as DRAINED.
-func (a *FixReplicationAction) tryPgRewind(
-	ctx context.Context,
-	primary *store.Pooler,
-	replica *store.Pooler,
-) error {
-	a.logger.InfoContext(ctx, "attempting pg_rewind",
-		"replica", replica.Health().Multipooler.Id.Name,
-		"primary", primary.Health().Multipooler.Id.Name)
-
-	// Call RewindToSource - it handles the entire flow atomically
-	rewindReq := &multipoolermanagerdatapb.RewindToSourceRequest{
-		Source: primary.Health().Multipooler,
-	}
-	rewindResp, err := a.rpcClient.RewindToSource(ctx, replica.Health().Multipooler, rewindReq)
-	if err != nil {
-		// RPC failure (e.g. primary postgres unreachable) is transient — do not
-		// drain the pooler. Return an error so the next recovery cycle retries.
-		a.logger.WarnContext(ctx, "pg_rewind RPC failed, will retry next cycle",
-			"replica", replica.Health().Multipooler.Id.Name,
-			"error", err)
-		return mterrors.Wrap(err, "pg_rewind RPC failed")
-	}
-	if !rewindResp.Success {
-		// pg_rewind is not feasible (e.g. the required WAL has been recycled): the
-		// replica cannot rejoin and needs replacement.
-		//
-		// TODO: signal this durably via the pooler's lifecycle stage so the
-		// provisioner and orch treat the pooler as broken/needs-replacement. Orch
-		// must not write the pooler's topology Type — the pooler owns its own record
-		// and would clobber an external write. For now we surface an error so the
-		// failure is visible; the next recovery cycle will retry.
-		a.logger.WarnContext(ctx, "pg_rewind not feasible; pooler needs replacement",
-			"replica", replica.Health().Multipooler.Id.Name,
-			"error", rewindResp.ErrorMessage)
-		return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
-			"pg_rewind not feasible for %s: %s", replica.Health().Multipooler.Id.Name, rewindResp.ErrorMessage)
-	}
-
-	if rewindResp.RewindPerformed {
-		a.logger.InfoContext(ctx, "pg_rewind completed successfully - servers were diverged",
-			"replica", replica.Health().Multipooler.Id.Name)
-	} else {
-		a.logger.InfoContext(ctx, "pg_rewind not needed - timelines are compatible",
-			"replica", replica.Health().Multipooler.Id.Name)
-	}
 
 	return nil
 }

--- a/go/services/multiorch/recovery/actions/fix_replication_test.go
+++ b/go/services/multiorch/recovery/actions/fix_replication_test.go
@@ -760,186 +760,6 @@ func (c *replicationStatusClient) Status(
 	}, nil
 }
 
-// streamingAfterRewindClient wraps FakeClient to simulate the full pg_rewind
-// success path: the replica has no primary_conninfo initially, the WAL receiver
-// stays idle through the first verifyReplicationStarted window (exhausting all
-// attempts), then streams after RewindToSource restores primary_conninfo.
-//
-// Call sequence (with verifyMaxAttempts = N):
-//  1. verifyProblemExists        → no PrimaryConnInfo (triggers fix)
-//     2..N+1. verifyReplicationStarted after SetPrimary  → not streaming (all fail)
-//     N+2+.  verifyReplicationStarted after RewindToSource → streaming
-type streamingAfterRewindClient struct {
-	*rpcclient.FakeClient
-	replicaCallCount  int
-	nonStreamingCalls int // number of non-streaming calls after call 1 before transitioning
-}
-
-func (c *streamingAfterRewindClient) Status(
-	ctx context.Context,
-	pooler *clustermetadatapb.Multipooler,
-	request *multipoolermanagerdatapb.StatusRequest,
-) (*multipoolermanagerdatapb.StatusResponse, error) {
-	if pooler == nil || pooler.Id == nil || pooler.Id.Name != "replica1" {
-		return c.FakeClient.Status(ctx, pooler, request)
-	}
-	c.replicaCallCount++
-	switch {
-	case c.replicaCallCount == 1:
-		// verifyProblemExists: no primary_conninfo → triggers fix
-		return &multipoolermanagerdatapb.StatusResponse{
-			Status: &multipoolermanagerdatapb.Status{
-				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{},
-			},
-		}, nil
-	case c.replicaCallCount <= 1+c.nonStreamingCalls:
-		// verifyReplicationStarted after SetPrimary: WAL receiver idle
-		return &multipoolermanagerdatapb.StatusResponse{
-			Status: &multipoolermanagerdatapb.Status{
-				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-					WalReceiverStatus: "",
-				},
-			},
-		}, nil
-	default:
-		// verifyReplicationStarted after RewindToSource: streaming
-		return &multipoolermanagerdatapb.StatusResponse{
-			Status: &multipoolermanagerdatapb.Status{
-				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-					WalReceiverStatus: "streaming",
-					LastReceiveLsn:    "0/5000100",
-				},
-			},
-		}, nil
-	}
-}
-
-// TestFixReplicationAction_SucceedsViaRewind is a regression test for the bug where
-// RewindToSource did not restore primary_conninfo after pg_rewind, leaving the WAL
-// receiver with no primary to connect to. The full path under test:
-//
-//  1. SetPrimary is called but the WAL receiver never starts streaming.
-//  2. tryPgRewind → RewindToSource runs (which now restores primary_conninfo).
-//  3. verifyReplicationStarted sees "streaming" and the action succeeds.
-func TestFixReplicationAction_SucceedsViaRewind(t *testing.T) {
-	ctx := context.Background()
-	ts, _ := memorytopo.NewServerAndFactory(ctx, "cell1")
-	defer ts.Close()
-
-	const verifyAttempts = 3 // override default to keep test fast
-
-	baseFakeClient := rpcclient.NewFakeClient()
-	baseFakeClient.SetStatusResponse("multipooler-cell1-primary", &multipoolermanagerdatapb.StatusResponse{
-		Status: &multipoolermanagerdatapb.Status{
-			IsInitialized: true,
-			PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
-		},
-		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
-			Id:              fixReplPrimaryID,
-			TermRevocation:  &clustermetadatapb.TermRevocation{RevokedBelowTerm: 1},
-			CurrentPosition: leaderCurrentPosition(1),
-		},
-	})
-	baseFakeClient.SetStatusResponse("multipooler-cell1-replica1", &multipoolermanagerdatapb.StatusResponse{
-		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
-			TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 1},
-		},
-	})
-	baseFakeClient.UpdateConsensusRuleResponses = map[topoclient.ComponentID]*multipoolermanagerdatapb.UpdateConsensusRuleResponse{
-		"multipooler-cell1-primary": {},
-	}
-	// RewindToSource succeeds, simulating pg_rewind running and primary_conninfo
-	// being restored by the fix in rpc_manager.go.
-	baseFakeClient.RewindToSourceResponses = map[topoclient.ComponentID]*multipoolermanagerdatapb.RewindToSourceResponse{
-		"multipooler-cell1-replica1": {
-			Success:         true,
-			RewindPerformed: true,
-		},
-	}
-
-	fakeClient := &streamingAfterRewindClient{
-		FakeClient:        baseFakeClient,
-		nonStreamingCalls: verifyAttempts,
-	}
-	poolerStore := store.NewTestCache(t)
-
-	replicaID := &clustermetadatapb.ID{
-		Component: clustermetadatapb.ID_MULTIPOOLER,
-		Cell:      "cell1",
-		Name:      "replica1",
-	}
-	replica := &clustermetadatapb.Multipooler{
-		Id: replicaID,
-		ShardKey: &clustermetadatapb.ShardKey{
-			Database:   "testdb",
-			TableGroup: "default",
-			Shard:      "0",
-		},
-		Type: clustermetadatapb.PoolerType_REPLICA,
-	}
-	primary := &clustermetadatapb.Multipooler{
-		Id: &clustermetadatapb.ID{
-			Component: clustermetadatapb.ID_MULTIPOOLER,
-			Cell:      "cell1",
-			Name:      "primary",
-		},
-		ShardKey: &clustermetadatapb.ShardKey{
-			Database:   "testdb",
-			TableGroup: "default",
-			Shard:      "0",
-		},
-		Type:     clustermetadatapb.PoolerType_PRIMARY,
-		Hostname: "primary.example.com",
-		PortMap:  map[string]int32{"postgres": 5432},
-	}
-
-	require.NoError(t, ts.CreateMultipooler(ctx, replica))
-	require.NoError(t, ts.CreateMultipooler(ctx, primary))
-
-	store.SeedCache(t, poolerStore, store.NewPooler(&multiorchdatapb.PoolerHealthState{
-		Multipooler: replica,
-	}, nil))
-	store.SeedCache(t, poolerStore, store.NewPooler(&multiorchdatapb.PoolerHealthState{
-		Multipooler: primary,
-		Status:      &multipoolermanagerdatapb.Status{PostgresReady: true},
-		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
-			Id:             fixReplPrimaryID,
-			TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 1},
-			CurrentPosition: &clustermetadatapb.PoolerPosition{
-				Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
-					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
-					LeaderId:   fixReplPrimaryID,
-				}},
-			},
-			// Leader is rewind-ready, so fix_replication's tryPgRewind gate proceeds.
-			ReplicationPrimary: rewindReadyPrimary(1),
-		},
-	}, nil))
-
-	action := NewFixReplicationAction(config.NewTestConfig(), fakeClient, poolerStore, slog.Default())
-	action.verifyPollInterval = 10 * time.Millisecond
-	action.verifyMaxAttempts = verifyAttempts
-
-	problem := types.Problem{
-		Code: types.ProblemReplicaNotReplicating,
-		ShardKey: &clustermetadatapb.ShardKey{
-			Database:   "testdb",
-			TableGroup: "default",
-			Shard:      "0",
-		},
-		PoolerID: replicaID,
-	}
-
-	err := action.Execute(ctx, problem)
-	require.NoError(t, err, "fixNotReplicating must succeed via pg_rewind path")
-
-	// Verify the expected call sequence.
-	assert.Contains(t, fakeClient.CallLog, "SetPrimary(multipooler-cell1-replica1)",
-		"SetPrimary must be called first")
-	assert.Contains(t, fakeClient.CallLog, "RewindToSource(multipooler-cell1-replica1)",
-		"RewindToSource must be called when SetPrimary doesn't start streaming")
-}
-
 func TestFixReplicationAction_FailsWhenReplicationDoesNotStart(t *testing.T) {
 	ctx := context.Background()
 	ts, _ := memorytopo.NewServerAndFactory(ctx, "cell1")
@@ -966,13 +786,6 @@ func TestFixReplicationAction_FailsWhenReplicationDoesNotStart(t *testing.T) {
 	})
 	baseFakeClient.UpdateConsensusRuleResponses = map[topoclient.ComponentID]*multipoolermanagerdatapb.UpdateConsensusRuleResponse{
 		"multipooler-cell1-primary": {},
-	}
-	// pg_rewind dry-run fails, so it marks the pooler as DRAINED
-	baseFakeClient.RewindToSourceResponses = map[topoclient.ComponentID]*multipoolermanagerdatapb.RewindToSourceResponse{
-		"multipooler-cell1-replica1": {
-			Success:      false,
-			ErrorMessage: "pg_rewind not feasible: source timeline diverged before target's last checkpoint",
-		},
 	}
 
 	fakeClient := &replicationStatusClient{FakeClient: baseFakeClient, walReceiverStatus: "stopping"}
@@ -1020,9 +833,8 @@ func TestFixReplicationAction_FailsWhenReplicationDoesNotStart(t *testing.T) {
 		Multipooler: primary,
 		Status:      &multipoolermanagerdatapb.Status{PostgresReady: true},
 		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
-			Id:              fixReplPrimaryID,
-			CurrentPosition: leaderCurrentPosition(1),
-			// Leader is rewind-ready, so fix_replication's tryPgRewind gate proceeds.
+			Id:                 fixReplPrimaryID,
+			CurrentPosition:    leaderCurrentPosition(1),
 			ReplicationPrimary: rewindReadyPrimary(1),
 		},
 	}, nil))
@@ -1042,20 +854,19 @@ func TestFixReplicationAction_FailsWhenReplicationDoesNotStart(t *testing.T) {
 
 	err := action.Execute(ctx, problem)
 
-	// pg_rewind was not feasible, so the action fails with FAILED_PRECONDITION.
-	// Orch no longer drains the pooler itself; surfacing the broken pooler to the
-	// provisioner via its lifecycle stage is future work (see fix_replication.go).
+	// SetPrimary configured the replica but the WAL receiver never reached
+	// "streaming", so verifyReplicationStarted fails and the action returns an
+	// error (INTERNAL) for retry next cycle. Orch no longer runs pg_rewind itself:
+	// healing a diverged standby is the pooler's own responsibility (its monitor
+	// self-detects the stuck standby and rewinds), so no RewindToSource RPC fires.
 	require.Error(t, err)
-	assert.Equal(t, mtrpcpb.Code_FAILED_PRECONDITION, mterrors.Code(err))
+	assert.Equal(t, mtrpcpb.Code_INTERNAL, mterrors.Code(err))
 
 	// Verify SetPrimary was called (configuration was attempted)
 	assert.Contains(t, fakeClient.CallLog, "SetPrimary(multipooler-cell1-replica1)")
-	// Verify pg_rewind was tried after replication failed to start
-	assert.Contains(t, fakeClient.CallLog, "RewindToSource(multipooler-cell1-replica1)")
 
-	// The pooler's topology Type must be left untouched: orch no longer writes a
-	// pooler's record to mark it broken. Surfacing the broken pooler durably to the
-	// provisioner via its lifecycle stage is future work (see fix_replication.go).
+	// The pooler's topology Type must be left untouched: orch never writes a
+	// pooler's record.
 	updatedPooler, err := ts.GetMultipooler(ctx, replicaID)
 	require.NoError(t, err)
 	assert.Equal(t, clustermetadatapb.PoolerType_REPLICA, updatedPooler.Type)

--- a/go/services/multipooler/internal/grpcconsensusservice/service.go
+++ b/go/services/multipooler/internal/grpcconsensusservice/service.go
@@ -84,12 +84,3 @@ func (s *consensusService) SetPrimary(ctx context.Context, req *consensusdata.Se
 	}
 	return resp, nil
 }
-
-// RewindToSource performs pg_rewind to synchronize this server with a source
-func (s *consensusService) RewindToSource(ctx context.Context, req *multipoolermanagerdatapb.RewindToSourceRequest) (*multipoolermanagerdatapb.RewindToSourceResponse, error) {
-	resp, err := s.manager.RewindToSource(ctx, req.Source)
-	if err != nil {
-		return nil, mterrors.ToGRPC(err)
-	}
-	return resp, nil
-}

--- a/go/services/multipooler/internal/manager/config.go
+++ b/go/services/multipooler/internal/manager/config.go
@@ -16,6 +16,8 @@
 package manager
 
 import (
+	"time"
+
 	"github.com/multigres/multigres/go/common/backup"
 	"github.com/multigres/multigres/go/common/topoclient"
 	"github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager"
@@ -30,6 +32,13 @@ type Config struct {
 	ConsensusEnabled           bool                    // Whether consensus gRPC service is enabled
 	ConnPoolConfig             *connpoolmanager.Config // Connection pool config (manager created in MultipoolerManager)
 	BackendVpidTrackingEnabled bool                    // Whether to write active gateway-vpid/backend-pid mappings
+
+	// StandbyStuckDivergenceThreshold is how long a standby must stay unable to
+	// stream from its correctly-recorded leader before the monitor concludes its
+	// WAL diverged and self-heals via pg_rewind. Zero selects the built-in default
+	// (standbyStuckDivergenceThreshold). Not wired to a CLI flag — it exists as an
+	// internal, programmatic override for tests; production uses the default.
+	StandbyStuckDivergenceThreshold time.Duration
 
 	// pgBackRest TLS certificate paths for connecting to primary's pgBackRest server
 	PgBackRestCertFile string // TLS client certificate file path

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -177,6 +177,22 @@ type MultipoolerManager struct {
 	// process restart implicitly clears it.
 	walReceiverManuallyStopped atomic.Bool
 
+	// standbyStuckSince debounces the monitor's self-detection of a diverged
+	// standby. It holds the UnixNano of the first tick on which this standby was
+	// observed unable to stream from its correctly-recorded leader (0 = not
+	// currently stuck). Only once the condition has persisted past
+	// standbyStuckDivergenceThreshold does the monitor conclude the WAL has
+	// diverged and set suspectedDivergence, so a transient reconnect does not
+	// trigger a needless stop+rewind. Reset the moment streaming resumes or the
+	// stuck preconditions no longer hold.
+	standbyStuckSince atomic.Int64
+
+	// leaderReachableFn, when non-nil, overrides the divergence gate's leader
+	// liveness dial (standbyStuckDiverged -> leaderReachable). Tests set it because
+	// they have no real leader postgres to TCP-dial; production leaves it nil to
+	// use the default net.Dialer.
+	leaderReachableFn func(host string, port int32) bool
+
 	// pgMonitorLastLoggedReason tracks the last logged reason in the monitor to avoid duplicate logs.
 	pgMonitorLastLoggedReason string
 

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"strconv"
 	"time"
 
 	commonconsensus "github.com/multigres/multigres/go/common/consensus"
@@ -106,10 +108,15 @@ func (pm *MultipoolerManager) staleStandbyDemoteTarget() *clustermetadatapb.Pool
 
 // postgresState represents the state of PostgreSQL for monitoring
 type postgresState struct {
-	pgctldAvailable          bool
-	dirInitialized           bool
-	postgresRunning          bool
-	backupsAvailable         bool
+	pgctldAvailable  bool
+	dirInitialized   bool
+	postgresRunning  bool
+	backupsAvailable bool
+	// connInfo is the standby's primary_conninfo (parsed + redacted), read once
+	// per tick in discoverPostgresState so the monitor's decision paths can reuse
+	// it without re-querying. Nil when not running as a standby or when the read
+	// or parse failed this tick.
+	connInfo                 *multipoolermanagerdatapb.PrimaryConnInfo
 	pgMode                   pgmode.Mode
 	bootstrapSentinelPresent bool
 	// rewindSourceReady is true when this pooler is a primary whose last completed
@@ -193,7 +200,31 @@ const (
 	// is restore-from-backup leaving it enabled for a freshly-restored
 	// observer (see WrapRestoreCommand).
 	remedialActionDisableRestoreCommand
+
+	// remedialActionMarkStandbyDiverged means postgres is up as a standby whose
+	// primary_conninfo already points at the correctly-recorded leader, yet it has
+	// been unable to stream from that leader for longer than
+	// standbyStuckDivergenceThreshold. The most likely cause is timeline
+	// divergence: the WAL receiver connects, gets FATAL, and exits, leaving
+	// postgres up but not streaming. We conclude the WAL diverged and set
+	// suspectedDivergence, which routes the next tick through
+	// remedialActionRewindToLeader (a pg_rewind dry-run — cheap when there is no
+	// divergence). This replaces orch's old explicit RewindToSource RPC: the
+	// standby now self-heals a stuck-replica scenario without orch in the loop.
+	remedialActionMarkStandbyDiverged
 )
+
+// standbyStuckDivergenceThreshold is the default for how long a standby must stay
+// unable to stream from its correctly-recorded (and reachable) leader before the
+// monitor concludes its WAL diverged and rewinds. It debounces transient
+// reconnects (a brief WAL-receiver drop, a leader still finishing its
+// post-promotion checkpoint) so a needless stop+rewind does not fire on a hiccup.
+// The leader-liveness gate (see standbyStuckDiverged) already excludes the
+// failover case, so this threshold need only outlast a transient reconnect, not a
+// whole failover. The subsequent rewind is itself gated on the leader being
+// rewind-ready and rate-limited by exponential backoff. Overridable via
+// Config.StandbyStuckDivergenceThreshold (see stuckDivergenceThreshold).
+const standbyStuckDivergenceThreshold = 10 * time.Second
 
 // monitorPostgresIteration performs one iteration of PostgreSQL monitoring.
 // Returns the discovered postgres state on success, or an error if the state
@@ -320,6 +351,15 @@ func (pm *MultipoolerManager) discoverPostgresState(ctx context.Context) (postgr
 			// retries, matching the bootstrap-sentinel handling below.
 			return state, fmt.Errorf("determine recovery mode: %w", err)
 		}
+
+		if connInfoStr, err := pm.readPrimaryConnInfo(ctx); err != nil {
+			pm.logger.WarnContext(ctx, "Failed to determine primary_conninfo", "error", err)
+		} else if connInfo, err := parseAndRedactPrimaryConnInfo(connInfoStr); err != nil || connInfo == nil {
+			pm.logger.WarnContext(ctx, "Failed to determine parse primary_conninfo", "error", err)
+		} else {
+			state.connInfo = connInfo
+		}
+
 		// A primary is a rewind source only once it has checkpointed onto its
 		// current timeline. Cheap to skip on standbys (rewindSourceReady would
 		// return false anyway).
@@ -398,7 +438,12 @@ func (pm *MultipoolerManager) setMonitorReason(ctx context.Context, reason, mess
 //
 // Used by the postgres monitor to decide whether to trigger
 // remedialActionFixPrimaryConnInfo on each tick.
-func (pm *MultipoolerManager) primaryConnInfoDiffersFromRecorded(ctx context.Context) bool {
+//
+// connInfo is the primary_conninfo already read into postgresState this tick; when
+// non-nil it is compared directly, avoiding a redundant GUC read. Callers without
+// a fresh state snapshot (e.g. the SetPrimary RPC path) pass nil, in which case
+// the GUC is read here as before.
+func (pm *MultipoolerManager) primaryConnInfoDiffersFromRecorded(ctx context.Context, connInfo *multipoolermanagerdatapb.PrimaryConnInfo) bool {
 	// Don't detect drift we can't fix: when StopReplication has set the
 	// manual-stop flag, setPrimaryConnInfoLocked refuses every conninfo
 	// rewrite until StartReplication clears it. Detecting drift anyway would
@@ -433,6 +478,15 @@ func (pm *MultipoolerManager) primaryConnInfoDiffersFromRecorded(ctx context.Con
 		return false
 	}
 
+	// Fast path: primary_conninfo was already read into state this tick — compare
+	// directly rather than re-querying. An empty/absent conninfo parses to a
+	// zero-value struct, so its host/port won't match the (non-empty) target and
+	// it reads as drift, matching the read path below.
+	if connInfo != nil {
+		return connInfo.GetHost() != targetHost || connInfo.GetPort() != targetPort
+	}
+
+	// No pre-read snapshot (RPC path, or the tick's read failed): read the GUC.
 	// Use a short deadline so a slow query never blocks the monitor tick.
 	ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
@@ -567,22 +621,22 @@ func (pm *MultipoolerManager) determineReplicationSettingsAction(ctx context.Con
 		// primary_conninfo, so don't re-point at a leader we haven't rewound to.
 		// Fall through to the restore_command backstop below (a held node must not
 		// archive-replay either). Otherwise reconcile primary_conninfo drift.
-		if !pm.consensusMgr.SuspectedDivergence() && pm.primaryConnInfoDiffersFromRecorded(ctx) {
+		if !pm.consensusMgr.SuspectedDivergence() && pm.primaryConnInfoDiffersFromRecorded(ctx, state.connInfo) {
 			return remedialActionFixPrimaryConnInfo
 		}
-		// TODO: self-rewind detection. A replica may need pg_rewind even
-		// when it was never primary — phantom transactions can leak in
-		// (e.g. via a brief sync-replication ack that got rolled back on
-		// the primary). The old consensus flow let orch re-issue an
-		// explicit rewind whenever it suspected one; the new flow's
-		// SetPrimary is idempotent and won't repeat work, so the monitor
-		// needs to self-detect stuck replication. Check
-		// pg_stat_wal_receiver.status: if not "streaming" for
-		// >stuckThreshold AND we have a recorded primary, treat as
-		// suspected divergence — set suspectedDivergence=true so the next
-		// remedialActionFixPrimaryConnInfo iteration runs
-		// pg_rewind dry-run before re-establishing replication. Cheap
-		// when no divergence, conclusive when there is.
+		// Self-detect a diverged standby that was never a primary: phantom
+		// transactions can leak in (e.g. a brief sync-replication ack that got
+		// rolled back on the old primary), and the WAL receiver then FATALs on the
+		// new leader's timeline, leaving postgres up but not streaming. The
+		// drift check above already passed, so primary_conninfo points at the
+		// correctly-recorded leader; if streaming stays stuck past the debounce
+		// threshold we conclude the WAL diverged and mark it, routing the next tick
+		// through the rewind path (a pg_rewind dry-run — cheap when there is no
+		// divergence). Gated on !SuspectedDivergence so this does not re-fire once
+		// the rewind path already owns the incident.
+		if !pm.consensusMgr.SuspectedDivergence() && pm.standbyStuckDiverged(ctx, state) {
+			return remedialActionMarkStandbyDiverged
+		}
 	}
 
 	// restore_command is a standby concern: a cohort member must only ever
@@ -654,6 +708,121 @@ func (pm *MultipoolerManager) determineRemedialAction(ctx context.Context, curre
 	// Postgres is not running: start it, rewind-then-start (on suspected
 	// divergence), restore from backup, or bootstrap.
 	return pm.determinePostgresNotRunningAction(currentState)
+}
+
+// standbyStuckDiverged reports whether this up standby has been unable to stream
+// from its correctly-recorded leader for longer than
+// standbyStuckDivergenceThreshold — the signal that its WAL diverged and it needs
+// a pg_rewind, even though it was never a primary (so no demote path flagged it).
+// It is the self-heal replacement for orch's old RewindToSource RPC.
+//
+// The caller has already established that postgres is a standby, divergence is not
+// yet suspected, and primary_conninfo is not merely drifted (that is handled by
+// remedialActionFixPrimaryConnInfo first). This method independently re-confirms a
+// valid, non-revoked, non-self leader with an address, that primary_conninfo
+// actually points at it, that the WAL receiver is not streaming, and that the
+// recorded leader is actually reachable — then debounces via standbyStuckSince so
+// a transient reconnect does not trip it. It only observes/records; the
+// suspectedDivergence mutation happens in takeRemedialAction under the action lock.
+//
+// The reachability gate is load-bearing: "not streaming" happens both when this
+// node's WAL diverged (leader alive, receiver FATALs) AND when the leader is dead
+// (a failover in progress). Only the first warrants a rewind. Marking divergence
+// against a dead leader would be wrong twice over: there is nothing to rewind
+// against, and the stale suspectedDivergence flag makes the coordinator's
+// subsequent SetPrimary take the stale-primary-demote path and defer, stalling the
+// election. So we mark only when the leader is confirmed reachable — mirroring the
+// old orch guard that refused pg_rewind unless the primary was running.
+func (pm *MultipoolerManager) standbyStuckDiverged(ctx context.Context, state postgresState) bool {
+	// An admin/test that deliberately stopped replication is not "stuck".
+	if pm.walReceiverManuallyStopped.Load() {
+		pm.standbyStuckSince.Store(0)
+		return false
+	}
+	// Need a valid leader to rewind toward (non-self, non-revoked, with address).
+	host, port, ok := pm.consensusMgr.RewindTarget()
+	if !ok {
+		pm.standbyStuckSince.Store(0)
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+
+	// Confirm primary_conninfo (read into state this tick) points at the recorded
+	// leader. A nil value means the read/parse failed this tick — can't verify, so
+	// don't reset the debounce timer on a blip. If it points elsewhere, this is
+	// conninfo drift (handled by remedialActionFixPrimaryConnInfo), not divergence.
+	if state.connInfo == nil {
+		return false
+	}
+	if state.connInfo.GetHost() != host || state.connInfo.GetPort() != port {
+		pm.standbyStuckSince.Store(0)
+		return false
+	}
+
+	// If the WAL receiver is streaming, we are not stuck.
+	status, err := pm.queryReplicationStatus(ctx)
+	if err != nil {
+		return false // can't verify; leave the debounce timer as-is
+	}
+	if status.GetWalReceiverStatus() == "streaming" {
+		pm.standbyStuckSince.Store(0)
+		return false
+	}
+
+	// Distinguish divergence from a dead leader (failover): only a reachable
+	// leader we cannot stream from indicates our WAL diverged. An unreachable
+	// leader means an outage/failover — not our problem to rewind — so clear the
+	// timer and wait for the coordinator to name a new leader.
+	if !pm.leaderReachable(ctx, host, port) {
+		pm.standbyStuckSince.Store(0)
+		return false
+	}
+
+	// Not streaming from the right (reachable) leader: start (or continue) the
+	// debounce timer and only conclude divergence once it has persisted past the
+	// threshold.
+	now := time.Now().UnixNano()
+	since := pm.standbyStuckSince.Load()
+	if since == 0 {
+		pm.standbyStuckSince.Store(now)
+		return false
+	}
+	return time.Duration(now-since) >= pm.stuckDivergenceThreshold()
+}
+
+// stuckDivergenceThreshold returns the configured divergence-debounce window,
+// falling back to the built-in default when unset.
+func (pm *MultipoolerManager) stuckDivergenceThreshold() time.Duration {
+	if pm.config.StandbyStuckDivergenceThreshold > 0 {
+		return pm.config.StandbyStuckDivergenceThreshold
+	}
+	return standbyStuckDivergenceThreshold
+}
+
+// leaderReachableTimeout bounds the divergence-gate liveness dial so a black-holed
+// leader is treated as unreachable promptly rather than blocking the monitor tick.
+const leaderReachableTimeout = 1 * time.Second
+
+// leaderReachable reports whether the recorded leader's postgres endpoint accepts
+// a TCP connection — a liveness proxy used by standbyStuckDiverged to tell a
+// diverged standby (leader alive) apart from a failover (leader dead). A killed
+// postgres refuses the connection immediately; a partitioned one times out. The
+// actual pg_rewind revalidates via a real libpq connection, so a false "alive"
+// only costs a gated, rate-limited dry-run. Overridable via leaderReachableFn for
+// tests that have no real leader to dial.
+func (pm *MultipoolerManager) leaderReachable(ctx context.Context, host string, port int32) bool {
+	if pm.leaderReachableFn != nil {
+		return pm.leaderReachableFn(host, port)
+	}
+	dialer := net.Dialer{Timeout: leaderReachableTimeout}
+	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(int(port))))
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
 }
 
 // shouldRewindForDivergence reports whether an up standby should now be rewound
@@ -859,6 +1028,20 @@ func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action rem
 		// monitor tick (postgres running, no rewind pending), so it doesn't linger
 		// into a future, unrelated incident.
 
+	case remedialActionMarkStandbyDiverged:
+		pm.setMonitorReason(ctx, reasonPostgresRunning, "MonitorPostgres: PostgreSQL is running")
+		pm.logger.InfoContext(ctx, "MonitorPostgres: standby stuck not streaming from recorded leader past threshold; marking suspected divergence to self-heal via pg_rewind")
+		// Only mark the WAL suspect; the rewind itself happens on the next tick via
+		// shouldRewindForDivergence -> remedialActionRewindToLeader (gated on the
+		// leader being rewind-ready and rate-limited by backoff). This replaces
+		// orch's old RewindToSource RPC for a diverged-but-running standby.
+		if _, err := pm.consensusMgr.SetSuspectedDivergence(ctx, true); err != nil {
+			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to mark suspected divergence for stuck standby", "error", err)
+			return
+		}
+		// Clear the debounce timer; the rewind path now owns the incident.
+		pm.standbyStuckSince.Store(0)
+
 	case remedialActionRestoreFromBackup:
 		pm.setMonitorReason(ctx, reasonRestoringFromBackup, "MonitorPostgres: directory not initialized but backups available, restoring from backup")
 		if err := pm.actionLock.SetAction(ctx, multipoolermanagerdatapb.PostgresAction_POSTGRES_ACTION_RESTORING_FROM_BACKUP); err != nil {
@@ -955,9 +1138,9 @@ func (pm *MultipoolerManager) hasCompleteBackups(ctx context.Context) (bool, err
 // SetPrimary/Promote/standby-conninfo path routes through demoteStalePrimaryLocked
 // (which runs pg_rewind dry-run; cheap when there's no divergence) before
 // trusting local WAL. This bears on the broader self-rewind plan:
-//   - replicas with phantom transactions: orch sends an explicit
-//     RewindToSource RPC today; a future change should let the local monitor
-//     detect stuck replication and self-heal without needing orch in the loop.
+//   - replicas with phantom transactions: the monitor now self-detects a standby
+//     stuck unable to stream from its recorded leader (standbyStuckDiverged) and
+//     sets suspectedDivergence to route the rewind locally — no orch RPC needed.
 //   - primaries demoted unexpectedly (crash, SIGKILL, external pg_demote):
 //     the restart-as-standby helper should require callers to declare
 //     "clean" vs "unexpected" so an unexpected transition can set

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -1772,8 +1772,185 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 				pm.walReceiverManuallyStopped.Store(true)
 			}
 
-			got := pm.primaryConnInfoDiffersFromRecorded(t.Context())
+			got := pm.primaryConnInfoDiffersFromRecorded(t.Context(), nil)
 			assert.Equal(t, tt.want, got)
+			assert.NoError(t, mockQueryService.ExpectationsWereMet())
+		})
+	}
+}
+
+// TestStandbyStuckDiverged covers the monitor's self-detection of a diverged
+// standby (the local self-heal that replaced orch's RewindToSource RPC): a standby
+// whose primary_conninfo points at the correctly-recorded leader but that cannot
+// stream past the divergence threshold is concluded diverged. It re-confirms a
+// valid rewind target, that conninfo actually points at it, and that the WAL
+// receiver is not streaming, then debounces via standbyStuckSince.
+func TestStandbyStuckDiverged(t *testing.T) {
+	const (
+		recordedHost = "primary.example.com"
+		recordedPort = int32(5432)
+	)
+	recordedID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "zone1",
+		Name:      "primary-pooler",
+	}
+	seedRP := &clustermetadatapb.ReplicationPrimary{
+		Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
+			RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
+			LeaderId:   recordedID,
+		}},
+		Primary: &clustermetadatapb.PoolerAddress{Id: recordedID, Host: recordedHost, PostgresPort: recordedPort},
+	}
+
+	replStatusRow := func(walReceiverStatus string) [][]any {
+		return [][]any{{"0/5000000", "0/5000000", "f", "not paused", "2025-01-15 12:00:00+00", "", walReceiverStatus, nil, nil, nil}}
+	}
+	replStatusCols := []string{"replay_lsn", "receive_lsn", "is_paused", "pause_state", "xact_time", "conninfo", "wal_receiver_status", "last_msg_receive_time", "wal_receiver_status_interval", "wal_receiver_timeout"}
+
+	tests := []struct {
+		name string
+		// seedRP, when non-nil, is recorded before the call (populates RewindTarget).
+		seedRP *clustermetadatapb.ReplicationPrimary
+		// seedManualStop simulates a prior StopReplication.
+		seedManualStop bool
+		// seedStuckSincePast pre-arms the debounce timer to a long-past instant.
+		seedStuckSincePast bool
+		// configThreshold, when non-zero, is written to
+		// Config.StandbyStuckDivergenceThreshold to exercise the internal override.
+		configThreshold time.Duration
+		// mockConnInfo, when non-empty, is parsed into the postgresState.connInfo
+		// passed to standbyStuckDiverged (the monitor reads primary_conninfo into
+		// state once per tick rather than re-querying it here).
+		mockConnInfo string
+		// walReceiverStatus controls queryReplicationStatus; expectStatusQuery gates it.
+		walReceiverStatus string
+		expectStatusQuery bool
+		// leaderUnreachable makes the injected liveness dial report the leader down
+		// (a failover), so divergence must not be concluded. Default false = leader
+		// reachable.
+		leaderUnreachable bool
+		want              bool
+		// wantTimerArmed asserts the debounce timer is set after the call.
+		wantTimerArmed bool
+	}{
+		{
+			name:           "ManualStopIsNotStuck",
+			seedRP:         seedRP,
+			seedManualStop: true,
+			want:           false,
+		},
+		{
+			name: "NoRewindTarget",
+			// no seedRP -> RewindTarget !ok
+			want: false,
+		},
+		{
+			name:         "ConnInfoDoesNotPointAtLeader",
+			seedRP:       seedRP,
+			mockConnInfo: "host=other.example.com port=5432 user=replicator",
+			want:         false,
+		},
+		{
+			name:              "StreamingIsNotStuck",
+			seedRP:            seedRP,
+			mockConnInfo:      "host=primary.example.com port=5432 user=replicator",
+			expectStatusQuery: true,
+			walReceiverStatus: "streaming",
+			want:              false,
+		},
+		{
+			name:              "NotStreamingFirstObservationArmsTimer",
+			seedRP:            seedRP,
+			mockConnInfo:      "host=primary.example.com port=5432 user=replicator",
+			expectStatusQuery: true,
+			walReceiverStatus: "",
+			want:              false,
+			wantTimerArmed:    true,
+		},
+		{
+			name:               "NotStreamingPastThreshold",
+			seedRP:             seedRP,
+			seedStuckSincePast: true,
+			mockConnInfo:       "host=primary.example.com port=5432 user=replicator",
+			expectStatusQuery:  true,
+			walReceiverStatus:  "",
+			want:               true,
+			wantTimerArmed:     true,
+		},
+		{
+			// The internal Config override lengthens the threshold: pre-armed one
+			// hour ago but with a two-hour threshold, so the elapsed time has not
+			// yet reached it — not stuck, and the timer stays armed.
+			name:               "ConfigThresholdHonoredNotYetElapsed",
+			seedRP:             seedRP,
+			seedStuckSincePast: true,
+			configThreshold:    2 * time.Hour,
+			mockConnInfo:       "host=primary.example.com port=5432 user=replicator",
+			expectStatusQuery:  true,
+			walReceiverStatus:  "",
+			want:               false,
+			wantTimerArmed:     true,
+		},
+		{
+			// Leader is unreachable (a failover, not divergence): even past the
+			// threshold, do not conclude divergence, and clear the debounce timer.
+			name:               "UnreachableLeaderIsNotStuck",
+			seedRP:             seedRP,
+			seedStuckSincePast: true,
+			mockConnInfo:       "host=primary.example.com port=5432 user=replicator",
+			expectStatusQuery:  true,
+			walReceiverStatus:  "",
+			leaderUnreachable:  true,
+			want:               false,
+			wantTimerArmed:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockQueryService := mock.NewQueryService()
+			if tt.expectStatusQuery {
+				mockQueryService.AddQueryPatternOnce(
+					"pg_last_wal_replay_lsn",
+					mock.MakeQueryResult(replStatusCols, replStatusRow(tt.walReceiverStatus)))
+			}
+
+			pm, _ := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(0)})
+
+			if tt.configThreshold > 0 {
+				pm.config.StandbyStuckDivergenceThreshold = tt.configThreshold
+			}
+
+			// Inject the leader-liveness dial: tests have no real leader postgres.
+			leaderUnreachable := tt.leaderUnreachable
+			pm.leaderReachableFn = func(string, int32) bool { return !leaderUnreachable }
+
+			if tt.seedRP != nil {
+				lockCtx, err := pm.actionLock.Acquire(t.Context(), "test-seed")
+				require.NoError(t, err)
+				require.NoError(t, pm.consensusMgr.RecordTermPrimary(lockCtx, tt.seedRP))
+				pm.actionLock.Release(lockCtx)
+			}
+			if tt.seedManualStop {
+				pm.walReceiverManuallyStopped.Store(true)
+			}
+			if tt.seedStuckSincePast {
+				pm.standbyStuckSince.Store(time.Now().Add(-time.Hour).UnixNano())
+			}
+
+			// primary_conninfo is read into postgresState once per tick; supply it
+			// here the way discoverPostgresState would (nil when not applicable).
+			var state postgresState
+			if tt.mockConnInfo != "" {
+				connInfo, err := parseAndRedactPrimaryConnInfo(tt.mockConnInfo)
+				require.NoError(t, err)
+				state.connInfo = connInfo
+			}
+
+			got := pm.standbyStuckDiverged(t.Context(), state)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantTimerArmed, pm.standbyStuckSince.Load() != 0)
 			assert.NoError(t, mockQueryService.ExpectationsWereMet())
 		})
 	}

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -681,7 +681,7 @@ func (pm *MultipoolerManager) SetPrimary(ctx context.Context, req *consensusdata
 		// request may not be what actually got persisted.
 		if pgMode, err := pm.postgresMode(ctx); err != nil {
 			pm.logger.WarnContext(ctx, "SetPrimary: failed to check recovery status before drift check; skipping", "error", err)
-		} else if !pgMode.OutOfRecovery() && pm.primaryConnInfoDiffersFromRecorded(ctx) {
+		} else if !pgMode.OutOfRecovery() && pm.primaryConnInfoDiffersFromRecorded(ctx, nil) {
 			pm.reconcilePrimaryConnInfoToRecorded(ctx, "SetPrimary")
 		}
 		return &consensusdatapb.SetPrimaryResponse{ConsensusStatus: pm.consensusMgr.CachedConsensusStatus()}, nil

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -736,8 +736,8 @@ func (pm *MultipoolerManager) demoteToStandbyLocked(ctx context.Context, consens
 	}
 
 	// Mark the WAL as rewind-suspect: this node was just demoted, so the next
-	// restart-as-standby (the coordinator's RewindToSource, or the monitor's own
-	// demote path) must run pg_rewind before trusting local WAL.
+	// restart-as-standby (the monitor's demote path or its divergence-rewind
+	// path) must run pg_rewind before trusting local WAL.
 	if _, err := pm.consensusMgr.SetSuspectedDivergence(ctx, true); err != nil {
 		pm.logger.ErrorContext(ctx, "failed to set suspected divergence on emergency demote", "error", err)
 	}
@@ -763,57 +763,6 @@ func (pm *MultipoolerManager) demoteToStandbyLocked(ctx context.Context, consens
 		"connections_terminated", connectionsTerminated)
 
 	return nil
-}
-
-// RewindToSource pg_rewinds this server against source and brings it back as a
-// standby. The heavy lifting (stop, rewind, restart-as-standby, resume) is
-// shared with the stale-primary demote path via stopRewindRestartAsStandbyLocked.
-func (pm *MultipoolerManager) RewindToSource(ctx context.Context, source *clustermetadatapb.Multipooler) (*multipoolermanagerdatapb.RewindToSourceResponse, error) {
-	if err := pm.checkReady(); err != nil {
-		return nil, mterrors.Wrap(err, "multipooler not ready")
-	}
-
-	if source == nil || source.PortMap == nil {
-		return nil, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT, "source pooler or port_map is nil")
-	}
-	if source.Hostname == "" {
-		return nil, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT, "source hostname is required")
-	}
-	port, ok := source.PortMap["postgres"]
-	if !ok {
-		return nil, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT, "postgres port not found in source pooler's port map")
-	}
-
-	pm.logger.InfoContext(ctx, "RewindToSource RPC called", "source", source.Id.Name)
-
-	ctx, err := pm.actionLock.Acquire(ctx, "RewindToSource")
-	if err != nil {
-		return nil, mterrors.Wrap(err, "failed to acquire action lock")
-	}
-	defer pm.actionLock.Release(ctx)
-
-	if err := pm.actionLock.SetAction(ctx, multipoolermanagerdatapb.PostgresAction_POSTGRES_ACTION_REWIND); err != nil {
-		pm.logger.ErrorContext(ctx, "RewindToSource: failed to set action", "error", err)
-	}
-
-	// RewindToSource is an explicit "this WAL is suspect, rewind it" request from
-	// the caller; raise suspectedDivergence so restartAsStandbyLocked runs the
-	// pg_rewind dry-run. The caller (orch's FixReplicationAction) has already
-	// confirmed the source is rewind-ready before issuing this RPC.
-	if _, err := pm.consensusMgr.SetSuspectedDivergence(ctx, true); err != nil {
-		pm.logger.ErrorContext(ctx, "failed to set suspected divergence in RewindToSource", "error", err)
-	}
-	rewindPerformed, err := pm.restartAsStandbyLocked(ctx, source.Hostname, port)
-	if err != nil {
-		return nil, err
-	}
-
-	pm.logger.InfoContext(ctx, "RewindToSource completed successfully",
-		"rewind_performed", rewindPerformed)
-	return &multipoolermanagerdatapb.RewindToSourceResponse{
-		Success:         true,
-		RewindPerformed: rewindPerformed,
-	}, nil
 }
 
 // SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts by the monitor.
@@ -868,17 +817,19 @@ func (pm *MultipoolerManager) pgctldStopWithEscalation(ctx context.Context) erro
 	return mterrors.Wrap(lastErr, "failed to stop postgres after fast/immediate escalation")
 }
 
-// restartAsStandbyLocked is the shared core of RewindToSource and the
-// stale-primary branch of SetPrimary: it pauses the manager, stops
-// postgres, runs pg_rewind against source iff suspectedDivergence is set
+// restartAsStandbyLocked is the shared core of the stale-primary branch of
+// SetPrimary and the monitor's divergence-rewind paths: it pauses the manager,
+// stops postgres, runs pg_rewind against source iff suspectedDivergence is set
 // (patching pgbackrest paths in postgresql.auto.conf after the rewind
 // copies them from source), then restarts postgres as standby and
 // resumes the manager.
 //
 // Gating on suspectedDivergence: callers raise the flag when this node's WAL may
-// have diverged from the cluster's chosen history (demoteToStandbyLocked
-// sets it after an emergency demote; SetPrimary's stale-primary branch
-// and RewindToSource set it before calling here). When the flag is clear we
+// have diverged from the cluster's chosen history (demoteToStandbyLocked sets it
+// after an emergency demote; SetPrimary's stale-primary branch sets it; the
+// monitor sets it for a stale-primary demote, after crash recovery against a
+// different leader, and for a standby stuck unable to stream from its recorded
+// leader). When the flag is clear we
 // skip even the pg_rewind dry-run — the WAL is trusted and we just need to
 // come back as a standby. The flag is cleared only after postgres restarts and
 // is verified in recovery mode below, NOT as soon as pg_rewind returns: an early

--- a/go/services/multipooler/internal/manager/rpc_manager_test.go
+++ b/go/services/multipooler/internal/manager/rpc_manager_test.go
@@ -945,11 +945,27 @@ func TestUpdateConsensusRule_HistoryFailurePreventsGUCUpdate(t *testing.T) {
 		"If this fails, it means SetPolicy was called despite history insert failure")
 }
 
-// TestRewindToSource_ManagerReopenedOnError is a regression test for a bug where
-// RewindToSource would leave the manager closed if an error occurred after pausing.
-// The fix uses the Pause()/resume() pattern with defer to guarantee the manager
-// is always reopened, even on error paths.
-func TestRewindToSource_ManagerReopenedOnError(t *testing.T) {
+// rewindAsStandbyForTest drives the action-locked rewind core that used to sit
+// behind the RewindToSource RPC (removed in favor of the monitor's local
+// self-heal): it raises suspectedDivergence and calls restartAsStandbyLocked,
+// the shared helper these regression tests exercise. Callers still reach it via
+// SetPrimary's stale-primary branch and the monitor's divergence-rewind path.
+func rewindAsStandbyForTest(t *testing.T, manager *MultipoolerManager, source *clustermetadatapb.Multipooler) (bool, error) {
+	t.Helper()
+	lockCtx, err := manager.actionLock.Acquire(t.Context(), "test-rewind")
+	require.NoError(t, err)
+	defer manager.actionLock.Release(lockCtx)
+	if _, err := manager.consensusMgr.SetSuspectedDivergence(lockCtx, true); err != nil {
+		return false, err
+	}
+	return manager.restartAsStandbyLocked(lockCtx, source.Hostname, source.PortMap["postgres"])
+}
+
+// TestRestartAsStandby_ManagerReopenedOnError is a regression test for a bug where
+// the rewind path would leave the manager closed if an error occurred after
+// pausing. The fix uses the Pause()/resume() pattern with defer to guarantee the
+// manager is always reopened, even on error paths.
+func TestRestartAsStandby_ManagerReopenedOnError(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	ctx := context.Background()
 
@@ -1029,29 +1045,29 @@ func TestRewindToSource_ManagerReopenedOnError(t *testing.T) {
 		},
 	}
 
-	// Call RewindToSource - this should fail during the Stop call
-	_, err = manager.RewindToSource(ctx, source)
+	// Drive the rewind core - this should fail during the Stop call
+	_, err = rewindAsStandbyForTest(t, manager, source)
 
 	// Verify the call failed as expected
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "PostgreSQL stop failed")
 
 	// CRITICAL REGRESSION TEST: Verify the manager was reopened despite the error.
-	// This is the bug we're testing for: if RewindToSource fails, the manager must
+	// This is the bug we're testing for: if the rewind fails, the manager must
 	// still be reopened so the node can continue operating.
 	require.Eventually(t, func() bool {
 		manager.mu.Lock()
 		defer manager.mu.Unlock()
 		return manager.isOpen
-	}, 2*time.Second, 50*time.Millisecond, "REGRESSION: Manager should be reopened even when RewindToSource fails")
+	}, 2*time.Second, 50*time.Millisecond, "REGRESSION: Manager should be reopened even when the rewind fails")
 }
 
-// TestRewindToSource_RestoresPrimaryConnInfo is a regression test for the bug where
-// RewindToSource did not call setPrimaryConnInfoLocked after pg_rewind. When actual
+// TestRestartAsStandby_RestoresPrimaryConnInfo is a regression test for the bug where
+// the rewind path did not call setPrimaryConnInfoLocked after pg_rewind. When actual
 // pg_rewind runs it syncs postgresql.auto.conf from the source (which has no
 // primary_conninfo), wiping the value set by the earlier SetPrimary call and
 // leaving the WAL receiver with no primary to connect to.
-func TestRewindToSource_RestoresPrimaryConnInfo(t *testing.T) {
+func TestRestartAsStandby_RestoresPrimaryConnInfo(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	ctx := context.Background()
 
@@ -1148,9 +1164,9 @@ func TestRewindToSource_RestoresPrimaryConnInfo(t *testing.T) {
 		PortMap:  map[string]int32{"postgres": 5433},
 	}
 
-	resp, err := manager.RewindToSource(ctx, source)
+	rewindPerformed, err := rewindAsStandbyForTest(t, manager, source)
 	require.NoError(t, err)
-	assert.True(t, resp.RewindPerformed, "actual pg_rewind should have run (divergence detected)")
+	assert.True(t, rewindPerformed, "actual pg_rewind should have run (divergence detected)")
 
 	// Verify both actual rewind calls were made (dry-run + actual).
 	rewindCalls := mockPgctld.PgRewindCalls
@@ -1166,16 +1182,16 @@ func TestRewindToSource_RestoresPrimaryConnInfo(t *testing.T) {
 	assert.Contains(t, primaryConnInfoSet, "5433", "primary_conninfo must reference the source postgres port")
 }
 
-// TestRewindToSource_NoDivergence_StillSetsPrimaryConnInfo guards the helper
+// TestRestartAsStandby_NoDivergence_StillSetsPrimaryConnInfo guards the helper
 // contract introduced in the unified-rewind refactor: restartAsStandbyLocked
 // sets primary_conninfo on success regardless of whether pg_rewind actually
 // ran. The dry-run reports no divergence here, so runPgRewind returns
 // rewindPerformed=false and skips the actual rewind — but the helper must
 // still point primary_conninfo at source. Without this test, a regression
 // that gates the conninfo call on rewindPerformed would pass the divergence
-// test (TestRewindToSource_RestoresPrimaryConnInfo) and silently break
+// test (TestRestartAsStandby_RestoresPrimaryConnInfo) and silently break
 // callers that arrive via this path.
-func TestRewindToSource_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
+func TestRestartAsStandby_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	ctx := context.Background()
 
@@ -1266,9 +1282,9 @@ func TestRewindToSource_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
 		PortMap:  map[string]int32{"postgres": 5433},
 	}
 
-	resp, err := manager.RewindToSource(ctx, source)
+	rewindPerformed, err := rewindAsStandbyForTest(t, manager, source)
 	require.NoError(t, err)
-	assert.False(t, resp.RewindPerformed, "no divergence reported, so actual pg_rewind should not have run")
+	assert.False(t, rewindPerformed, "no divergence reported, so actual pg_rewind should not have run")
 
 	// Only the dry-run should have fired; no actual rewind.
 	rewindCalls := mockPgctld.PgRewindCalls
@@ -1279,90 +1295,6 @@ func TestRewindToSource_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
 	assert.NotEmpty(t, primaryConnInfoSet, "primary_conninfo must be set even when no rewind runs")
 	assert.Contains(t, primaryConnInfoSet, "source-host", "primary_conninfo must reference the source host")
 	assert.Contains(t, primaryConnInfoSet, "5433", "primary_conninfo must reference the source postgres port")
-}
-
-// TestRewindToSource_InvalidArgs verifies the four input-validation branches
-// at the top of RewindToSource return INVALID_ARGUMENT without touching
-// postgres. The manager is constructed but never reaches setInitialized; the
-// validation happens before checkReady, so this is enough.
-func TestRewindToSource_InvalidArgs(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	ctx := context.Background()
-
-	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
-	defer ts.Close()
-
-	poolerDir := t.TempDir()
-	serviceID := &clustermetadatapb.ID{
-		Component: clustermetadatapb.ID_MULTIPOOLER,
-		Cell:      "zone1",
-		Name:      "test-pooler",
-	}
-	multipooler := &clustermetadatapb.Multipooler{
-		Id:        serviceID,
-		PoolerDir: poolerDir,
-		Type:      clustermetadatapb.PoolerType_REPLICA,
-		PortMap:   map[string]int32{"postgres": 5432},
-		ShardKey: &clustermetadatapb.ShardKey{
-			Database:   "postgres",
-			TableGroup: constants.DefaultTableGroup,
-			Shard:      constants.DefaultShard,
-		},
-	}
-
-	manager, err := NewMultipoolerManager(logger, multipooler, &Config{TopoClient: ts})
-	require.NoError(t, err)
-	defer manager.ShutdownForTest(t.Context())
-
-	createPgDataDir(t, poolerDir)
-	require.NoError(t, manager.setInitialized())
-	manager.mu.Lock()
-	manager.isOpen = true
-	manager.state = ManagerStateReady
-	manager.ctx, manager.cancel = context.WithCancel(ctx)
-	manager.mu.Unlock()
-
-	cases := []struct {
-		name   string
-		source *clustermetadatapb.Multipooler
-	}{
-		{
-			name:   "nil source",
-			source: nil,
-		},
-		{
-			name: "nil port map",
-			source: &clustermetadatapb.Multipooler{
-				Id:       &clustermetadatapb.ID{Name: "src"},
-				Hostname: "src-host",
-			},
-		},
-		{
-			name: "empty hostname",
-			source: &clustermetadatapb.Multipooler{
-				Id:      &clustermetadatapb.ID{Name: "src"},
-				PortMap: map[string]int32{"postgres": 5433},
-			},
-		},
-		{
-			name: "missing postgres port",
-			source: &clustermetadatapb.Multipooler{
-				Id:       &clustermetadatapb.ID{Name: "src"},
-				Hostname: "src-host",
-				PortMap:  map[string]int32{"grpc": 8080},
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			resp, err := manager.RewindToSource(ctx, tc.source)
-			require.Error(t, err)
-			assert.Nil(t, resp)
-			assert.Equal(t, mtrpcpb.Code_INVALID_ARGUMENT, mterrors.Code(err),
-				"expected INVALID_ARGUMENT, got %v: %v", mterrors.Code(err), err)
-		})
-	}
 }
 
 func TestSetPostgresRestartsEnabledRPC(t *testing.T) {

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -57,14 +57,15 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 	// slower, which widens a window where the killed primary's postgres restarts as
 	// a stale primary before a multiorch coordinator that still holds a stale leader
 	// view has adopted the new term. That coordinator then issues an un-termed
-	// RewindToSource demoting the *current* primary, cascading into a re-election
-	// that re-promotes the killed node instead of it rejoining as a standby. This is
-	// a real coordinator term-awareness bug (cascade re-election, MUL-557 family),
-	// not a test-timing flake, so it is tracked and fixed separately rather than
-	// masked by loosening this test's invariants. The test still runs — with
-	// per-test retries — in the non-coverage "Run full integration test suite" job.
+	// stale-primary demote-to-standby against the *current* primary, cascading into
+	// a re-election that re-promotes the killed node instead of it rejoining as a
+	// standby. This is a real coordinator term-awareness bug (cascade re-election,
+	// MUL-557 family), not a test-timing flake, so it is tracked and fixed
+	// separately rather than masked by loosening this test's invariants. The test
+	// still runs — with per-test retries — in the non-coverage "Run full
+	// integration test suite" job.
 	if utils.RunningUnderCoverage() {
-		t.Skip("quarantined under coverage: exposes a stale-coordinator RewindToSource re-promotion (cascade re-election, MUL-557 family); tracked in a separate investigation")
+		t.Skip("quarantined under coverage: exposes a stale-coordinator demote-to-standby re-promotion (cascade re-election, MUL-557 family); tracked in a separate investigation")
 	}
 
 	// Create an isolated shard for this test

--- a/go/test/endtoend/multiorch/rewind_diverged_replica_test.go
+++ b/go/test/endtoend/multiorch/rewind_diverged_replica_test.go
@@ -27,13 +27,15 @@ import (
 	"github.com/multigres/multigres/go/test/utils"
 )
 
-// TestRewindDivergedReplica tests multiorch's ability to detect a replica with a
+// TestRewindDivergedReplica tests the cluster's ability to detect a replica with a
 // diverged timeline (higher LSN than the primary on a different timeline) and repair
 // it using pg_rewind so it can rejoin replication.
 //
-// This test exercises FixReplicationAction.tryPgRewind(), which is the code path
-// taken when fixNotReplicating sets primary_conninfo but the WAL receiver fails
-// to start because of a timeline divergence.
+// The rewind is driven locally by the diverged pooler's monitor, not by orch: when
+// a standby's primary_conninfo points at the recorded leader but the WAL receiver
+// stays unable to stream past the divergence threshold, the monitor sets
+// suspectedDivergence and rewinds against the recorded leader (self-heal). Orch's
+// FixReplication only delivers the leader identity via SetPrimary.
 //
 // Scenario:
 //  1. 3-node cluster: primary (P) + 2 standbys (R1, R2)
@@ -42,8 +44,8 @@ import (
 //  4. Write a diverging row to R1 (exists on the new timeline only)
 //  5. Restart R1 as a standby — WAL receiver starts, immediately FAILs due to
 //     timeline conflict (R1's timeline > P's), enters retry-wait state
-//  6. Re-enable orch — detects WAL receiver not streaming, verifyReplicationStarted
-//     times out → tryPgRewind → RewindToSource RPC → pg_rewind runs
+//  6. Re-enable orch — the pooler's monitor observes the stuck standby, marks
+//     suspected divergence, and rewinds R1 to P locally
 //  7. Verify R1 rejoins P with the diverged row absent and baseline data present
 func TestRewindDivergedReplica(t *testing.T) {
 	if testing.Short() {
@@ -162,7 +164,9 @@ func TestRewindDivergedReplica(t *testing.T) {
 	// Re-enable postgres restarts so multipooler manages R1 going forward
 	resumeRestarts()
 
-	// Block until orch fully repairs R1 via pg_rewind (fix-replication path).
+	// Block until the shard is problem-free again: orch delivers the leader
+	// identity via SetPrimary and the pooler's monitor rewinds R1 locally, after
+	// which the not-replicating problem clears.
 	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioFixReplication)
 
 	// Verify data consistency: baseline present, diverged row absent

--- a/proto/consensusservice.proto
+++ b/proto/consensusservice.proto
@@ -31,11 +31,6 @@ service MultipoolerConsensus {
   rpc UpdateConsensusRule(multipoolermanagerdata.UpdateConsensusRuleRequest)
     returns (multipoolermanagerdata.UpdateConsensusRuleResponse);
 
-  // RewindToSource performs pg_rewind to synchronize this server with a source.
-  // This is used to repair diverged timelines after failover.
-  rpc RewindToSource(multipoolermanagerdata.RewindToSourceRequest)
-    returns (multipoolermanagerdata.RewindToSourceResponse);
-
   // Appointment protocol: Recruit, then concurrent Promote (to the leader) and
   // SetPrimary (to the other cohort members).
 

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -249,8 +249,6 @@ enum PostgresAction {
   POSTGRES_ACTION_RESTORING_FROM_BACKUP = 2;
   // No backup exists yet; running initdb and creating the first pgBackRest backup.
   POSTGRES_ACTION_CREATING_FIRST_BACKUP = 3;
-  // A pg_rewind operation is running to re-sync this server with the primary.
-  POSTGRES_ACTION_REWIND = 4;
 }
 
 // Status gets unified status that works for both PRIMARY and REPLICA poolers
@@ -574,33 +572,6 @@ message BackupMetadata {
     COMPLETE = 2;
     // TODO: add VALID/INVALID states
   }
-}
-
-// =============================================================================
-// PgRewind APIs
-// =============================================================================
-
-// RewindToSourceRequest requests pg_rewind to synchronize with a source server.
-// This operation:
-// 1. Stops PostgreSQL
-// 2. Runs pg_rewind --dry-run to check if rewind is needed
-// 3. If needed, runs actual pg_rewind
-// 4. Starts PostgreSQL
-message RewindToSourceRequest {
-  // Source multipooler (the primary) to rewind to
-  clustermetadata.Multipooler source = 1;
-}
-
-message RewindToSourceResponse {
-  // True if the operation completed successfully
-  bool success = 1;
-
-  // Error message if operation failed
-  string error_message = 2;
-
-  // True if servers had diverged and pg_rewind was performed
-  // False if timelines were compatible and no rewind was needed
-  bool rewind_performed = 3;
 }
 
 // =============================================================================

--- a/web/multiadmin/lib/api/generated/multipoolermanagerdata_pb.ts
+++ b/web/multiadmin/lib/api/generated/multipoolermanagerdata_pb.ts
@@ -19,7 +19,7 @@
 
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
 import { Duration, Message, proto3, protoInt64, Timestamp } from "@bufbuild/protobuf";
-import { AvailabilityStatus, ConsensusStatus, ID, Multipooler, PoolerType, RoutingRole, RuleNumber } from "./clustermetadata_pb";
+import { AvailabilityStatus, ConsensusStatus, ID, PoolerType, RoutingRole, RuleNumber } from "./clustermetadata_pb";
 
 /**
  * PostgresStatus is the observed state of the PostgreSQL server process.
@@ -106,13 +106,6 @@ export enum PostgresAction {
    * @generated from enum value: POSTGRES_ACTION_CREATING_FIRST_BACKUP = 3;
    */
   CREATING_FIRST_BACKUP = 3,
-
-  /**
-   * A pg_rewind operation is running to re-sync this server with the primary.
-   *
-   * @generated from enum value: POSTGRES_ACTION_REWIND = 4;
-   */
-  REWIND = 4,
 }
 // Retrieve enum metadata with: proto3.getEnumType(PostgresAction)
 proto3.util.setEnumType(PostgresAction, "multipoolermanagerdata.PostgresAction", [
@@ -120,7 +113,6 @@ proto3.util.setEnumType(PostgresAction, "multipoolermanagerdata.PostgresAction",
   { no: 1, name: "POSTGRES_ACTION_STARTING" },
   { no: 2, name: "POSTGRES_ACTION_RESTORING_FROM_BACKUP" },
   { no: 3, name: "POSTGRES_ACTION_CREATING_FIRST_BACKUP" },
-  { no: 4, name: "POSTGRES_ACTION_REWIND" },
 ]);
 
 /**
@@ -2203,108 +2195,6 @@ proto3.util.setEnumType(BackupMetadata_Status, "multipoolermanagerdata.BackupMet
   { no: 1, name: "INCOMPLETE" },
   { no: 2, name: "COMPLETE" },
 ]);
-
-/**
- * RewindToSourceRequest requests pg_rewind to synchronize with a source server.
- * This operation:
- * 1. Stops PostgreSQL
- * 2. Runs pg_rewind --dry-run to check if rewind is needed
- * 3. If needed, runs actual pg_rewind
- * 4. Starts PostgreSQL
- *
- * @generated from message multipoolermanagerdata.RewindToSourceRequest
- */
-export class RewindToSourceRequest extends Message<RewindToSourceRequest> {
-  /**
-   * Source multipooler (the primary) to rewind to
-   *
-   * @generated from field: clustermetadata.Multipooler source = 1;
-   */
-  source?: Multipooler;
-
-  constructor(data?: PartialMessage<RewindToSourceRequest>) {
-    super();
-    proto3.util.initPartial(data, this);
-  }
-
-  static readonly runtime: typeof proto3 = proto3;
-  static readonly typeName = "multipoolermanagerdata.RewindToSourceRequest";
-  static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "source", kind: "message", T: Multipooler },
-  ]);
-
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RewindToSourceRequest {
-    return new RewindToSourceRequest().fromBinary(bytes, options);
-  }
-
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): RewindToSourceRequest {
-    return new RewindToSourceRequest().fromJson(jsonValue, options);
-  }
-
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): RewindToSourceRequest {
-    return new RewindToSourceRequest().fromJsonString(jsonString, options);
-  }
-
-  static equals(a: RewindToSourceRequest | PlainMessage<RewindToSourceRequest> | undefined, b: RewindToSourceRequest | PlainMessage<RewindToSourceRequest> | undefined): boolean {
-    return proto3.util.equals(RewindToSourceRequest, a, b);
-  }
-}
-
-/**
- * @generated from message multipoolermanagerdata.RewindToSourceResponse
- */
-export class RewindToSourceResponse extends Message<RewindToSourceResponse> {
-  /**
-   * True if the operation completed successfully
-   *
-   * @generated from field: bool success = 1;
-   */
-  success = false;
-
-  /**
-   * Error message if operation failed
-   *
-   * @generated from field: string error_message = 2;
-   */
-  errorMessage = "";
-
-  /**
-   * True if servers had diverged and pg_rewind was performed
-   * False if timelines were compatible and no rewind was needed
-   *
-   * @generated from field: bool rewind_performed = 3;
-   */
-  rewindPerformed = false;
-
-  constructor(data?: PartialMessage<RewindToSourceResponse>) {
-    super();
-    proto3.util.initPartial(data, this);
-  }
-
-  static readonly runtime: typeof proto3 = proto3;
-  static readonly typeName = "multipoolermanagerdata.RewindToSourceResponse";
-  static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "success", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-    { no: 2, name: "error_message", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "rewind_performed", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-  ]);
-
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RewindToSourceResponse {
-    return new RewindToSourceResponse().fromBinary(bytes, options);
-  }
-
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): RewindToSourceResponse {
-    return new RewindToSourceResponse().fromJson(jsonValue, options);
-  }
-
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): RewindToSourceResponse {
-    return new RewindToSourceResponse().fromJsonString(jsonString, options);
-  }
-
-  static equals(a: RewindToSourceResponse | PlainMessage<RewindToSourceResponse> | undefined, b: RewindToSourceResponse | PlainMessage<RewindToSourceResponse> | undefined): boolean {
-    return proto3.util.equals(RewindToSourceResponse, a, b);
-  }
-}
 
 /**
  * SetPostgresRestartsEnabledRequest enables or disables automatic PostgreSQL restarts


### PR DESCRIPTION
## What

Removes the `RewindToSource` consensus RPC and moves diverged-standby repair into the pooler's own monitor.

A diverged standby used to be repaired by multiorch's `FixReplication` action issuing the `RewindToSource` RPC. With the monitor's automatic rewind-until-successful loop already in place, that cross-node RPC is redundant for every case except one: a standby that stays up, in recovery, with correct `primary_conninfo`, whose WAL receiver FATALs on a diverged timeline (phantom transactions). This PR closes that gap so the RPC can go.

## Changes

- **Local self-detection of a stuck diverged standby** (`standbyStuckDiverged`): in recovery, `primary_conninfo` points at the correctly-recorded rewind target, the WAL receiver has not streamed past a debounce threshold, **and the recorded leader is reachable**. It sets `suspectedDivergence`, routing the next monitor tick through the existing local rewind path (`restartAsStandbyLocked`) — gated on the leader being rewind-ready and rate-limited by backoff. The rewind reports `POSTGRES_ACTION_STARTING`.
- **Leader-liveness gate (load-bearing).** "Not streaming" happens both when the WAL diverged (leader alive, receiver FATALs) *and* when the leader is dead (a failover in progress). Only the first warrants a rewind. Marking divergence against a dead leader would stall the coordinator's election — its subsequent `SetPrimary` would take the stale-primary-demote path and defer. So the monitor concludes divergence only when a TCP dial confirms the leader is up, mirroring the old orch guard that refused `pg_rewind` unless the primary was running. The dial is injectable (`leaderReachableFn`) for tests.
- **Debounce window**: `Config.StandbyStuckDivergenceThreshold` (default `10s`) — only needs to outlast a transient reconnect now that the liveness gate excludes failover. It's an internal, programmatic override (no CLI flag); production uses the default. The e2e `FixReplication` recovery budget is widened to 45s to reflect that pooler-local self-heal legitimately takes longer than the old orch-immediate `RewindToSource` (measured ~20s locally vs the old ~5s).
- **`FixReplication` no longer escalates to `pg_rewind`**: it delivers the leader identity via `SetPrimary` and returns an error for retry when streaming doesn't start; the pooler self-heals. `tryPgRewind` is removed.
- **`RewindToSource` removed end to end**: proto (`consensusservice.proto`, `multipoolermanagerdata.proto` messages), regenerated pb, the manager method, the gRPC handler, and the `rpcclient` interface/impl/fake. `restartAsStandbyLocked` is kept (shared with `SetPrimary`'s stale-primary branch and the monitor).
- **`POSTGRES_ACTION_REWIND` enum removed**; `reserved 4` / `reserved "POSTGRES_ACTION_REWIND"` so the number/name can't be silently reused.

## Tests

- Added `TestStandbyStuckDiverged` (unit), including `UnreachableLeaderIsNotStuck` (pins the failover-vs-divergence distinction) and a `Config`-override case.
- Retargeted the `RewindToSource` manager regression tests to `restartAsStandbyLocked`; dropped the RPC-boundary `InvalidArgs` test.
- Reworked the `FixReplication` tests for the no-orch-rewind behavior.
- Updated the multiorch e2e (`TestRewindDivergedReplica`) and the backupfaults e2e (`TestPrimaryCrashWithUnarchivedWAL_NoDataLoss`) — comment + shortened threshold flag — so a diverged restore rejoins via the local self-heal within the recovery budget.

**Verification:** `go build ./go/...` clean, `make proto` produces no diff, gofumpt-clean. Unit suites pass. Integration (local): `TestRewindDivergedReplica`, `TestFixReplication`, both `TestDemoteStalePrimary_*`, `TestPrimaryGracefulShutdownTriggersFailover`, and the backupfaults regression test (which exercises *both* a failover and a diverged rejoin) all pass; backupfaults ran 3/3 clean.

## Note on the liveness gate

The gate resolves a subtlety the first cut missed: a pure time threshold cannot tell divergence (needs a *short* threshold to rejoin in budget) apart from failover (needs a threshold *longer* than failover so the old rule is revoked before a standby is mis-flagged). The distinguishing signal is leader liveness, not time — hence the dial. A false "alive" only costs a gated, rate-limited `pg_rewind` dry-run; a false "dead" just retries next tick.

## Follow-up (not in this PR)

Fully removing `FixReplication` remains gated on giving the pooler a topology-driven way to learn a new leader's **address** when it missed the consensus fan-out (a pooler learns the leader's host:port only from a pushed `SetPrimary`; the WAL-replicated rule carries only the leader ID). Tracked separately.
