### PR TITLE
fix(multipooler): detect a stale leader from the rule store, not just pgMode

### DIFF
--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -662,7 +662,7 @@ func (pm *MultipoolerManager) SetPrimary(ctx context.Context, req *consensusdata
 	}
 	eventlog.Emit(ctx, pm.logger, eventlog.Started, setPrimaryEvent)
 
-	resp, err := pm.setPrimaryLocked(ctx, req)
+	resp, err := pm.setPrimaryLocked(ctx, req, selfPos)
 	if err != nil {
 		eventlog.Emit(ctx, pm.logger, eventlog.Failed, setPrimaryEvent, "error", err)
 	} else {
@@ -671,7 +671,7 @@ func (pm *MultipoolerManager) SetPrimary(ctx context.Context, req *consensusdata
 	return resp, err
 }
 
-func (pm *MultipoolerManager) setPrimaryLocked(ctx context.Context, req *consensusdatapb.SetPrimaryRequest) (*consensusdatapb.SetPrimaryResponse, error) {
+func (pm *MultipoolerManager) setPrimaryLocked(ctx context.Context, req *consensusdatapb.SetPrimaryRequest, selfPos *clustermetadatapb.PoolerPosition) (*consensusdatapb.SetPrimaryResponse, error) {
 	rp := req.GetReplicationPrimary()
 	leader := rp.GetPrimary()
 	incomingPosition := commonconsensus.FormatRulePosition(rp.GetPosition())
@@ -685,7 +685,8 @@ func (pm *MultipoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 		return nil, mterrors.Wrap(err, "failed to check recovery status")
 	}
 
-	if pgMode.OutOfRecovery() {
+	walRule := commonconsensus.PossiblyUndecidedRule(selfPos.GetPosition())
+	if pgMode.OutOfRecovery() || commonconsensus.RuleNamesLeader(walRule, pm.serviceID) {
 		if _, err := pm.consensusMgr.SetSuspectedDivergence(ctx, true); err != nil {
 			pm.logger.ErrorContext(ctx, "failed to set suspected divergence in SetPrimary", "error", err)
 		}

--- a/go/services/multipooler/internal/manager/rpc_set_primary_test.go
+++ b/go/services/multipooler/internal/manager/rpc_set_primary_test.go
@@ -21,11 +21,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor/mock"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus/consensustest"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
+	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 )
 
 // newLeaderAddress builds a PoolerAddress suitable for use as the leader in a
@@ -470,6 +472,59 @@ func TestSetPrimary_StalePrimaryDemotes(t *testing.T) {
 	healthState := pm.healthStreamer.getState()
 	assert.NotEqual(t, clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY, healthState.RoutingState.GetRole(),
 		"a demoted pooler must not advertise itself as the routing primary")
+}
+
+// TestSetPrimary_StaleLeaderByRuleStoreMarksDivergence verifies the rule-store /
+// WAL leadership trigger: even when postgres reports standby (pg_is_in_recovery=t,
+// so pgMode is NOT out of recovery), if this pooler's own committed rule still
+// names IT as the leader, SetPrimary treats it as a possibly-diverged stale leader
+// — it sets suspected divergence and enters the demote-via-rewind path (deferring
+// here with UNAVAILABLE because the incoming leader is not yet rewind-ready).
+//
+// This catches a stale primary whose postgres was demoted but whose WAL/rule store
+// still asserts leadership — a case that pgMode alone, and a highest-known-rule
+// role check (which would see the newer leader this node has already been told
+// about), would both miss.
+func TestSetPrimary_StaleLeaderByRuleStoreMarksDivergence(t *testing.T) {
+	mockQueryService := mock.NewQueryService()
+	// setPrimaryLocked's postgresMode: in recovery (standby), so only the
+	// rule-store leadership check can trip divergence — not pgMode.
+	mockQueryService.AddQueryPattern("SELECT pg_is_in_recovery",
+		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
+
+	// setupManagerWithMockDB's pooler is zone1/test-pooler; our own committed rule
+	// still names us the leader at term 2, even though postgres reports standby.
+	selfID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "test-pooler",
+	}
+	selfPos := &clustermetadatapb.PoolerPosition{
+		Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
+			RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2},
+			LeaderId:   selfID,
+		}},
+		Lsn: "16/B374D848",
+	}
+	pm, _ := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: selfPos})
+
+	require.False(t, pm.consensusMgr.SuspectedDivergence(), "precondition: divergence not yet suspected")
+
+	// A higher rule naming a different new leader that is NOT yet rewind-ready.
+	leader := newLeaderAddress("new-primary", "primary-host", 5432)
+	req := &consensusdatapb.SetPrimaryRequest{
+		ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
+			Position:    &clustermetadatapb.RulePosition{Decision: ruleAtTermForLeader(leader, 10)},
+			Primary:     leader,
+			RewindReady: false,
+		},
+	}
+	_, err := pm.SetPrimary(t.Context(), req)
+
+	// The demote defers (leader not rewind-ready) — but only AFTER the rule-store
+	// leadership check flagged suspected divergence.
+	require.Error(t, err)
+	assert.Equal(t, mtrpcpb.Code_UNAVAILABLE, mterrors.Code(err))
+	assert.True(t, pm.consensusMgr.SuspectedDivergence(),
+		"a standby whose own committed rule still names it leader must be flagged as a possibly-diverged stale leader")
 }
 
 // TestSetPrimary_IgnoresRevokedRule verifies that when the incoming rule is


### PR DESCRIPTION
`SetPrimary` decides whether to rewind before following a new primary by flagging suspected divergence when this pooler looks like a (possibly stale) leader whose WAL may have diverged. It previously keyed only on `pgMode.OutOfRecovery()` — postgres itself reporting primary.

A stale leader whose postgres was **already demoted to standby**, but whose committed rule still names it the leader, slipped through: `pgMode` reads standby, so no divergence was suspected, and it followed the new primary without rewinding its possibly-diverged WAL.

This also trips suspected divergence when the pooler's **own current-position rule names itself leader**. It keys on `CurrentPosition` (the rule replicated through this node's WAL), not the highest-known rule — a stale leader that has already been told about the new leader carries a `ReplicationPrimary` naming that leader, so a highest-known-rule role check would report not-leader and miss exactly this case.
