### PR TITLE
fix(multipooler): clear restore_command when a standby joins the cohort out-of-band

### DIFF
--- a/go/services/multiorch/recovery/actions/reconcile_cohort.go
+++ b/go/services/multiorch/recovery/actions/reconcile_cohort.go
@@ -29,6 +29,7 @@ import (
 	"github.com/multigres/multigres/go/services/multiorch/store"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 )
 
@@ -97,11 +98,13 @@ func (a *ReconcileCohortAction) Execute(ctx context.Context, problem types.Probl
 	// be gone from the cache (the whole point of "cohort member is no longer
 	// tracked"), so we operate on the problem's raw ID directly.
 	var targetID *clustermetadatapb.ID
+	var target *store.Pooler
 	if op == multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_ADD {
-		target, err := store.FindPoolerByID(a.poolerStore, problem.PoolerID)
+		t, err := store.FindPoolerByID(a.poolerStore, problem.PoolerID)
 		if err != nil {
 			return mterrors.Wrap(err, "failed to find target pooler")
 		}
+		target = t
 		targetID = target.Health().Multipooler.Id
 	} else {
 		targetID = problem.PoolerID
@@ -136,11 +139,64 @@ func (a *ReconcileCohortAction) Execute(ctx context.Context, problem types.Probl
 		return mterrors.Wrap(err, "UpdateConsensusRule failed")
 	}
 
+	// A member that joins an already-established cohort out-of-band (provisioned
+	// after a failover, added here rather than through the promotion-time Recruit
+	// wave) never received Recruit's synchronous restore_command clear. The ADD
+	// above only amends the leader's rule + synchronous_standby_names; it runs on
+	// the leader and cannot touch the joining member's restore_command. Left set,
+	// a restart-as-standby can resolve recovery_target_timeline=latest through the
+	// archive to a divergent timeline and FATAL at startup. Drive the member-side
+	// clear synchronously by re-issuing SetPrimary carrying the post-ADD rule: the
+	// member now sees itself named in that rule and clears restore_command before
+	// the monitor's ~one-tick backstop would. Best-effort — the ADD (the action's
+	// contract) already succeeded, and the monitor backstop still covers a failure
+	// here — so a member-side hiccup does not fail cohort reconciliation.
+	if op == multipoolermanagerdatapb.CohortUpdateOperation_COHORT_UPDATE_OPERATION_ADD && target != nil {
+		a.clearJoiningMemberArchive(ctx, leader, target)
+	}
+
 	a.logger.InfoContext(ctx, "reconcile cohort action completed",
 		"target", targetID.Name,
 		"primary", leader.Health().Multipooler.Id.Name,
 		"operation", op.String())
 	return nil
+}
+
+// clearJoiningMemberArchive re-issues SetPrimary to a pooler just added to the
+// cohort so it clears restore_command synchronously (see the caller for why).
+//
+// It re-reads the leader's status to obtain the post-ADD rule — the rule that
+// now names the member — because the member-side clear keys off cohort
+// membership as asserted by the rule this SetPrimary delivers. The cached
+// pre-ADD rule would not name the member, so relaying it would not trigger the
+// clear. Failures are logged and swallowed: this is a best-effort hardening step
+// layered on top of the pooler's own monitor backstop.
+func (a *ReconcileCohortAction) clearJoiningMemberArchive(ctx context.Context, leader, target *store.Pooler) {
+	statusResp, err := a.rpcClient.Status(ctx, leader.Health().Multipooler, &multipoolermanagerdatapb.StatusRequest{})
+	if err != nil {
+		a.logger.WarnContext(ctx, "reconcile cohort: could not read leader status to clear joining member's archive; relying on monitor backstop",
+			"target", target.Health().Multipooler.Id.Name, "error", err)
+		return
+	}
+	// The leader's own rule store reflects the ADD synchronously (UpdateConsensusRule
+	// commits before returning), so HighestKnownRule here is the post-ADD rule.
+	postAddRule := commonconsensus.HighestKnownRule([]*clustermetadatapb.ConsensusStatus{statusResp.GetConsensusStatus()})
+	if postAddRule == nil {
+		a.logger.WarnContext(ctx, "reconcile cohort: leader reported no rule after ADD; relying on monitor backstop",
+			"target", target.Health().Multipooler.Id.Name)
+		return
+	}
+	setPrimaryReq := &consensusdatapb.SetPrimaryRequest{
+		ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
+			Position:    postAddRule,
+			Primary:     topoclient.PoolerAddressFor(leader.Health().Multipooler),
+			RewindReady: commonconsensus.ReplicationPrimaryOrNil(statusResp.GetConsensusStatus()).GetRewindReady(),
+		},
+	}
+	if _, err := a.rpcClient.SetPrimary(ctx, target.Health().Multipooler, setPrimaryReq); err != nil {
+		a.logger.WarnContext(ctx, "reconcile cohort: SetPrimary to clear joining member's archive failed; relying on monitor backstop",
+			"target", target.Health().Multipooler.Id.Name, "error", err)
+	}
 }
 
 // RecoveryAction interface implementation

--- a/go/services/multiorch/recovery/actions/reconcile_cohort_test.go
+++ b/go/services/multiorch/recovery/actions/reconcile_cohort_test.go
@@ -116,6 +116,17 @@ func TestReconcileCohortAction_Execute(t *testing.T) {
 		require.NotNil(t, req.ExpectedOutgoingRule, "CAS guard must be set")
 		assert.Equal(t, int64(3), req.ExpectedOutgoingRule.CoordinatorTerm)
 		assert.Equal(t, int64(7), req.ExpectedOutgoingRule.LeaderSubterm)
+
+		// After recording membership on the leader, the action re-issues
+		// SetPrimary to the joining member so it clears restore_command
+		// synchronously — a member that joins an already-established cohort
+		// out-of-band never went through Recruit's clear. The rule relayed is
+		// the leader's post-ADD rule (re-read from the leader's status).
+		assert.Contains(t, fakeClient.CallLog, "Status(multipooler-cell1-primary)")
+		assert.Contains(t, fakeClient.CallLog, "SetPrimary(multipooler-cell1-replica1)")
+		setReq := fakeClient.SetPrimaryRequests["multipooler-cell1-replica1"]
+		require.NotNil(t, setReq)
+		assert.Equal(t, primaryID.Name, setReq.GetReplicationPrimary().GetPrimary().GetId().GetName())
 	})
 
 	t.Run("ProblemCohortMemberIneligible issues UpdateConsensusRule with REMOVE", func(t *testing.T) {

--- a/go/services/multiorch/recovery/analysis/cohort_mismatch_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/cohort_mismatch_analyzer.go
@@ -195,8 +195,19 @@ func (a *CohortMismatchAnalyzer) Analyze(sa *ShardAnalysis) ([]types.Problem, er
 }
 
 // isAdditionCandidate reports whether a non-cohort pooler is healthy enough to
-// be added: it must be a non-leader REPLICA, initialized, replicating, and not
-// signaling INELIGIBLE.
+// be added: it must be a non-leader REPLICA, initialized, actively streaming
+// from the leader, and not signaling INELIGIBLE.
+//
+// The "actively streaming" requirement (walReceiverStreaming, not merely
+// primary_conninfo set + replay unpaused) is load-bearing for restore_command
+// safety: admission clears the joining member's restore_command (ReconcileCohort
+// re-issues SetPrimary, which clears it once the node is named in the rule). A
+// node still catching up from the archive (receiver not yet streaming) would be
+// stranded if we admitted it and stripped the archive out from under it. Gating
+// on an active receiver here makes "a cohort member is, by construction,
+// streaming and archive-independent" a local property of admission rather than
+// something that only holds because ReplicaNotReplicating (higher priority)
+// happens to preempt this analyzer until the receiver comes up.
 //
 // TODO: long-term, most of these checks should fold into the pooler's
 // self-reported cohort eligibility signal. The pooler is in the best position
@@ -222,6 +233,13 @@ func (a *CohortMismatchAnalyzer) isAdditionCandidate(_ *ShardAnalysis, pa *store
 	// Replication must be configured and not stopped — otherwise the standby
 	// can't acknowledge writes and adding it would degrade durability.
 	if primaryConnInfoHost(pa) == "" || !walReplayNotPaused(pa) {
+		return false
+	}
+	// The WAL receiver must actually be streaming from the leader — configured
+	// + replaying also matches a node still catching up from the archive, and
+	// admitting such a node would clear its restore_command mid-catch-up. See
+	// the doc comment above.
+	if !walReceiverStreaming(pa) {
 		return false
 	}
 	if types.PoolerIsCohortIneligible(pa.Health().GetAvailabilityStatus()) {

--- a/go/services/multiorch/recovery/analysis/cohort_mismatch_analyzer_test.go
+++ b/go/services/multiorch/recovery/analysis/cohort_mismatch_analyzer_test.go
@@ -67,7 +67,9 @@ func TestCohortMismatchAnalyzer_Analyze(t *testing.T) {
 			Status: &multipoolermanagerdatapb.Status{
 				IsInitialized: true,
 				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-					PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{Host: "primary.example.com"},
+					PrimaryConnInfo:   &multipoolermanagerdatapb.PrimaryConnInfo{Host: "primary.example.com"},
+					WalReceiverStatus: "streaming",
+					LastReceiveLsn:    "0/3000000",
 				},
 			},
 		})
@@ -190,6 +192,37 @@ func TestCohortMismatchAnalyzer_Analyze(t *testing.T) {
 	t.Run("ignores replica with stopped replication", func(t *testing.T) {
 		pa := healthyReplicaPA(replicaA, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE)
 		pa.Mutate(func(h *multiorchdatapb.PoolerHealthState) { h.Status.ReplicationStatus.IsWalReplayPaused = true })
+		sa := healthyShard(nil, pa)
+		problems, err := analyzer.Analyze(sa)
+		require.NoError(t, err)
+		assert.Empty(t, problems)
+	})
+
+	t.Run("ignores replica whose WAL receiver is not yet streaming (archive catch-up)", func(t *testing.T) {
+		// primary_conninfo is set and replay is running, but the WAL receiver is
+		// not streaming — the node is still catching up from the archive. It must
+		// NOT be admitted to the cohort yet, because admission clears its
+		// restore_command and would strand it mid-catch-up.
+		pa := healthyReplicaPA(replicaA, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE)
+		pa.Mutate(func(h *multiorchdatapb.PoolerHealthState) {
+			h.Status.ReplicationStatus.WalReceiverStatus = ""
+			h.Status.ReplicationStatus.LastReceiveLsn = ""
+		})
+		sa := healthyShard(nil, pa)
+		problems, err := analyzer.Analyze(sa)
+		require.NoError(t, err)
+		assert.Empty(t, problems)
+	})
+
+	t.Run("ignores replica reporting streaming with no WAL received yet (reconnect flicker)", func(t *testing.T) {
+		// postgres briefly reports "streaming" after a receiver reconnect before
+		// any WAL arrives (LastReceiveLsn empty). That is not genuine streaming, so
+		// the node must not be admitted on the strength of the flicker.
+		pa := healthyReplicaPA(replicaA, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE)
+		pa.Mutate(func(h *multiorchdatapb.PoolerHealthState) {
+			h.Status.ReplicationStatus.WalReceiverStatus = "streaming"
+			h.Status.ReplicationStatus.LastReceiveLsn = ""
+		})
 		sa := healthyShard(nil, pa)
 		problems, err := analyzer.Analyze(sa)
 		require.NoError(t, err)

--- a/go/services/multiorch/recovery/analysis/shard_analysis.go
+++ b/go/services/multiorch/recovery/analysis/shard_analysis.go
@@ -126,6 +126,30 @@ func walReceiverActive(p *store.Pooler) bool {
 	return rs.GetWalReceiverStatus() == "streaming" || rs.GetWalReceiverStatus() == "waiting"
 }
 
+// walReceiverStreaming is a stricter form of walReceiverActive: it additionally
+// rejects the brief window after a receiver reconnect where postgres reports
+// "streaming" before any WAL has actually arrived (LastReceiveLsn still empty) —
+// the same FATAL-retry flicker FixReplication guards against. It is the signal
+// that a standby has bridged any initial archive catch-up and is genuinely
+// pulling WAL from the leader, which is what cohort admission requires (a cohort
+// member must advance only by streaming, never the archive). "waiting" stays
+// healthy: the receiver is connected and current, the primary just has nothing
+// new to send.
+func walReceiverStreaming(p *store.Pooler) bool {
+	rs := p.Health().GetStatus().GetReplicationStatus()
+	if rs == nil {
+		return false
+	}
+	switch rs.GetWalReceiverStatus() {
+	case "waiting":
+		return true
+	case "streaming":
+		return rs.GetLastReceiveLsn() != ""
+	default:
+		return false
+	}
+}
+
 // compareLeaderTimeline compares two leader riders by rule position. LSN is
 // intentionally excluded from the comparison (CompareRulePosition already
 // stops at decision-then-proposal): for leaders, the coordinator term must be

--- a/go/services/multipooler/internal/manager/pg_replication.go
+++ b/go/services/multipooler/internal/manager/pg_replication.go
@@ -542,6 +542,26 @@ func (pm *MultipoolerManager) resetRestoreCommand(ctx context.Context) error {
 	return pm.reloadPostgresConfig(ctx)
 }
 
+// clearRestoreCommandIfSet clears restore_command and stops any in-flight
+// archive fetch, but only when restore_command is currently set. Reading first
+// makes it a cheap no-op on hot paths that may call it repeatedly (e.g. every
+// SetPrimary to a settled cohort member), avoiding a needless ALTER SYSTEM +
+// config reload each time. See resetRestoreCommand for why a cohort member must
+// never retain restore_command.
+func (pm *MultipoolerManager) clearRestoreCommandIfSet(ctx context.Context) error {
+	current, err := pm.readRestoreCommand(ctx)
+	if err != nil {
+		return err
+	}
+	if current == "" {
+		return nil
+	}
+	if err := pm.resetRestoreCommand(ctx); err != nil {
+		return err
+	}
+	return pm.stopRestoreCommand(ctx)
+}
+
 // stopRestoreCommand asks pgctld to stop any in-flight restore_command
 // invocation (see pgctld.StopRestoreCommand) — postgres cannot cancel one on
 // its own, a config change only affects the next fetch decision. Requires the

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -624,6 +624,37 @@ func (pm *MultipoolerManager) SetPrimary(ctx context.Context, req *consensusdata
 		pm.logger.ErrorContext(ctx, "failed to record replication primary in SetPrimary", "error", err)
 	}
 
+	// If this pooler is (or is now being told it is) a cohort member, it must
+	// never resume WAL playback from the archive — only stream from the leader.
+	// Clear restore_command synchronously, mirroring what Recruit does when a
+	// member joins during a promotion wave.
+	//
+	// Why here, and not conditional on the change actually being applied: the
+	// clear must run BEFORE the "incoming position not higher" no-op gate below.
+	// A member that joins an already-established cohort out-of-band — provisioned
+	// after a failover and added via UpdateConsensusRule/ReconcileCohort rather
+	// than Recruit — never goes through Recruit's synchronous clear. multiorch
+	// drives this member-side clear by re-issuing SetPrimary after the cohort ADD;
+	// that call is frequently a position no-op (the member may already follow this
+	// leader), so leaving the clear on the apply path only would strand
+	// restore_command until the monitor backstop notices ~one tick later, during
+	// which a restart-as-standby could FATAL on a divergent archive timeline (see
+	// resetRestoreCommand).
+	//
+	// Why here, and not in SetPrimary's caller-side gate or UpdateConsensusRule:
+	// membership is decided by the rule, which RecordTermPrimary just folded into
+	// HighestKnownRule, so IsPotentialCohortMember reflects the rule this call is
+	// delivering — making the clear race-free without waiting for the member to
+	// independently stream the new rule. It sits after the revoked-rule early
+	// return above, so a revoked rule never reaches here to trigger a clear. An
+	// observer still catching up is not named in any rule yet, so it is correctly
+	// left with restore_command.
+	if pm.consensusMgr.IsPotentialCohortMember(pm.serviceID) {
+		if err := pm.clearRestoreCommandIfSet(ctx); err != nil {
+			pm.logger.WarnContext(ctx, "SetPrimary: failed to clear restore_command for cohort member", "error", err)
+		}
+	}
+
 	// Observe the freshest view of our rule. SetPrimary is the staleness gate,
 	// so we want authoritative state — not the cached snapshot.
 	selfPos, err := pm.consensusMgr.Rules().ObservePosition(ctx)
@@ -692,16 +723,9 @@ func (pm *MultipoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 		}
 	}
 
-	// If this pooler is being asked to serve a cohort member, it should not be accepting any WAL
-	// from the restore_command / pgbackrest WAL archive, only from the indicated primary.
-	if pm.consensusMgr.IsPotentialCohortMember(pm.serviceID) {
-		if err := pm.resetRestoreCommand(ctx); err != nil {
-			pm.logger.WarnContext(ctx, "SetPrimary: failed to clear restore_command for cohort member", "error", err)
-		}
-		if err := pm.stopRestoreCommand(ctx); err != nil {
-			pm.logger.WarnContext(ctx, "SetPrimary: failed to confirm restore_command stopped for cohort member", "error", err)
-		}
-	}
+	// The cohort-member restore_command clear runs in SetPrimary (the public
+	// entrypoint) before the no-op position gate, so it covers this apply path as
+	// well as the no-op path that never reaches here.
 
 	if pm.consensusMgr.SuspectedDivergence() {
 		// Demoting a (likely diverged) stale primary restarts it as a standby of the

--- a/go/services/multipooler/internal/manager/rpc_set_primary_test.go
+++ b/go/services/multipooler/internal/manager/rpc_set_primary_test.go
@@ -756,6 +756,11 @@ func TestSetPrimary_ClearsRestoreCommandForCohortMember(t *testing.T) {
 	mockQueryService.AddQueryPatternOnce("SELECT pg_wal_replay_resume",
 		mock.MakeQueryResult(nil, nil))
 
+	// SetPrimary reads restore_command first and only clears it when set, so
+	// return a non-empty value to drive the clear.
+	mockQueryService.AddQueryPattern("current_setting\\('restore_command'",
+		mock.MakeQueryResult([]string{"current_setting"}, [][]any{{"pgbackrest archive-get %f %p"}}))
+
 	// The restore_command clear-and-confirm this test exists to check.
 	var resetCalled bool
 	mockQueryService.AddQueryPatternWithCallback(
@@ -785,4 +790,63 @@ func TestSetPrimary_ClearsRestoreCommandForCohortMember(t *testing.T) {
 	require.NotNil(t, resp)
 
 	assert.True(t, resetCalled, "restore_command should be cleared when the incoming rule names this pooler a cohort member")
+}
+
+// TestSetPrimary_ClearsRestoreCommandForCohortMemberOnNoOp verifies the clear
+// still fires when SetPrimary is a position no-op (the incoming rule ties the
+// pooler's already-observed rule). This is the case a member hits once it has
+// streamed the cohort rule that names it: a re-issued SetPrimary from
+// ReconcileCohort no longer advances the position, but the invariant must still
+// be enforced. The clear runs before the no-op gate, keyed on cohort membership
+// (here established by the pooler's own current rule), not on the change being
+// applied. See setPrimaryLocked — the apply-path clear moved into SetPrimary so
+// it also covers this no-op path.
+func TestSetPrimary_ClearsRestoreCommandForCohortMemberOnNoOp(t *testing.T) {
+	mockQueryService := mock.NewQueryService()
+
+	// Out of recovery so the no-op path's drift reconcile is skipped; the only
+	// recovery-mode read on this path is the single pg_is_in_recovery below.
+	mockQueryService.AddQueryPatternOnce("SELECT pg_is_in_recovery",
+		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"f"}}))
+
+	// restore_command is set, so the clear proceeds even though the position is
+	// a no-op.
+	mockQueryService.AddQueryPattern("current_setting\\('restore_command'",
+		mock.MakeQueryResult([]string{"current_setting"}, [][]any{{"pgbackrest archive-get %f %p"}}))
+	var resetCalled bool
+	mockQueryService.AddQueryPatternWithCallback(
+		"ALTER SYSTEM RESET restore_command",
+		mock.MakeQueryResult(nil, nil),
+		func(string) { resetCalled = true },
+	)
+	expectReloadConfig(mockQueryService)
+
+	leader := newLeaderAddress("new-primary", "primary-host", 5432)
+	// The pooler's own current rule (term 7) already names it as a cohort member
+	// — i.e. it has streamed the rule that added it. The incoming SetPrimary
+	// carries the same rule, so it is a position no-op.
+	cohort := []*clustermetadatapb.ID{
+		{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "test-pooler"},
+		leader.GetId(),
+	}
+	selfPos := makeRulePosition(7)
+	selfPos.GetPosition().GetDecision().LeaderId = leader.GetId()
+	selfPos.GetPosition().GetDecision().CohortMembers = cohort
+
+	incomingRule := ruleAtTermForLeader(leader, 7)
+	incomingRule.CohortMembers = cohort
+
+	pm, _ := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: selfPos})
+
+	req := &consensusdatapb.SetPrimaryRequest{
+		ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
+			Position: &clustermetadatapb.RulePosition{Decision: incomingRule},
+			Primary:  leader,
+		},
+	}
+	resp, err := pm.SetPrimary(t.Context(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.True(t, resetCalled, "restore_command should be cleared on the no-op path when this pooler is a cohort member")
 }


### PR DESCRIPTION
Fixes MUL-1139

## Scope: fast-path hardening, not a new enforcement model

This PR does **not** change how the "cohort member ⇒ no `restore_command`" invariant is generally enforced. Membership is conferred by a rule, and a rule can take effect on a node purely by WAL replay, with no code running on that node at that instant. A standby replaying WAL cannot get a synchronous notification of that transition (postgres fires no triggers and delivers no `LISTEN/NOTIFY` during recovery), so the general, source-agnostic enforcement is — and remains — the pooler's monitor backstop (`shouldDisableRestoreCommand` → `remedialActionDisableRestoreCommand`), which clears on its periodic reconcile regardless of how membership was learned.

What this PR adds is a **synchronous fast path for the one control-plane sequence we know about** — a standby joining an already-established cohort out-of-band — so the clear happens at cohort-join time instead of ~one monitor tick (~9s measured) later. The monitor remains the backstop for anything the fast path misses (e.g. the re-issued `SetPrimary` failing, which is why it's best-effort). Reducing the monitor's transition-detection latency is the general lever and is left as separate follow-up.

## Problem

A cohort member must never resume WAL playback from the archive — only stream from the leader. Left with `restore_command` set, a restart-as-standby can resolve `recovery_target_timeline=latest` via archive-get to a divergent timeline and FATAL at startup (see the docstring on `resetRestoreCommand`).

`Recruit` is the only path that clears a joining member's `restore_command` synchronously, and it only fires during the promotion/failover recruit wave. A standby provisioned **after** a failover completes (e.g. a fresh replica restored from backup once a new leader is already elected) never receives `Recruit`. It joins the already-established cohort out-of-band:

1. `FixReplication` → `SetPrimary`, while the node is still an observer (not yet named in the rule), so the cohort-gated clear is **correctly** skipped.
2. `PoolerNotInCohort` → `UpdateConsensusRule(ADD)`, which runs on the **primary** and cannot touch the joining member's `restore_command`.

The node therefore streams as a recorded cohort member with `restore_command` still set, cleared only ~9s later by the monitor backstop — a window in which a restart-as-standby risks the divergent-archive FATAL. This is now the default exposure under start-as-standby.

```mermaid
sequenceDiagram
    autonumber
    participant ORCH as multiorch
    participant P1 as pooler-1
    participant P2 as pooler-2
    participant P3 as pooler-3
    participant P4 as pooler-4

    Note over ORCH,P3: Recruit wave<br/>failover, P3 promoted
    ORCH->>P1: Recruit()
    ORCH->>P2: Recruit()
    Note over P1,P2: restore_command<br/>cleared in Recruit
    ORCH->>P3: Promote()

    Note over ORCH,P4: P4 provisioned<br/>after failover
    Note over P4: restore_command<br/>SET by pgbackrest
    ORCH->>P4: SetPrimary<br/>(P4 still observer)
    Note over P4: not in rule,<br/>clear skipped
    ORCH->>P3: UpdateConsensusRule<br/>ADD P4
    Note over P3: primary-only,<br/>cannot clear P4
    P3-->>P4: rule replicated<br/>via WAL stream
    Note over P4: GAP: member,<br/>restore_command<br/>still set
```

## Fix

Clear at the observer → cohort-member transition:

- **Member side** (`SetPrimary`): move the cohort-member clear out of `setPrimaryLocked` (apply-path only) up into the public `SetPrimary`, right after `RecordTermPrimary`, so it also covers the **no-op position path**. `RecordTermPrimary` folds the incoming rule into `HighestKnownRule`, so `IsPotentialCohortMember` reflects the rule the leader is delivering *now* — race-free, without waiting for the member to independently stream it. New `clearRestoreCommandIfSet` (reads first) keeps repeated calls cheap.
- **Multiorch side** (`ReconcileCohort`): after a successful ADD, re-read the leader's post-ADD rule and re-issue `SetPrimary` to the new member so the member-side clear fires synchronously. Best-effort — the ADD already succeeded and the monitor backstop still covers a failure here.

Clearing unconditionally in `SetPrimary` would strand a lagging observer that still legitimately needs the archive, and `UpdateConsensusRule` runs on the primary (the wrong node) — so the clear belongs precisely at this transition.

```mermaid
sequenceDiagram
    autonumber
    participant ORCH as multiorch
    participant P1 as pooler-1
    participant P2 as pooler-2
    participant P3 as pooler-3
    participant P4 as pooler-4

    Note over ORCH,P3: Recruit wave<br/>failover, P3 promoted
    ORCH->>P1: Recruit()
    ORCH->>P2: Recruit()
    Note over P1,P2: restore_command<br/>cleared in Recruit
    ORCH->>P3: Promote()

    Note over ORCH,P4: P4 provisioned<br/>after failover
    Note over P4: restore_command<br/>SET by pgbackrest
    ORCH->>P4: SetPrimary<br/>(P4 still observer)
    Note over P4: not in rule,<br/>clear skipped
    ORCH->>P3: UpdateConsensusRule<br/>ADD P4
    Note over P3: primary-only,<br/>cannot clear P4

    alt SetPrimary arrives first
        ORCH->>P4: SetPrimary<br/>(post-ADD rule)
        Note over P4: RPC rule is higher,<br/>names P4 - clear fires
        P3-->>P4: rule replicated<br/>via WAL stream
    else rule replicated first
        P3-->>P4: rule replicated<br/>via WAL stream
        ORCH->>P4: SetPrimary<br/>(post-ADD, no-op pos)
        Note over P4: CurrentPosition names P4<br/>clear before no-op gate
    end
    Note over P4: restore_command<br/>cleared either way
```

**Why both orderings clear `restore_command`.** The re-issued `SetPrimary` (RPC) and P4 observing the ADD rule via WAL streaming race, and either can land first. `SetPrimary` calls `RecordTermPrimary` first, which folds the delivered rule into `HighestKnownRule = max(CurrentPosition-from-streaming, RPC-delivered rule)`; the clear is gated on `IsPotentialCohortMember`, which reads that max.

- *SetPrimary first:* P4 has not streamed the rule yet, so `CurrentPosition` is the pre-ADD rule — but the RPC-delivered post-ADD rule is strictly higher (same coordinator term, fresh `leader_subterm`), so it wins `HighestKnownRule`, names P4, and the clear fires (this is also the strictly-higher apply path). Streaming later just catches `CurrentPosition` up to a rule P4 already acted on.
- *Replication first:* `CurrentPosition` already names P4, so the incoming `SetPrimary` is a position no-op — but the clear runs *before* the no-op gate in the public `SetPrimary` (this is why it was moved out of `setPrimaryLocked`), so it still fires.

There is no interleaving where a rule naming P4 reaches it — by either path — and the clear fails to run, because membership is recognized from whichever of the two sources is ahead.

## Why the early clear is safe for a still-lagging standby

The re-issued `SetPrimary` can arrive before the node has replayed up to the ADD rule, so it could clear `restore_command` while the node is still catching up. This is safe because a node is only admitted to the cohort once its WAL receiver is genuinely streaming from the leader — this PR makes that a direct precondition of admission:

- `isAdditionCandidate` now requires `walReceiverStreaming` (receiver `waiting`, or `streaming` with a non-empty `LastReceiveLsn`), not merely `primary_conninfo` set + replay unpaused. A node still bridging an initial archive gap (receiver not yet streaming) is therefore not admitted, so its `restore_command` is not cleared out from under it. The `LastReceiveLsn` guard also rejects the post-reconnect flicker where postgres reports `streaming` before any WAL has arrived.
- This makes "a cohort member is, by construction, streaming and archive-independent" a **local** property of the admission gate, rather than something that only held indirectly because `ProblemReplicaNotReplicating` (PriorityHigh) preempts `ProblemPoolerNotInCohort` (PriorityNormal) in the engine's per-pooler dedup until the receiver comes up.

Note also that the pre-existing monitor backstop already clears `restore_command` for any cohort member regardless of streaming state, so the fast-path clear does not introduce a new hazard class; it only changes timing.

## Testing

- Unit: `manager` and `multiorch/recovery/...` green, incl. a new no-op-path test (`TestSetPrimary_ClearsRestoreCommandForCohortMemberOnNoOp`) and a strengthened `TestReconcileCohortAction_Execute`.
- Integration: `multiorch` full suite passes; `backupfaults` `TestPrimaryCrashWithUnarchivedWAL_NoDataLoss` (which provisions pooler-4 post-failover, then asserts `restore_command` cleared) passes with a **single-read** assertion — i.e. the clear is synchronous, not reliant on the ~9s backstop.








