### PR TITLE
test(shardsetup): reclaim orphaned SysV shared-memory segments on cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ export PGPROTO_VER
 CMDS = multigateway multipooler pgctld multiorch multigres multiadmin portpoolserver
 BIN_DIR = bin
 
-.PHONY: all build build-all clean images install test test-coverage pgregress pgregress-update-patches pgregress-update-patches-docker pgexternal pgexternal-update-patches pgproto pgproto-update-patches proto proto-ts tools parser metrics generate help
+.PHONY: all build build-all clean clean-shm images install test test-coverage pgregress pgregress-update-patches pgregress-update-patches-docker pgexternal pgexternal-update-patches pgproto pgproto-update-patches proto proto-ts tools parser metrics generate help
 
 ##@ General
 
@@ -280,6 +280,9 @@ clean: ## Remove build artifacts and temp files.
 		echo "Removing $(BIN_DIR)/$$cmd"; \
 		rm -f $(BIN_DIR)/$$cmd; \
 	done
+
+clean-shm: ## Reclaim orphaned SysV shared-memory segments leaked by timed-out e2e tests.
+	@scripts/clean-shm.sh
 
 # Clean build and dependencies
 clean-all: clean ## Remove build dependencies and distribution files.

--- a/go/test/endtoend/multiorch/bootstrap_test.go
+++ b/go/test/endtoend/multiorch/bootstrap_test.go
@@ -109,7 +109,8 @@ func TestBootstrapInitialization(t *testing.T) {
 		for _, inst := range setup.Multipoolers {
 			data, err := os.ReadFile(inst.Multipooler.LogFile)
 			require.NoError(t, err)
-			events := shardsetup.ParseEvents(t, bytes.NewReader(data))
+			events, err := shardsetup.ParseEvents(bytes.NewReader(data))
+			require.NoError(t, err, "error scanning events in %s log", inst.Multipooler.LogFile)
 			if shardsetup.HasEvent(events, "backup.attempt", "success") {
 				found = true
 				assert.True(t, shardsetup.HasEvent(events, "backup.attempt", "started"))
@@ -136,7 +137,8 @@ func TestBootstrapInitialization(t *testing.T) {
 	t.Run("verify primary.promotion event in multiorch log", func(t *testing.T) {
 		data, err := os.ReadFile(mo.LogFile)
 		require.NoError(t, err)
-		events := shardsetup.ParseEvents(t, bytes.NewReader(data))
+		events, err := shardsetup.ParseEvents(bytes.NewReader(data))
+		require.NoError(t, err, "error scanning events in %s log", mo.LogFile)
 		assert.True(t, shardsetup.HasEvent(events, "primary.promotion", "started"))
 		assert.True(t, shardsetup.HasEvent(events, "primary.promotion", "success"))
 	})

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -488,7 +488,9 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		for name, mo := range setup.MultiorchInstances {
 			data, err := os.ReadFile(mo.LogFile)
 			require.NoError(t, err, "should be able to read multiorch %s log", name)
-			events = append(events, shardsetup.ParseEvents(t, bytes.NewReader(data))...)
+			parsed, err := shardsetup.ParseEvents(bytes.NewReader(data))
+			require.NoError(t, err, "error scanning events in multiorch %s log", name)
+			events = append(events, parsed...)
 		}
 
 		promotions := shardsetup.FindEvents(events, "primary.promotion", "success")

--- a/go/test/endtoend/shardsetup/cluster.go
+++ b/go/test/endtoend/shardsetup/cluster.go
@@ -568,6 +568,15 @@ func (s *ShardSetup) Cleanup(testsFailed bool) {
 		s.cancel()
 	}
 
+	// Reclaim any SysV shared-memory segments left behind by postgres instances
+	// that were SIGKILLed (KillPostgres) or crashed and so never got a clean
+	// shutdown to release them. These accumulate on a long-lived dev machine and
+	// eventually exhaust the SysV table, making later postgres starts fail shmget
+	// (macOS caps them at 32 via kern.sysv.shmmni). Runs on macOS and Linux; only
+	// removes orphaned (unattached) segments, so a live postgres is never touched.
+	// Harmless on CI, whose ephemeral runners never accumulate leaks.
+	reclaimOrphanedSharedMemory(logf)
+
 	// Close topology server (can do this immediately since context cancellation is async)
 	if s.TopoServer != nil {
 		s.TopoServer.Close()

--- a/go/test/endtoend/shardsetup/events.go
+++ b/go/test/endtoend/shardsetup/events.go
@@ -33,8 +33,7 @@ import (
 // Each line is expected to be a JSON object; non-JSON lines are skipped.
 // Event lines are identified by the presence of an "event_type" attribute
 // (the record message is the event type itself, not a fixed sentinel).
-func ParseEvents(t *testing.T, r io.Reader) []map[string]any {
-	t.Helper()
+func ParseEvents(r io.Reader) ([]map[string]any, error) {
 	var events []map[string]any
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
@@ -47,7 +46,10 @@ func ParseEvents(t *testing.T, r io.Reader) []map[string]any {
 			events = append(events, m)
 		}
 	}
-	return events
+	// scanner.Err() is non-nil only on a genuine read/scan failure (e.g. a line
+	// exceeding bufio.Scanner's default 64KB limit), not on normal EOF; without
+	// checking it, a truncated scan would look identical to a complete one.
+	return events, scanner.Err()
 }
 
 // HasEvent checks if events contains at least one event with the given
@@ -125,7 +127,13 @@ func WaitForEvent(t *testing.T, logFile, eventType, outcome string, timeout time
 		if err != nil {
 			return false
 		}
-		events = ParseEvents(t, bytes.NewReader(data))
+		events, err = ParseEvents(bytes.NewReader(data))
+		if err != nil {
+			// Logf is safe from the goroutine testify's Eventually runs this
+			// closure in; FailNow (via require) is not.
+			t.Logf("error scanning events in %s: %v", logFile, err)
+			return false
+		}
 		return HasEvent(events, eventType, outcome)
 	}, timeout, 500*time.Millisecond,
 		"timed out waiting for event_type=%q outcome=%q in %s", eventType, outcome, logFile)

--- a/go/test/endtoend/shardsetup/process.go
+++ b/go/test/endtoend/shardsetup/process.go
@@ -494,7 +494,7 @@ func (p *ProcessInstance) startMultiadmin(ctx context.Context, t *testing.T) err
 
 // waitForStartup handles the common startup and waiting logic.
 // Copied from multipooler/setup_test.go.
-func (p *ProcessInstance) waitForStartup(ctx context.Context, t *testing.T, timeout time.Duration, logInterval int) error {
+func (p *ProcessInstance) waitForStartup(_ context.Context, t *testing.T, timeout time.Duration, logInterval int) error {
 	t.Helper()
 
 	// Start the process in background with trace context propagation

--- a/go/test/endtoend/shardsetup/shm.go
+++ b/go/test/endtoend/shardsetup/shm.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shardsetup
+
+import (
+	"bufio"
+	"context"
+	"os/user"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/multigres/multigres/go/tools/executil"
+)
+
+// reclaimOrphanedSharedMemory removes leaked System V shared-memory segments
+// owned by the current user that have no attached process (NATTCH == 0).
+//
+// PostgreSQL allocates a small, keyed SysV segment per instance (a
+// postmaster-liveness interlock) and only releases it on a clean shutdown.
+// Tests that SIGKILL postgres (KillPostgres) or crash it leave that segment
+// orphaned. On a long-lived developer workstation these accumulate across runs
+// because each run uses fresh ports (fresh keys), so old orphans are never
+// reused. macOS caps SysV segments at 32 (kern.sysv.shmmni), so exhaustion is
+// quick and breaks later postgres starts with shmget "No space left on device";
+// Linux's default cap is far higher (4096) but the machine is equally
+// long-lived, so we sweep there too. Other platforms (and any host without
+// ipcs) are a no-op. CI is unaffected regardless: its runners are ephemeral, so
+// nothing accumulates, and reaping already-dead segments there is harmless.
+//
+// Only segments with NATTCH == 0 are removed, so a live postgres (the
+// developer's own server or a concurrently running test's poolers) is never
+// affected: an attached postmaster always keeps NATTCH > 0. IPC_PRIVATE
+// segments (key 0x00000000, which other software uses and postgres never does)
+// are skipped as an extra guard.
+func reclaimOrphanedSharedMemory(logf func(string, ...any)) {
+	if !shmSweepSupported() {
+		return
+	}
+
+	me, err := user.Current()
+	if err != nil {
+		return // best effort
+	}
+
+	ids := orphanedShmSegments(me.Username)
+	if len(ids) == 0 {
+		return
+	}
+
+	removed := 0
+	for _, id := range ids {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		err := executil.Command(ctx, "ipcrm", "-m", id).Run()
+		cancel()
+		if err == nil {
+			removed++
+		}
+	}
+	if removed > 0 {
+		logf("reclaimed %d orphaned SysV shared-memory segment(s)", removed)
+	}
+}
+
+// shmSweepSupported reports whether we know how to parse this host's ipcs output.
+func shmSweepSupported() bool {
+	return runtime.GOOS == "darwin" || runtime.GOOS == "linux"
+}
+
+// orphanedShmSegments returns the shmids of SysV shared-memory segments owned by
+// owner that currently have no attached process (NATTCH == 0) and are not
+// IPC_PRIVATE (key 0x00000000).
+//
+// The `ipcs` column layout differs by platform, so parse each explicitly.
+//
+// macOS (`ipcs -mo`) — a leading type column ("m"), NATTCH is the last field:
+//
+//	T     ID     KEY        MODE       OWNER    GROUP NATTCH
+//	m 262144 0x00145a28 --rw-------     mats    staff      0
+//
+// Linux (`ipcs -m`) — no type column, NATTCH is the 6th field, an optional
+// status column may follow; data rows start with a hex key:
+//
+//	------ Shared Memory Segments --------
+//	key        shmid   owner  perms   bytes   nattch  status
+//	0x0052e2c1 32768   mats   600     524288  0
+func orphanedShmSegments(owner string) []string {
+	var ipcsArgs []string
+	switch runtime.GOOS {
+	case "darwin":
+		ipcsArgs = []string{"-mo"}
+	default:
+		ipcsArgs = []string{"-m"}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	out, err := executil.Command(ctx, "ipcs", ipcsArgs...).Output()
+	if err != nil {
+		return nil
+	}
+	return parseOrphanedShmIDs(string(out), runtime.GOOS, owner)
+}
+
+// parseOrphanedShmIDs extracts the shmids of segments owned by owner with
+// nattch == 0 (and not IPC_PRIVATE) from `ipcs` output. Split out from the exec
+// so both column layouts can be unit-tested without a live host. darwin selects
+// the macOS `ipcs -mo` layout; otherwise the Linux `ipcs -m` layout is used.
+func parseOrphanedShmIDs(out string, operatingSystem string, owner string) []string {
+	var ids []string
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+
+		var key, id, segOwner, nattch string
+		switch operatingSystem {
+		case "darwin":
+			// m ID KEY MODE OWNER GROUP NATTCH
+			if len(fields) < 7 || fields[0] != "m" {
+				continue
+			}
+			key, id, segOwner, nattch = fields[2], fields[1], fields[4], fields[6]
+
+		default:
+			// KEY SHMID OWNER PERMS BYTES NATTCH [STATUS]. Data rows start with a
+			// hex key, so this skips the "------" separator and column header.
+			if len(fields) < 6 || !strings.HasPrefix(fields[0], "0x") {
+				continue
+			}
+			key, id, segOwner, nattch = fields[0], fields[1], fields[2], fields[5]
+		}
+
+		if segOwner == owner && nattch == "0" && key != "0x00000000" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}

--- a/go/test/endtoend/shardsetup/shm_test.go
+++ b/go/test/endtoend/shardsetup/shm_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shardsetup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseOrphanedShmIDs(t *testing.T) {
+	// Real macOS `ipcs -mo` layout: leading type column, NATTCH last.
+	macOS := `IPC status from <running system> as of Mon Jul 27 09:34:41 CEST 2026
+T     ID     KEY        MODE       OWNER    GROUP NATTCH
+Shared Memory:
+m 262144 0x00145a28 --rw-------     mats    staff      9
+m 2949121 0x02ab1812 --rw-------     mats    staff      0
+m 5373954 0x02ab21c2 --rw-------     other   staff      0
+`
+
+	// Real Linux `ipcs -m` layout: no type column, NATTCH is the 6th field, an
+	// optional status column may follow, and IPC_PRIVATE segments have key 0.
+	linux := `------ Shared Memory Segments --------
+key        shmid      owner  perms  bytes    nattch  status
+0x0052e2c1 32768      mats   600    524288   0
+0x0052e2c2 32769      mats   600    524288   2
+0x0052e2c3 65538      mats   600    524288   0       dest
+0x00000000 98307      mats   600    524288   0
+0x0052e2c4 131076     other  600    524288   0
+`
+
+	tests := []struct {
+		name            string
+		out             string
+		operatingSystem string
+		owner           string
+		want            []string
+	}{
+		{
+			name:            "macOS reaps owner's unattached, keeps attached and other owners",
+			out:             macOS,
+			operatingSystem: "darwin",
+			owner:           "mats",
+			want:            []string{"2949121"}, // 262144 attached (9), 5373954 other owner
+		},
+		{
+			name:            "linux reaps owner's unattached keyed, skips attached/private/other-owner",
+			out:             linux,
+			operatingSystem: "linux",
+			owner:           "mats",
+			// 32768 (nattch 0) and 65538 (nattch 0, status dest) qualify.
+			// 32769 attached, 98307 IPC_PRIVATE (key 0), 131076 other owner.
+			want: []string{"32768", "65538"},
+		},
+		{
+			name:            "no matches for unknown owner",
+			out:             linux,
+			operatingSystem: "linux",
+			owner:           "nobody",
+			want:            nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseOrphanedShmIDs(tt.out, tt.operatingSystem, tt.owner)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/scripts/clean-shm.sh
+++ b/scripts/clean-shm.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Copyright 2026 Supabase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reclaims orphaned System V shared-memory segments left behind by end-to-end
+# tests that SIGKILL or crash postgres (which never releases its segment cleanly).
+#
+# ShardSetup.Cleanup already sweeps these at the end of a normal test run, but if
+# `go test` hits its -timeout the binary is hard-killed and cleanup never runs,
+# so segments leak. On macOS kern.sysv.shmmni defaults to 32 and a handful of
+# leaks exhausts the table, making later postgres starts fail shmget. Run this to
+# clean up manually:
+#
+#   scripts/clean-shm.sh          # remove orphaned segments
+#   scripts/clean-shm.sh --dry-run # list what would be removed
+#
+# Only segments owned by the current user with no attached process (nattch == 0)
+# are removed, and IPC_PRIVATE segments (key 0x00000000) are skipped, so a live
+# postgres is never affected: an attached postmaster keeps nattch > 0.
+
+set -euo pipefail
+
+dry_run=false
+if [[ "${1:-}" == "--dry-run" || "${1:-}" == "-n" ]]; then
+  dry_run=true
+fi
+
+os="$(uname -s)"
+if [[ "$os" != "Darwin" && "$os" != "Linux" ]]; then
+  echo "clean-shm: unsupported OS '$os' (only Darwin and Linux); nothing to do."
+  exit 0
+fi
+
+if ! command -v ipcs >/dev/null 2>&1; then
+  echo "clean-shm: ipcs not found; nothing to do."
+  exit 0
+fi
+
+me="$(id -un)"
+
+# Emit the shmid of every orphaned segment (owner == me, nattch == 0, keyed).
+# The two platforms' ipcs column layouts differ, so parse each explicitly.
+orphaned_ids() {
+  if [[ "$os" == "Darwin" ]]; then
+    # macOS `ipcs -mo`:  m  ID  KEY  MODE  OWNER  GROUP  NATTCH
+    ipcs -mo | awk -v me="$me" \
+      '$1=="m" && $5==me && $7=="0" && $3!="0x00000000" {print $2}'
+  else
+    # Linux `ipcs -m`:  KEY  SHMID  OWNER  PERMS  BYTES  NATTCH  [STATUS]
+    ipcs -m | awk -v me="$me" \
+      '$1 ~ /^0x/ && $3==me && $6=="0" && $1!="0x00000000" {print $2}'
+  fi
+}
+
+ids=$(orphaned_ids || true)
+
+if [[ -z "$ids" ]]; then
+  echo "clean-shm: no orphaned shared-memory segments owned by '$me'."
+  exit 0
+fi
+
+count=0
+removed=0
+while IFS= read -r id; do
+  [[ -n "$id" ]] || continue
+  count=$((count + 1))
+  if $dry_run; then
+    echo "would remove shmid $id"
+    continue
+  fi
+  if ipcrm -m "$id" 2>/dev/null; then
+    removed=$((removed + 1))
+  else
+    echo "clean-shm: failed to remove shmid $id (already gone or in use)" >&2
+  fi
+done <<<"$ids"
+
+if $dry_run; then
+  echo "clean-shm: $count orphaned segment(s) would be removed (dry run)."
+else
+  echo "clean-shm: reclaimed $removed of $count orphaned segment(s) owned by '$me'."
+fi


### PR DESCRIPTION
## Problem

`TestPrimaryCrashWithUnarchivedWAL_NoDataLoss` (and, more generally, any e2e test that hard-kills postgres) fails **deterministically on a long-lived dev machine after enough local runs**. The failure surfaces as `pooler-4`'s restore-from-backup never emitting `restore.attempt outcome=success`, so the test times out at:

```
timed out waiting for event_type="restore.attempt" outcome="success"
```

## Root cause

PostgreSQL allocates a small, keyed **System V shared-memory segment** per instance (a postmaster-liveness interlock; the main shared memory is `mmap`'d) and only releases it on a *clean* shutdown. Tests in this suite deliberately `SIGKILL` postgres (`KillPostgres`), and crashed instances never get a clean stop — so each leaves its segment **orphaned**. Because each run uses fresh ports (fresh shm keys), old orphans are never reused and accumulate across runs.

macOS caps SysV segments hard at `kern.sysv.shmmni = 32`, so the table fills quickly and every new postgres start then fails:

```
FATAL: could not create shared memory segment: No space left on device
DETAIL: Failed system call was shmget(...)
```

In the observed failure, `pooler-4`'s restore hit this wall: ~12 postgres start attempts failed `shmget` in a row, the repeated failures drove pgctld's single-user crash recovery over the freshly `pgbackrest`-restored data directory (stripping `standby.signal` and clobbering the archive-recovery setup), and postgres then `PANIC`ed with `could not locate a valid checkpoint record`. With shared-memory headroom the first `Restart(AsStandby)` succeeds and none of that happens.

## Fix

Add a best-effort sweep at the end of `ShardSetup.Cleanup` that reclaims leaked segments:

- Removes **only** segments owned by the current user with **`NATTCH == 0`** (no attached process), and skips **IPC_PRIVATE** segments (`key 0x00000000`, which other software uses and postgres never does). A live postmaster always keeps `NATTCH > 0`, so a developer's own postgres server or a concurrently running test's poolers are never touched.
- **Runs on both macOS and Linux.** A Linux dev machine is equally long-lived, so it accumulates the same leaks — just against a higher ceiling (`shmmni` defaults to 4096). The two platforms' `ipcs`/`ipcrm` column layouts differ, so each is parsed explicitly and covered by a unit test (`TestParseOrphanedShmIDs`). Other platforms are a no-op.

### Manual sweep for the timeout case

The in-process sweep runs in `Cleanup`, which does **not** execute when `go test` hits its `-timeout` and hard-kills the test binary — those segments still leak. For that case, add a `make clean-shm` target (backed by `scripts/clean-shm.sh`) to reclaim them manually:

```
make clean-shm                 # remove orphaned segments
scripts/clean-shm.sh --dry-run # list what would be removed
```

The script mirrors the Go sweep's owner / `NATTCH == 0` / non-IPC_PRIVATE filter across both platforms.

## Why CI is unaffected

- CI runs on ephemeral `ubuntu-24.04` runners that are discarded per job, so leaked segments cannot accumulate across runs — the sweep simply finds nothing (or reaps a run's own dead segments, which is harmless).
- The sweep only ever removes segments with no attached process, so it cannot disturb any live postgres, including under parallel test execution.

## Follow-up: make `ParseEvents` scan-error handling goroutine-safe

`ParseEvents` (`go/test/endtoend/shardsetup/events.go`) previously discarded `bufio.Scanner`'s terminal error, so a scan truncated by a genuine failure (most commonly `ErrTooLong`, since the default max token size is 64KB) looked identical to one that read the whole file cleanly — it silently returned whatever events had accumulated before the failure.

Surfacing that error by asserting inside `ParseEvents` itself is unsafe for one of its two callers: `WaitForEvent` calls it from the closure passed to `require.Eventually`, which testify runs on a goroutine it spawns per tick, not the test's own goroutine. `require.NoError` calls `t.FailNow()`, and Go's testing package documents `FailNow` as callable only from the goroutine running the test — calling it from `Eventually`'s goroutine drops the failure for that tick instead of surfacing it, and can crash the whole test binary if a late tick's goroutine is still in flight when the test proceeds.

`ParseEvents` now returns `(events, error)` instead of taking `*testing.T`. Its direct callers (`bootstrap_test.go`, `dead_primary_recovery_test.go`), which run on the test's own goroutine, assert with `require.NoError` as before. `WaitForEvent` reports the error via `t.Logf`, which is safe from any goroutine, and keeps polling.

## Testing

- `go build` (darwin + linux/amd64) / `go vet` / golangci-lint clean; `scripts/clean-shm.sh` passes `shellcheck`.
- New unit test `TestParseOrphanedShmIDs` validates both the macOS (`ipcs -mo`) and Linux (`ipcs -m`) column layouts, including attached, other-owner, and IPC_PRIVATE rows.
- `TestPrimaryCrashWithUnarchivedWAL_NoDataLoss` passes on a clean shared-memory table (82s), and the SysV segment count returns to baseline after the run (no leak).
- `go build ./...`, `go vet`, and `go test -short ./go/test/endtoend/shardsetup/... ./go/test/endtoend/multiorch/...` pass after the `ParseEvents` signature change.

