### PR TITLE
refactor(pgctld): consolidate standby.signal handling into shared helpers

### DIFF
--- a/go/cmd/pgctld/command/crash_recovery.go
+++ b/go/cmd/pgctld/command/crash_recovery.go
@@ -80,11 +80,43 @@ func crashRecoveryNeeded(ctx context.Context) (bool, error) {
 	return !cleanlyStopped, nil
 }
 
+// standbySignalPath returns the path to the standby.signal marker file inside dataDir.
+func standbySignalPath(dataDir string) string {
+	return filepath.Join(dataDir, constants.StandbySignalFile)
+}
+
 // hasStandbySignal reports whether a standby.signal marker file is present, i.e.
 // PostgreSQL is configured to start in standby mode.
 func hasStandbySignal() bool {
-	_, err := os.Stat(filepath.Join(pgctld.PostgresDataDir(), constants.StandbySignalFile))
+	_, err := os.Stat(standbySignalPath(pgctld.PostgresDataDir()))
 	return err == nil
+}
+
+// createStandbySignal creates an empty standby.signal file in dataDir so that
+// PostgreSQL comes up in recovery (standby) mode instead of as a writable
+// primary. The write truncates any existing file, so it is idempotent.
+func createStandbySignal(logger *slog.Logger, dataDir string) (string, error) {
+	path := standbySignalPath(dataDir)
+	if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+		return path, fmt.Errorf("failed to create standby.signal: %w", err)
+	}
+	logger.Info("standby.signal created successfully", "path", path)
+	return path, nil
+}
+
+// removeStandbySignal removes standby.signal from dataDir so that PostgreSQL
+// starts as a writable primary instead of recovering as a standby. A no-op if
+// the file does not exist.
+func removeStandbySignal(logger *slog.Logger, dataDir string) (string, error) {
+	path := standbySignalPath(dataDir)
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return path, nil
+		}
+		return path, fmt.Errorf("failed to remove standby.signal: %w", err)
+	}
+	logger.Info("standby.signal removed successfully", "path", path)
+	return path, nil
 }
 
 // runCrashRecovery performs crash recovery in single-user mode (postgres --single),
@@ -112,17 +144,17 @@ func runCrashRecoveryInDir(
 	run func(context.Context) ([]byte, error),
 	r *retry.Retry,
 ) error {
-	signalPath := filepath.Join(dataDir, constants.StandbySignalFile)
+	signalPath := standbySignalPath(dataDir)
 	if _, err := os.Stat(signalPath); err == nil {
 		logger.InfoContext(ctx, "Temporarily removing standby.signal for single-user crash recovery",
 			"path", signalPath)
-		if rmErr := os.Remove(signalPath); rmErr != nil {
+		if _, rmErr := removeStandbySignal(logger, dataDir); rmErr != nil {
 			return fmt.Errorf("failed to remove standby.signal before crash recovery: %w", rmErr)
 		}
 		// Recreate even if recovery fails, so the node is not silently converted
 		// from a standby into a primary on the next start.
 		defer func() {
-			if wErr := os.WriteFile(signalPath, []byte(""), 0o644); wErr != nil {
+			if _, wErr := createStandbySignal(logger, dataDir); wErr != nil {
 				logger.ErrorContext(ctx, "failed to recreate standby.signal after crash recovery", "error", wErr, "path", signalPath)
 			}
 		}()

--- a/go/cmd/pgctld/command/crash_recovery_test.go
+++ b/go/cmd/pgctld/command/crash_recovery_test.go
@@ -181,8 +181,8 @@ func fileExists(t *testing.T, path string) bool {
 // stays a standby.
 func TestRunCrashRecoveryInDir_RemovesAndRestoresStandbySignal(t *testing.T) {
 	dir := t.TempDir()
-	signalPath := filepath.Join(dir, constants.StandbySignalFile)
-	require.NoError(t, os.WriteFile(signalPath, []byte(""), 0o644))
+	signalPath, err1 := createStandbySignal(testLogger(), dir)
+	require.NoError(t, err1)
 
 	var signalPresentDuringRun bool
 	runner := func(ctx context.Context) ([]byte, error) {
@@ -201,8 +201,8 @@ func TestRunCrashRecoveryInDir_RemovesAndRestoresStandbySignal(t *testing.T) {
 // convert a standby into a primary on its next start.
 func TestRunCrashRecoveryInDir_RestoresStandbySignalOnFailure(t *testing.T) {
 	dir := t.TempDir()
-	signalPath := filepath.Join(dir, constants.StandbySignalFile)
-	require.NoError(t, os.WriteFile(signalPath, []byte(""), 0o644))
+	signalPath, err1 := createStandbySignal(testLogger(), dir)
+	require.NoError(t, err1)
 
 	runner := func(ctx context.Context) ([]byte, error) {
 		return []byte("FATAL:  could not access data directory"), errors.New("exit status 1")
@@ -217,7 +217,7 @@ func TestRunCrashRecoveryInDir_RestoresStandbySignalOnFailure(t *testing.T) {
 // (no standby.signal) is crash-recovered without a spurious signal being created.
 func TestRunCrashRecoveryInDir_NoStandbySignal_LeavesNoneBehind(t *testing.T) {
 	dir := t.TempDir()
-	signalPath := filepath.Join(dir, constants.StandbySignalFile)
+	signalPath := standbySignalPath(dir)
 
 	calls := 0
 	runner := func(ctx context.Context) ([]byte, error) {
@@ -238,7 +238,7 @@ func TestRunCrashRecoveryInDir_NoStandbySignal_LeavesNoneBehind(t *testing.T) {
 // but os.Remove fails.
 func TestRunCrashRecoveryInDir_RemoveFailureSkipsRecovery(t *testing.T) {
 	dir := t.TempDir()
-	signalPath := filepath.Join(dir, constants.StandbySignalFile)
+	signalPath := standbySignalPath(dir)
 	require.NoError(t, os.Mkdir(signalPath, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(signalPath, "child"), []byte(""), 0o644))
 

--- a/go/cmd/pgctld/command/restart.go
+++ b/go/cmd/pgctld/command/restart.go
@@ -17,10 +17,7 @@ package command
 import (
 	"fmt"
 	"log/slog"
-	"os"
-	"path/filepath"
 
-	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/services/pgctld"
 	"github.com/multigres/multigres/go/tools/viperutil"
 
@@ -122,12 +119,9 @@ func RestartPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtl
 
 	// Create standby.signal if restarting as standby
 	if asStandby {
-		standbySignalPath := filepath.Join(config.PostgresDataDir, constants.StandbySignalFile)
-		logger.Info("Creating standby.signal file", "path", standbySignalPath)
-		if err := os.WriteFile(standbySignalPath, []byte(""), 0o644); err != nil {
-			return nil, fmt.Errorf("failed to create standby.signal: %w", err)
+		if _, err := createStandbySignal(logger, config.PostgresDataDir); err != nil {
+			return nil, err
 		}
-		logger.Info("standby.signal created successfully", "path", standbySignalPath)
 	}
 
 	// Start the server with detailed context

--- a/go/cmd/pgctld/command/root.go
+++ b/go/cmd/pgctld/command/root.go
@@ -266,7 +266,7 @@ management for PostgreSQL servers.`,
 }
 
 // validateGlobalFlags validates required global flags for all pgctld commands
-func (pc *PgCtlCommand) validateGlobalFlags(cmd *cobra.Command, args []string) error {
+func (pc *PgCtlCommand) validateGlobalFlags(_ *cobra.Command, _ []string) error {
 	// Validate pooler-dir is required and non-empty for all commands
 	poolerDir := pc.GetPoolerDir()
 	if poolerDir == "" {


### PR DESCRIPTION
The Restart path and single-user crash recovery each wrote or removed standby.signal inline with duplicated os.WriteFile / os.Remove logic.

Introduce standbySignalPath, createStandbySignal, and removeStandbySignal and route those existing operations through them: hasStandbySignal, restart-as-standby, and the temporary remove/recreate around single-user crash recovery now share the helpers, which log consistently and return the resolved path. No behavior change.

Also mark the unused validateGlobalFlags parameters as _ to satisfy the linter.