### PR TITLE
fix(query-serving): preserve DateStyle and savepoint state

### DIFF
--- a/go/common/pgsettings/reportable.go
+++ b/go/common/pgsettings/reportable.go
@@ -43,3 +43,11 @@ func ReportableGUCName(name string) (string, bool) {
 	display, ok := reportableGUCs[CanonicalGUCName(name)]
 	return display, ok
 }
+
+// UseReportedValueForSessionState reports whether replay must use PostgreSQL's
+// complete GUC_REPORT value instead of the original input. DateStyle's style
+// and order components can be set independently, so replaying partial input on
+// a fresh backend can produce a different effective value.
+func UseReportedValueForSessionState(name string) bool {
+	return CanonicalGUCName(name) == "datestyle"
+}

--- a/go/services/multigateway/engine/apply_session_state.go
+++ b/go/services/multigateway/engine/apply_session_state.go
@@ -29,6 +29,15 @@ import (
 	"github.com/multigres/multigres/go/services/multigateway/handler"
 )
 
+// reportedValueSessionStateGUCs lists GUCs whose original SET value can have
+// a different effect when replayed on a fresh backend. DateStyle has separately
+// settable style and order components, so its complete reported value must
+// replace partial input. Add other context-sensitive canonical GUC_REPORT
+// names here.
+var reportedValueSessionStateGUCs = map[string]struct{}{
+	"datestyle": {},
+}
+
 // ApplySessionState records a SET/RESET in the gateway's local session-settings
 // tracker. The pool propagates the tracked settings to a backend on the next
 // query via ApplySettings, so the change survives pool rotation.
@@ -448,7 +457,7 @@ func (s *ApplySessionState) StreamExecute(
 		if s.BindRefs != nil {
 			return s.executeSetWithNormalizedBinds(ctx, conn, state, bindVars, callback)
 		}
-		return s.executeSet(ctx, conn, state, callback)
+		return s.executeSet(ctx, conn, state, info, callback)
 	case ast.VAR_SET_DEFAULT:
 		return s.executeSetDefault(ctx, state, callback)
 	case ast.VAR_RESET, ast.VAR_RESET_ALL:
@@ -470,9 +479,17 @@ func (s *ApplySessionState) executeSet(
 	ctx context.Context,
 	conn *server.Conn,
 	state *handler.MultigatewayConnectionState,
+	info PlanExecInfo,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
 	value := extractVariableValue(s.VariableStmt.Args)
+	if _, useReported := reportedValueSessionStateGUCs[pgsettings.CanonicalGUCName(s.VariableStmt.Name)]; useReported && info.Exchange != nil {
+		if displayName, reportable := pgsettings.ReportableGUCName(s.VariableStmt.Name); reportable {
+			if effective, ok := info.Exchange.ReportedSettings[displayName]; ok {
+				value = effective
+			}
+		}
+	}
 	return s.applyTracked(ctx, conn, state, s.VariableStmt.Name, value, s.VariableStmt.IsLocal, callback)
 }
 

--- a/go/services/multigateway/engine/apply_session_state.go
+++ b/go/services/multigateway/engine/apply_session_state.go
@@ -29,15 +29,6 @@ import (
 	"github.com/multigres/multigres/go/services/multigateway/handler"
 )
 
-// reportedValueSessionStateGUCs lists GUCs whose original SET value can have
-// a different effect when replayed on a fresh backend. DateStyle has separately
-// settable style and order components, so its complete reported value must
-// replace partial input. Add other context-sensitive canonical GUC_REPORT
-// names here.
-var reportedValueSessionStateGUCs = map[string]struct{}{
-	"datestyle": {},
-}
-
 // ApplySessionState records a SET/RESET in the gateway's local session-settings
 // tracker. The pool propagates the tracked settings to a backend on the next
 // query via ApplySettings, so the change survives pool rotation.
@@ -168,10 +159,10 @@ func (s *ApplySessionState) PortalStreamExecute(
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
 	if s.BindRefs != nil {
-		// No reported-settings wrapping here: a bound set_config is always a
-		// silent tracker (NewApplySessionStateFromBind), so applyTracked returns
-		// before the callback and the paired Route owns the client response.
-		return s.executeSetWithBinds(ctx, conn, state, portalInfo, callback)
+		// A bound set_config is always a silent tracker
+		// (NewApplySessionStateFromBind); the paired Route owns the response and
+		// supplies any canonical GUC_REPORT value through info.Exchange.
+		return s.executeSetWithBinds(ctx, conn, state, portalInfo, info, callback)
 	}
 	// Forward info so StreamExecute can attach any GUC_REPORT values a preceding
 	// ValidateSetting captured — this is the branch a real SET takes.
@@ -197,9 +188,10 @@ func (s *ApplySessionState) executeSetWithBinds(
 	conn *server.Conn,
 	state *handler.MultigatewayConnectionState,
 	portalInfo *preparedstatement.PortalInfo,
+	info PlanExecInfo,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	return s.executeSetWithResolvedParams(ctx, conn, state, portalSetConfigResolver(portalInfo), callback)
+	return s.executeSetWithResolvedParams(ctx, conn, state, portalSetConfigResolver(portalInfo), info, callback)
 }
 
 func portalSetConfigResolver(portalInfo *preparedstatement.PortalInfo) setConfigParamResolver {
@@ -225,9 +217,10 @@ func (s *ApplySessionState) executeSetWithNormalizedBinds(
 	conn *server.Conn,
 	state *handler.MultigatewayConnectionState,
 	bindVars []*ast.A_Const,
+	info PlanExecInfo,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	return s.executeSetWithResolvedParams(ctx, conn, state, normalizedSetConfigResolver(bindVars), callback)
+	return s.executeSetWithResolvedParams(ctx, conn, state, normalizedSetConfigResolver(bindVars), info, callback)
 }
 
 func normalizedSetConfigResolver(bindVars []*ast.A_Const) setConfigParamResolver {
@@ -320,6 +313,7 @@ func (s *ApplySessionState) executeSetWithResolvedParams(
 	conn *server.Conn,
 	state *handler.MultigatewayConnectionState,
 	resolver setConfigParamResolver,
+	info PlanExecInfo,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
 	resolved, err := s.resolveSetConfig(resolver)
@@ -329,6 +323,7 @@ func (s *ApplySessionState) executeSetWithResolvedParams(
 	if !resolved.shouldTrack {
 		return nil
 	}
+	resolved.value = reportedSessionStateValue(info.Exchange, resolved.name, resolved.value)
 	return s.applyTracked(ctx, conn, state, resolved.name, resolved.value, resolved.isLocal, callback)
 }
 
@@ -407,7 +402,7 @@ func (s *ApplySessionState) prepareSilentTrackingAction(
 			return silentTrackingAction{}, true, err
 		}
 		if !resolved.shouldTrack {
-			return silentTrackingAction{apply: func() {}}, true, nil
+			return silentTrackingAction{apply: func(*SequenceExchange) {}}, true, nil
 		}
 		action, preview, err := prepareTrackedSetActionWithBackendPreview(conn, state, resolved.name, resolved.value, resolved.isLocal)
 		return silentTrackingAction{apply: action, previewPostSessionSettings: preview}, true, err
@@ -421,11 +416,11 @@ func (s *ApplySessionState) prepareSilentTrackingAction(
 			return removeBackendSessionVariableFromMap(settings, name)
 		}
 		return silentTrackingAction{
-			apply:                      func() { resetTrackedSessionVariable(state, name) },
+			apply:                      func(*SequenceExchange) { resetTrackedSessionVariable(state, name) },
 			previewPostSessionSettings: preview,
 		}, true, nil
 	case ast.VAR_RESET_ALL:
-		return silentTrackingAction{apply: func() {
+		return silentTrackingAction{apply: func(*SequenceExchange) {
 			resetAllSessionVariablesPreservingRoleAuth(state)
 			state.ResetGatewayManagedVariables()
 		}}, true, nil
@@ -455,7 +450,7 @@ func (s *ApplySessionState) StreamExecute(
 	switch s.VariableStmt.Kind {
 	case ast.VAR_SET_VALUE:
 		if s.BindRefs != nil {
-			return s.executeSetWithNormalizedBinds(ctx, conn, state, bindVars, callback)
+			return s.executeSetWithNormalizedBinds(ctx, conn, state, bindVars, info, callback)
 		}
 		return s.executeSet(ctx, conn, state, info, callback)
 	case ast.VAR_SET_DEFAULT:
@@ -482,15 +477,22 @@ func (s *ApplySessionState) executeSet(
 	info PlanExecInfo,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	value := extractVariableValue(s.VariableStmt.Args)
-	if _, useReported := reportedValueSessionStateGUCs[pgsettings.CanonicalGUCName(s.VariableStmt.Name)]; useReported && info.Exchange != nil {
-		if displayName, reportable := pgsettings.ReportableGUCName(s.VariableStmt.Name); reportable {
-			if effective, ok := info.Exchange.ReportedSettings[displayName]; ok {
-				value = effective
-			}
-		}
-	}
+	value := reportedSessionStateValue(info.Exchange, s.VariableStmt.Name, extractVariableValue(s.VariableStmt.Args))
 	return s.applyTracked(ctx, conn, state, s.VariableStmt.Name, value, s.VariableStmt.IsLocal, callback)
+}
+
+func reportedSessionStateValue(exchange *SequenceExchange, name, value string) string {
+	if !pgsettings.UseReportedValueForSessionState(name) {
+		return value
+	}
+	displayName, reportable := pgsettings.ReportableGUCName(name)
+	if !reportable || exchange == nil {
+		return value
+	}
+	if effective, ok := exchange.ReportedSettings[displayName]; ok {
+		return effective
+	}
+	return value
 }
 
 // withReportedSettings wraps callback so the SET's CommandComplete result also
@@ -542,7 +544,7 @@ func (s *ApplySessionState) applyTracked(
 	if err != nil {
 		return err
 	}
-	action()
+	action(nil)
 
 	if s.SilentTracking {
 		return nil
@@ -556,16 +558,18 @@ func (s *ApplySessionState) applyTracked(
 // prepareTrackedSetAction validates and captures a non-failing state update for
 // a tracked SET / set_config. Callers can run this before a client-visible Route
 // and invoke the returned action only after PostgreSQL accepts the statement.
-func prepareTrackedSetAction(conn *server.Conn, state *handler.MultigatewayConnectionState, name, value string, isLocal bool) (func(), error) {
+type trackedSetAction func(*SequenceExchange)
+
+func prepareTrackedSetAction(conn *server.Conn, state *handler.MultigatewayConnectionState, name, value string, isLocal bool) (trackedSetAction, error) {
 	action, _, err := prepareTrackedSetActionWithBackendPreview(conn, state, name, value, isLocal)
 	return action, err
 }
 
-func prepareTrackedSetActionWithBackendPreview(conn *server.Conn, state *handler.MultigatewayConnectionState, name, value string, isLocal bool) (func(), func(map[string]string) map[string]string, error) {
+func prepareTrackedSetActionWithBackendPreview(conn *server.Conn, state *handler.MultigatewayConnectionState, name, value string, isLocal bool) (trackedSetAction, func(map[string]string) map[string]string, error) {
 	inTransaction := conn != nil && conn.IsInTransaction()
 	skipLeakyLocal := isLocal && !inTransaction && handler.IsGatewayManagedVariable(name)
 	if skipLeakyLocal {
-		return func() {}, nil, nil
+		return func(*SequenceExchange) {}, nil, nil
 	}
 
 	if handler.IsGatewayManagedVariable(name) {
@@ -587,15 +591,15 @@ func prepareTrackedSetActionWithBackendPreview(conn *server.Conn, state *handler
 				return applyBackendSessionVariableToMap(settings, name, value)
 			}
 		}
-		return func() {
+		return func(*SequenceExchange) {
 			// name is gateway-managed and the value validated above, so this cannot
 			// return the not-managed/invalid error paths.
 			_, _ = state.ApplyGatewayManagedVariable(name, value, isLocal)
 		}, preview, nil
 	}
 
-	action := func() {
-		applyTrackedSessionVariable(state, name, value)
+	action := func(exchange *SequenceExchange) {
+		applyTrackedSessionVariable(state, name, reportedSessionStateValue(exchange, name, value))
 	}
 	preview := func(settings map[string]string) map[string]string {
 		return applyBackendSessionVariableToMap(settings, name, value)

--- a/go/services/multigateway/engine/apply_session_state_test.go
+++ b/go/services/multigateway/engine/apply_session_state_test.go
@@ -65,6 +65,35 @@ func TestApplySessionState_SET_UpdatesStateAndReturnsSynthetic(t *testing.T) {
 	assert.Equal(t, "SET", results[0].CommandTag)
 }
 
+func TestApplySessionState_SET_UsesReportedValueOnlyWhenNeededForReplay(t *testing.T) {
+	tests := []struct {
+		name, input, reportedName, reportedValue, want string
+	}{
+		{"datestyle", "dmy", "DateStyle", "Postgres, DMY", "Postgres, DMY"},
+		{"timezone", "-7", "TimeZone", "<-07>+07", "-7"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &handler.MultigatewayConnectionState{}
+			stmt := &ast.VariableSetStmt{
+				Kind: ast.VAR_SET_VALUE,
+				Name: tt.name,
+				Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: tt.input}}}},
+			}
+			primitive := NewApplySessionState("SET", stmt)
+			exchange := &SequenceExchange{ReportedSettings: map[string]string{tt.reportedName: tt.reportedValue}}
+
+			require.NoError(t, primitive.StreamExecute(context.Background(), nil, server.NewTestConn(&bytes.Buffer{}).Conn,
+				state, nil, PlanExecInfo{Exchange: exchange}, func(context.Context, *sqltypes.Result) error { return nil }))
+
+			value, ok := state.GetSessionVariable(tt.name)
+			require.True(t, ok)
+			assert.Equal(t, tt.want, value)
+		})
+	}
+}
+
 func TestApplySessionState_RoleSessionAuthorizationTracking(t *testing.T) {
 	testConn := server.NewTestConn(&bytes.Buffer{})
 	state := &handler.MultigatewayConnectionState{}

--- a/go/services/multigateway/engine/apply_session_state_test.go
+++ b/go/services/multigateway/engine/apply_session_state_test.go
@@ -94,6 +94,11 @@ func TestApplySessionState_SET_UsesReportedValueOnlyWhenNeededForReplay(t *testi
 	}
 }
 
+func TestReportedSessionStateValueFallsBackWhenDateStyleWasNotReported(t *testing.T) {
+	exchange := &SequenceExchange{ReportedSettings: map[string]string{"TimeZone": "UTC"}}
+	require.Equal(t, "DMY", reportedSessionStateValue(exchange, "datestyle", "DMY"))
+}
+
 func TestApplySessionState_RoleSessionAuthorizationTracking(t *testing.T) {
 	testConn := server.NewTestConn(&bytes.Buffer{})
 	state := &handler.MultigatewayConnectionState{}

--- a/go/services/multigateway/engine/engine.go
+++ b/go/services/multigateway/engine/engine.go
@@ -111,19 +111,33 @@ type PlanExecInfo struct {
 // runtime-computed data to a later sibling without abusing connection state
 // (session-lifetime) or stashing per-execution values on the cached plan.
 type SequenceExchange struct {
-	// ReportedSettings holds GUC_REPORT values a validating primitive captured
-	// from set_config's canonical return, keyed by PostgreSQL's ParameterStatus
-	// display name, for a trailing ApplySessionState to emit. nil until written.
+	// ReportedSettings holds canonical GUC_REPORT values captured from validation
+	// or a routed statement, keyed by PostgreSQL's ParameterStatus display name,
+	// for a trailing ApplySessionState to emit and track. nil until written.
 	ReportedSettings map[string]string
 }
 
 // AddReportedSetting records a canonical GUC value under its ParameterStatus
-// display name for a later sibling to emit.
+// display name for a later sibling to emit or track.
 func (e *SequenceExchange) AddReportedSetting(displayName, value string) {
 	if e.ReportedSettings == nil {
 		e.ReportedSettings = make(map[string]string)
 	}
 	e.ReportedSettings[displayName] = value
+}
+
+func captureReportedSettings(exchange *SequenceExchange, callback func(context.Context, *sqltypes.Result) error) func(context.Context, *sqltypes.Result) error {
+	return func(ctx context.Context, result *sqltypes.Result) error {
+		if exchange != nil && result != nil {
+			for name, value := range result.ParameterStatus {
+				exchange.AddReportedSetting(name, value)
+			}
+		}
+		if callback == nil {
+			return nil
+		}
+		return callback(ctx, result)
+	}
 }
 
 // IExecute is the execution interface that provides access to execution

--- a/go/services/multigateway/engine/prepared_statement_primitive.go
+++ b/go/services/multigateway/engine/prepared_statement_primitive.go
@@ -199,11 +199,15 @@ func (p *PreparedStatementPrimitive) executeExecute(
 	if err != nil {
 		return err
 	}
-	if err := exec.StreamExecute(ctx, conn, p.tableGroup, constants.DefaultShard, p.executeStmt.SqlString(), executeSQLPreparedStatement, state, callInfo, false, callback); err != nil {
+	exchange := info.Exchange
+	if exchange == nil {
+		exchange = &SequenceExchange{}
+	}
+	if err := exec.StreamExecute(ctx, conn, p.tableGroup, constants.DefaultShard, p.executeStmt.SqlString(), executeSQLPreparedStatement, state, callInfo, false, captureReportedSettings(exchange, callback)); err != nil {
 		return err
 	}
 	for _, action := range trackActions {
-		action()
+		action(exchange)
 	}
 	return nil
 }
@@ -213,12 +217,12 @@ func (p *PreparedStatementPrimitive) prepareSetConfigTracking(
 	state *handler.MultigatewayConnectionState,
 	portalInfo *preparedstatement.PortalInfo,
 	info PlanExecInfo,
-) ([]func(), PlanExecInfo, error) {
+) ([]trackedSetAction, PlanExecInfo, error) {
 	if len(p.setConfigs) == 0 {
 		return nil, info, nil
 	}
 
-	var actions []func()
+	var actions []trackedSetAction
 	for _, sc := range p.setConfigs {
 		resolved, err := p.resolvePreparedSetConfig(sc, portalInfo)
 		if err != nil {

--- a/go/services/multigateway/engine/prepared_statement_primitive_test.go
+++ b/go/services/multigateway/engine/prepared_statement_primitive_test.go
@@ -116,7 +116,7 @@ func TestSQLPreparedSetConfigTrackingBranches(t *testing.T) {
 	require.Len(t, actions, 1)
 	assert.True(t, info.HasPostQuerySessionSettings)
 	assert.Equal(t, "prepared", info.PostQuerySessionSettings["application_name"])
-	actions[0]()
+	actions[0](nil)
 	got, ok := state.GetSessionVariable("application_name")
 	require.True(t, ok)
 	assert.Equal(t, "prepared", got)
@@ -127,7 +127,7 @@ func TestSQLPreparedSetConfigTrackingBranches(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, actions, 1)
 	assert.False(t, info.HasPostQuerySessionSettings)
-	actions[0]()
+	actions[0](nil)
 
 	p.setConfigs = []SQLPreparedSetConfig{{Name: "statement_timeout", Value: "invalid"}}
 	_, _, err = p.prepareSetConfigTracking(conn, state, nil, PlanExecInfo{})

--- a/go/services/multigateway/engine/resolve_set_config.go
+++ b/go/services/multigateway/engine/resolve_set_config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/common/pgsettings"
 	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/pb/query"
@@ -183,8 +184,35 @@ func (s *ResolveTrackSetConfig) execute(
 	if err != nil {
 		return err
 	}
-	if err := exec.StreamExecute(ctx, conn, s.TableGroup, s.Shard, applySQL, nil, state, PlanExecInfo{}, false, callback); err != nil {
+	keepStructured := resolvedSetConfigsNeedReportedValue(rows, len(s.Aliases))
+	appliedRows := 0
+	applyCallback := callback
+	if keepStructured {
+		applyCallback = func(ctx context.Context, result *sqltypes.Result) error {
+			for _, applied := range result.StructuredRows() {
+				if appliedRows >= len(rows) || len(applied.Values) != len(s.Aliases) {
+					return mterrors.NewPgError("ERROR", mterrors.PgSSInternalError,
+						"internal error resolving set_config (please report this as a bug)",
+						"set_config apply result does not match the resolved input")
+				}
+				for ci, value := range applied.Values {
+					name := rows[appliedRows].Values[ci*3]
+					if !name.IsNull() && !value.IsNull() && pgsettings.UseReportedValueForSessionState(string(name)) {
+						rows[appliedRows].Values[ci*3+1] = value
+					}
+				}
+				appliedRows++
+			}
+			return callback(ctx, result)
+		}
+	}
+	if err := exec.StreamExecute(ctx, conn, s.TableGroup, s.Shard, applySQL, nil, state, PlanExecInfo{}, keepStructured, applyCallback); err != nil {
 		return err
+	}
+	if keepStructured && appliedRows != len(rows) {
+		return mterrors.NewPgError("ERROR", mterrors.PgSSInternalError,
+			"internal error resolving set_config (please report this as a bug)",
+			"set_config apply returned an unexpected number of rows")
 	}
 
 	// Track settings only after a successful apply, so we never record a setting
@@ -271,6 +299,18 @@ func (s *ResolveTrackSetConfig) buildApplySQL(rows []*sqltypes.Row) (string, err
 	return strings.Join(legs, " UNION ALL "), nil
 }
 
+func resolvedSetConfigsNeedReportedValue(rows []*sqltypes.Row, numCalls int) bool {
+	for _, row := range rows {
+		for ci := range numCalls {
+			name := row.Values[ci*3]
+			if !name.IsNull() && pgsettings.UseReportedValueForSessionState(string(name)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // prepareTrackActions validates and captures the state updates for resolved
 // set_config tuples. Ordinary session-scoped (is_local=false) GUCs go to
 // SessionSettings. Gateway-managed GUCs (currently statement_timeout) are
@@ -349,9 +389,10 @@ func (s *ResolveTrackSetConfig) prepareTrackActions(conn *server.Conn, state *ha
 			}
 
 			nameCopy := nameStr
-			valueCopy := valueStr
+			valueIndex := ci*3 + 1
+			rowCopy := row
 			actions = append(actions, func() {
-				applyTrackedSessionVariable(state, nameCopy, valueCopy)
+				applyTrackedSessionVariable(state, nameCopy, string(rowCopy.Values[valueIndex]))
 			})
 		}
 	}

--- a/go/services/multigateway/engine/resolve_set_config_test.go
+++ b/go/services/multigateway/engine/resolve_set_config_test.go
@@ -74,10 +74,12 @@ func (p *resolveRowsPrimitive) GetQuery() string      { return "resolve" }
 func (p *resolveRowsPrimitive) String() string        { return "resolveRowsPrimitive" }
 
 type resolveApplyExec struct {
-	applyCalls int
-	applySQL   string
-	applyErr   error
-	onCallback func()
+	applyCalls     int
+	applySQL       string
+	applyErr       error
+	applyRows      []*sqltypes.Row
+	keepStructured bool
+	onCallback     func()
 }
 
 func (e *resolveApplyExec) StreamExecute(
@@ -89,18 +91,19 @@ func (e *resolveApplyExec) StreamExecute(
 	_ *query.ExecuteSqlPreparedStatement,
 	_ *handler.MultigatewayConnectionState,
 	_ PlanExecInfo,
-	_ bool,
+	keepStructured bool,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
 	e.applyCalls++
 	e.applySQL = sql
+	e.keepStructured = keepStructured
 	if e.applyErr != nil {
 		return e.applyErr
 	}
 	if e.onCallback != nil {
 		e.onCallback()
 	}
-	return callback(ctx, &sqltypes.Result{CommandTag: "SELECT 1"})
+	return callback(ctx, &sqltypes.Result{Rows: e.applyRows, CommandTag: "SELECT 1"})
 }
 
 func (e *resolveApplyExec) PortalStreamExecute(context.Context, string, string, *server.Conn, *handler.MultigatewayConnectionState, *preparedstatement.PortalInfo, int32, bool, PlanExecInfo, bool, func(context.Context, *sqltypes.Result) error) error {
@@ -204,6 +207,21 @@ func TestResolveTrackSetConfig_TracksGatewayManagedOnlyAfterApplySuccess(t *test
 	assert.Contains(t, exec.applySQL, "statement_timeout")
 	assert.Equal(t, 1, callbacks)
 	assert.Equal(t, time.Minute, state.GetStatementTimeout())
+}
+
+func TestResolveTrackSetConfig_TracksCanonicalDateStyle(t *testing.T) {
+	prim := newResolveSetConfigForTest(setConfigResolveRow("DateStyle", "DMY", false))
+	exec := &resolveApplyExec{applyRows: []*sqltypes.Row{{Values: []sqltypes.Value{[]byte("Postgres, DMY")}}}}
+	state := handler.NewMultigatewayConnectionState()
+
+	err := prim.StreamExecute(context.Background(), exec, server.NewTestConn(&bytes.Buffer{}).Conn,
+		state, nil, PlanExecInfo{}, func(context.Context, *sqltypes.Result) error { return nil })
+
+	require.NoError(t, err)
+	assert.True(t, exec.keepStructured)
+	value, ok := state.GetSessionVariable("datestyle")
+	require.True(t, ok)
+	assert.Equal(t, "Postgres, DMY", value)
 }
 
 func TestResolveTrackSetConfig_DoesNotTrackWhenApplyFails(t *testing.T) {

--- a/go/services/multigateway/engine/resolve_set_config_test.go
+++ b/go/services/multigateway/engine/resolve_set_config_test.go
@@ -224,6 +224,41 @@ func TestResolveTrackSetConfig_TracksCanonicalDateStyle(t *testing.T) {
 	assert.Equal(t, "Postgres, DMY", value)
 }
 
+func TestResolveTrackSetConfig_RejectsMalformedCanonicalResult(t *testing.T) {
+	tests := []struct {
+		name      string
+		applyRows []*sqltypes.Row
+		wantError string
+	}{
+		{
+			name:      "wrong column count",
+			applyRows: []*sqltypes.Row{{Values: []sqltypes.Value{[]byte("Postgres, DMY"), []byte("extra")}}},
+			wantError: "set_config apply result does not match the resolved input",
+		},
+		{
+			name:      "missing row",
+			wantError: "set_config apply returned an unexpected number of rows",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prim := newResolveSetConfigForTest(setConfigResolveRow("DateStyle", "DMY", false))
+			exec := &resolveApplyExec{applyRows: tt.applyRows}
+			state := handler.NewMultigatewayConnectionState()
+
+			err := prim.StreamExecute(t.Context(), exec, server.NewTestConn(&bytes.Buffer{}).Conn,
+				state, nil, PlanExecInfo{}, func(context.Context, *sqltypes.Result) error { return nil })
+
+			var diag *mterrors.PgDiagnostic
+			require.ErrorAs(t, err, &diag)
+			require.Equal(t, tt.wantError, diag.Detail)
+			_, tracked := state.GetSessionVariable("datestyle")
+			require.False(t, tracked)
+		})
+	}
+}
+
 func TestResolveTrackSetConfig_DoesNotTrackWhenApplyFails(t *testing.T) {
 	prim := newResolveSetConfigForTest(setConfigResolveRow("statement_timeout", "1min", false))
 	applyErr := errors.New("backend rejected apply")

--- a/go/services/multigateway/engine/sequence.go
+++ b/go/services/multigateway/engine/sequence.go
@@ -39,7 +39,7 @@ func NewSequence(primitives []Primitive) *Sequence {
 }
 
 type silentTrackingAction struct {
-	apply func()
+	apply trackedSetAction
 
 	// previewPostSessionSettings mutates/returns a copy of the backend session
 	// settings that should be recorded if the routed statement succeeds. It is
@@ -147,9 +147,10 @@ func (s *Sequence) StreamExecute(
 	}
 
 	// exchange is created once and shared (by pointer) with every child, so an
-	// earlier primitive can hand runtime data to a later sibling. It is scoped to
-	// this execution — never the cached plan.
+	// earlier primitive or routed ParameterStatus can hand runtime data to a
+	// later sibling. It is scoped to this execution — never the cached plan.
 	exchange := &SequenceExchange{}
+	callback = captureReportedSettings(exchange, callback)
 
 	// info is forwarded to every child; only the routing child (the leading
 	// Route in planSelectStmt's Sequence) forwards it onward to IExecute. The
@@ -161,7 +162,7 @@ func (s *Sequence) StreamExecute(
 	for i, p := range s.Primitives {
 		if action, ok := prepared.actions[i]; ok {
 			if action.apply != nil {
-				action.apply()
+				action.apply(exchange)
 			}
 			continue
 		}
@@ -204,12 +205,13 @@ func (s *Sequence) PortalStreamExecute(
 	// exchange is created once and shared (by pointer) with every child — see the
 	// StreamExecute counterpart.
 	exchange := &SequenceExchange{}
+	callback = captureReportedSettings(exchange, callback)
 
 	postQueryInfoAttached := false
 	for i, p := range s.Primitives {
 		if action, ok := prepared.actions[i]; ok {
 			if action.apply != nil {
-				action.apply()
+				action.apply(exchange)
 			}
 			continue
 		}

--- a/go/services/multigateway/engine/sequence_test.go
+++ b/go/services/multigateway/engine/sequence_test.go
@@ -39,6 +39,7 @@ type recordingPrimitive struct {
 	streamInfos   []PlanExecInfo
 	portalInfos   []PlanExecInfo
 	stateAtStream map[string]string
+	streamResult  *sqltypes.Result
 	err           error
 }
 
@@ -46,14 +47,20 @@ func (r *recordingPrimitive) StreamExecute(
 	_ context.Context, _ IExecute, _ *server.Conn,
 	state *handler.MultigatewayConnectionState, _ []*ast.A_Const,
 	info PlanExecInfo,
-	_ func(context.Context, *sqltypes.Result) error,
+	callback func(context.Context, *sqltypes.Result) error,
 ) error {
 	r.streamCalls++
 	r.streamInfos = append(r.streamInfos, info)
 	if state != nil {
 		r.stateAtStream = state.GetSessionSettings()
 	}
-	return r.err
+	if r.err != nil {
+		return r.err
+	}
+	if r.streamResult != nil {
+		return callback(context.Background(), r.streamResult)
+	}
+	return nil
 }
 
 func (r *recordingPrimitive) PortalStreamExecute(
@@ -84,6 +91,14 @@ func silentWorkMemTrack(value string) *ApplySessionState {
 	return NewApplySessionStateSilent("SELECT set_config('work_mem', '"+value+"', false)", &ast.VariableSetStmt{
 		Kind: ast.VAR_SET_VALUE,
 		Name: "work_mem",
+		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: value}}}},
+	})
+}
+
+func silentDateStyleTrack(value string) *ApplySessionState {
+	return NewApplySessionStateSilent("SELECT set_config('datestyle', '"+value+"', false)", &ast.VariableSetStmt{
+		Kind: ast.VAR_SET_VALUE,
+		Name: "datestyle",
 		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: value}}}},
 	})
 }
@@ -139,6 +154,22 @@ func TestSequence_StreamExecute_PostQuerySettingsSentBeforeGatewayMutation(t *te
 	got, ok := state.GetSessionVariable("work_mem")
 	require.True(t, ok)
 	assert.Equal(t, "256MB", got)
+}
+
+func TestSequence_StreamExecute_SetConfigTracksReportedDateStyle(t *testing.T) {
+	route := &recordingPrimitive{streamResult: &sqltypes.Result{
+		CommandTag:      "SELECT 1",
+		ParameterStatus: map[string]string{"DateStyle": "Postgres, DMY"},
+	}}
+	seq := NewSequence([]Primitive{route, silentDateStyleTrack("DMY")})
+	state := handler.NewMultigatewayConnectionState()
+
+	require.NoError(t, seq.StreamExecute(context.Background(), nil, server.NewTestConn(&bytes.Buffer{}).Conn,
+		state, nil, PlanExecInfo{}, func(context.Context, *sqltypes.Result) error { return nil }))
+
+	value, ok := state.GetSessionVariable("datestyle")
+	require.True(t, ok)
+	assert.Equal(t, "Postgres, DMY", value)
 }
 
 func TestSequence_StreamExecute_DoesNotApplyPreparedTrackingAfterRouteFailure(t *testing.T) {

--- a/go/services/multigateway/engine/sequence_test.go
+++ b/go/services/multigateway/engine/sequence_test.go
@@ -172,6 +172,55 @@ func TestSequence_StreamExecute_SetConfigTracksReportedDateStyle(t *testing.T) {
 	assert.Equal(t, "Postgres, DMY", value)
 }
 
+func TestSequence_StreamExecute_AppliesSilentResetActions(t *testing.T) {
+	tests := []struct {
+		name string
+		stmt *ast.VariableSetStmt
+	}{
+		{"reset", &ast.VariableSetStmt{Kind: ast.VAR_RESET, Name: "work_mem"}},
+		{"reset all", &ast.VariableSetStmt{Kind: ast.VAR_RESET_ALL}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := handler.NewMultigatewayConnectionState()
+			state.SetSessionVariable("work_mem", "256MB")
+			seq := NewSequence([]Primitive{
+				&recordingPrimitive{},
+				NewApplySessionStateSilent(tt.name, tt.stmt),
+			})
+
+			require.NoError(t, seq.StreamExecute(t.Context(), nil, server.NewTestConn(&bytes.Buffer{}).Conn,
+				state, nil, PlanExecInfo{}, nil))
+
+			_, tracked := state.GetSessionVariable("work_mem")
+			require.False(t, tracked)
+		})
+	}
+}
+
+func TestPrepareSilentTrackingActionNoop(t *testing.T) {
+	tracker := NewApplySessionStateSilent("set_config", &ast.VariableSetStmt{Kind: ast.VAR_SET_VALUE})
+	action, handled, err := tracker.prepareSilentTrackingAction(nil, handler.NewMultigatewayConnectionState(), func() (resolvedSetConfig, error) {
+		return resolvedSetConfig{shouldTrack: false}, nil
+	})
+
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.NotNil(t, action.apply)
+	action.apply(nil)
+}
+
+func TestCaptureReportedSettingsWithoutCallback(t *testing.T) {
+	exchange := &SequenceExchange{}
+	callback := captureReportedSettings(exchange, nil)
+
+	require.NoError(t, callback(t.Context(), &sqltypes.Result{
+		ParameterStatus: map[string]string{"DateStyle": "Postgres, DMY"},
+	}))
+	require.Equal(t, map[string]string{"DateStyle": "Postgres, DMY"}, exchange.ReportedSettings)
+}
+
 func TestSequence_StreamExecute_DoesNotApplyPreparedTrackingAfterRouteFailure(t *testing.T) {
 	routeErr := errors.New("backend rejected query")
 	route := &recordingPrimitive{err: routeErr}

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -106,6 +106,14 @@ func (e *Executor) applyReservedSessionSettingsIfNeeded(ctx context.Context, con
 	if options == nil {
 		return nil
 	}
+	if conn.SessionStateUntrusted() {
+		// ROLLBACK TO SAVEPOINT already restored the backend's GUC stack. Only
+		// connstate is stale; issuing RESET/SET here would overwrite surviving
+		// outer SET LOCAL values. Synchronize bookkeeping without backend SQL.
+		e.poolManager.RecordSettingsOnConn(conn.Conn(), options.SessionSettings)
+		conn.ClearSessionStateUntrusted()
+		return nil
+	}
 	return e.poolManager.ApplySettingsToConn(ctx, conn.Conn(), options.SessionSettings)
 }
 

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -30,6 +30,7 @@ import (
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
+	"github.com/multigres/multigres/go/common/pgsettings"
 	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/common/queryservice"
@@ -94,12 +95,51 @@ func (e *Executor) successfulQueryReleaseSettingsFromOptions(options *query.Exec
 	return e.sessionSettingsFromOptions(options)
 }
 
-func (e *Executor) recordPostQuerySessionSettings(conn *regular.Conn, options *query.ExecuteOptions) {
-	settings, ok := e.postQuerySessionSettingsFromOptions(options)
-	if !ok || e.poolManager == nil {
-		return
+func (e *Executor) recordPostQuerySessionSettings(conn *regular.Conn, options *query.ExecuteOptions) map[string]string {
+	if options == nil || !options.GetHasPostQuerySessionSettings() {
+		return nil
 	}
-	e.poolManager.RecordSettingsOnConn(conn, settings)
+	var reported map[string]string
+	if conn != nil {
+		reported = canonicalizePostQuerySessionSettings(options.PostQuerySessionSettings, conn.RawConn().ServerParams())
+	}
+	if e.poolManager != nil {
+		e.poolManager.RecordSettingsOnConn(conn, e.sessionSettingsForPool(options.PostQuerySessionSettings))
+	}
+	return reported
+}
+
+func canonicalizePostQuerySessionSettings(settings, serverParams map[string]string) map[string]string {
+	reported := make(map[string]string)
+	for name := range settings {
+		if !pgsettings.UseReportedValueForSessionState(name) {
+			continue
+		}
+		displayName, ok := pgsettings.ReportableGUCName(name)
+		if !ok {
+			continue
+		}
+		if value, ok := serverParams[displayName]; ok {
+			settings[name] = value
+			reported[displayName] = value
+		}
+	}
+	return reported
+}
+
+// finishPostQuerySessionSettings records the backend's authoritative value and
+// forwards it so the gateway tracker uses the same value for replay.
+func (e *Executor) finishPostQuerySessionSettings(
+	ctx context.Context,
+	conn *regular.Conn,
+	options *query.ExecuteOptions,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	reported := e.recordPostQuerySessionSettings(conn, options)
+	if len(reported) == 0 || callback == nil {
+		return nil
+	}
+	return callback(ctx, &sqltypes.Result{ParameterStatus: reported})
 }
 
 func (e *Executor) applyReservedSessionSettingsIfNeeded(ctx context.Context, conn *reserved.Conn, options *query.ExecuteOptions) error {
@@ -408,7 +448,9 @@ func (e *Executor) StreamExecute(
 		if err := conn.Conn.QueryStreaming(ctx, querySQL, callback); err != nil {
 			return nil, wrapQueryError(err)
 		}
-		e.recordPostQuerySessionSettings(conn.Conn, options)
+		if err := e.finishPostQuerySessionSettings(ctx, conn.Conn, options, callback); err != nil {
+			return nil, err
+		}
 		return nil, nil
 	}
 
@@ -416,7 +458,9 @@ func (e *Executor) StreamExecute(
 	if err := conn.Conn.QueryStreamingWithRetry(ctx, sql, callback); err != nil {
 		return nil, wrapQueryError(err)
 	}
-	e.recordPostQuerySessionSettings(conn.Conn, options)
+	if err := e.finishPostQuerySessionSettings(ctx, conn.Conn, options, callback); err != nil {
+		return nil, err
+	}
 
 	return nil, nil
 }
@@ -593,7 +637,9 @@ func (e *Executor) reserveAndStreamExecute(
 		return nil, wrapQueryError(err)
 	}
 
-	e.recordPostQuerySessionSettings(reservedConn.Conn(), options)
+	if err := e.finishPostQuerySessionSettings(ctx, reservedConn.Conn(), options, callback); err != nil {
+		return e.buildReservedState(reservedConn), err
+	}
 	releaseSettings := e.successfulQueryReleaseSettingsFromOptions(options)
 
 	if reservationOptions.GetMarkSessionStateUntrusted() {
@@ -785,10 +831,13 @@ func (e *Executor) streamExecuteOnReservedConnWithPostState(
 	releaseSettings := gatewaySessionSettings
 	if hasPostQuerySessionSettings {
 		releaseSettings = postQuerySessionSettings
-		e.recordPostQuerySessionSettings(rc.Conn(), &query.ExecuteOptions{
+		options := &query.ExecuteOptions{
 			HasPostQuerySessionSettings: true,
 			PostQuerySessionSettings:    postQuerySessionSettings,
-		})
+		}
+		if err := e.finishPostQuerySessionSettings(ctx, rc.Conn(), options, callback); err != nil {
+			return e.buildReservedStateFromAPI(rc), err
+		}
 	}
 
 	if reservationOptions.GetMarkSessionStateUntrusted() {
@@ -1092,7 +1141,9 @@ func (e *Executor) portalExecuteWithReserved(
 		return e.portalReservedError(reservedConn, portal.Name, options, newlyReserved, err)
 	}
 
-	e.recordPostQuerySessionSettings(reservedConn.Conn(), options)
+	if err := e.finishPostQuerySessionSettings(ctx, reservedConn.Conn(), options, callback); err != nil {
+		return e.buildReservedState(reservedConn), err
+	}
 	releaseSettings := e.successfulQueryReleaseSettingsFromOptions(options)
 
 	if reservationOptions.GetMarkSessionStateUntrusted() {
@@ -1217,7 +1268,9 @@ func (e *Executor) portalExecuteWithRegular(
 	if err != nil {
 		return nil, wrapQueryError(err)
 	}
-	e.recordPostQuerySessionSettings(conn.Conn, options)
+	if err := e.finishPostQuerySessionSettings(ctx, conn.Conn, options, callback); err != nil {
+		return nil, err
+	}
 
 	// No reserved connection for regular execution
 	return nil, nil

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"maps"
 	"sync"
 	"testing"
 	"time"
@@ -47,6 +48,7 @@ import (
 // mockReservedConn is a hand-rolled stub satisfying reservedConnAPI for unit tests.
 // It records what the executor calls and lets tests inject errors.
 type mockReservedConn struct {
+	conn             *regular.Conn
 	connID           int64
 	inTxn            bool
 	remainingReasons uint32
@@ -75,7 +77,7 @@ func (m *mockReservedConn) ConnID() int64            { return m.connID }
 func (m *mockReservedConn) ProcessID() uint32        { return 0 }
 func (m *mockReservedConn) RemainingReasons() uint32 { return m.remainingReasons }
 func (m *mockReservedConn) IsInTransaction() bool    { return m.inTxn }
-func (m *mockReservedConn) Conn() *regular.Conn      { return nil }
+func (m *mockReservedConn) Conn() *regular.Conn      { return m.conn }
 
 func (m *mockReservedConn) BeginWithQuery(_ context.Context, q string) error {
 	m.beginCalls = append(m.beginCalls, q)
@@ -251,6 +253,19 @@ func newAdminConnFactory(t *testing.T, server *fakepgserver.Server) func(context
 		}
 		return &connpool.Pooled[*admin.Conn]{Conn: admin.NewConn(clientConn)}, nil
 	}
+}
+
+func newRegularConnWithServerParams(t *testing.T, params map[string]string) *regular.Conn {
+	t.Helper()
+	server := fakepgserver.New(t)
+	server.SetNeverFail(true)
+	t.Cleanup(server.Close)
+
+	clientConn, err := client.Connect(t.Context(), t.Context(), server.ClientConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clientConn.Close() })
+	maps.Copy(clientConn.ServerParams(), params)
+	return regular.NewConn(clientConn, nil)
 }
 
 func newVpidTrackingExecutor(t *testing.T, server *fakepgserver.Server) *Executor {
@@ -1069,6 +1084,42 @@ func TestCanonicalizePostQuerySessionSettings(t *testing.T) {
 
 	require.Equal(t, map[string]string{"datestyle": "Postgres, DMY", "timezone": "-7"}, settings)
 	require.Equal(t, map[string]string{"DateStyle": "Postgres, DMY"}, reported)
+}
+
+func TestFinishPostQuerySessionSettingsReportsCanonicalValue(t *testing.T) {
+	conn := newRegularConnWithServerParams(t, map[string]string{"DateStyle": "Postgres, DMY"})
+	manager := &stubPoolManager{}
+	e := &Executor{poolManager: manager}
+	options := &query.ExecuteOptions{
+		HasPostQuerySessionSettings: true,
+		PostQuerySessionSettings:    map[string]string{"datestyle": "DMY"},
+	}
+	callbackErr := errors.New("callback failed")
+
+	err := e.finishPostQuerySessionSettings(t.Context(), conn, options, func(_ context.Context, result *sqltypes.Result) error {
+		require.Equal(t, map[string]string{"DateStyle": "Postgres, DMY"}, result.ParameterStatus)
+		return callbackErr
+	})
+
+	require.ErrorIs(t, err, callbackErr)
+	require.Equal(t, map[string]string{"datestyle": "Postgres, DMY"}, options.PostQuerySessionSettings)
+	require.Equal(t, options.PostQuerySessionSettings, manager.recordedSettings)
+}
+
+func TestStreamExecuteOnReservedConnReturnsPostQueryCallbackError(t *testing.T) {
+	conn := newRegularConnWithServerParams(t, map[string]string{"DateStyle": "Postgres, DMY"})
+	rc := &mockReservedConn{conn: conn, connID: 42}
+	e := &Executor{poolManager: &stubPoolManager{}}
+	callbackErr := errors.New("callback failed")
+
+	state, err := e.streamExecuteOnReservedConnWithPostState(
+		t.Context(), rc, "SELECT 1", &query.ReservationOptions{}, nil,
+		map[string]string{"datestyle": "DMY"}, true, false,
+		func(context.Context, *sqltypes.Result) error { return callbackErr },
+	)
+
+	require.ErrorIs(t, err, callbackErr)
+	require.Equal(t, uint64(42), state.GetReservedConnectionId())
 }
 
 func TestApplyReservedSessionSettings_UntrustedSyncsCacheWithoutSQL(t *testing.T) {

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -1060,6 +1060,17 @@ func TestSessionSettingsFromOptions_NilOptions(t *testing.T) {
 	require.Nil(t, e.sessionSettingsFromOptions(nil))
 }
 
+func TestCanonicalizePostQuerySessionSettings(t *testing.T) {
+	settings := map[string]string{"datestyle": "DMY", "timezone": "-7"}
+	reported := canonicalizePostQuerySessionSettings(settings, map[string]string{
+		"DateStyle": "Postgres, DMY",
+		"TimeZone":  "<-07>+07",
+	})
+
+	require.Equal(t, map[string]string{"datestyle": "Postgres, DMY", "timezone": "-7"}, settings)
+	require.Equal(t, map[string]string{"DateStyle": "Postgres, DMY"}, reported)
+}
+
 func TestApplyReservedSessionSettings_UntrustedSyncsCacheWithoutSQL(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -148,17 +148,19 @@ func (m *mockReservedConn) MarkSessionStateUntrusted() {
 var _ reservedConnAPI = (*mockReservedConn)(nil)
 
 type stubPoolManager struct {
-	reservedConn     *reserved.Conn
-	reservedConnOK   bool
-	regularConn      regular.PooledConn
-	regularErr       error
-	newReservedConn  *reserved.Conn
-	newReservedPool  *reserved.Pool
-	newReservedErr   error
-	reservedPool     *reserved.Pool
-	settingsCache    *connstate.SettingsCache
-	adminConnFactory func(context.Context) (admin.PooledConn, error)
-	adminErr         error
+	reservedConn       *reserved.Conn
+	reservedConnOK     bool
+	regularConn        regular.PooledConn
+	regularErr         error
+	newReservedConn    *reserved.Conn
+	newReservedPool    *reserved.Pool
+	newReservedErr     error
+	reservedPool       *reserved.Pool
+	settingsCache      *connstate.SettingsCache
+	adminConnFactory   func(context.Context) (admin.PooledConn, error)
+	adminErr           error
+	applySettingsCalls int
+	recordedSettings   map[string]string
 }
 
 func (m *stubPoolManager) Open(context.Context, *connpoolmanager.ConnectionConfig) {}
@@ -220,13 +222,20 @@ func (m *stubPoolManager) GetReservedConn(int64, string) (*reserved.Conn, bool) 
 }
 
 func (m *stubPoolManager) ApplySettingsToConn(context.Context, *regular.Conn, map[string]string) error {
+	m.applySettingsCalls++
 	return nil
 }
-func (m *stubPoolManager) RecordSettingsOnConn(*regular.Conn, map[string]string) {}
-func (m *stubPoolManager) WaitForDrain(context.Context) error                    { return nil }
-func (m *stubPoolManager) WaitForReservedDrain(context.Context) error            { return nil }
-func (m *stubPoolManager) CloseReservedConnections(context.Context) int          { return 0 }
-func (m *stubPoolManager) Stats() connpoolmanager.ManagerStats                   { return connpoolmanager.ManagerStats{} }
+
+func (m *stubPoolManager) RecordSettingsOnConn(conn *regular.Conn, settings map[string]string) {
+	m.recordedSettings = settings
+	if conn != nil && m.settingsCache != nil {
+		conn.State().SetSettings(m.settingsCache.GetOrCreate(settings))
+	}
+}
+func (m *stubPoolManager) WaitForDrain(context.Context) error           { return nil }
+func (m *stubPoolManager) WaitForReservedDrain(context.Context) error   { return nil }
+func (m *stubPoolManager) CloseReservedConnections(context.Context) int { return 0 }
+func (m *stubPoolManager) Stats() connpoolmanager.ManagerStats          { return connpoolmanager.ManagerStats{} }
 func (m *stubPoolManager) CredentialQueryRecorder() connpoolmanager.CredentialQueryRecorder {
 	return nil
 }
@@ -1049,6 +1058,41 @@ func TestScramKeysFromOptions(t *testing.T) {
 func TestSessionSettingsFromOptions_NilOptions(t *testing.T) {
 	e := &Executor{}
 	require.Nil(t, e.sessionSettingsFromOptions(nil))
+}
+
+func TestApplyReservedSessionSettings_UntrustedSyncsCacheWithoutSQL(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	cache := connstate.NewSettingsCache(16)
+	pool := reserved.NewPool(t.Context(), &reserved.PoolConfig{
+		InactivityTimeout: time.Minute,
+		SettingsCache:     cache,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig: server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{
+				Capacity:     1,
+				MaxIdleCount: 1,
+			},
+		},
+	})
+	defer pool.Close()
+
+	stale := cache.GetOrCreate(map[string]string{"parallel_setup_cost": "0"})
+	rconn, err := pool.NewConn(t.Context(), stale)
+	require.NoError(t, err)
+	rconn.MarkSessionStateUntrusted()
+
+	manager := &stubPoolManager{settingsCache: cache}
+	e := &Executor{poolManager: manager}
+	desired := map[string]string{"min_parallel_table_scan_size": "0"}
+
+	require.NoError(t, e.applyReservedSessionSettingsIfNeeded(t.Context(), rconn, &query.ExecuteOptions{SessionSettings: desired}))
+	require.Zero(t, manager.applySettingsCalls, "restored SET LOCAL state must not be overwritten by reconciliation SQL")
+	require.Equal(t, desired, manager.recordedSettings)
+	require.Equal(t, cache.GetOrCreate(desired), rconn.Conn().Settings())
+	require.False(t, rconn.SessionStateUntrusted())
 }
 
 // --- trackVpid* early-return tests ---

--- a/go/test/endtoend/queryserving/unsafe_funccall_test.go
+++ b/go/test/endtoend/queryserving/unsafe_funccall_test.go
@@ -79,6 +79,29 @@ func TestMultigateway_SetConfigRoutedAsSET(t *testing.T) {
 		}
 	})
 
+	t.Run("partial DateStyle uses PostgreSQL's canonical value for replay", func(t *testing.T) {
+		cfg, err := pgx.ParseConfig(shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable"))
+		require.NoError(t, err)
+		cfg.RuntimeParams["DateStyle"] = "Postgres, MDY"
+		conn, err := pgx.ConnectConfig(ctx, cfg)
+		require.NoError(t, err)
+		defer conn.Close(ctx)
+
+		var setConfigResult string
+		err = conn.QueryRow(ctx,
+			"SELECT set_config('DateStyle', $1, false)", "DMY").Scan(&setConfigResult)
+		require.NoError(t, err)
+		require.Equal(t, "Postgres, DMY", setConfigResult)
+
+		for i := range 100 {
+			var got string
+			err = conn.QueryRow(ctx, "SHOW DateStyle").Scan(&got)
+			require.NoError(t, err, "iteration %d", i)
+			require.Equal(t, "Postgres, DMY", got,
+				"iteration %d: replay must preserve DateStyle's unchanged style component", i)
+		}
+	})
+
 	// pg_catalog.set_config should resolve to the same built-in and route
 	// through the same rewrite path. Confirms the qualified-name handling.
 	t.Run("pg_catalog.set_config also rewrites", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- store PostgreSQL's complete reported `DateStyle` value so partial settings replay consistently on fresh backends
- retain original SET input for reportable GUCs whose values are not context-sensitive
- after `ROLLBACK TO SAVEPOINT`, synchronize reserved-connection metadata without issuing RESET/SET SQL that would overwrite surviving outer `SET LOCAL` values

Extracted from #1306 so reservation-aware RESET planning can be reviewed independently.

## Testing

- `go test -short -count=1 ./go/services/multigateway/engine ./go/services/multipooler/internal/executor`
- PostgreSQL compatibility suite triggered via PR label
