### PR TITLE
feat(multipooler)!: remove deprecated connpool admin credential flags/env vars

### DIFF
--- a/docs/query_serving/connection_pooling.md
+++ b/docs/query_serving/connection_pooling.md
@@ -718,20 +718,31 @@ globalRegularCapacity  = globalCapacity * (1 - reservedRatio)
 globalReservedCapacity = globalCapacity * reservedRatio
 ```
 
+### Admin Pool Credentials
+
+The admin pool authenticates as the PostgreSQL superuser. Credentials are
+configured via the standard PostgreSQL environment variables — there are no CLI
+flags for the superuser name or password:
+
+| Env Var                  | Default    | Description                                                                        |
+| ------------------------ | ---------- | ---------------------------------------------------------------------------------- |
+| `POSTGRES_USER`          | `postgres` | PostgreSQL superuser for admin and internal operations                             |
+| `POSTGRES_PASSWORD`      | -          | PostgreSQL superuser password                                                      |
+| `POSTGRES_PASSWORD_FILE` | -          | Path to a file containing the password (takes precedence over `POSTGRES_PASSWORD`) |
+
 ### Admin Pool Flags
 
-| Flag                        | Default    | Env Var                                        | Description                                            |
-| --------------------------- | ---------- | ---------------------------------------------- | ------------------------------------------------------ |
-| `--connpool-admin-user`     | `postgres` | `CONNPOOL_ADMIN_USER`, `POSTGRES_USER`         | PostgreSQL superuser for admin and internal operations |
-| `--connpool-admin-password` | -          | `CONNPOOL_ADMIN_PASSWORD`, `POSTGRES_PASSWORD` | PostgreSQL superuser password                          |
-| `--connpool-admin-capacity` | 5          | -                                              | Maximum admin connections                              |
+| Flag                        | Default | Env Var | Description               |
+| --------------------------- | ------- | ------- | ------------------------- |
+| `--connpool-admin-capacity` | 5       | -       | Maximum admin connections |
 
-`CONNPOOL_ADMIN_USER` takes precedence over `POSTGRES_USER`, and `CONNPOOL_ADMIN_PASSWORD`
-takes precedence over `POSTGRES_PASSWORD` when both are set.
-
-> **Deprecated:** `--connpool-admin-user`, `--connpool-admin-password`, `CONNPOOL_ADMIN_USER`,
-> and `CONNPOOL_ADMIN_PASSWORD` are deprecated and will be removed in a future release.
-> Use `POSTGRES_USER` and `POSTGRES_PASSWORD` instead.
+> **Deprecated:** `--connpool-admin-password-file` and `CONNPOOL_ADMIN_PASSWORD_FILE`
+> are deprecated aliases for `POSTGRES_PASSWORD_FILE` and will be removed in a
+> future release. Use `POSTGRES_PASSWORD_FILE` instead.
+>
+> The previously deprecated `--connpool-admin-user`, `--connpool-admin-password`,
+> `CONNPOOL_ADMIN_USER`, and `CONNPOOL_ADMIN_PASSWORD` flags/env vars have been
+> **removed**. Use `POSTGRES_USER` and `POSTGRES_PASSWORD` instead.
 
 ### Per-User Pool Flags (Timeouts Only)
 

--- a/go/services/multipooler/internal/connpoolmanager/config.go
+++ b/go/services/multipooler/internal/connpoolmanager/config.go
@@ -67,10 +67,9 @@ type ConnectionConfig struct {
 type pgPasswordSource int
 
 const (
-	pwSourceNone   pgPasswordSource = iota
-	pwSourceEnv                     // CONNPOOL_ADMIN_PASSWORD / POSTGRES_PASSWORD env var
-	pwSourceOption                  // --connpool-admin-password flag
-	pwSourceFile                    // password file path (flag or env var)
+	pwSourceNone pgPasswordSource = iota
+	pwSourceEnv                   // POSTGRES_PASSWORD env var
+	pwSourceFile                  // password file path (deprecated flag or env var)
 )
 
 // Config holds viper-backed configuration values for the connection pool manager.
@@ -206,17 +205,20 @@ func NewConfig(reg *viperutil.Registry) *Config {
 	)
 
 	return &Config{
-		// PostgreSQL superuser credentials (also used for internal system queries)
+		// PostgreSQL superuser credentials (also used for internal system queries).
+		// Configured via the standard POSTGRES_USER / POSTGRES_PASSWORD env vars —
+		// no CLI flags. The former --connpool-admin-user/--connpool-admin-password
+		// flags and CONNPOOL_ADMIN_USER/CONNPOOL_ADMIN_PASSWORD env vars were removed.
 		pgUser: viperutil.Configure(reg, "connpool.pg.user", viperutil.Options[string]{
-			Default:  constants.DefaultPostgresUser,
-			FlagName: "connpool-admin-user",
-			EnvVars:  []string{"CONNPOOL_ADMIN_USER", constants.PgUserEnvVar},
+			Default: constants.DefaultPostgresUser,
+			EnvVars: []string{constants.PgUserEnvVar},
 		}),
 		pgPassword: viperutil.Configure(reg, "connpool.pg.password", viperutil.Options[string]{
-			Default:  "",
-			FlagName: "connpool-admin-password",
-			EnvVars:  []string{"CONNPOOL_ADMIN_PASSWORD", constants.PgPasswordEnvVar},
+			Default: "",
+			EnvVars: []string{constants.PgPasswordEnvVar},
 		}),
+		// The --connpool-admin-password-file flag and CONNPOOL_ADMIN_PASSWORD_FILE
+		// env var are deprecated aliases; use POSTGRES_PASSWORD_FILE instead.
 		pgPasswordFile: viperutil.Configure(reg, "connpool.pg.password-file", viperutil.Options[string]{
 			Default:  "",
 			FlagName: "connpool-admin-password-file",
@@ -317,10 +319,14 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 	// Save the FlagSet so ResolvePgPassword can use pflag.Flag.Changed to
 	// distinguish "flag explicitly set" from "flag at default value".
 	c.flagSet = fs
-	// PostgreSQL superuser credentials
-	fs.String("connpool-admin-user", c.pgUser.Default(), "PostgreSQL superuser for admin and internal operations (env: CONNPOOL_ADMIN_USER or POSTGRES_USER)")
-	fs.String("connpool-admin-password", c.pgPassword.Default(), "PostgreSQL superuser password (env: CONNPOOL_ADMIN_PASSWORD or POSTGRES_PASSWORD). --connpool-admin-password-file takes precedence.")
-	fs.String("connpool-admin-password-file", c.pgPasswordFile.Default(), "Path to a file containing the PostgreSQL superuser password (plaintext, docker-library/postgres convention). Takes precedence over --connpool-admin-password (env: CONNPOOL_ADMIN_PASSWORD_FILE or POSTGRES_PASSWORD_FILE).")
+	// PostgreSQL superuser credentials are configured via the standard
+	// POSTGRES_USER / POSTGRES_PASSWORD env vars — no CLI flags. Use
+	// POSTGRES_PASSWORD_FILE for file-based passwords.
+	//
+	// --connpool-admin-password-file is a deprecated alias for
+	// POSTGRES_PASSWORD_FILE, kept for backwards compatibility.
+	fs.String("connpool-admin-password-file", c.pgPasswordFile.Default(), "DEPRECATED: use POSTGRES_PASSWORD_FILE instead. Path to a file containing the PostgreSQL superuser password (plaintext, docker-library/postgres convention) (env: CONNPOOL_ADMIN_PASSWORD_FILE or POSTGRES_PASSWORD_FILE).")
+	_ = fs.MarkDeprecated("connpool-admin-password-file", "use "+constants.PgPasswordFileEnvVar+" env var instead")
 
 	// PostgreSQL TLS (multipooler → postgres). Mirrors libpq sslmode/sslrootcert.
 	fs.String("pg-client-sslmode", c.pgSSLMode.Default(), "TLS mode for connections to PostgreSQL: disable|prefer|require|verify-ca|verify-full (libpq parity; sslmode=allow is not supported)")
@@ -355,8 +361,8 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 	fs.Duration("connpool-drain-grace-period", c.drainGracePeriod.Default(), "How long to wait for in-flight connections to drain during not-serving transitions before force-closing reserved connections")
 
 	viperutil.BindFlags(fs,
-		c.pgUser,
-		c.pgPassword,
+		// pgUser and pgPassword are env-only (POSTGRES_USER / POSTGRES_PASSWORD),
+		// so they are not bound to any flag here.
 		c.pgPasswordFile,
 		c.pgSSLMode,
 		c.pgSSLRootCert,
@@ -400,21 +406,18 @@ func (c *Config) PgPassword() (string, pgPasswordSource) {
 }
 
 // ResolvePgPassword chooses the password source and caches the result so
-// subsequent PgPassword() calls return it. Three independent inputs are
+// subsequent PgPassword() calls return it. Two independent inputs are
 // considered, in strict precedence order — once a higher-precedence input is
 // "explicitly set" it is authoritative and lower-precedence inputs are NOT
 // consulted, even when the higher-precedence value turns out to be empty
 // (those empty cases become errors instead of fallthroughs):
 //
-//  1. File path: --connpool-admin-password-file flag, or
-//     CONNPOOL_ADMIN_PASSWORD_FILE / POSTGRES_PASSWORD_FILE env.
+//  1. File path: POSTGRES_PASSWORD_FILE env, or the deprecated
+//     --connpool-admin-password-file flag / CONNPOOL_ADMIN_PASSWORD_FILE env.
 //     - Path explicitly empty                  → error.
 //     - Path set, file content empty           → error.
 //     - Path set, file content non-empty       → use it, source=File.
-//  2. Flag option: --connpool-admin-password.
-//     - Flag set to empty                      → error.
-//     - Flag set to non-empty                  → use it, source=Option.
-//  3. Env var: CONNPOOL_ADMIN_PASSWORD or POSTGRES_PASSWORD.
+//  2. Env var: POSTGRES_PASSWORD.
 //     - Env set to empty                       → error.
 //     - Env set to non-empty                   → use it, source=Env.
 //
@@ -441,34 +444,19 @@ func (c *Config) ResolvePgPassword() error {
 		c.pgPasswordSource = pwSourceFile
 		return nil
 	}
-	// Row 3, 4: --connpool-admin-password flag explicitly set.
-	if c.flagSet != nil {
-		if flag := c.flagSet.Lookup("connpool-admin-password"); flag != nil && flag.Changed {
-			v := flag.Value.String()
-			if v == "" {
-				c.pgPasswordSource = pwSourceNone
-				return errors.New("--connpool-admin-password is set to the empty string; unset it or provide a non-empty password")
-			}
-			c.pgPasswordCached = v
-			c.pgPasswordSource = pwSourceOption
-			return nil
+	// Row 3, 4: POSTGRES_PASSWORD env var.
+	if v, ok := os.LookupEnv(constants.PgPasswordEnvVar); ok {
+		if v == "" {
+			c.pgPasswordSource = pwSourceNone
+			return fmt.Errorf("env var %s is set to the empty string; unset it or provide a non-empty password", constants.PgPasswordEnvVar)
 		}
+		c.pgPasswordCached = v
+		c.pgPasswordSource = pwSourceEnv
+		return nil
 	}
-	// Row 5, 6: env vars. CONNPOOL_ADMIN_PASSWORD checked before POSTGRES_PASSWORD.
-	for _, name := range []string{"CONNPOOL_ADMIN_PASSWORD", constants.PgPasswordEnvVar} {
-		if v, ok := os.LookupEnv(name); ok {
-			if v == "" {
-				c.pgPasswordSource = pwSourceNone
-				return fmt.Errorf("env var %s is set to the empty string; unset it or provide a non-empty password", name)
-			}
-			c.pgPasswordCached = v
-			c.pgPasswordSource = pwSourceEnv
-			return nil
-		}
-	}
-	// Row 7: no source configured.
+	// Row 5: no source configured.
 	c.pgPasswordSource = pwSourceNone
-	return errors.New("admin password not configured: set CONNPOOL_ADMIN_PASSWORD or POSTGRES_PASSWORD env var, --connpool-admin-password flag, or --connpool-admin-password-file / CONNPOOL_ADMIN_PASSWORD_FILE / POSTGRES_PASSWORD_FILE to point at a password file")
+	return fmt.Errorf("admin password not configured: set %s env var, or %s / --connpool-admin-password-file / CONNPOOL_ADMIN_PASSWORD_FILE (deprecated) to point at a password file", constants.PgPasswordEnvVar, constants.PgPasswordFileEnvVar)
 }
 
 // passwordFileExplicit reports whether the file-path input was explicitly

--- a/go/services/multipooler/internal/connpoolmanager/config_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/config_test.go
@@ -79,13 +79,11 @@ func TestConfig_RegisterFlags(t *testing.T) {
 	cmd := &cobra.Command{}
 	config.RegisterFlags(cmd.Flags())
 
-	// Verify flags are registered.
-	adminUserFlag := cmd.Flags().Lookup("connpool-admin-user")
-	require.NotNil(t, adminUserFlag)
-	assert.Equal(t, constants.DefaultPostgresUser, adminUserFlag.DefValue)
-
-	adminPasswordFlag := cmd.Flags().Lookup("connpool-admin-password")
-	require.NotNil(t, adminPasswordFlag)
+	// Superuser credentials are env-only (POSTGRES_USER / POSTGRES_PASSWORD);
+	// the deprecated --connpool-admin-user/--connpool-admin-password flags were
+	// removed and must not be registered.
+	assert.Nil(t, cmd.Flags().Lookup("connpool-admin-user"), "connpool-admin-user flag should not be registered")
+	assert.Nil(t, cmd.Flags().Lookup("connpool-admin-password"), "connpool-admin-password flag should not be registered")
 
 	adminCapFlag := cmd.Flags().Lookup("connpool-admin-capacity")
 	require.NotNil(t, adminCapFlag)
@@ -214,62 +212,6 @@ func TestUserPoolStats(t *testing.T) {
 
 // --- PgUser / PgPassword env-var tests ---
 
-func TestConfig_ConnpoolAdminUser_EnvVar(t *testing.T) {
-	t.Setenv("CONNPOOL_ADMIN_USER", "connpool_user")
-
-	reg := viperutil.NewRegistry()
-	config := NewConfig(reg)
-
-	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	config.RegisterFlags(fs)
-
-	assert.Equal(t, "connpool_user", config.PgUser())
-}
-
-func TestConfig_ConnpoolAdminPassword_EnvVar(t *testing.T) {
-	t.Setenv("CONNPOOL_ADMIN_PASSWORD", "connpool_pass")
-
-	reg := viperutil.NewRegistry()
-	config := NewConfig(reg)
-
-	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	config.RegisterFlags(fs)
-
-	require.NoError(t, config.ResolvePgPassword())
-	pw, source := config.PgPassword()
-	assert.Equal(t, "connpool_pass", pw)
-	assert.Equal(t, pwSourceEnv, source)
-}
-
-func TestConfig_ConnpoolAdminUser_TakesPrecedence(t *testing.T) {
-	t.Setenv("CONNPOOL_ADMIN_USER", "connpool_user")
-	t.Setenv(constants.PgUserEnvVar, "postgres_user")
-
-	reg := viperutil.NewRegistry()
-	config := NewConfig(reg)
-
-	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	config.RegisterFlags(fs)
-
-	assert.Equal(t, "connpool_user", config.PgUser())
-}
-
-func TestConfig_ConnpoolAdminPassword_TakesPrecedence(t *testing.T) {
-	t.Setenv("CONNPOOL_ADMIN_PASSWORD", "connpool_pass")
-	t.Setenv(constants.PgPasswordEnvVar, "postgres_pass")
-
-	reg := viperutil.NewRegistry()
-	config := NewConfig(reg)
-
-	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	config.RegisterFlags(fs)
-
-	require.NoError(t, config.ResolvePgPassword())
-	pw, source := config.PgPassword()
-	assert.Equal(t, "connpool_pass", pw)
-	assert.Equal(t, pwSourceEnv, source)
-}
-
 func TestConfig_PgPassword_EnvVar(t *testing.T) {
 	t.Setenv(constants.PgPasswordEnvVar, "test-password")
 
@@ -337,43 +279,22 @@ func TestResolvePgPassword_FilePathEnvSetEmpty_Errors(t *testing.T) {
 	assert.Contains(t, err.Error(), "file path is set to the empty string")
 }
 
-// Row 3: --connpool-admin-password flag set to a non-empty value, no file
-// path configured. Flag wins over any env var; source must be Option.
-func TestResolvePgPassword_OptionFlagSet_UsesOption(t *testing.T) {
+// The deprecated CONNPOOL_ADMIN_PASSWORD_FILE env var still resolves via the
+// file path (kept as a backwards-compatible alias for POSTGRES_PASSWORD_FILE).
+func TestResolvePgPassword_DeprecatedFileEnvVar_StillWorks(t *testing.T) {
 	require.NoError(t, os.Unsetenv(constants.PgPasswordFileEnvVar))
-	require.NoError(t, os.Unsetenv("CONNPOOL_ADMIN_PASSWORD_FILE"))
-	// Set env vars to a distinct value to prove the flag dominates.
-	t.Setenv("CONNPOOL_ADMIN_PASSWORD", "from-env-should-be-ignored")
+	require.NoError(t, os.Unsetenv(constants.PgPasswordEnvVar))
+	t.Setenv("CONNPOOL_ADMIN_PASSWORD_FILE", writePwFile(t, "from-deprecated-file"))
 
 	reg := viperutil.NewRegistry()
 	config := NewConfig(reg)
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	config.RegisterFlags(fs)
-	require.NoError(t, fs.Set("connpool-admin-password", "from-flag"))
 
 	require.NoError(t, config.ResolvePgPassword())
 	pw, source := config.PgPassword()
-	assert.Equal(t, "from-flag", pw)
-	assert.Equal(t, pwSourceOption, source)
-}
-
-// Row 4: --connpool-admin-password flag explicitly set to the empty string.
-// Resolver must error even when env vars are set to a non-empty value.
-func TestResolvePgPassword_OptionFlagSetEmpty_Errors(t *testing.T) {
-	require.NoError(t, os.Unsetenv(constants.PgPasswordFileEnvVar))
-	require.NoError(t, os.Unsetenv("CONNPOOL_ADMIN_PASSWORD_FILE"))
-	t.Setenv("CONNPOOL_ADMIN_PASSWORD", "from-env-should-be-ignored")
-
-	reg := viperutil.NewRegistry()
-	config := NewConfig(reg)
-	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	config.RegisterFlags(fs)
-	require.NoError(t, fs.Set("connpool-admin-password", ""))
-
-	err := config.ResolvePgPassword()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--connpool-admin-password")
-	assert.Contains(t, err.Error(), "empty string")
+	assert.Equal(t, "from-deprecated-file", pw)
+	assert.Equal(t, pwSourceFile, source)
 }
 
 // No source configured at all: file path unset, neither env var set. Both
@@ -383,7 +304,6 @@ func TestResolvePgPassword_NoSourceConfigured(t *testing.T) {
 	require.NoError(t, os.Unsetenv(constants.PgPasswordFileEnvVar))
 	require.NoError(t, os.Unsetenv("CONNPOOL_ADMIN_PASSWORD_FILE"))
 	require.NoError(t, os.Unsetenv(constants.PgPasswordEnvVar))
-	require.NoError(t, os.Unsetenv("CONNPOOL_ADMIN_PASSWORD"))
 
 	reg := viperutil.NewRegistry()
 	config := NewConfig(reg)
@@ -399,7 +319,8 @@ func TestResolvePgPassword_NoSourceConfigured(t *testing.T) {
 // (operator typed POSTGRES_PASSWORD= in a unit file or manifest). Distinct
 // from "unset" via os.LookupEnv; resolver must reject it explicitly.
 func TestResolvePgPassword_PostgresPasswordSetEmpty(t *testing.T) {
-	require.NoError(t, os.Unsetenv("CONNPOOL_ADMIN_PASSWORD"))
+	require.NoError(t, os.Unsetenv(constants.PgPasswordFileEnvVar))
+	require.NoError(t, os.Unsetenv("CONNPOOL_ADMIN_PASSWORD_FILE"))
 	t.Setenv(constants.PgPasswordEnvVar, "")
 
 	reg := viperutil.NewRegistry()
@@ -410,23 +331,6 @@ func TestResolvePgPassword_PostgresPasswordSetEmpty(t *testing.T) {
 	err := config.ResolvePgPassword()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "POSTGRES_PASSWORD")
-	assert.Contains(t, err.Error(), "empty string")
-}
-
-// CONNPOOL_ADMIN_PASSWORD deliberately set to empty — same misconfiguration,
-// different env-var name.
-func TestResolvePgPassword_ConnpoolAdminPasswordSetEmpty(t *testing.T) {
-	require.NoError(t, os.Unsetenv(constants.PgPasswordEnvVar))
-	t.Setenv("CONNPOOL_ADMIN_PASSWORD", "")
-
-	reg := viperutil.NewRegistry()
-	config := NewConfig(reg)
-	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	config.RegisterFlags(fs)
-
-	err := config.ResolvePgPassword()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "CONNPOOL_ADMIN_PASSWORD")
 	assert.Contains(t, err.Error(), "empty string")
 }
 


### PR DESCRIPTION
## Summary

Removes the previously deprecated connpool admin credential flags and environment variables, standardizing on the PostgreSQL-native `POSTGRES_USER` / `POSTGRES_PASSWORD` mechanism. Supersedes the stale #726 (which predates the `internal/connpoolmanager` move and could not be rebased).

**Removed** (were marked deprecated in `docs/query_serving/connection_pooling.md`):
- `--connpool-admin-user` flag
- `--connpool-admin-password` flag
- `CONNPOOL_ADMIN_USER` env var
- `CONNPOOL_ADMIN_PASSWORD` env var

The admin-pool superuser is now configured **env-only** via `POSTGRES_USER` / `POSTGRES_PASSWORD` — no CLI flags.

**Newly deprecated** (kept working as backwards-compatible aliases; use `POSTGRES_PASSWORD_FILE` instead):
- `--connpool-admin-password-file` flag (now marked deprecated via pflag)
- `CONNPOOL_ADMIN_PASSWORD_FILE` env var

## Password resolution

Precedence is unchanged except the removed inline `--connpool-admin-password` tier. Order is now:
1. **File path** — `POSTGRES_PASSWORD_FILE` (or the deprecated `--connpool-admin-password-file` / `CONNPOOL_ADMIN_PASSWORD_FILE` aliases)
2. **Env var** — `POSTGRES_PASSWORD`

`os.LookupEnv` / `pflag.Changed` still distinguish "explicitly set empty" (error) from "unset" (fall through).

## Why this is safe

- Nothing in this repo passes the removed flags/env vars (only the config definition + docs referenced them).
- **multigres-operator** already provisions `POSTGRES_USER` / `POSTGRES_PASSWORD` and dropped its `connpoolAdminPasswordEnvVar()` helper — no ecosystem consumer depends on the removed options.

## Testing

- `go test ./go/services/multipooler/internal/connpoolmanager/` — pass
- `golangci-lint run` on the package — 0 issues
- Added a regression test locking in that the deprecated `CONNPOOL_ADMIN_PASSWORD_FILE` alias still resolves.

## Breaking change

`--connpool-admin-user`, `--connpool-admin-password`, `CONNPOOL_ADMIN_USER`, and `CONNPOOL_ADMIN_PASSWORD` are removed. Use `POSTGRES_USER` and `POSTGRES_PASSWORD` instead.