### PR TITLE
fix(query-serving): preserve batch semantics and recover stale connections

### DIFF
--- a/docker/Dockerfile.pgregress
+++ b/docker/Dockerfile.pgregress
@@ -75,6 +75,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends postgresql-comm
 
 # Generate the glibc locales the PostgreSQL regression collate tests reference
 # (collate.sql -> en_US; collate.linux.utf8.sql -> de_DE, sv_SE, tr_TR, ja_JP.eucjp).
+# Generate both Turkish locale spellings: PostgreSQL's test sets lc_time to the
+# exact libc name "tr_TR", while tr_TR.UTF-8 alone only provides tr_TR.utf8.
 # Without them the tests self-skip and produce spurious diffs — the exact failure
 # mode seen when regenerating on macOS. en_US.UTF-8 is also the default LANG.
 RUN sed -i -E \
@@ -83,6 +85,7 @@ RUN sed -i -E \
       -e 's/^# *(fr_FR.UTF-8 UTF-8)/\1/' \
       -e 's/^# *(sv_SE.UTF-8 UTF-8)/\1/' \
       -e 's/^# *(tr_TR.UTF-8 UTF-8)/\1/' \
+      -e 's/^# *(tr_TR ISO-8859-9)/\1/' \
       -e 's/^# *(ja_JP.EUC-JP EUC-JP)/\1/' \
       /etc/locale.gen \
     && locale-gen

--- a/go/services/multigateway/handler/handler.go
+++ b/go/services/multigateway/handler/handler.go
@@ -311,42 +311,16 @@ func (h *MultigatewayHandler) HandleQuery(ctx context.Context, conn *server.Conn
 
 	execStart := time.Now()
 
-	// For multi-statement batches, use implicit transaction handling.
-	// Exception: sessions with temp table reservations iterate and plan each
-	// statement individually so that DISCARD TEMP and other special statements
-	// get proper primitives. The PG backend handles auto-commit natively on
-	// the reserved connection.
-	// Per-table metrics are emitted per-statement inside executeWithImplicitTransaction.
-	// For multi-statement batches, per-table metrics, span attributes, and query log
-	// enrichment are handled per-statement inside executeWithImplicitTransaction.
-	// The batch-level recordQueryCompletion gets nil result (no plan type for a batch).
+	// Every multi-statement query uses the same per-statement transaction state
+	// machine. Backend affinity (for example, a temp-table reservation) changes
+	// where statements run, never their batch semantics.
 	var result *ExecuteResult
 	if len(asts) > 1 {
-		if st.HasTempTableReservation() {
-			h.logger.DebugContext(ctx, "executing multi-statement batch on temp-table-reserved session",
-				"statement_count", len(asts))
-			var allTablesUsed []string
-			for _, stmt := range asts {
-				stmtCtx, cancel := h.statementTimeoutCtx(ctx, st, stmt)
-				var stmtResult *ExecuteResult
-				stmtResult, err = h.executor.StreamExecute(stmtCtx, conn, st, stmt.SqlString(), stmt, countingCallback)
-				cancel()
-				if stmtResult != nil {
-					allTablesUsed = append(allTablesUsed, stmtResult.TablesUsed...)
-				}
-				if err != nil {
-					break
-				}
-			}
-			if len(allTablesUsed) > 0 {
-				result = &ExecuteResult{TablesUsed: allTablesUsed}
-			}
-		} else {
-			h.logger.DebugContext(ctx, "executing multi-statement batch with implicit transaction handling",
-				"statement_count", len(asts),
-				"already_in_transaction", conn.IsInTransaction())
-			err = h.executeWithImplicitTransaction(ctx, conn, st, queryStr, asts, countingCallback)
-		}
+		h.logger.DebugContext(ctx, "executing multi-statement batch with implicit transaction handling",
+			"statement_count", len(asts),
+			"already_in_transaction", conn.IsInTransaction(),
+			"temp_table_reserved", st.HasTempTableReservation())
+		err = h.executeWithImplicitTransaction(ctx, conn, st, queryStr, asts, countingCallback)
 	} else {
 		// Single statement - execute with timeout enforcement
 		ctx, cancel := h.statementTimeoutCtx(ctx, st, asts[0])

--- a/go/services/multigateway/handler/transaction_helpers.go
+++ b/go/services/multigateway/handler/transaction_helpers.go
@@ -33,6 +33,24 @@ func transactionChainOutsideBlockError(kind ast.TransactionStmtKind) error {
 		command+" AND CHAIN can only be used in transaction blocks", "")
 }
 
+func savepointOutsideBlockError(kind ast.TransactionStmtKind) error {
+	command := "SAVEPOINT"
+	switch kind {
+	case ast.TRANS_STMT_ROLLBACK_TO:
+		command = "ROLLBACK TO SAVEPOINT"
+	case ast.TRANS_STMT_RELEASE:
+		command = "RELEASE SAVEPOINT"
+	}
+	return mterrors.NewPgError("ERROR", mterrors.PgSSNoActiveTransaction,
+		command+" can only be used in transaction blocks", "")
+}
+
+func implicitConclusionWarning() *sqltypes.Result {
+	return &sqltypes.Result{Notices: []*mterrors.PgDiagnostic{
+		mterrors.NewPgNotice("WARNING", mterrors.PgSSNoActiveTransaction, "there is no transaction in progress", ""),
+	}}
+}
+
 // executeWithImplicitTransaction handles multi-statement batches by:
 // - Injecting synthetic BEGIN at start and after each COMMIT/ROLLBACK
 // - Tracking implicit vs explicit transaction segments
@@ -140,6 +158,17 @@ func (h *MultigatewayHandler) executeWithImplicitTransaction(
 			isImplicitTx = true
 		}
 
+		// A synthetic BEGIN makes the physical backend transactional, but PostgreSQL
+		// still treats savepoint commands as outside an explicit transaction until a
+		// user BEGIN adopts the implicit block.
+		if txStmt, ok := stmt.(*ast.TransactionStmt); ok && isImplicitTx {
+			switch txStmt.Kind {
+			case ast.TRANS_STMT_SAVEPOINT, ast.TRANS_STMT_ROLLBACK_TO, ast.TRANS_STMT_RELEASE:
+				rollbackImplicit()
+				return savepointOutsideBlockError(txStmt.Kind)
+			}
+		}
+
 		// User's BEGIN - skip execution (we already started), mark as explicit.
 		// Still send a result to the client so the response count matches their statements.
 		//
@@ -185,6 +214,13 @@ func (h *MultigatewayHandler) executeWithImplicitTransaction(
 				// preceding statements in this batch do not commit.
 				rollbackImplicit()
 				return transactionChainOutsideBlockError(txStmt.Kind)
+			}
+			if isImplicitTx {
+				// COMMIT/ROLLBACK ends the implicit segment but PostgreSQL warns that
+				// no explicit transaction is in progress.
+				if err := callback(ctx, implicitConclusionWarning()); err != nil {
+					return err
+				}
 			}
 			if err := execute(stmt); err != nil {
 				return err

--- a/go/services/multigateway/handler/transaction_helpers_test.go
+++ b/go/services/multigateway/handler/transaction_helpers_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
@@ -204,6 +205,54 @@ func TestExecuteWithImplicitTransaction_UserRollbackMidBatch(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, []string{"BEGIN", "OTHER", "ROLLBACK", "BEGIN", "OTHER", "COMMIT"}, stmtDescriptions(mock.executedStmts))
+}
+
+func TestExecuteWithImplicitTransaction_ImplicitConclusionWarns(t *testing.T) {
+	for _, command := range []string{"COMMIT", "ROLLBACK"} {
+		t.Run(command, func(t *testing.T) {
+			mock := &trackingMockExecutor{errOnCallIndex: -1}
+			h := newTestHandler(mock)
+			state := NewMultigatewayConnectionState()
+			stmts := parseStmts(t, "SELECT 1; "+command+"; SELECT 2")
+			var notices []*mterrors.PgDiagnostic
+
+			err := h.executeWithImplicitTransaction(
+				context.Background(), newImplicitTxTestConn(), state, "", stmts,
+				func(_ context.Context, result *sqltypes.Result) error {
+					notices = append(notices, result.Notices...)
+					return nil
+				},
+			)
+
+			require.NoError(t, err)
+			require.Len(t, notices, 1)
+			require.Equal(t, mterrors.PgSSNoActiveTransaction, notices[0].Code)
+			require.Equal(t, "there is no transaction in progress", notices[0].Message)
+		})
+	}
+}
+
+func TestExecuteWithImplicitTransaction_RejectsSavepointsInImplicitBlock(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT 1; SAVEPOINT sp",
+		"ROLLBACK TO SAVEPOINT sp; SELECT 2",
+		"SELECT 2; RELEASE SAVEPOINT sp; SELECT 3",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			mock := &trackingMockExecutor{errOnCallIndex: -1}
+			h := newTestHandler(mock)
+			state := NewMultigatewayConnectionState()
+
+			err := h.executeWithImplicitTransaction(
+				context.Background(), newImplicitTxTestConn(), state, sql, parseStmts(t, sql),
+				func(context.Context, *sqltypes.Result) error { return nil },
+			)
+
+			require.Error(t, err)
+			require.Equal(t, mterrors.PgSSNoActiveTransaction, mterrors.ExtractSQLSTATE(err))
+			require.Equal(t, "ROLLBACK", stmtDescription(mock.executedStmts[len(mock.executedStmts)-1]))
+		})
+	}
 }
 
 func TestExecuteWithImplicitTransaction_AlreadyInTransaction(t *testing.T) {

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -472,6 +472,14 @@ func (e *Executor) reserveAndStreamExecute(
 			return nil
 		}
 		reservedOpts = append(reservedOpts, reserved.WithValidate(validate))
+	} else {
+		// Non-transaction reservations (for example CREATE TEMP) have no other
+		// pre-registration write to expose a socket PostgreSQL closed while idle.
+		// Probe it here so the reserved pool can discard and retry stale sockets.
+		reservedOpts = append(reservedOpts, reserved.WithValidate(func(ctx context.Context, conn *regular.Conn) error {
+			_, err := conn.Query(ctx, "SELECT 1")
+			return err
+		}))
 	}
 
 	// Create a reserved connection

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -349,6 +349,64 @@ func TestReserveAndStreamExecute_BeginRetriesIdleSessionTimeout(t *testing.T) {
 	server.VerifyAllExecutedOrFail()
 }
 
+func TestReserveAndStreamExecute_TempReservationRetriesStaleSocket(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.OrderMatters()
+
+	server.AddExpectedExecuteFetch(fakepgserver.ExpectedExecuteFetch{
+		Query:       "SELECT warmup",
+		QueryResult: fakepgserver.MakeResult([]string{"?column?"}, [][]any{{1}}),
+	})
+	server.AddExpectedExecuteFetch(fakepgserver.ExpectedExecuteFetch{
+		Query: "SELECT 1",
+		Error: mterrors.NewIdleSessionTimeout(),
+	})
+	server.AddExpectedExecuteFetch(fakepgserver.ExpectedExecuteFetch{
+		Query:       "SELECT 1",
+		QueryResult: fakepgserver.MakeResult([]string{"?column?"}, [][]any{{1}}),
+	})
+	server.AddExpectedExecuteFetch(fakepgserver.ExpectedExecuteFetch{
+		Query:       "CREATE TEMP TABLE t(i int)",
+		QueryResult: &sqltypes.Result{CommandTag: "CREATE TABLE"},
+	})
+
+	pool := reserved.NewPool(context.Background(), &reserved.PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig: server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{
+				Capacity:     2,
+				MaxIdleCount: 2,
+			},
+		},
+	})
+	defer pool.Close()
+
+	warm, err := pool.NewConn(context.Background(), nil)
+	require.NoError(t, err)
+	_, err = warm.Query(context.Background(), "SELECT warmup")
+	require.NoError(t, err)
+	warm.Release(reserved.ReleaseCommit, nil)
+
+	e := newTestExecutor()
+	e.metrics = newQueryStats()
+	e.poolManager = &stubPoolManager{newReservedPool: pool}
+
+	state, err := e.reserveAndStreamExecute(
+		context.Background(),
+		"CREATE TEMP TABLE t(i int)",
+		&query.ExecuteOptions{User: "postgres"},
+		&query.ReservationOptions{Reasons: protoutil.ReasonTempTable},
+		noopCallback,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, protoutil.ReasonTempTable, state.GetReservationReasons())
+	server.VerifyAllExecutedOrFail()
+}
+
 // TestStreamExecuteOnReservedConn_AdvisoryLockStillHeld verifies that after a
 // statement on an advisory-lock-reserved connection, if PostgreSQL still
 // reports an advisory lock the connection stays reserved.

--- a/go/services/multipooler/internal/pools/connpool/pool.go
+++ b/go/services/multipooler/internal/pools/connpool/pool.go
@@ -25,6 +25,7 @@ import (
 
 	"go.opentelemetry.io/otel/semconv/v1.37.0/dbconv"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/services/multipooler/internal/connstate"
 )
 
@@ -868,18 +869,16 @@ func (pool *Pool[C]) getWithSettings(ctx context.Context, settings *connstate.Se
 				}
 			}
 		}
-		// apply our settings now; if we can't we assume that the conn is broken
-		// and close it without returning to the pool
-		if err := conn.Conn.ApplySettings(ctx, settings); err != nil {
-			conn.Close()
-			pool.closedConn()
+		// Apply the requested settings. If the idle socket died, reconnect this
+		// same pooled slot and hydrate the fresh PostgreSQL session with the
+		// requested settings instead of selecting another potentially dead idle
+		// connection.
+		if err := pool.applySettingsWithReconnect(ctx, conn, settings); err != nil {
 			return returnErr(err)
 		}
 	} else if settings.NeedsReapplyOnReuse() {
 		// Refresh role OIDs without replaying already-matching GUCs.
-		if err := conn.Conn.ApplySettings(ctx, settings); err != nil {
-			conn.Close()
-			pool.closedConn()
+		if err := pool.applySettingsWithReconnect(ctx, conn, settings); err != nil {
 			return returnErr(err)
 		}
 	}
@@ -890,6 +889,34 @@ func (pool *Pool[C]) getWithSettings(ctx context.Context, settings *connstate.Se
 	}
 	pool.otelConnectionCount.Add(ctx, 1, pool.Name, dbconv.ClientConnectionStateUsed)
 	return conn, nil
+}
+
+// applySettingsWithReconnect applies desired settings and repairs a stale idle
+// socket in place. A fresh PostgreSQL session starts clean, so desired must be
+// applied successfully before the pooled slot can be handed to the caller or
+// returned to a settings bucket.
+func (pool *Pool[C]) applySettingsWithReconnect(ctx context.Context, conn *Pooled[C], desired *connstate.Settings) error {
+	err := conn.Conn.ApplySettings(ctx, desired)
+	if err == nil {
+		return nil
+	}
+	if !mterrors.IsConnectionError(err) {
+		conn.Close()
+		pool.closedConn()
+		return err
+	}
+
+	conn.Close()
+	if err := pool.connReopen(ctx, conn, monotonicNow()); err != nil {
+		pool.closedConn()
+		return err
+	}
+	if err := conn.Conn.ApplySettings(ctx, desired); err != nil {
+		conn.Close()
+		pool.closedConn()
+		return err
+	}
+	return nil
 }
 
 // SetCapacity changes the capacity (number of open connections) on the pool.

--- a/go/services/multipooler/internal/pools/regular/pool.go
+++ b/go/services/multipooler/internal/pools/regular/pool.go
@@ -95,10 +95,10 @@ func (p *Pool) Get(ctx context.Context) (PooledConn, error) {
 // hits a stale socket — a connection PostgreSQL closed silently while it
 // sat idle in the pool — the connpool closes the conn and surfaces a
 // connection-class error. Without retry here, callers see that error
-// transparently even though a fresh socket would succeed. We retry with
-// the same regime as the reserved pool (constants.MaxConnPoolRetryAttempts
-// attempts, constants.ConnPoolRetryBackoff between them); each attempt
-// dials a replacement conn since the previous one was closed.
+// transparently even though a fresh socket would succeed. The underlying
+// connpool first reconnects that same pooled slot and hydrates it with the
+// requested settings. We retain the reserved pool's retry regime for failures
+// that persist after that fresh reconnect.
 //
 // Non-connection errors (timeout, malformed SETs, pool closed) propagate
 // unchanged. The settings==nil/empty fast path is unaffected: that case

--- a/go/services/multipooler/internal/pools/regular/pool_test.go
+++ b/go/services/multipooler/internal/pools/regular/pool_test.go
@@ -138,9 +138,58 @@ func TestPool_GetWithSettings_RetriesOnConnectionError(t *testing.T) {
 	server.VerifyAllExecutedOrFail()
 }
 
+// TestPool_GetWithSettings_ReconnectsSelectedIdleSlot verifies that settings
+// recovery redials the selected slot rather than consuming another idle slot.
+func TestPool_GetWithSettings_ReconnectsSelectedIdleSlot(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.OrderMatters()
+	server.AddExpectedExecuteFetch(fakepgserver.ExpectedExecuteFetch{
+		Query: "SELECT pg_catalog.set_config*",
+		Error: connErrFATAL(),
+	})
+	server.AddExpectedExecuteFetch(fakepgserver.ExpectedExecuteFetch{
+		Query:       "SELECT pg_catalog.set_config*",
+		QueryResult: &sqltypes.Result{},
+	})
+
+	pool := NewPool(context.Background(), &PoolConfig{
+		ClientConfig: server.ClientConfig(),
+		ConnPoolConfig: &connpool.Config{
+			Capacity:     4,
+			MaxIdleCount: 4,
+		},
+	})
+	pool.Open()
+	defer pool.Close()
+
+	borrowed := make([]PooledConn, 4)
+	oldPIDs := make(map[uint32]struct{}, len(borrowed))
+	for i := range borrowed {
+		var err error
+		borrowed[i], err = pool.Get(context.Background())
+		require.NoError(t, err)
+		oldPIDs[borrowed[i].Conn.ProcessID()] = struct{}{}
+	}
+	for _, conn := range borrowed {
+		conn.Recycle()
+	}
+	require.Equal(t, int64(4), pool.Stats().Active)
+
+	settings := connstate.NewSettings(map[string]string{"search_path": "public"}, 0)
+	pooled, err := pool.GetWithSettings(context.Background(), settings)
+	require.NoError(t, err)
+	defer pooled.Recycle()
+
+	_, reusedOldBackend := oldPIDs[pooled.Conn.ProcessID()]
+	assert.False(t, reusedOldBackend, "stale pooled slot must contain a freshly dialed PostgreSQL backend")
+	assert.Equal(t, settings, pooled.Conn.Settings())
+	assert.Equal(t, int64(4), pool.Stats().Active, "reconnect should preserve the selected pool slot")
+	server.VerifyAllExecutedOrFail()
+}
+
 // TestPool_GetWithSettings_NonConnectionErrorNoRetry covers the
-// non-connection-error branch: the error propagates verbatim with no
-// retry.
+// non-connection-error branch: the error propagates verbatim with no retry.
 func TestPool_GetWithSettings_NonConnectionErrorNoRetry(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
@@ -176,7 +225,8 @@ func TestPool_GetWithSettings_ExhaustedRetries(t *testing.T) {
 
 	server.OrderMatters()
 
-	for range constants.MaxConnPoolRetryAttempts {
+	// Each outer attempt tries the selected socket, then one fresh reconnect.
+	for range 2 * constants.MaxConnPoolRetryAttempts {
 		server.AddExpectedExecuteFetch(fakepgserver.ExpectedExecuteFetch{
 			Query: "SELECT pg_catalog.set_config*",
 			Error: connErrFATAL(),

--- a/go/test/endtoend/pgregresstest/isolation.go
+++ b/go/test/endtoend/pgregresstest/isolation.go
@@ -27,6 +27,12 @@ import (
 	"github.com/multigres/multigres/go/tools/executil"
 )
 
+const (
+	detachPartitionCancelTest  = "detach-partition-concurrently-4"
+	detachPartitionPIDOriginal = "insert into d4_pid select pg_backend_pid();"
+	detachPartitionPIDPinned   = "insert into d4_pid select pg_backend_pid() from multigres.backend_vpid bv cross join lateral pg_advisory_lock(bv.vpid) where bv.backend_pid = pg_backend_pid();"
+)
+
 // patchIsolationtester rewrites two pieces of
 // src/test/isolation/isolationtester.c so the harness works against
 // multigateway:
@@ -146,6 +152,36 @@ func (pb *PostgresBuilder) patchIsolationtester(t *testing.T, ctx context.Contex
 	return nil
 }
 
+// patchDetachPartitionCancel pins session s2 before it records the backend PID
+// that a later step cancels. Without the pin, transaction pooling may run the
+// blocked detach on a different backend.
+func (pb *PostgresBuilder) patchDetachPartitionCancel(t *testing.T, ctx context.Context) error {
+	t.Helper()
+	rel := filepath.Join("src", "test", "isolation", "specs", detachPartitionCancelTest+".spec")
+	abs := filepath.Join(pb.SourceDir, rel)
+
+	reset := executil.Command(ctx, "git", "-C", pb.SourceDir, "checkout", "--", rel)
+	if out, err := reset.CombinedOutput(); err != nil {
+		return fmt.Errorf("reset %s: %w\n%s", rel, err, out)
+	}
+
+	src, err := os.ReadFile(abs)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", abs, err)
+	}
+
+	if bytes.Count(src, []byte(detachPartitionPIDOriginal)) != 1 {
+		return fmt.Errorf("%s: expected query not found exactly once (PG version drift?)", rel)
+	}
+	src = bytes.Replace(src, []byte(detachPartitionPIDOriginal), []byte(detachPartitionPIDPinned), 1)
+
+	if err := os.WriteFile(abs, src, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", abs, err)
+	}
+	t.Logf("Patched %s: pin the backend whose PID is later canceled", rel)
+	return nil
+}
+
 // BuildIsolation builds the PostgreSQL isolation test tools (isolationtester and
 // pg_isolation_regress). Must be called after Build().
 func (pb *PostgresBuilder) BuildIsolation(t *testing.T, ctx context.Context) error {
@@ -153,6 +189,9 @@ func (pb *PostgresBuilder) BuildIsolation(t *testing.T, ctx context.Context) err
 
 	if err := pb.patchIsolationtester(t, ctx); err != nil {
 		return fmt.Errorf("patch isolationtester: %w", err)
+	}
+	if err := pb.patchDetachPartitionCancel(t, ctx); err != nil {
+		return fmt.Errorf("patch detach partition cancellation: %w", err)
 	}
 
 	isolationDir := filepath.Join(pb.BuildDir, "src", "test", "isolation")

--- a/go/test/endtoend/pgregresstest/main_test.go
+++ b/go/test/endtoend/pgregresstest/main_test.go
@@ -180,6 +180,9 @@ var setupManager = shardsetup.NewSharedSetupManager(func(t *testing.T) *shardset
 	opts := []shardsetup.SetupOption{
 		shardsetup.WithMultipoolerCount(2), // primary + standby
 		shardsetup.WithMultigateway(),      // enable multigateway for PostgreSQL connections
+		// Generated PostgreSQL allows 60 connections. Keep pooled capacity below
+		// that ceiling so admin and monitoring connections retain headroom.
+		shardsetup.WithMultipoolerExtraArgs("--connpool-global-capacity=50"),
 		// Force C locale on initdb so locale-sensitive expected outputs
 		// (char/varchar collation, to_char 'L' currency symbol, etc.) reproduce
 		// upstream PostgreSQL behavior. Keep UTF8 encoding so the unicode /

--- a/go/test/endtoend/pgregresstest/patch_verify.go
+++ b/go/test/endtoend/pgregresstest/patch_verify.go
@@ -213,6 +213,7 @@ func normalizeNotificationPIDs(input []byte) []byte {
 // normalizeRunPaths masks per-run path segments so diff/patch operate on
 // run-independent bytes.
 func normalizeRunPaths(input []byte) []byte {
+	input = bytes.ReplaceAll(input, []byte("/private/tmp/"), []byte("/tmp/"))
 	return runBuildDirRe.ReplaceAll(input, []byte("builds/[RUN]"))
 }
 

--- a/go/test/endtoend/pgregresstest/patch_verify.go
+++ b/go/test/endtoend/pgregresstest/patch_verify.go
@@ -151,8 +151,13 @@ var (
 )
 
 func normalizeTestOutput(name, patchDir string, input []byte) []byte {
-	if name == "stats" && filepath.Base(patchDir) == "isolation" {
-		return normalizeIsolationStats(input)
+	if filepath.Base(patchDir) == "isolation" {
+		switch name {
+		case "stats":
+			return normalizeIsolationStats(input)
+		case detachPartitionCancelTest:
+			return bytes.ReplaceAll(input, []byte(detachPartitionPIDPinned), []byte(detachPartitionPIDOriginal))
+		}
 	}
 	if name == "prepare" || name == "psql" || name == "guc" {
 		return normalizePoolerPreparedNames(input)

--- a/go/test/endtoend/pgregresstest/patch_verify_test.go
+++ b/go/test/endtoend/pgregresstest/patch_verify_test.go
@@ -524,10 +524,14 @@ func stringsContains(s, substr string) bool {
 // lines) must normalize to a stable token, or no committed patch containing
 // such a line could ever verify on a later run.
 func TestNormalizeRunPaths(t *testing.T) {
-	in := `could not open file "/tmp/multigres_pg_cache/builds/20260703-091540.026410/build/src/test/regress/results/lotest.txt": No such file or directory`
 	want := `could not open file "/tmp/multigres_pg_cache/builds/[RUN]/build/src/test/regress/results/lotest.txt": No such file or directory`
-	if got := string(normalizeRunPaths([]byte(in))); got != want {
-		t.Fatalf("normalizeRunPaths = %q, want %q", got, want)
+	for _, in := range []string{
+		`could not open file "/tmp/multigres_pg_cache/builds/20260703-091540.026410/build/src/test/regress/results/lotest.txt": No such file or directory`,
+		`could not open file "/private/tmp/multigres_pg_cache/builds/20260703-091540.026410/build/src/test/regress/results/lotest.txt": No such file or directory`,
+	} {
+		if got := string(normalizeRunPaths([]byte(in))); got != want {
+			t.Fatalf("normalizeRunPaths = %q, want %q", got, want)
+		}
 	}
 
 	// Lines without a run path pass through untouched.

--- a/go/test/endtoend/pgregresstest/patch_verify_test.go
+++ b/go/test/endtoend/pgregresstest/patch_verify_test.go
@@ -436,6 +436,17 @@ func TestNormalizeIsolationStats(t *testing.T) {
 	}
 }
 
+func TestNormalizeDetachPartitionCancel(t *testing.T) {
+	in := detachPartitionPIDPinned + "\n"
+	want := detachPartitionPIDOriginal + "\n"
+	if got := string(normalizeTestOutput(detachPartitionCancelTest, "/patches/isolation", []byte(in))); got != want {
+		t.Fatalf("normalize detach partition queries = %q, want %q", got, want)
+	}
+	if got := string(normalizeTestOutput(detachPartitionCancelTest, "/patches", []byte(in))); got != in {
+		t.Fatalf("non-isolation output changed: %q", got)
+	}
+}
+
 func TestNormalizePoolerPreparedNames(t *testing.T) {
 	in := "ppstmt1 ppstmt987 prepstmt2 stmt3"
 	want := "ppstmt<ID> ppstmt<ID> prepstmt2 stmt3"

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/contrib/pg_walinspect/oldextversions.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/contrib/pg_walinspect/oldextversions.patch
@@ -1,0 +1,31 @@
+# Known safety divergence: Multigres rejects non-temporary replication slots
+# because their position cannot yet be migrated across primary failover. This
+# test requests a persistent physical slot only to keep checkpoints from
+# recycling WAL; the failed drop is direct fallout from the rejected creation.
+--- a
++++ b
+@@ -20,11 +20,7 @@
+ 
+ -- Make sure checkpoints don't interfere with the test.
+ SELECT 'init' FROM pg_create_physical_replication_slot('regress_pg_walinspect_slot', true, false);
+-?column?
+-----------
+-init
+-(1 row)
+-
++ERROR: pg_create_physical_replication_slot requires temporary=true: Multigres cannot yet migrate a replication slot across a primary failover, so only temporary (session-scoped) slots are supported
+ CREATE TABLE sample_tbl(col1 int, col2 int);
+ SELECT pg_current_wal_lsn() AS wal_lsn1 \gset
+ INSERT INTO sample_tbl SELECT * FROM generate_series(1, 2);
+@@ -60,10 +56,6 @@
+ (4 rows)
+ 
+ SELECT pg_drop_replication_slot('regress_pg_walinspect_slot');
+-pg_drop_replication_slot
+---------------------------
+-
+-(1 row)
+-
++ERROR: replication slot "regress_pg_walinspect_slot" does not exist
+ DROP TABLE sample_tbl;
+ DROP EXTENSION pg_walinspect;

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/contrib/pg_walinspect/pg_walinspect.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/contrib/pg_walinspect/pg_walinspect.patch
@@ -1,0 +1,31 @@
+# Known safety divergence: Multigres rejects non-temporary replication slots
+# because their position cannot yet be migrated across primary failover. This
+# test requests a persistent physical slot only to keep checkpoints from
+# recycling WAL; the failed drop is direct fallout from the rejected creation.
+--- a
++++ b
+@@ -3,11 +3,7 @@
+ \set VERBOSITY terse
+ -- Make sure checkpoints don't interfere with the test.
+ SELECT 'init' FROM pg_create_physical_replication_slot('regress_pg_walinspect_slot', true, false);
+-?column?
+-----------
+-init
+-(1 row)
+-
++ERROR: pg_create_physical_replication_slot requires temporary=true: Multigres cannot yet migrate a replication slot across a primary failover, so only temporary (session-scoped) slots are supported
+ CREATE TABLE sample_tbl(col1 int, col2 int);
+ -- Save some LSNs for comparisons.
+ SELECT pg_current_wal_lsn() AS wal_lsn1 \gset
+@@ -264,10 +260,6 @@
+ -- ===================================================================
+ DROP ROLE regress_pg_walinspect;
+ SELECT pg_drop_replication_slot('regress_pg_walinspect_slot');
+-pg_drop_replication_slot
+---------------------------
+-
+-(1 row)
+-
++ERROR: replication slot "regress_pg_walinspect_slot" does not exist
+ DROP TABLE sample_tbl;
+ DROP EXTENSION pg_walinspect;

--- a/go/test/endtoend/queryserving/multi_statement_transaction_test.go
+++ b/go/test/endtoend/queryserving/multi_statement_transaction_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+func TestMultiStatementTransactionSemantics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping multi-statement test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup := getSharedSetup(t)
+	for _, target := range setup.GetComparisonTargets(t) {
+		t.Run(target.Name, func(t *testing.T) {
+			ctx := utils.WithTimeout(t, 30*time.Second)
+			db, err := sql.Open("postgres", shardsetup.GetTestUserDSN("localhost", target.Port, "sslmode=disable", "connect_timeout=5"))
+			require.NoError(t, err)
+			defer db.Close()
+			db.SetMaxOpenConns(1)
+
+			_, err = db.ExecContext(ctx, "CREATE TEMP TABLE multi_statement_test(v int)")
+			require.NoError(t, err)
+
+			_, err = db.ExecContext(ctx, "INSERT INTO multi_statement_test VALUES (1); SELECT 1/0")
+			require.Error(t, err)
+			var count int
+			require.NoError(t, db.QueryRowContext(ctx, "SELECT count(*) FROM multi_statement_test").Scan(&count))
+			assert.Zero(t, count, "implicit batch transaction must roll back as one unit")
+
+			_, err = db.ExecContext(ctx, "SELECT 1; BEGIN; INSERT INTO multi_statement_test VALUES (2)")
+			require.NoError(t, err)
+			_, err = db.ExecContext(ctx, "ROLLBACK")
+			require.NoError(t, err)
+			require.NoError(t, db.QueryRowContext(ctx, "SELECT count(*) FROM multi_statement_test").Scan(&count))
+			assert.Zero(t, count, "BEGIN inside the batch must survive until the next query")
+
+			_, err = db.ExecContext(ctx, "INSERT INTO multi_statement_test VALUES (7); COMMIT; INSERT INTO multi_statement_test VALUES (8); SELECT 1/0")
+			require.Error(t, err)
+			var values []int
+			rows, err := db.QueryContext(ctx, "SELECT v FROM multi_statement_test ORDER BY v")
+			require.NoError(t, err)
+			defer rows.Close()
+			for rows.Next() {
+				var value int
+				require.NoError(t, rows.Scan(&value))
+				values = append(values, value)
+			}
+			require.NoError(t, rows.Err())
+			assert.Equal(t, []int{7}, values)
+
+			_, err = db.ExecContext(ctx, "DISCARD TEMP")
+			require.NoError(t, err)
+			err = db.QueryRowContext(ctx, "SELECT count(*) FROM multi_statement_test").Scan(&count)
+			require.Error(t, err, "DISCARD TEMP must release the reservation and remove the temp table")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- route every split multi-statement simple query through the same implicit transaction state machine, including temp-reserved sessions
- preserve PostgreSQL rollback, explicit transaction-boundary, savepoint, `AND CHAIN`, and final `CommandComplete` behavior
- reconnect stale pooled settings slots and retry stale sockets when creating non-transaction reservations such as `CREATE TEMP`
- harden the pgregress harness with the required Turkish libc locale, pool headroom below PostgreSQL's connection ceiling, and macOS temporary-path normalization

Extracted from #1306. Reserved session-state replay remains there; parser diagnostics are in #1310.

## Testing

- `go test -short -count=1 ./go/services/multigateway/handler ./go/services/multipooler/internal/executor ./go/services/multipooler/internal/pools/connpool ./go/services/multipooler/internal/pools/regular`
- `go test -short -count=1 -run '^TestNormalizeRunPaths$' ./go/test/endtoend/pgregresstest`
- PostgreSQL compatibility suite triggered via PR label
