### PR TITLE
feat(multipooler): track WAL-receive advance time on standbys

### DIFF
--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -610,8 +610,16 @@ type StandbyReplicationStatus struct {
 	// before terminating the WAL receiver connection.
 	// From current_setting('wal_receiver_timeout').
 	WalReceiverTimeout *durationpb.Duration `protobuf:"bytes,11,opt,name=wal_receiver_timeout,json=walReceiverTimeout,proto3" json:"wal_receiver_timeout,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// When last_receive_lsn (pg_last_wal_receive_lsn — WAL streamed from the
+	// primary) last increased, as observed by the standby's heartbeat reader on
+	// its regular tick. This is a WAL-*progress* signal, distinct from
+	// last_msg_receive_time (which advances on keepalives with no new WAL). It is
+	// unaffected by restore_command/archive replay, which advances replay_lsn but
+	// not receive_lsn — so a fresh value means the leader is actively streaming new
+	// WAL to this standby. Null if the reader has not yet observed a value.
+	LastReceiveLsnAdvanceTime *timestamppb.Timestamp `protobuf:"bytes,12,opt,name=last_receive_lsn_advance_time,json=lastReceiveLsnAdvanceTime,proto3" json:"last_receive_lsn_advance_time,omitempty"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
 }
 
 func (x *StandbyReplicationStatus) Reset() {
@@ -717,6 +725,13 @@ func (x *StandbyReplicationStatus) GetWalReceiverStatusInterval() *durationpb.Du
 func (x *StandbyReplicationStatus) GetWalReceiverTimeout() *durationpb.Duration {
 	if x != nil {
 		return x.WalReceiverTimeout
+	}
+	return nil
+}
+
+func (x *StandbyReplicationStatus) GetLastReceiveLsnAdvanceTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastReceiveLsnAdvanceTime
 	}
 	return nil
 }
@@ -2817,7 +2832,7 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\x04port\x18\x02 \x01(\x05R\x04port\x12\x12\n" +
 	"\x04user\x18\x03 \x01(\tR\x04user\x12)\n" +
 	"\x10application_name\x18\x04 \x01(\tR\x0fapplicationName\x12\x10\n" +
-	"\x03raw\x18\x05 \x01(\tR\x03raw\"\xb9\x05\n" +
+	"\x03raw\x18\x05 \x01(\tR\x03raw\"\x97\x06\n" +
 	"\x18StandbyReplicationStatus\x12&\n" +
 	"\x0flast_replay_lsn\x18\x01 \x01(\tR\rlastReplayLsn\x12(\n" +
 	"\x10last_receive_lsn\x18\x02 \x01(\tR\x0elastReceiveLsn\x12/\n" +
@@ -2830,7 +2845,8 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\x15last_msg_receive_time\x18\t \x01(\v2\x1a.google.protobuf.TimestampR\x12lastMsgReceiveTime\x12Z\n" +
 	"\x1cwal_receiver_status_interval\x18\n" +
 	" \x01(\v2\x19.google.protobuf.DurationR\x19walReceiverStatusInterval\x12K\n" +
-	"\x14wal_receiver_timeout\x18\v \x01(\v2\x19.google.protobuf.DurationR\x12walReceiverTimeout\"g\n" +
+	"\x14wal_receiver_timeout\x18\v \x01(\v2\x19.google.protobuf.DurationR\x12walReceiverTimeout\x12\\\n" +
+	"\x1dlast_receive_lsn_advance_time\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\x19lastReceiveLsnAdvanceTime\"g\n" +
 	"\x11WaitForLSNRequest\x12\x1d\n" +
 	"\n" +
 	"target_lsn\x18\x01 \x01(\tR\ttargetLsn\x123\n" +
@@ -3081,54 +3097,55 @@ var file_multipoolermanagerdata_proto_depIdxs = []int32{
 	47, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
 	46, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
 	46, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
-	46, // 5: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
-	3,  // 6: multipoolermanagerdata.StopReplicationRequest.mode:type_name -> multipoolermanagerdata.ReplicationPauseMode
-	9,  // 7: multipoolermanagerdata.StopReplicationResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
-	6,  // 8: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
-	4,  // 9: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
-	48, // 10: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
-	48, // 11: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
-	16, // 12: multipoolermanagerdata.PrimaryStatus.sync_replication_config:type_name -> multipoolermanagerdata.SynchronousReplicationConfiguration
-	49, // 13: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
-	17, // 14: multipoolermanagerdata.Status.primary_status:type_name -> multipoolermanagerdata.PrimaryStatus
-	9,  // 15: multipoolermanagerdata.Status.replication_status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
-	0,  // 16: multipoolermanagerdata.Status.postgres_status:type_name -> multipoolermanagerdata.PostgresStatus
-	1,  // 17: multipoolermanagerdata.Status.postgres_action:type_name -> multipoolermanagerdata.PostgresAction
-	46, // 18: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
-	18, // 19: multipoolermanagerdata.StatusResponse.status:type_name -> multipoolermanagerdata.Status
-	50, // 20: multipoolermanagerdata.StatusResponse.availability_status:type_name -> clustermetadata.AvailabilityStatus
-	51, // 21: multipoolermanagerdata.StatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
-	22, // 22: multipoolermanagerdata.ManagerHealthStreamClientMessage.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartRequest
-	23, // 23: multipoolermanagerdata.ManagerHealthStreamClientMessage.poll:type_name -> multipoolermanagerdata.ManagerHealthStreamPollRequest
-	46, // 24: multipoolermanagerdata.ManagerHealthStreamStartRequest.snapshot_interval:type_name -> google.protobuf.Duration
-	46, // 25: multipoolermanagerdata.ManagerHealthStreamStartRequest.staleness_timeout:type_name -> google.protobuf.Duration
-	46, // 26: multipoolermanagerdata.ManagerHealthStreamStartResponse.snapshot_interval:type_name -> google.protobuf.Duration
-	46, // 27: multipoolermanagerdata.ManagerHealthStreamStartResponse.staleness_timeout:type_name -> google.protobuf.Duration
-	24, // 28: multipoolermanagerdata.ManagerHealthStreamResponse.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartResponse
-	26, // 29: multipoolermanagerdata.ManagerHealthStreamResponse.snapshot:type_name -> multipoolermanagerdata.ManagerHealthSnapshot
-	20, // 30: multipoolermanagerdata.ManagerHealthSnapshot.status:type_name -> multipoolermanagerdata.StatusResponse
-	46, // 31: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
-	2,  // 32: multipoolermanagerdata.ManagerHealthSnapshot.trigger:type_name -> multipoolermanagerdata.SnapshotTrigger
-	47, // 33: multipoolermanagerdata.ManagerHealthSnapshot.captured_at:type_name -> google.protobuf.Timestamp
-	5,  // 34: multipoolermanagerdata.UpdateConsensusRuleRequest.operation:type_name -> multipoolermanagerdata.CohortUpdateOperation
-	48, // 35: multipoolermanagerdata.UpdateConsensusRuleRequest.standby_ids:type_name -> clustermetadata.ID
-	52, // 36: multipoolermanagerdata.UpdateConsensusRuleRequest.expected_outgoing_rule:type_name -> clustermetadata.RuleNumber
-	48, // 37: multipoolermanagerdata.UpdateConsensusRuleRequest.coordinator_id:type_name -> clustermetadata.ID
-	44, // 38: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
-	39, // 39: multipoolermanagerdata.GetBackupsResponse.backups:type_name -> multipoolermanagerdata.BackupMetadata
-	39, // 40: multipoolermanagerdata.GetBackupByJobIdResponse.backup:type_name -> multipoolermanagerdata.BackupMetadata
-	45, // 41: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	46, // 42: multipoolermanagerdata.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
-	7,  // 43: multipoolermanagerdata.BackupMetadata.status:type_name -> multipoolermanagerdata.BackupMetadata.Status
-	53, // 44: multipoolermanagerdata.BackupMetadata.routing_role:type_name -> clustermetadata.RoutingRole
-	47, // 45: multipoolermanagerdata.BackupMetadata.start_timestamp:type_name -> google.protobuf.Timestamp
-	47, // 46: multipoolermanagerdata.BackupMetadata.stop_timestamp:type_name -> google.protobuf.Timestamp
-	54, // 47: multipoolermanagerdata.RewindToSourceRequest.source:type_name -> clustermetadata.Multipooler
-	48, // [48:48] is the sub-list for method output_type
-	48, // [48:48] is the sub-list for method input_type
-	48, // [48:48] is the sub-list for extension type_name
-	48, // [48:48] is the sub-list for extension extendee
-	0,  // [0:48] is the sub-list for field type_name
+	47, // 5: multipoolermanagerdata.StandbyReplicationStatus.last_receive_lsn_advance_time:type_name -> google.protobuf.Timestamp
+	46, // 6: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
+	3,  // 7: multipoolermanagerdata.StopReplicationRequest.mode:type_name -> multipoolermanagerdata.ReplicationPauseMode
+	9,  // 8: multipoolermanagerdata.StopReplicationResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
+	6,  // 9: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
+	4,  // 10: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
+	48, // 11: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
+	48, // 12: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
+	16, // 13: multipoolermanagerdata.PrimaryStatus.sync_replication_config:type_name -> multipoolermanagerdata.SynchronousReplicationConfiguration
+	49, // 14: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
+	17, // 15: multipoolermanagerdata.Status.primary_status:type_name -> multipoolermanagerdata.PrimaryStatus
+	9,  // 16: multipoolermanagerdata.Status.replication_status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
+	0,  // 17: multipoolermanagerdata.Status.postgres_status:type_name -> multipoolermanagerdata.PostgresStatus
+	1,  // 18: multipoolermanagerdata.Status.postgres_action:type_name -> multipoolermanagerdata.PostgresAction
+	46, // 19: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
+	18, // 20: multipoolermanagerdata.StatusResponse.status:type_name -> multipoolermanagerdata.Status
+	50, // 21: multipoolermanagerdata.StatusResponse.availability_status:type_name -> clustermetadata.AvailabilityStatus
+	51, // 22: multipoolermanagerdata.StatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	22, // 23: multipoolermanagerdata.ManagerHealthStreamClientMessage.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartRequest
+	23, // 24: multipoolermanagerdata.ManagerHealthStreamClientMessage.poll:type_name -> multipoolermanagerdata.ManagerHealthStreamPollRequest
+	46, // 25: multipoolermanagerdata.ManagerHealthStreamStartRequest.snapshot_interval:type_name -> google.protobuf.Duration
+	46, // 26: multipoolermanagerdata.ManagerHealthStreamStartRequest.staleness_timeout:type_name -> google.protobuf.Duration
+	46, // 27: multipoolermanagerdata.ManagerHealthStreamStartResponse.snapshot_interval:type_name -> google.protobuf.Duration
+	46, // 28: multipoolermanagerdata.ManagerHealthStreamStartResponse.staleness_timeout:type_name -> google.protobuf.Duration
+	24, // 29: multipoolermanagerdata.ManagerHealthStreamResponse.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartResponse
+	26, // 30: multipoolermanagerdata.ManagerHealthStreamResponse.snapshot:type_name -> multipoolermanagerdata.ManagerHealthSnapshot
+	20, // 31: multipoolermanagerdata.ManagerHealthSnapshot.status:type_name -> multipoolermanagerdata.StatusResponse
+	46, // 32: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
+	2,  // 33: multipoolermanagerdata.ManagerHealthSnapshot.trigger:type_name -> multipoolermanagerdata.SnapshotTrigger
+	47, // 34: multipoolermanagerdata.ManagerHealthSnapshot.captured_at:type_name -> google.protobuf.Timestamp
+	5,  // 35: multipoolermanagerdata.UpdateConsensusRuleRequest.operation:type_name -> multipoolermanagerdata.CohortUpdateOperation
+	48, // 36: multipoolermanagerdata.UpdateConsensusRuleRequest.standby_ids:type_name -> clustermetadata.ID
+	52, // 37: multipoolermanagerdata.UpdateConsensusRuleRequest.expected_outgoing_rule:type_name -> clustermetadata.RuleNumber
+	48, // 38: multipoolermanagerdata.UpdateConsensusRuleRequest.coordinator_id:type_name -> clustermetadata.ID
+	44, // 39: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
+	39, // 40: multipoolermanagerdata.GetBackupsResponse.backups:type_name -> multipoolermanagerdata.BackupMetadata
+	39, // 41: multipoolermanagerdata.GetBackupByJobIdResponse.backup:type_name -> multipoolermanagerdata.BackupMetadata
+	45, // 42: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	46, // 43: multipoolermanagerdata.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
+	7,  // 44: multipoolermanagerdata.BackupMetadata.status:type_name -> multipoolermanagerdata.BackupMetadata.Status
+	53, // 45: multipoolermanagerdata.BackupMetadata.routing_role:type_name -> clustermetadata.RoutingRole
+	47, // 46: multipoolermanagerdata.BackupMetadata.start_timestamp:type_name -> google.protobuf.Timestamp
+	47, // 47: multipoolermanagerdata.BackupMetadata.stop_timestamp:type_name -> google.protobuf.Timestamp
+	54, // 48: multipoolermanagerdata.RewindToSourceRequest.source:type_name -> clustermetadata.Multipooler
+	49, // [49:49] is the sub-list for method output_type
+	49, // [49:49] is the sub-list for method input_type
+	49, // [49:49] is the sub-list for extension type_name
+	49, // [49:49] is the sub-list for extension extendee
+	0,  // [0:49] is the sub-list for field type_name
 }
 
 func init() { file_multipoolermanagerdata_proto_init() }

--- a/go/services/multipooler/internal/heartbeat/reader.go
+++ b/go/services/multipooler/internal/heartbeat/reader.go
@@ -59,7 +59,12 @@ type Reader struct {
 	// last observed pg_last_wal_receive_lsn() and when it last increased. This is a
 	// WAL-progress signal (new WAL streamed from the primary), distinct from the
 	// heartbeat lag and from last_msg_receive_time (which advances on keepalives).
-	// Guarded by lagMu. haveReceiveLSN is false until the first value is observed.
+	// We stamp the advance time here, at this ~1s tick, and report it — rather than
+	// leaving orch to diff the raw LSN across its coarser health snapshots — so a
+	// consumer knows the AGE of the last advance at this resolution, independent of
+	// the snapshot cadence. That matters when the staleness threshold is only a small
+	// multiple of that cadence. Guarded by lagMu; haveReceiveLSN is false until the
+	// first value is observed.
 	lastReceiveLSN            pgutil.LSN
 	lastReceiveLSNAdvanceTime time.Time
 	haveReceiveLSN            bool

--- a/go/services/multipooler/internal/heartbeat/reader.go
+++ b/go/services/multipooler/internal/heartbeat/reader.go
@@ -28,6 +28,7 @@ import (
 	"github.com/multigres/multigres/go/common/mterrors"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
+	"github.com/multigres/multigres/go/tools/pgutil"
 	"github.com/multigres/multigres/go/tools/timer"
 )
 
@@ -53,6 +54,15 @@ type Reader struct {
 	lastKnownLag   time.Duration
 	lastKnownTime  time.Time
 	lastKnownError error
+
+	// lastReceiveLSN / lastReceiveLSNAdvanceTime track WAL streaming progress: the
+	// last observed pg_last_wal_receive_lsn() and when it last increased. This is a
+	// WAL-progress signal (new WAL streamed from the primary), distinct from the
+	// heartbeat lag and from last_msg_receive_time (which advances on keepalives).
+	// Guarded by lagMu. haveReceiveLSN is false until the first value is observed.
+	lastReceiveLSN            pgutil.LSN
+	lastReceiveLSNAdvanceTime time.Time
+	haveReceiveLSN            bool
 
 	reads      atomic.Int64
 	readErrors atomic.Int64
@@ -117,48 +127,84 @@ func (r *Reader) Status() (time.Duration, error) {
 }
 
 // readHeartbeat reads from the heartbeat table exactly once, updating
-// the last known lag and/or error, and incrementing counters.
+// the last known lag and/or error, the WAL-receive advance tracking, and counters.
 func (r *Reader) readHeartbeat(ctx context.Context) {
 	readCtx, cancel := context.WithTimeout(ctx, r.interval)
 	defer cancel()
 
-	ts, err := r.fetchMostRecentHeartbeat(readCtx)
+	tsNano, receiveLSN, haveReceiveLSN, err := r.fetchMostRecentHeartbeat(readCtx)
 	if err != nil {
-		r.recordError(mterrors.Wrap(err, "failed to read most recent heartbeat"))
-	} else {
-		lag := r.now().Sub(time.Unix(0, ts))
-		r.reads.Add(1)
-
-		r.lagMu.Lock()
-		r.lastKnownTime = r.now()
-		r.lastKnownLag = lag
-		r.lastKnownError = nil
-		r.lagMu.Unlock()
-
-		r.logger.DebugContext(ctx, "Heartbeat read",
-			"shard_id", r.shardID,
-			"lag", lag)
+		r.recordError(err)
+		return
 	}
+	// Read the clock once so lag and the advance timestamp reflect the same instant.
+	now := r.now()
+	lag := now.Sub(time.Unix(0, tsNano))
+	r.reads.Add(1)
+
+	r.lagMu.Lock()
+	r.lastKnownTime = now
+	r.lastKnownLag = lag
+	r.lastKnownError = nil
+	// First observation, or a genuine increase, marks WAL-receive progress.
+	// receive_lsn is monotonic during streaming; a non-increase (idle keepalives)
+	// leaves the timestamp untouched so it can age out.
+	if haveReceiveLSN && (!r.haveReceiveLSN || receiveLSN > r.lastReceiveLSN) {
+		r.lastReceiveLSN = receiveLSN
+		r.lastReceiveLSNAdvanceTime = now
+		r.haveReceiveLSN = true
+	}
+	r.lagMu.Unlock()
+
+	r.logger.DebugContext(ctx, "Heartbeat read",
+		"shard_id", r.shardID,
+		"lag", lag)
 }
 
-// fetchMostRecentHeartbeat fetches the most recently recorded heartbeat from the heartbeat table,
-// returning the timestamp of the heartbeat in nanoseconds.
-func (r *Reader) fetchMostRecentHeartbeat(ctx context.Context) (int64, error) {
+// fetchMostRecentHeartbeat fetches the heartbeat row plus the WAL receiver's
+// current streamed position in one query. It returns the heartbeat timestamp in
+// nanoseconds, the parsed pg_last_wal_receive_lsn(), and whether that LSN was
+// present (haveReceiveLSN is false when NULL — streaming disabled/not yet
+// started). It returns a wrapped error on failure; a missing heartbeat row counts
+// as a failure (the writer always maintains it when multigres is healthy).
+// receive_lsn advances ONLY via streaming replication from the primary (not
+// restore_command/archive replay), so its advancement is a "the primary is
+// streaming new WAL to this standby" signal.
+func (r *Reader) fetchMostRecentHeartbeat(ctx context.Context) (tsNano int64, receiveLSN pgutil.LSN, haveReceiveLSN bool, err error) {
 	result, err := r.queryService.QueryArgs(ctx,
-		"SELECT ts FROM multigres.heartbeat WHERE shard_id = $1",
+		"SELECT ts, pg_last_wal_receive_lsn()::text FROM multigres.heartbeat WHERE shard_id = $1",
 		r.shardID)
 	if err != nil {
-		return 0, mterrors.Wrap(err, "failed to fetch heartbeat")
+		return 0, 0, false, mterrors.Wrap(err, "failed to read most recent heartbeat")
 	}
 	if result == nil || len(result.StructuredRows()) == 0 {
-		return 0, mterrors.Wrap(errors.New("no heartbeat found"), "failed to fetch heartbeat")
+		return 0, 0, false, mterrors.Wrap(errors.New("no heartbeat found"), "failed to read most recent heartbeat")
+	}
+	row := result.StructuredRows()[0]
+
+	tsNano, err = executor.GetInt64(row, 0)
+	if err != nil {
+		return 0, 0, false, mterrors.Wrap(err, "failed to parse heartbeat timestamp")
 	}
 
-	tsNano, err := strconv.ParseInt(string(result.StructuredRows()[0].Values[0]), 10, 64)
-	if err != nil {
-		return 0, mterrors.Wrap(err, "failed to parse heartbeat timestamp")
+	// receive_lsn is best-effort: a NULL/unparseable value just leaves advance
+	// tracking untouched; it must not fail the heartbeat-lag read.
+	if raw, rawErr := executor.GetString(row, 1); rawErr == nil && raw != "" {
+		if lsn, lsnErr := pgutil.ParseLSN(raw); lsnErr != nil {
+			r.logger.DebugContext(ctx, "failed to parse pg_last_wal_receive_lsn", "value", raw, "error", lsnErr)
+		} else {
+			receiveLSN, haveReceiveLSN = lsn, true
+		}
 	}
-	return tsNano, nil
+	return tsNano, receiveLSN, haveReceiveLSN, nil
+}
+
+// LastReceiveLSNAdvance returns when pg_last_wal_receive_lsn() was last observed
+// to increase, and whether any value has been observed yet.
+func (r *Reader) LastReceiveLSNAdvance() (time.Time, bool) {
+	r.lagMu.Lock()
+	defer r.lagMu.Unlock()
+	return r.lastReceiveLSNAdvanceTime, r.haveReceiveLSN
 }
 
 // recordError keeps track of the lastKnown error for reporting to Status().

--- a/go/services/multipooler/internal/heartbeat/reader.go
+++ b/go/services/multipooler/internal/heartbeat/reader.go
@@ -187,7 +187,7 @@ func (r *Reader) fetchMostRecentHeartbeat(ctx context.Context) (tsNano int64, re
 		return 0, 0, false, mterrors.Wrap(err, "failed to parse heartbeat timestamp")
 	}
 
-	// receive_lsn is best-effort: a NULL/unparseable value just leaves advance
+	// receive_lsn is best-effort: a NULL/unparsable value just leaves advance
 	// tracking untouched; it must not fail the heartbeat-lag read.
 	if raw, rawErr := executor.GetString(row, 1); rawErr == nil && raw != "" {
 		if lsn, lsnErr := pgutil.ParseLSN(raw); lsnErr != nil {

--- a/go/services/multipooler/internal/heartbeat/reader_test.go
+++ b/go/services/multipooler/internal/heartbeat/reader_test.go
@@ -34,9 +34,9 @@ func TestReaderReadHeartbeat(t *testing.T) {
 	defer tr.Close()
 
 	// Add query result for heartbeat read
-	queryService.AddQueryPattern("SELECT ts FROM multigres\\.heartbeat WHERE shard_id.*", mock.MakeQueryResult(
-		[]string{"ts"},
-		[][]any{{now.Add(-10 * time.Second).UnixNano()}},
+	queryService.AddQueryPattern("SELECT ts, pg_last_wal_receive_lsn.*FROM multigres\\.heartbeat WHERE shard_id.*", mock.MakeQueryResult(
+		[]string{"ts", "receive_lsn"},
+		[][]any{{now.Add(-10 * time.Second).UnixNano(), "0/16E5D38"}},
 	))
 
 	tr.readHeartbeat(t.Context())
@@ -47,6 +47,56 @@ func TestReaderReadHeartbeat(t *testing.T) {
 	assert.Equal(t, expectedLag, lag, "wrong latest lag")
 	assert.EqualValues(t, 1, tr.Reads(), "wrong read count")
 	assert.EqualValues(t, 0, tr.ReadErrors(), "wrong read error count")
+
+	// The same read also observes pg_last_wal_receive_lsn and stamps its advance time.
+	advanceAt, ok := tr.LastReceiveLSNAdvance()
+	require.True(t, ok, "should have observed a receive LSN")
+	assert.Equal(t, now, advanceAt, "advance time should be the read time")
+}
+
+// TestReaderTracksReceiveLSNAdvance verifies the WAL-receive progress tracking:
+// the first observation stamps the advance time, a genuine LSN increase bumps it,
+// and an unchanged LSN (idle keepalives) leaves it in place.
+func TestReaderTracksReceiveLSNAdvance(t *testing.T) {
+	queryService := mock.NewQueryService()
+	tr := newTestReader(t, queryService, nil)
+	defer tr.Close()
+
+	clock := time.Now()
+	tr.now = func() time.Time { return clock }
+
+	const pattern = "SELECT ts, pg_last_wal_receive_lsn.*FROM multigres\\.heartbeat WHERE shard_id.*"
+	addRead := func(lsn string) {
+		queryService.AddQueryPatternOnce(pattern, mock.MakeQueryResult(
+			[]string{"ts", "receive_lsn"},
+			[][]any{{clock.UnixNano(), lsn}},
+		))
+	}
+
+	// First observation stamps the advance time.
+	addRead("0/100")
+	tr.readHeartbeat(t.Context())
+	at1, ok := tr.LastReceiveLSNAdvance()
+	require.True(t, ok)
+	assert.Equal(t, clock, at1)
+
+	// A genuine increase bumps the advance time.
+	clock = clock.Add(1 * time.Second)
+	addRead("0/200")
+	tr.readHeartbeat(t.Context())
+	at2, ok := tr.LastReceiveLSNAdvance()
+	require.True(t, ok)
+	assert.Equal(t, clock, at2)
+	assert.True(t, at2.After(at1), "advance time should move forward on an LSN increase")
+
+	// No increase leaves the advance time unchanged (idle keepalives keep the
+	// connection alive but produce no new WAL).
+	clock = clock.Add(1 * time.Second)
+	addRead("0/200")
+	tr.readHeartbeat(t.Context())
+	at3, ok := tr.LastReceiveLSNAdvance()
+	require.True(t, ok)
+	assert.Equal(t, at2, at3, "advance time must not move when receive_lsn is unchanged")
 }
 
 // TestReaderReadHeartbeatError tests that we properly account for errors
@@ -75,9 +125,9 @@ func TestReaderOpen(t *testing.T) {
 	defer tr.Close()
 
 	// Add query result for heartbeat reads
-	queryService.AddQueryPattern("SELECT ts FROM multigres\\.heartbeat WHERE shard_id.*", mock.MakeQueryResult(
-		[]string{"ts"},
-		[][]any{{time.Now().Add(-5 * time.Second).UnixNano()}},
+	queryService.AddQueryPattern("SELECT ts, pg_last_wal_receive_lsn.*FROM multigres\\.heartbeat WHERE shard_id.*", mock.MakeQueryResult(
+		[]string{"ts", "receive_lsn"},
+		[][]any{{time.Now().Add(-5 * time.Second).UnixNano(), "0/16E5D38"}},
 	))
 
 	assert.False(t, tr.IsOpen())
@@ -102,9 +152,9 @@ func TestReaderOpenClose(t *testing.T) {
 	queryService := mock.NewQueryService()
 	tr := newTestReader(t, queryService, nil)
 
-	queryService.AddQueryPattern("SELECT ts FROM multigres\\.heartbeat WHERE shard_id.*", mock.MakeQueryResult(
-		[]string{"ts"},
-		[][]any{{time.Now().Add(-5 * time.Second).UnixNano()}},
+	queryService.AddQueryPattern("SELECT ts, pg_last_wal_receive_lsn.*FROM multigres\\.heartbeat WHERE shard_id.*", mock.MakeQueryResult(
+		[]string{"ts", "receive_lsn"},
+		[][]any{{time.Now().Add(-5 * time.Second).UnixNano(), "0/16E5D38"}},
 	))
 
 	assert.False(t, tr.IsOpen())

--- a/go/services/multipooler/internal/heartbeat/reader_test.go
+++ b/go/services/multipooler/internal/heartbeat/reader_test.go
@@ -99,6 +99,54 @@ func TestReaderTracksReceiveLSNAdvance(t *testing.T) {
 	assert.Equal(t, at2, at3, "advance time must not move when receive_lsn is unchanged")
 }
 
+// TestReaderReadHeartbeatBadTimestamp covers the "failed to parse heartbeat
+// timestamp" path: a non-integer ts is a read error, not a silent skip.
+func TestReaderReadHeartbeatBadTimestamp(t *testing.T) {
+	queryService := mock.NewQueryService()
+	now := time.Now()
+	tr := newTestReader(t, queryService, &now)
+	defer tr.Close()
+
+	queryService.AddQueryPattern("SELECT ts, pg_last_wal_receive_lsn.*FROM multigres\\.heartbeat WHERE shard_id.*", mock.MakeQueryResult(
+		[]string{"ts", "receive_lsn"},
+		[][]any{{"not-a-number", "0/16E5D38"}},
+	))
+
+	tr.readHeartbeat(t.Context())
+	_, err := tr.Status()
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to parse heartbeat timestamp")
+	assert.EqualValues(t, 0, tr.Reads(), "a parse failure is not a successful read")
+	assert.EqualValues(t, 1, tr.ReadErrors(), "wrong read error count")
+}
+
+// TestReaderUnparsableReceiveLSN covers the "failed to parse pg_last_wal_receive_lsn"
+// path: a present-but-unparsable receive_lsn is best-effort — it must not fail the
+// heartbeat-lag read, and no advance is recorded.
+func TestReaderUnparsableReceiveLSN(t *testing.T) {
+	queryService := mock.NewQueryService()
+	now := time.Now()
+	tr := newTestReader(t, queryService, &now)
+	defer tr.Close()
+
+	queryService.AddQueryPattern("SELECT ts, pg_last_wal_receive_lsn.*FROM multigres\\.heartbeat WHERE shard_id.*", mock.MakeQueryResult(
+		[]string{"ts", "receive_lsn"},
+		[][]any{{now.Add(-5 * time.Second).UnixNano(), "garbage"}},
+	))
+
+	tr.readHeartbeat(t.Context())
+	lag, err := tr.Status()
+
+	require.NoError(t, err, "an unparsable receive_lsn must not fail the lag read")
+	assert.Equal(t, 5*time.Second, lag)
+	assert.EqualValues(t, 1, tr.Reads())
+	assert.EqualValues(t, 0, tr.ReadErrors())
+
+	_, ok := tr.LastReceiveLSNAdvance()
+	assert.False(t, ok, "an unparsable receive_lsn records no advance")
+}
+
 // TestReaderReadHeartbeatError tests that we properly account for errors
 // encountered in the reading of heartbeat.
 func TestReaderReadHeartbeatError(t *testing.T) {

--- a/go/services/multipooler/internal/heartbeat/repltracker_test.go
+++ b/go/services/multipooler/internal/heartbeat/repltracker_test.go
@@ -57,9 +57,9 @@ func TestReplTrackerStopWriting(t *testing.T) {
 	queryService := mock.NewQueryService()
 
 	queryService.AddQueryPattern("INSERT INTO multigres", mock.MakeQueryResult([]string{}, [][]any{}))
-	queryService.AddQueryPattern("SELECT ts FROM multigres", mock.MakeQueryResult(
-		[]string{"ts"},
-		[][]any{{time.Now().Add(-5 * time.Second).UnixNano()}},
+	queryService.AddQueryPattern("SELECT ts, pg_last_wal_receive_lsn.*FROM multigres", mock.MakeQueryResult(
+		[]string{"ts", "receive_lsn"},
+		[][]any{{time.Now().Add(-5 * time.Second).UnixNano(), "0/16E5D38"}},
 	))
 
 	logger := slog.Default()
@@ -173,9 +173,9 @@ func TestReplTrackerOnStateChangeGating(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			queryService := mock.NewQueryService()
 			queryService.AddQueryPattern("INSERT INTO multigres", mock.MakeQueryResult([]string{}, [][]any{}))
-			queryService.AddQueryPattern("SELECT ts FROM multigres", mock.MakeQueryResult(
-				[]string{"ts"},
-				[][]any{{time.Now().Add(-5 * time.Second).UnixNano()}},
+			queryService.AddQueryPattern("SELECT ts, pg_last_wal_receive_lsn.*FROM multigres", mock.MakeQueryResult(
+				[]string{"ts", "receive_lsn"},
+				[][]any{{time.Now().Add(-5 * time.Second).UnixNano(), "0/16E5D38"}},
 			))
 
 			rt := NewReplTracker(queryService, slog.Default(), []byte("test-shard"), "test-pooler", 250)
@@ -195,9 +195,9 @@ func TestReplTrackerStartAndStopWriting(t *testing.T) {
 
 	// Setup queries for both writer and reader
 	queryService.AddQueryPattern("INSERT INTO multigres", mock.MakeQueryResult([]string{}, [][]any{}))
-	queryService.AddQueryPattern("SELECT ts FROM multigres", mock.MakeQueryResult(
-		[]string{"ts"},
-		[][]any{{time.Now().Add(-5 * time.Second).UnixNano()}},
+	queryService.AddQueryPattern("SELECT ts, pg_last_wal_receive_lsn.*FROM multigres", mock.MakeQueryResult(
+		[]string{"ts", "receive_lsn"},
+		[][]any{{time.Now().Add(-5 * time.Second).UnixNano(), "0/16E5D38"}},
 	))
 
 	logger := slog.Default()

--- a/go/services/multipooler/internal/manager/pg_replication.go
+++ b/go/services/multipooler/internal/manager/pg_replication.go
@@ -339,6 +339,19 @@ func (pm *MultipoolerManager) queryReplicationStatus(ctx context.Context) (*mult
 	}
 	status.PrimaryConnInfo = parsedConnInfo
 
+	// Stamp the WAL-receive-advance time tracked by the heartbeat reader on its
+	// regular tick (not recomputed per call), so orch can distinguish "streaming
+	// new WAL from the primary" from a connected-but-idle receiver. It's a
+	// streaming-only signal: restore_command/archive replay does not advance
+	// pg_last_wal_receive_lsn(). Left unset until the reader observes a value.
+	if pm.replTracker != nil {
+		if reader := pm.replTracker.HeartbeatReader(); reader != nil {
+			if advanceTime, ok := reader.LastReceiveLSNAdvance(); ok {
+				status.LastReceiveLsnAdvanceTime = timestamppb.New(advanceTime)
+			}
+		}
+	}
+
 	return status, nil
 }
 

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -350,7 +350,7 @@ func (pm *MultipoolerManager) Status(ctx context.Context) (*multipoolermanagerda
 		return resp, nil
 	}
 	// Acting as standby - get replication status (skip guardrails since we already checked recovery mode)
-	replStatus, err := pm.getStandbyStatusInternal(ctx)
+	replStatus, err := pm.queryReplicationStatus(ctx)
 	if err != nil {
 		pm.logger.WarnContext(ctx, "Failed to get standby replication status", "error", err)
 		// Return partial status instead of error
@@ -565,12 +565,6 @@ func (pm *MultipoolerManager) getPrimaryStatusInternal(ctx context.Context) (*mu
 	status.MaxWalSenders = maxWalSenders
 
 	return status, nil
-}
-
-// getStandbyStatusInternal gets standby replication status without guardrail checks.
-// Called by Status() which has already verified the PostgreSQL role.
-func (pm *MultipoolerManager) getStandbyStatusInternal(ctx context.Context) (*multipoolermanagerdatapb.StandbyReplicationStatus, error) {
-	return pm.queryReplicationStatus(ctx)
 }
 
 // PrimaryStatus gets the status of the leader server

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -84,6 +84,15 @@ message StandbyReplicationStatus {
   // before terminating the WAL receiver connection.
   // From current_setting('wal_receiver_timeout').
   google.protobuf.Duration wal_receiver_timeout = 11;
+
+  // When last_receive_lsn (pg_last_wal_receive_lsn — WAL streamed from the
+  // primary) last increased, as observed by the standby's heartbeat reader on
+  // its regular tick. This is a WAL-*progress* signal, distinct from
+  // last_msg_receive_time (which advances on keepalives with no new WAL). It is
+  // unaffected by restore_command/archive replay, which advances replay_lsn but
+  // not receive_lsn — so a fresh value means the leader is actively streaming new
+  // WAL to this standby. Null if the reader has not yet observed a value.
+  google.protobuf.Timestamp last_receive_lsn_advance_time = 12;
 }
 
 // Wait for PostgreSQL server to reach a specific LSN position

--- a/web/multiadmin/lib/api/generated/multipoolermanagerdata_pb.ts
+++ b/web/multiadmin/lib/api/generated/multipoolermanagerdata_pb.ts
@@ -488,6 +488,19 @@ export class StandbyReplicationStatus extends Message<StandbyReplicationStatus> 
    */
   walReceiverTimeout?: Duration;
 
+  /**
+   * When last_receive_lsn (pg_last_wal_receive_lsn — WAL streamed from the
+   * primary) last increased, as observed by the standby's heartbeat reader on
+   * its regular tick. This is a WAL-*progress* signal, distinct from
+   * last_msg_receive_time (which advances on keepalives with no new WAL). It is
+   * unaffected by restore_command/archive replay, which advances replay_lsn but
+   * not receive_lsn — so a fresh value means the leader is actively streaming new
+   * WAL to this standby. Null if the reader has not yet observed a value.
+   *
+   * @generated from field: google.protobuf.Timestamp last_receive_lsn_advance_time = 12;
+   */
+  lastReceiveLsnAdvanceTime?: Timestamp;
+
   constructor(data?: PartialMessage<StandbyReplicationStatus>) {
     super();
     proto3.util.initPartial(data, this);
@@ -507,6 +520,7 @@ export class StandbyReplicationStatus extends Message<StandbyReplicationStatus> 
     { no: 9, name: "last_msg_receive_time", kind: "message", T: Timestamp },
     { no: 10, name: "wal_receiver_status_interval", kind: "message", T: Duration },
     { no: 11, name: "wal_receiver_timeout", kind: "message", T: Duration },
+    { no: 12, name: "last_receive_lsn_advance_time", kind: "message", T: Timestamp },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): StandbyReplicationStatus {


### PR DESCRIPTION
## What

Adds a per-standby signal: **when `pg_last_wal_receive_lsn()` last increased**, surfaced on `StandbyReplicationStatus.last_receive_lsn_advance_time`.

The heartbeat reader already runs on standbys at ~1s. It now samples the WAL receiver's streamed position in the same query it uses for lag, and records the timestamp of each genuine *increase* (idle keepalives, which don't advance the LSN, leave it to age out).

## Why

This plumbs a signal that **LeaderStuck** failover detection will consume. `receive_lsn` advances **only** via streaming replication from the primary — `restore_command`/archive replay advances `replay_lsn`, not `receive_lsn` — so a fresh value is direct evidence the leader is actively streaming new WAL to this standby. A future analyzer will treat a durability-sufficient set of standbys with fresh advance times as proof the leader is making progress, and only fail over a reachable-but-stuck leader when no such progress exists.

No behavior change yet: this PR only plumbs the signal (reader → `queryReplicationStatus` → proto → orch health stream). The analyzer that consumes it lands separately.

## Why report the advance *time*, not just the LSN?

Orch could instead diff `last_receive_lsn` across its own health snapshots — but those arrive on a ~5s cadence (`DefaultSnapshotInterval`), so orch could only place the last advance to within ±5s and would learn of a stall a full cadence late. The standby samples at ~1s, so stamping the advance time at the source lets a consumer know the *age* of the last increase at that resolution, independent of the snapshot cadence. That matters because the LeaderStuck staleness threshold is only a small multiple of the snapshot cadence, where ±5s of slop would blur the decision. (Trade-off: it's a pooler-clock timestamp compared against orch's clock — negligible NTP skew versus the threshold, same as the existing lag fields. If we later want it skew-immune at coarser resolution, orch-side diffing is a drop-in swap since the consumer just reads a timestamp.)

## Notes

- Populated in `queryReplicationStatus` (single build site) so no caller sees a half-populated struct.
- Row reads use the bounds-checked `executor.Get*` helpers; a NULL LSN (streaming not started) is treated as absent, never an error on the lag path.