### PR TITLE
fix(query-serving): capture set_config's confirmed value for SET/RESET GUC replay

### DIFF
--- a/go/services/multigateway/engine/apply_session_state.go
+++ b/go/services/multigateway/engine/apply_session_state.go
@@ -448,7 +448,7 @@ func (s *ApplySessionState) StreamExecute(
 		if s.BindRefs != nil {
 			return s.executeSetWithNormalizedBinds(ctx, conn, state, bindVars, callback)
 		}
-		return s.executeSet(ctx, conn, state, callback)
+		return s.executeSet(ctx, conn, state, info, callback)
 	case ast.VAR_SET_DEFAULT:
 		return s.executeSetDefault(ctx, state, callback)
 	case ast.VAR_RESET, ast.VAR_RESET_ALL:
@@ -459,8 +459,18 @@ func (s *ApplySessionState) StreamExecute(
 }
 
 // executeSet handles SET commands: update local state and return a synthetic
-// response. The value is NOT validated against PostgreSQL — see the
-// ApplySessionState doc comment.
+// response.
+//
+// The value recorded into SessionSettings is PostgreSQL's own confirmed value
+// when available: a preceding ValidateSetting in the same Sequence (the
+// Sequence[ValidateSetting, ApplySessionState] plan for a SET outside a
+// transaction) captures set_config's canonical return and leaves it on
+// info.Exchange.ConfirmedValue. That is PostgreSQL's actual resolved value
+// (e.g. DateStyle 'ISO' resolves to 'ISO, MDY'), not necessarily what the
+// client typed, and it is what must be replayed onto a backend on pool
+// rotation. Falls back to the client's literal when there is no preceding
+// ValidateSetting (e.g. a plan built without one) so this primitive still
+// works standalone.
 //
 // Two modes:
 //   - SilentTracking: update state, no callback (a sibling primitive in a
@@ -470,9 +480,13 @@ func (s *ApplySessionState) executeSet(
 	ctx context.Context,
 	conn *server.Conn,
 	state *handler.MultigatewayConnectionState,
+	info PlanExecInfo,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
 	value := extractVariableValue(s.VariableStmt.Args)
+	if info.Exchange != nil && info.Exchange.HasConfirmedValue {
+		value = info.Exchange.ConfirmedValue
+	}
 	return s.applyTracked(ctx, conn, state, s.VariableStmt.Name, value, s.VariableStmt.IsLocal, callback)
 }
 

--- a/go/services/multigateway/engine/apply_session_state_test.go
+++ b/go/services/multigateway/engine/apply_session_state_test.go
@@ -65,6 +65,61 @@ func TestApplySessionState_SET_UpdatesStateAndReturnsSynthetic(t *testing.T) {
 	assert.Equal(t, "SET", results[0].CommandTag)
 }
 
+// TestApplySessionState_SET_UsesConfirmedValueFromExchange verifies the Step
+// 1a wiring: when a preceding ValidateSetting in the same Sequence captured
+// PostgreSQL's confirmed value onto the exchange, executeSet records THAT
+// into SessionSettings instead of re-deriving it from the client's literal;
+// this is what fixes replay of merge-semantic GUCs (e.g. DateStyle) onto a
+// rotated backend.
+func TestApplySessionState_SET_UsesConfirmedValueFromExchange(t *testing.T) {
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	state := &handler.MultigatewayConnectionState{}
+	ctx := context.Background()
+
+	stmt := &ast.VariableSetStmt{
+		Kind: ast.VAR_SET_VALUE,
+		Name: "datestyle",
+		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "ISO"}}}},
+	}
+	ssr := NewApplySessionState("SET DateStyle = 'ISO'", stmt)
+
+	exchange := &SequenceExchange{}
+	exchange.SetConfirmedValue("ISO, MDY")
+
+	var results []*sqltypes.Result
+	err := ssr.StreamExecute(ctx, nil, testConn.Conn, state, nil, PlanExecInfo{Exchange: exchange}, collectCallback(&results))
+	require.NoError(t, err)
+
+	val, exists := state.GetSessionVariable("datestyle")
+	assert.True(t, exists)
+	assert.Equal(t, "ISO, MDY", val, "must record PostgreSQL's resolved value, not the client's literal 'ISO'")
+}
+
+// TestApplySessionState_SET_FallsBackToLiteralWithoutExchange verifies
+// executeSet still works standalone (no preceding ValidateSetting) by falling
+// back to the client's literal, so existing plans without an exchange are
+// unaffected.
+func TestApplySessionState_SET_FallsBackToLiteralWithoutExchange(t *testing.T) {
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	state := &handler.MultigatewayConnectionState{}
+	ctx := context.Background()
+
+	stmt := &ast.VariableSetStmt{
+		Kind: ast.VAR_SET_VALUE,
+		Name: "datestyle",
+		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "ISO"}}}},
+	}
+	ssr := NewApplySessionState("SET DateStyle = 'ISO'", stmt)
+
+	var results []*sqltypes.Result
+	err := ssr.StreamExecute(ctx, nil, testConn.Conn, state, nil, PlanExecInfo{}, collectCallback(&results))
+	require.NoError(t, err)
+
+	val, exists := state.GetSessionVariable("datestyle")
+	assert.True(t, exists)
+	assert.Equal(t, "ISO", val)
+}
+
 func TestApplySessionState_RoleSessionAuthorizationTracking(t *testing.T) {
 	testConn := server.NewTestConn(&bytes.Buffer{})
 	state := &handler.MultigatewayConnectionState{}

--- a/go/services/multigateway/engine/copy_statement_test.go
+++ b/go/services/multigateway/engine/copy_statement_test.go
@@ -39,9 +39,17 @@ import (
 type mockIExecute struct {
 	// StreamExecute behavior
 	streamExecuteErr error
+	// streamExecuteResult, when non-nil, is passed to StreamExecute's callback
+	// before returning streamExecuteErr: lets a test simulate a backend
+	// response (e.g. set_config's returned row) without a real connection.
+	streamExecuteResult *sqltypes.Result
 	// lastStreamResv captures the reservation intent of the most recent
 	// StreamExecute call so tests can assert what a primitive forwarded.
 	lastStreamResv PlanExecInfo
+	// lastStreamKeepStructured captures the keepStructured argument of the most
+	// recent StreamExecute call so tests can assert whether a primitive opted
+	// out of opaque row passthrough.
+	lastStreamKeepStructured bool
 
 	// CopyInitiate behavior
 	copyInitiateErr     error
@@ -85,10 +93,16 @@ func (m *mockIExecute) StreamExecute(
 	preparedStatement *query.ExecuteSqlPreparedStatement,
 	state *handler.MultigatewayConnectionState,
 	info PlanExecInfo,
-	_ bool,
+	keepStructured bool,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
 	m.lastStreamResv = info
+	m.lastStreamKeepStructured = keepStructured
+	if m.streamExecuteResult != nil && callback != nil {
+		if err := callback(ctx, m.streamExecuteResult); err != nil {
+			return err
+		}
+	}
 	return m.streamExecuteErr
 }
 

--- a/go/services/multigateway/engine/engine.go
+++ b/go/services/multigateway/engine/engine.go
@@ -115,6 +115,17 @@ type SequenceExchange struct {
 	// from set_config's canonical return, keyed by PostgreSQL's ParameterStatus
 	// display name, for a trailing ApplySessionState to emit. nil until written.
 	ReportedSettings map[string]string
+
+	// ConfirmedValue is set_config's own canonical return for this Sequence's
+	// tracked GUC: PostgreSQL's actual resolved value (e.g. DateStyle 'ISO' ->
+	// 'ISO, MDY'), not the client's literal. Unlike ReportedSettings (gated to
+	// the fixed GUC_REPORT set and keyed by display name, for the client-facing
+	// ParameterStatus echo), this carries the confirmed value for ANY tracked
+	// GUC so a trailing ApplySessionState can record it into SessionSettings,
+	// the map replayed onto a backend on pool rotation, instead of the literal.
+	// HasConfirmedValue distinguishes "not written" from "confirmed empty".
+	ConfirmedValue    string
+	HasConfirmedValue bool
 }
 
 // AddReportedSetting records a canonical GUC value under its ParameterStatus
@@ -124,6 +135,13 @@ func (e *SequenceExchange) AddReportedSetting(displayName, value string) {
 		e.ReportedSettings = make(map[string]string)
 	}
 	e.ReportedSettings[displayName] = value
+}
+
+// SetConfirmedValue records set_config's canonical return for this Sequence's
+// tracked GUC, for a later sibling to use instead of the client's literal.
+func (e *SequenceExchange) SetConfirmedValue(value string) {
+	e.ConfirmedValue = value
+	e.HasConfirmedValue = true
 }
 
 // IExecute is the execution interface that provides access to execution

--- a/go/services/multigateway/engine/transaction_primitive.go
+++ b/go/services/multigateway/engine/transaction_primitive.go
@@ -288,6 +288,14 @@ func (t *TransactionPrimitive) executeCommit(
 			return err
 		}
 		conn.SetTxnStatus(protocol.TxnStatusInBlock)
+		// PostgreSQL started the new transaction as part of COMMIT AND CHAIN
+		// itself, so there is no deferred BEGIN text left to send here.
+		// Restoring PendingBeginQuery still signals that this (new, chained)
+		// transaction has not run a statement yet, the same way it does for
+		// a fresh BEGIN. The reservation is already transactional, so the
+		// scatter_conn.go consumers that would otherwise send this as a real
+		// BeginQuery skip that and just clear it once a statement lands.
+		state.PendingBeginQuery = chainBeginQuery
 		if !hasTransactionReservation(state) {
 			// This should not happen after a successful backend COMMIT AND CHAIN, but
 			// if the reservation disappeared, fail closed locally rather than
@@ -442,6 +450,11 @@ func (t *TransactionPrimitive) executeRollback(
 			return err
 		}
 		conn.SetTxnStatus(protocol.TxnStatusInBlock)
+		// See executeCommit's identical assignment: PostgreSQL already started
+		// the new transaction as part of ROLLBACK AND CHAIN, so this is not a
+		// real BEGIN to send, just a signal that the new transaction has not
+		// run a statement yet.
+		state.PendingBeginQuery = chainBeginQuery
 		if !hasTransactionReservation(state) {
 			// This should not happen after a successful backend ROLLBACK AND CHAIN,
 			// but if the reservation disappeared, fail closed locally rather than

--- a/go/services/multigateway/engine/transaction_primitive_test.go
+++ b/go/services/multigateway/engine/transaction_primitive_test.go
@@ -343,8 +343,43 @@ func TestTransactionPrimitive_CommitAndChain_WithReservedConnectionKeepsBackendC
 	require.NotNil(t, callbackResult)
 	require.Equal(t, "COMMIT", callbackResult.CommandTag)
 	require.NotEmpty(t, state.ShardStates, "successful AND CHAIN keeps the reserved backend transaction")
-	require.Empty(t, state.PendingBeginQuery, "backend already executed COMMIT AND CHAIN")
 	require.Equal(t, "START TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY DEFERRABLE", state.ActiveTransactionBeginQuery)
+	// PostgreSQL already started the new transaction as part of COMMIT AND
+	// CHAIN, so there is no real BEGIN text left to send. But PendingBeginQuery
+	// is restored anyway (rather than left empty) to signal that this new
+	// transaction has not run a statement yet, so a SET immediately after this
+	// still takes the literal-tracking path instead of risking fixing a
+	// REPEATABLE READ/SERIALIZABLE snapshot one statement early. scatter_conn.go's
+	// reservation-reuse paths clear it, without sending it as a real BeginQuery,
+	// once a statement actually reaches this already-transactional backend.
+	require.Equal(t, "START TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY DEFERRABLE", state.PendingBeginQuery)
+}
+
+func TestTransactionPrimitive_RollbackAndChain_WithReservedConnectionKeepsBackendChained(t *testing.T) {
+	mockExec := &txMockIExecute{}
+	conn := newTxTestConn()
+	state := newTestReservedState("tg1", conn)
+	state.ActiveTransactionBeginQuery = "START TRANSACTION ISOLATION LEVEL SERIALIZABLE READ ONLY DEFERRABLE"
+	state.TxnStartTime = time.Now()
+	var callbackResult *sqltypes.Result
+
+	tp := NewTransactionPrimitive(ast.TRANS_STMT_ROLLBACK, "", true, "ROLLBACK AND CHAIN", "tg1", nil)
+	err := tp.StreamExecute(context.Background(), mockExec, conn, state, nil, PlanExecInfo{}, func(_ context.Context, r *sqltypes.Result) error {
+		callbackResult = r
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, protocol.TxnStatusInBlock, conn.TxnStatus())
+	require.Equal(t, 1, mockExec.concludeTransactionCount)
+	require.NotNil(t, callbackResult)
+	require.Equal(t, "ROLLBACK", callbackResult.CommandTag)
+	require.NotEmpty(t, state.ShardStates, "successful AND CHAIN keeps the reserved backend transaction")
+	require.Equal(t, "START TRANSACTION ISOLATION LEVEL SERIALIZABLE READ ONLY DEFERRABLE", state.ActiveTransactionBeginQuery)
+	// See CommitAndChain_WithReservedConnectionKeepsBackendChained: restored
+	// (not left empty) to signal the new transaction has not run a statement
+	// yet, even though PostgreSQL already started it via ROLLBACK AND CHAIN.
+	require.Equal(t, "START TRANSACTION ISOLATION LEVEL SERIALIZABLE READ ONLY DEFERRABLE", state.PendingBeginQuery)
 }
 
 func TestTransactionPrimitive_CommitAndChain_ConcludeErrorFailsClosed(t *testing.T) {

--- a/go/services/multigateway/engine/validate_setting.go
+++ b/go/services/multigateway/engine/validate_setting.go
@@ -26,12 +26,14 @@ import (
 	"github.com/multigres/multigres/go/services/multigateway/handler"
 )
 
-// ValidateSetting validates a SET's value against PostgreSQL without persisting
-// it on the pooled backend.
+// ValidateSetting runs a SET's value through PostgreSQL's own set_config(),
+// either as a throwaway validation probe or as the real, persisting change,
+// depending on Persist.
 //
-// It runs `SELECT pg_catalog.set_config(name, value, true)` on a backend. The
+// The default (Persist false) validates without persisting: it runs
+// `SELECT pg_catalog.set_config(name, value, true)` on a backend. The
 // is_local := true argument scopes the change to the statement's own implicit
-// transaction, so it reverts the instant the statement completes — leaving the
+// transaction, so it reverts the instant the statement completes, leaving the
 // backend's session state (and therefore multipooler's per-backend connstate)
 // exactly as it was. multipooler must remain the sole authority on backend
 // session GUCs; routing a raw `SET name = value` here would mutate the backend
@@ -40,11 +42,22 @@ import (
 // or out-of-range value raises the same error a real SET would, surfacing it at
 // SET time rather than on a later unrelated query.
 //
-// The result row is discarded; this primitive emits nothing to the client. It
-// is the first step of Sequence[ValidateSetting, ApplySessionState]: the
-// trailing ApplySessionState records the setting for pool-rotation replay and
-// emits the synthetic CommandComplete("SET"), and runs only if validation
-// succeeded because the Sequence stops on the first child's error.
+// When Persist is true, is_local := false instead: the change genuinely
+// persists on the backend (matching a plain SET's real semantics: survives
+// COMMIT, still reverts on ROLLBACK / ROLLBACK TO SAVEPOINT). This mode is
+// for planVariableSetStmt's in-transaction SET, once an earlier statement in
+// the same transaction has already run, so it is safe to route the value
+// through set_config (see planVariableSetStmt's PendingBeginQuery gate) and
+// the backend is already pinned for the rest of the transaction and must
+// actually carry the new value, not just validate it.
+//
+// Either way, the result row is discarded; this primitive emits nothing to
+// the client. It is the first step of Sequence[ValidateSetting,
+// ApplySessionState]: the trailing ApplySessionState records the setting
+// (PostgreSQL's own confirmed value, captured from set_config's return) for
+// pool-rotation replay and emits the synthetic CommandComplete("SET"), and
+// runs only if this step succeeded because the Sequence stops on the first
+// child's error.
 type ValidateSetting struct {
 	TableGroup string
 	Shard      string
@@ -57,6 +70,12 @@ type ValidateSetting struct {
 	// reportable GUC's reverted value is captured the same way a SET's new value
 	// is. Value is ignored when IsReset is true.
 	IsReset bool
+	// Persist, when true, makes the underlying set_config call use is_local :=
+	// false so the change genuinely persists on the backend, instead of
+	// reverting immediately. Defaults to false: the ordinary, outside-transaction
+	// case is a throwaway validation probe that must not mutate the pooled
+	// backend.
+	Persist bool
 	// Query is the original SQL string, for debug output.
 	Query string
 }
@@ -85,41 +104,67 @@ func NewValidateSettingReset(tableGroup, shard, name, sql string) *ValidateSetti
 	}
 }
 
+// NewValidateSettingPersist creates a ValidateSetting primitive whose
+// set_config call persists for real (is_local := false) instead of reverting.
+// Used by planVariableSetStmt for an in-transaction SET once an earlier
+// statement has already run; see the Persist field doc comment above.
+func NewValidateSettingPersist(tableGroup, shard, name, value, sql string) *ValidateSetting {
+	return &ValidateSetting{
+		TableGroup: tableGroup,
+		Shard:      shard,
+		Name:       name,
+		Value:      value,
+		Persist:    true,
+		Query:      sql,
+	}
+}
+
 // validateSQL deparses `SELECT pg_catalog.set_config('<name>', '<value>', true)`
 // from an AST rather than formatting a string. Building the tree and letting the
 // deparser render it means the name and value are quoted/escaped by the
 // canonical path (ast.QuoteStringLiteral), so a single quote in either — a
 // hostile variable name or value — cannot break out of the string literal.
-// is_local is true so the validation reverts when the statement completes.
+// is_local is the inverse of Persist: true (revert) by default, false (persist)
+// when Persist is set.
 func (v *ValidateSetting) validateSQL() string {
+	return buildSetConfigSQL(v.Name, v.Value, !v.Persist, v.IsReset)
+}
+
+// buildSetConfigSQL deparses `SELECT pg_catalog.set_config('<name>', '<value>',
+// <isLocal>)` from an AST rather than formatting a string, so the name and
+// value are quoted/escaped by the canonical path (ast.QuoteStringLiteral) and
+// a single quote in either cannot break out of the string literal. isReset
+// passes NULL as the value (resets the GUC to its default and returns that
+// default) instead of the literal value.
+func buildSetConfigSQL(name, value string, isLocal, isReset bool) string {
 	funcname := ast.NewNodeList(ast.NewString("pg_catalog"), ast.NewString("set_config"))
 	// A RESET passes NULL as the value, which resets the GUC to its default and
 	// returns that default; a SET passes the literal value.
-	valueArg := ast.NewA_Const(ast.NewString(v.Value), 0)
-	if v.IsReset {
+	valueArg := ast.NewA_Const(ast.NewString(value), 0)
+	if isReset {
 		valueArg = ast.NewA_ConstNull(0)
 	}
 	args := ast.NewNodeList(
-		ast.NewA_Const(ast.NewString(v.Name), 0),
+		ast.NewA_Const(ast.NewString(name), 0),
 		valueArg,
-		ast.NewA_Const(ast.NewBoolean(true), 0),
+		ast.NewA_Const(ast.NewBoolean(isLocal), 0),
 	)
 	sel := ast.NewSelectStmt()
 	sel.TargetList.Append(ast.NewResTarget("", ast.NewFuncCall(funcname, args, 0)))
 	return sel.SqlString()
 }
 
-// validate runs the set_config validation query on a backend. It captures the
-// scalar the query returns: set_config's canonical, effective value for the
-// GUC, and always records it on the Sequence exchange as ConfirmedValue so
-// the trailing ApplySessionState can record PostgreSQL's actual resolved value
+// run executes the set_config query on a backend (validating and reverting,
+// or persisting for real, depending on Persist). It captures the scalar the
+// query returns: set_config's canonical, effective value for the GUC, and
+// always records it on the Sequence exchange as ConfirmedValue so the
+// trailing ApplySessionState can record PostgreSQL's actual resolved value
 // into SessionSettings instead of the client's literal (e.g. DateStyle 'ISO'
 // resolves to 'ISO, MDY'). When the GUC is also one PostgreSQL reports via
 // ParameterStatus, the same captured value is additionally recorded under its
 // ParameterStatus display name so the client learns the new value too. Nothing
-// is emitted to the client here; only an execution error matters for
-// validation itself.
-func (v *ValidateSetting) validate(
+// is emitted to the client here; only an execution error matters.
+func (v *ValidateSetting) run(
 	ctx context.Context,
 	exec IExecute,
 	conn *server.Conn,
@@ -166,7 +211,7 @@ func (v *ValidateSetting) StreamExecute(
 	info PlanExecInfo,
 	_ func(context.Context, *sqltypes.Result) error,
 ) error {
-	return v.validate(ctx, exec, conn, state, info)
+	return v.run(ctx, exec, conn, state, info)
 }
 
 // PortalStreamExecute mirrors StreamExecute. The validation SQL carries no
@@ -182,7 +227,7 @@ func (v *ValidateSetting) PortalStreamExecute(
 	info PlanExecInfo,
 	_ func(context.Context, *sqltypes.Result) error,
 ) error {
-	return v.validate(ctx, exec, conn, state, info)
+	return v.run(ctx, exec, conn, state, info)
 }
 
 // GetTableGroup returns the target tablegroup.

--- a/go/services/multigateway/engine/validate_setting.go
+++ b/go/services/multigateway/engine/validate_setting.go
@@ -110,14 +110,15 @@ func (v *ValidateSetting) validateSQL() string {
 }
 
 // validate runs the set_config validation query on a backend. It captures the
-// scalar the query returns — set_config's canonical, effective value for the GUC
-// — and, when the GUC is one PostgreSQL reports via ParameterStatus, records it
-// on the Sequence exchange under its ParameterStatus display name so the trailing
-// ApplySessionState emits it. This is how the client learns the new value of e.g.
-// standard_conforming_strings; capturing set_config's return means the reported
-// value is PostgreSQL's own canonicalization (DateStyle 'ISO' → 'ISO, MDY'),
-// never the raw string the client typed. Nothing is emitted to the client here;
-// only an execution error matters for validation itself.
+// scalar the query returns: set_config's canonical, effective value for the
+// GUC, and always records it on the Sequence exchange as ConfirmedValue so
+// the trailing ApplySessionState can record PostgreSQL's actual resolved value
+// into SessionSettings instead of the client's literal (e.g. DateStyle 'ISO'
+// resolves to 'ISO, MDY'). When the GUC is also one PostgreSQL reports via
+// ParameterStatus, the same captured value is additionally recorded under its
+// ParameterStatus display name so the client learns the new value too. Nothing
+// is emitted to the client here; only an execution error matters for
+// validation itself.
 func (v *ValidateSetting) validate(
 	ctx context.Context,
 	exec IExecute,
@@ -129,7 +130,7 @@ func (v *ValidateSetting) validate(
 
 	var effective string
 	capture := func(_ context.Context, result *sqltypes.Result) error {
-		if reportable && len(result.Rows) > 0 && len(result.Rows[0].Values) > 0 {
+		if len(result.Rows) > 0 && len(result.Rows[0].Values) > 0 {
 			if val := result.Rows[0].Values[0]; !val.IsNull() {
 				effective = string(val)
 			}
@@ -137,17 +138,18 @@ func (v *ValidateSetting) validate(
 		return nil
 	}
 
-	// keepStructured is set exactly when the row has to be parsed: under opaque
-	// row passthrough the multipooler returns the DataRow frames verbatim in
-	// PassthroughBlock and leaves Rows empty, which would silently yield an empty
-	// effective value. Non-reportable GUCs never read the row, so they keep the
-	// default passthrough path.
-	if err := exec.StreamExecute(ctx, conn, v.TableGroup, v.Shard, v.validateSQL(), nil, state, PlanExecInfo{}, reportable, capture); err != nil {
+	// keepStructured is always true here: the query is a single-row, single-
+	// column set_config() result (negligible size either way), and the
+	// confirmed value must always be parsed now, not just for reportable GUCs.
+	if err := exec.StreamExecute(ctx, conn, v.TableGroup, v.Shard, v.validateSQL(), nil, state, PlanExecInfo{}, true, capture); err != nil {
 		return err
 	}
 
-	if reportable && info.Exchange != nil {
-		info.Exchange.AddReportedSetting(display, effective)
+	if info.Exchange != nil {
+		info.Exchange.SetConfirmedValue(effective)
+		if reportable {
+			info.Exchange.AddReportedSetting(display, effective)
+		}
 	}
 	return nil
 }

--- a/go/services/multigateway/engine/validate_setting_test.go
+++ b/go/services/multigateway/engine/validate_setting_test.go
@@ -21,7 +21,20 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/sqltypes"
 )
+
+// setConfigResultRow builds the single-row, single-column result
+// set_config(...) returns, as mockIExecute's StreamExecute would hand back to
+// ValidateSetting's capture callback.
+func setConfigResultRow(value string) *sqltypes.Result {
+	return &sqltypes.Result{
+		Rows: []*sqltypes.Row{
+			{Values: []sqltypes.Value{[]byte(value)}},
+		},
+	}
+}
 
 func TestValidateSetting_ValidateSQL(t *testing.T) {
 	tests := []struct {
@@ -84,5 +97,56 @@ func TestValidateSetting_PropagatesError(t *testing.T) {
 func TestValidateSetting_SuccessReturnsNil(t *testing.T) {
 	v := NewValidateSetting("default", "0-inf", "work_mem", "64MB", "SET work_mem = '64MB'")
 	err := v.StreamExecute(context.Background(), &mockIExecute{}, nil, nil, nil, PlanExecInfo{}, nil)
+	require.NoError(t, err)
+}
+
+// TestValidateSetting_CapturesConfirmedValueForNonReportableGUC verifies the
+// core Step 1a fix: a GUC PostgreSQL does NOT report via ParameterStatus
+// (e.g. work_mem, or any planner GUC) still gets its set_config-confirmed
+// value captured onto the exchange for SessionSettings to use; it must not
+// be silently dropped just because it isn't one of the 8 reportable names.
+// It must also NOT appear in ReportedSettings, since that map drives the
+// client-facing ParameterStatus echo and non-reportable GUCs must never be
+// announced there.
+func TestValidateSetting_CapturesConfirmedValueForNonReportableGUC(t *testing.T) {
+	mockExec := &mockIExecute{streamExecuteResult: setConfigResultRow("4MB")}
+	exchange := &SequenceExchange{}
+
+	v := NewValidateSetting("default", "0-inf", "work_mem", "4MB", "SET work_mem = '4MB'")
+	err := v.StreamExecute(context.Background(), mockExec, nil, nil, nil, PlanExecInfo{Exchange: exchange}, nil)
+
+	require.NoError(t, err)
+	assert.True(t, mockExec.lastStreamKeepStructured, "must always request structured rows now, not just for reportable GUCs")
+	require.True(t, exchange.HasConfirmedValue)
+	assert.Equal(t, "4MB", exchange.ConfirmedValue)
+	assert.Empty(t, exchange.ReportedSettings, "a non-reportable GUC must never be added to the client-facing ParameterStatus echo")
+}
+
+// TestValidateSetting_CapturesConfirmedValueAndReportsForReportableGUC
+// verifies a reportable GUC gets BOTH: the confirmed value on the exchange
+// (for SessionSettings, new behavior) and the ParameterStatus-display-name
+// entry in ReportedSettings (for the client echo, unchanged behavior), and
+// that PostgreSQL's resolved value (not the client's literal) is what's
+// captured in both places.
+func TestValidateSetting_CapturesConfirmedValueAndReportsForReportableGUC(t *testing.T) {
+	mockExec := &mockIExecute{streamExecuteResult: setConfigResultRow("ISO, MDY")}
+	exchange := &SequenceExchange{}
+
+	v := NewValidateSetting("default", "0-inf", "datestyle", "ISO", "SET DateStyle = 'ISO'")
+	err := v.StreamExecute(context.Background(), mockExec, nil, nil, nil, PlanExecInfo{Exchange: exchange}, nil)
+
+	require.NoError(t, err)
+	require.True(t, exchange.HasConfirmedValue)
+	assert.Equal(t, "ISO, MDY", exchange.ConfirmedValue)
+	assert.Equal(t, map[string]string{"DateStyle": "ISO, MDY"}, exchange.ReportedSettings,
+		"reportable GUC must still drive the client echo, keyed by its ParameterStatus display name")
+}
+
+// TestValidateSetting_NilExchangeDoesNotPanic confirms validate is safe to
+// call with no exchange (e.g. a plan built outside a Sequence).
+func TestValidateSetting_NilExchangeDoesNotPanic(t *testing.T) {
+	mockExec := &mockIExecute{streamExecuteResult: setConfigResultRow("4MB")}
+	v := NewValidateSetting("default", "0-inf", "work_mem", "4MB", "SET work_mem = '4MB'")
+	err := v.StreamExecute(context.Background(), mockExec, nil, nil, nil, PlanExecInfo{}, nil)
 	require.NoError(t, err)
 }

--- a/go/services/multigateway/engine/validate_setting_test.go
+++ b/go/services/multigateway/engine/validate_setting_test.go
@@ -77,6 +77,16 @@ func TestValidateSetting_ValidateSQL(t *testing.T) {
 	}
 }
 
+// TestValidateSettingPersist_ValidateSQL confirms Persist flips is_local to
+// FALSE, the opposite of the default probe-and-revert mode above: the
+// generated SQL is what makes the change actually stick on the backend
+// instead of reverting.
+func TestValidateSettingPersist_ValidateSQL(t *testing.T) {
+	v := NewValidateSettingPersist("default", "0-inf", "work_mem", "256MB", "SET ...")
+	assert.Equal(t, "SELECT pg_catalog.set_config('work_mem', '256MB', FALSE)", v.validateSQL())
+	assert.True(t, v.Persist)
+}
+
 // TestValidateSetting_PropagatesError confirms the primitive surfaces the
 // backend's error (e.g. an out-of-range value) up to the caller — this is what
 // makes a bad SET fail at SET time. The Sequence relies on this to stop before
@@ -149,4 +159,33 @@ func TestValidateSetting_NilExchangeDoesNotPanic(t *testing.T) {
 	v := NewValidateSetting("default", "0-inf", "work_mem", "4MB", "SET work_mem = '4MB'")
 	err := v.StreamExecute(context.Background(), mockExec, nil, nil, nil, PlanExecInfo{}, nil)
 	require.NoError(t, err)
+}
+
+// TestValidateSettingPersist_PropagatesError mirrors
+// TestValidateSetting_PropagatesError for the Persist mode planVariableSetStmt
+// uses for in-transaction SET: an out-of-range value must still fail at SET
+// time, before the trailing ApplySessionState tracks anything.
+func TestValidateSettingPersist_PropagatesError(t *testing.T) {
+	wantErr := errors.New("100 is outside the valid range for parameter \"extra_float_digits\" (-15 .. 3)")
+	mockExec := &mockIExecute{streamExecuteErr: wantErr}
+
+	v := NewValidateSettingPersist("default", "0-inf", "extra_float_digits", "100", "SET extra_float_digits = 100")
+	err := v.StreamExecute(context.Background(), mockExec, nil, nil, nil, PlanExecInfo{}, nil)
+	require.ErrorIs(t, err, wantErr, "apply error must propagate so the SET fails at SET time")
+}
+
+// TestValidateSettingPersist_CapturesConfirmedValue confirms the Persist mode
+// captures set_config's confirmed value onto the exchange the same way the
+// default probe-and-revert mode does; only the generated SQL (is_local)
+// differs between the two modes, not this capture path.
+func TestValidateSettingPersist_CapturesConfirmedValue(t *testing.T) {
+	mockExec := &mockIExecute{streamExecuteResult: setConfigResultRow("4MB")}
+	exchange := &SequenceExchange{}
+
+	v := NewValidateSettingPersist("default", "0-inf", "work_mem", "4MB", "SET work_mem = '4MB'")
+	err := v.StreamExecute(context.Background(), mockExec, nil, nil, nil, PlanExecInfo{Exchange: exchange}, nil)
+
+	require.NoError(t, err)
+	require.True(t, exchange.HasConfirmedValue)
+	assert.Equal(t, "4MB", exchange.ConfirmedValue)
 }

--- a/go/services/multigateway/executor/executor.go
+++ b/go/services/multigateway/executor/executor.go
@@ -92,7 +92,7 @@ func (e *Executor) StreamExecute(
 		"connection_id", conn.ConnectionID())
 
 	planStart := time.Now()
-	plan, bindVars, cacheHit, normalizedSQL, fingerprint, err := e.resolvePlan(ctx, queryStr, astStmt, conn)
+	plan, bindVars, cacheHit, normalizedSQL, fingerprint, err := e.resolvePlan(ctx, queryStr, astStmt, conn, state)
 	planTime := time.Since(planStart)
 	if err != nil {
 		e.logger.ErrorContext(ctx, "query planning failed",
@@ -134,9 +134,10 @@ func (e *Executor) resolvePlan(
 	queryStr string,
 	astStmt ast.Stmt,
 	conn *server.Conn,
+	state *handler.MultigatewayConnectionState,
 ) (*engine.Plan, []*ast.A_Const, bool, string, string, error) {
 	if !isCacheable(astStmt) {
-		plan, err := e.planner.Plan(queryStr, astStmt, conn, planner.PlanOptions{})
+		plan, err := e.planner.Plan(queryStr, astStmt, conn, planner.PlanOptions{State: state})
 		if err != nil {
 			return nil, nil, false, "", "", err
 		}
@@ -215,7 +216,7 @@ func (e *Executor) PortalStreamExecute(
 		"connection_id", conn.ConnectionID())
 
 	planStart := time.Now()
-	plan, cacheHit, normalizedSQL, fingerprint, err := e.resolvePortalPlan(ctx, portalInfo, conn)
+	plan, cacheHit, normalizedSQL, fingerprint, err := e.resolvePortalPlan(ctx, portalInfo, conn, state)
 	planTime := time.Since(planStart)
 	if err != nil {
 		e.logger.ErrorContext(ctx, "portal query planning failed",
@@ -264,6 +265,7 @@ func (e *Executor) resolvePortalPlan(
 	ctx context.Context,
 	portalInfo *preparedstatement.PortalInfo,
 	conn *server.Conn,
+	state *handler.MultigatewayConnectionState,
 ) (*engine.Plan, bool, string, string, error) {
 	astStmt := portalInfo.PreparedStatementInfo.AstStmt()
 
@@ -283,7 +285,7 @@ func (e *Executor) resolvePortalPlan(
 	// is always correct to serve to the other. The protocol difference lives in
 	// the plan's PortalStreamExecute vs StreamExecute, never in its content.
 	if !isCacheable(astStmt) {
-		plan, err := e.planner.Plan(portalInfo.PreparedStatementInfo.Query, astStmt, conn, planner.PlanOptions{IsPortal: true})
+		plan, err := e.planner.Plan(portalInfo.PreparedStatementInfo.Query, astStmt, conn, planner.PlanOptions{IsPortal: true, State: state})
 		if err != nil {
 			return nil, false, "", "", err
 		}

--- a/go/services/multigateway/planner/planner.go
+++ b/go/services/multigateway/planner/planner.go
@@ -24,6 +24,7 @@ import (
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/services/multigateway/engine"
+	"github.com/multigres/multigres/go/services/multigateway/handler"
 )
 
 // Planner is responsible for creating query execution plans.
@@ -97,6 +98,20 @@ type PlanOptions struct {
 	// Derived by Plan from analysis.NeedsCurrentSettingRewrite so the routing
 	// builders can gate the rewrite without re-walking the tree.
 	RewriteCurrentSetting bool
+
+	// State is the connection's session state. It exists for planning
+	// functions whose plan shape depends on per-connection runtime state
+	// rather than the statement's own AST, currently only
+	// planVariableSetStmt's in-transaction SET gate, which reads
+	// State.PendingBeginQuery to tell whether an earlier statement in the same
+	// transaction has already run. nil is safe: it behaves like the signal is
+	// unavailable.
+	//
+	// Only the non-cacheable VariableSetStmt dispatch reads State, so it never
+	// needs populating on the cacheable path. The same reasoning as the
+	// IsPortal invariant above applies: State-conditional planning must stay
+	// off any plan that can be served from the cache to a different connection.
+	State *handler.MultigatewayConnectionState
 }
 
 // Plan creates an execution plan for the given SQL query and AST.
@@ -189,7 +204,7 @@ func (p *Planner) Plan(
 
 	switch stmt.NodeTag() {
 	case ast.T_VariableSetStmt:
-		plan, err = p.planVariableSetStmt(sql, stmt.(*ast.VariableSetStmt), conn)
+		plan, err = p.planVariableSetStmt(sql, stmt.(*ast.VariableSetStmt), conn, opts.State)
 
 	case ast.T_CopyStmt:
 		plan, err = p.planCopyStmt(sql, stmt.(*ast.CopyStmt))

--- a/go/services/multigateway/planner/variable_set_stmt.go
+++ b/go/services/multigateway/planner/variable_set_stmt.go
@@ -36,6 +36,15 @@ import (
 //     name/value errors at SET time (matching PostgreSQL) without persisting on
 //     the pooled backend, and ApplySessionState records it for pool-rotation
 //     replay only if validation succeeded.
+//   - Inside an explicit transaction, once an earlier statement has already
+//     run (state.PendingBeginQuery is empty), SET var = value is instead
+//     planned as Sequence[ValidateSetting(Persist), ApplySessionState]:
+//     with Persist set, ValidateSetting runs set_config(name, value,
+//     is_local := false), which really persists the change (like a plain
+//     SET) and captures PostgreSQL's confirmed value for ApplySessionState
+//     to record. For the transaction's own first statement, this instead
+//     stays on Sequence[Route, ApplySessionStateSilent]; see the
+//     is-in-transaction branch below for why.
 //   - RESET / RESET ALL update local tracking only (no backend round-trip).
 //   - Gateway-managed variables, SET LOCAL, and SET TRANSACTION / FROM CURRENT
 //     are handled by their dedicated paths below.
@@ -43,6 +52,7 @@ func (p *Planner) planVariableSetStmt(
 	sql string,
 	stmt *ast.VariableSetStmt,
 	conn *server.Conn,
+	state *handler.MultigatewayConnectionState,
 ) (*engine.Plan, error) {
 	// Transaction-only variables are backend state, not replayable session GUCs.
 	// In particular, RESET transaction_isolation/read_only/deferrable must reach
@@ -137,7 +147,35 @@ func (p *Planner) planVariableSetStmt(
 		// silently track it after success. Validating via SELECT set_config(...)
 		// would assign a SERIALIZABLE snapshot before the user's first real query;
 		// plain SET does not.
+		//
+		// That risk only applies to the transaction's own first statement: a
+		// REPEATABLE READ/SERIALIZABLE transaction fixes its snapshot at the
+		// first query-shaped statement, so once an earlier statement in the
+		// same transaction has already run, the snapshot is already fixed and
+		// set_config's confirmed value can be captured safely, the same way
+		// the outside-transaction path does, instead of tracking the client's
+		// literal (the source of item 8's ROLLBACK TO SAVEPOINT drift).
+		//
+		// state.PendingBeginQuery == "" reliably means "this transaction's own
+		// first statement has already run" even right after a COMMIT/ROLLBACK
+		// AND CHAIN that kept the backend reservation active: transaction_primitive.go
+		// restores PendingBeginQuery to a non-empty value in that case too
+		// (there is no real BEGIN text left to send, since PostgreSQL already
+		// started the new transaction as part of the CHAIN itself, but the new
+		// transaction has not run a statement yet either), and scatter_conn.go's
+		// reservation-reuse paths clear it once a statement actually reaches
+		// the backend, the same way they do for a fresh deferred BEGIN.
 		if conn != nil && conn.IsInTransaction() {
+			if state != nil && state.PendingBeginQuery == "" {
+				value := extractVariableValue(stmt.Args)
+				apply := engine.NewValidateSettingPersist(p.defaultTableGroup, constants.DefaultShard, stmt.Name, value, sql)
+				track := engine.NewApplySessionState(sql, stmt)
+				plan := engine.NewPlan(sql, engine.NewSequence([]engine.Primitive{apply, track}))
+				p.logger.Debug("created persist-set-config-then-track SET plan inside transaction",
+					"variable", stmt.Name, "plan", plan.String())
+				return plan, nil
+			}
+
 			route := engine.NewRoute(p.defaultTableGroup, constants.DefaultShard, sql, stmt)
 			track := engine.NewApplySessionStateSilent(sql, stmt)
 			plan := engine.NewPlan(sql, engine.NewSequence([]engine.Primitive{route, track}))

--- a/go/services/multigateway/planner/variable_set_stmt_test.go
+++ b/go/services/multigateway/planner/variable_set_stmt_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/services/multigateway/engine"
+	"github.com/multigres/multigres/go/services/multigateway/handler"
 )
 
 func TestPlanVariableSetStmt_SET(t *testing.T) {
@@ -39,7 +40,7 @@ func TestPlanVariableSetStmt_SET(t *testing.T) {
 		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "256MB"}}}},
 	}
 
-	plan, err := p.planVariableSetStmt("SET work_mem = '256MB'", stmt, testConn.Conn)
+	plan, err := p.planVariableSetStmt("SET work_mem = '256MB'", stmt, testConn.Conn, nil)
 	require.NoError(t, err)
 	require.NotNil(t, plan)
 
@@ -59,6 +60,11 @@ func TestPlanVariableSetStmt_SET_InTransactionRoutesThenTracks(t *testing.T) {
 	p := NewPlanner("default", logger, nil)
 	testConn := server.NewTestConn(&bytes.Buffer{})
 	testConn.Conn.SetTxnStatus(protocol.TxnStatusInBlock)
+	// PendingBeginQuery still set means this is the transaction's own first
+	// statement, no earlier statement has run yet, so the snapshot-timing
+	// risk still applies and the plan must stay on the plain-literal path.
+	state := handler.NewMultigatewayConnectionState()
+	state.PendingBeginQuery = "BEGIN"
 
 	stmt := &ast.VariableSetStmt{
 		Kind: ast.VAR_SET_VALUE,
@@ -66,7 +72,7 @@ func TestPlanVariableSetStmt_SET_InTransactionRoutesThenTracks(t *testing.T) {
 		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "256MB"}}}},
 	}
 
-	plan, err := p.planVariableSetStmt("SET work_mem = '256MB'", stmt, testConn.Conn)
+	plan, err := p.planVariableSetStmt("SET work_mem = '256MB'", stmt, testConn.Conn, state)
 	require.NoError(t, err)
 	require.NotNil(t, plan)
 
@@ -78,6 +84,42 @@ func TestPlanVariableSetStmt_SET_InTransactionRoutesThenTracks(t *testing.T) {
 	track, ok := seq.Primitives[1].(*engine.ApplySessionState)
 	require.True(t, ok, "second primitive should track after success, got %T", seq.Primitives[1])
 	assert.True(t, track.SilentTracking)
+}
+
+// TestPlanVariableSetStmt_SET_InTransactionAfterFirstStatementCapturesConfirmedValue
+// covers the Step 1b gate: once an earlier statement in the same transaction
+// has already run (PendingBeginQuery consumed/empty), the snapshot-timing risk
+// that keeps the transaction's first SET on the plain-literal path no longer
+// applies, so the plan captures set_config's confirmed value instead of
+// tracking the client's literal: the fix for item 8's ROLLBACK TO SAVEPOINT
+// drift.
+func TestPlanVariableSetStmt_SET_InTransactionAfterFirstStatementCapturesConfirmedValue(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	p := NewPlanner("default", logger, nil)
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	testConn.Conn.SetTxnStatus(protocol.TxnStatusInBlock)
+	// PendingBeginQuery empty means an earlier statement already consumed it.
+	state := handler.NewMultigatewayConnectionState()
+
+	stmt := &ast.VariableSetStmt{
+		Kind: ast.VAR_SET_VALUE,
+		Name: "work_mem",
+		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "256MB"}}}},
+	}
+
+	plan, err := p.planVariableSetStmt("SET work_mem = '256MB'", stmt, testConn.Conn, state)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	seq, ok := plan.Primitive.(*engine.Sequence)
+	require.True(t, ok, "expected Sequence primitive, got %T", plan.Primitive)
+	require.Len(t, seq.Primitives, 2, "expected [ValidateSetting(Persist), ApplySessionState]")
+	apply, ok := seq.Primitives[0].(*engine.ValidateSetting)
+	require.True(t, ok, "first primitive should apply+capture via set_config, got %T", seq.Primitives[0])
+	assert.True(t, apply.Persist, "must persist for real, not revert like the outside-transaction probe")
+	track, ok := seq.Primitives[1].(*engine.ApplySessionState)
+	require.True(t, ok, "second primitive should track and emit SET, got %T", seq.Primitives[1])
+	assert.False(t, track.SilentTracking, "the Persist primitive emits nothing itself, so the tracker must emit CommandComplete(\"SET\")")
 }
 
 func TestPlanVariableSetStmt_RESET_RoleAuth_InTransactionRoutesThenTracks(t *testing.T) {
@@ -111,7 +153,7 @@ func TestPlanVariableSetStmt_RESET_RoleAuth_InTransactionRoutesThenTracks(t *tes
 			testConn := server.NewTestConn(&bytes.Buffer{})
 			testConn.Conn.SetTxnStatus(protocol.TxnStatusInBlock)
 
-			plan, err := p.planVariableSetStmt(tt.sql, tt.stmt, testConn.Conn)
+			plan, err := p.planVariableSetStmt(tt.sql, tt.stmt, testConn.Conn, nil)
 			require.NoError(t, err)
 			require.NotNil(t, plan)
 
@@ -142,7 +184,7 @@ func TestPlanVariableSetStmt_RESET_RoleAuth_OutsideTransactionStaysLocalOnly(t *
 
 	stmt := &ast.VariableSetStmt{Kind: ast.VAR_RESET, Name: "role"}
 
-	plan, err := p.planVariableSetStmt("RESET ROLE", stmt, testConn.Conn)
+	plan, err := p.planVariableSetStmt("RESET ROLE", stmt, testConn.Conn, nil)
 	require.NoError(t, err)
 	require.NotNil(t, plan)
 
@@ -164,7 +206,7 @@ func TestPlanVariableSetStmt_SET_IdleSessionTimeoutGatewayManaged(t *testing.T) 
 		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "58s"}}}},
 	}
 
-	plan, err := p.planVariableSetStmt("SET idle_session_timeout = '58s'", stmt, testConn.Conn)
+	plan, err := p.planVariableSetStmt("SET idle_session_timeout = '58s'", stmt, testConn.Conn, nil)
 	require.NoError(t, err)
 	require.NotNil(t, plan)
 	_, ok := plan.Primitive.(*engine.GatewaySessionState)
@@ -182,7 +224,7 @@ func TestPlanVariableSetStmt_SET_IdleSessionTimeoutInvalidErrors(t *testing.T) {
 		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "not-a-duration"}}}},
 	}
 
-	plan, err := p.planVariableSetStmt("SET idle_session_timeout = 'not-a-duration'", stmt, testConn.Conn)
+	plan, err := p.planVariableSetStmt("SET idle_session_timeout = 'not-a-duration'", stmt, testConn.Conn, nil)
 	require.Error(t, err)
 	assert.Nil(t, plan)
 }
@@ -197,7 +239,7 @@ func TestPlanVariableSetStmt_RESET(t *testing.T) {
 		Name: "work_mem",
 	}
 
-	plan, err := p.planVariableSetStmt("RESET work_mem", stmt, testConn.Conn)
+	plan, err := p.planVariableSetStmt("RESET work_mem", stmt, testConn.Conn, nil)
 	require.NoError(t, err)
 	require.NotNil(t, plan)
 
@@ -240,7 +282,7 @@ func TestPlanVariableSetStmt_RESET_ALL(t *testing.T) {
 		Kind: ast.VAR_RESET_ALL,
 	}
 
-	plan, err := p.planVariableSetStmt("RESET ALL", stmt, testConn.Conn)
+	plan, err := p.planVariableSetStmt("RESET ALL", stmt, testConn.Conn, nil)
 	require.NoError(t, err)
 	require.NotNil(t, plan)
 
@@ -260,7 +302,7 @@ func TestPlanVariableSetStmt_SET_LOCAL_PassesThrough(t *testing.T) {
 		Args:    &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "256MB"}}}},
 	}
 
-	plan, err := p.planVariableSetStmt("SET LOCAL work_mem = '256MB'", stmt, testConn.Conn)
+	plan, err := p.planVariableSetStmt("SET LOCAL work_mem = '256MB'", stmt, testConn.Conn, nil)
 	require.NoError(t, err)
 	require.NotNil(t, plan)
 
@@ -279,7 +321,7 @@ func TestPlanVariableSetStmt_SET_DEFAULT_TreatedAsReset(t *testing.T) {
 		Name: "work_mem",
 	}
 
-	plan, err := p.planVariableSetStmt("SET work_mem TO DEFAULT", stmt, testConn.Conn)
+	plan, err := p.planVariableSetStmt("SET work_mem TO DEFAULT", stmt, testConn.Conn, nil)
 	require.NoError(t, err)
 	require.NotNil(t, plan)
 
@@ -299,7 +341,7 @@ func TestPlanVariableSetStmt_SET_TIME_ZONE_DEFAULT_TreatedAsReset(t *testing.T) 
 		Name: "timezone",
 	}
 
-	plan, err := p.planVariableSetStmt("SET TIME ZONE DEFAULT", stmt, testConn.Conn)
+	plan, err := p.planVariableSetStmt("SET TIME ZONE DEFAULT", stmt, testConn.Conn, nil)
 	require.NoError(t, err)
 	require.NotNil(t, plan)
 
@@ -332,7 +374,7 @@ func TestPlanVariableSetStmt_SET_MULTI_PassesThrough(t *testing.T) {
 		Name: "TRANSACTION",
 	}
 
-	plan, err := p.planVariableSetStmt("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE", stmt, testConn.Conn)
+	plan, err := p.planVariableSetStmt("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE", stmt, testConn.Conn, nil)
 	require.NoError(t, err)
 	require.NotNil(t, plan)
 
@@ -351,7 +393,7 @@ func TestPlanVariableSetStmt_SET_CURRENT_PassesThrough(t *testing.T) {
 		Name: "search_path",
 	}
 
-	plan, err := p.planVariableSetStmt("SET search_path FROM CURRENT", stmt, testConn.Conn)
+	plan, err := p.planVariableSetStmt("SET search_path FROM CURRENT", stmt, testConn.Conn, nil)
 	require.NoError(t, err)
 	require.NotNil(t, plan)
 

--- a/go/services/multigateway/scatterconn/scatter_conn.go
+++ b/go/services/multigateway/scatterconn/scatter_conn.go
@@ -289,13 +289,23 @@ func (sc *ScatterConn) StreamExecute(
 		// Temp-table reservations were the original case, but session advisory locks
 		// and holdable portals also pin a backend; once the client sends BEGIN, the
 		// transaction must start on that same reserved backend.
-		if state.PendingBeginQuery != "" && !protoutil.HasTransactionReason(ss.ReservedState.GetReservationReasons()) {
-			sc.logger.DebugContext(ctx, "adding deferred BEGIN via reservation options",
-				"pending_begin", state.PendingBeginQuery,
-				"existing_reasons", protoutil.ReasonsString(ss.ReservedState.GetReservationReasons()))
-			reservationOpts = &querypb.ReservationOptions{
-				Reasons:    protoutil.ReasonTransaction,
-				BeginQuery: state.PendingBeginQuery,
+		//
+		// A non-empty PendingBeginQuery here does not always mean there is real
+		// BEGIN text left to send: after a COMMIT/ROLLBACK AND CHAIN that kept
+		// this same reservation active, PendingBeginQuery is restored purely to
+		// signal that the new (chained) transaction has not run a statement
+		// yet, even though PostgreSQL already started it as part of the CHAIN
+		// itself. HasTransactionReason is already true in that case, so this
+		// statement is reaching the backend either way; only clear it.
+		if state.PendingBeginQuery != "" {
+			if !protoutil.HasTransactionReason(ss.ReservedState.GetReservationReasons()) {
+				sc.logger.DebugContext(ctx, "adding deferred BEGIN via reservation options",
+					"pending_begin", state.PendingBeginQuery,
+					"existing_reasons", protoutil.ReasonsString(ss.ReservedState.GetReservationReasons()))
+				reservationOpts = &querypb.ReservationOptions{
+					Reasons:    protoutil.ReasonTransaction,
+					BeginQuery: state.PendingBeginQuery,
+				}
 			}
 			state.PendingBeginQuery = ""
 		}
@@ -534,6 +544,14 @@ func (sc *ScatterConn) PortalStreamExecute(
 	if ss != nil && ss.ReservedState.GetReservedConnectionId() != 0 {
 		eo.ReservedConnectionId = ss.ReservedState.GetReservedConnectionId()
 		qs, err = sc.gateway.QueryServiceByID(ctx, ss.ReservedState.GetPoolerId(), target)
+
+		// A portal reaching an already-reserved connection is never a fresh
+		// deferred-BEGIN promotion (unlike StreamExecute's Case 1, this portal
+		// path does not promote a non-transactional reservation, see the
+		// comment below), so any PendingBeginQuery surviving to here is only
+		// ever the COMMIT/ROLLBACK AND CHAIN signal that the new transaction
+		// has not run a statement yet; there is nothing to send, just clear it.
+		state.PendingBeginQuery = ""
 
 		// If this portal touches a session-level advisory lock or a logical
 		// replication slot, OR the reason(s) onto the existing reservation so
@@ -996,6 +1014,12 @@ func (sc *ScatterConn) CopyOutInitiate(
 	ss := state.GetMatchingShardState(target)
 	if ss != nil && ss.ReservedState.GetReservedConnectionId() != 0 {
 		execOptions.ReservedConnectionId = ss.ReservedState.GetReservedConnectionId()
+		// COPY reaching an already-reserved connection never promotes it (no
+		// BeginQuery is ever sent here, unlike the branch below), so any
+		// PendingBeginQuery surviving to here is only ever the COMMIT/ROLLBACK
+		// AND CHAIN signal that the new transaction has not run a statement
+		// yet; clear it now that one has.
+		state.PendingBeginQuery = ""
 	} else if conn.IsInTransaction() {
 		reservationOpts = protoutil.NewTransactionReservationOptions()
 		if state.HasTempTableReservation() {
@@ -1147,6 +1171,12 @@ func (sc *ScatterConn) CopyInitiate(
 	ss := state.GetMatchingShardState(target)
 	if ss != nil && ss.ReservedState.GetReservedConnectionId() != 0 {
 		execOptions.ReservedConnectionId = ss.ReservedState.GetReservedConnectionId()
+		// COPY reaching an already-reserved connection never promotes it (no
+		// BeginQuery is ever sent here, unlike the branch below), so any
+		// PendingBeginQuery surviving to here is only ever the COMMIT/ROLLBACK
+		// AND CHAIN signal that the new transaction has not run a statement
+		// yet; clear it now that one has.
+		state.PendingBeginQuery = ""
 	} else if conn.IsInTransaction() {
 		// Deferred BEGIN: pass transaction reservation options so the executor
 		// executes BEGIN on the new connection before initiating COPY.

--- a/go/services/multigateway/scatterconn/scatter_conn_test.go
+++ b/go/services/multigateway/scatterconn/scatter_conn_test.go
@@ -195,6 +195,12 @@ func TestScatterConn_Case1_ExistingReservedConnection(t *testing.T) {
 	state := handler.NewMultigatewayConnectionState()
 	conn := newTestConn()
 	conn.SetTxnStatus(protocol.TxnStatusInBlock)
+	// Simulates a COMMIT/ROLLBACK AND CHAIN that kept this reservation active:
+	// transaction_primitive.go restores PendingBeginQuery to signal the new
+	// transaction has not run a statement yet, even though PostgreSQL already
+	// started it via CHAIN, so ReservationReasons already includes
+	// ReasonTransaction below.
+	state.PendingBeginQuery = "BEGIN"
 
 	target := protoutil.NewTarget("", "tg1", "", querypb.Mode_MODE_WRITABLE)
 	state.SetReservedConnection(target, &querypb.ReservedState{
@@ -211,6 +217,10 @@ func TestScatterConn_Case1_ExistingReservedConnection(t *testing.T) {
 	require.True(t, gw.streamExecuteCalled, "should call StreamExecute on the found query service")
 	require.Equal(t, "SELECT 1", gw.streamExecuteSQL)
 	require.Equal(t, uint64(42), gw.streamExecuteOpts.ReservedConnectionId)
+	require.Nil(t, gw.streamExecuteReservationOps,
+		"already transactional, so this must not be resent as a real BeginQuery")
+	require.Empty(t, state.PendingBeginQuery,
+		"a statement reaching the backend on the reused reservation answers it, even though it was not sent as a real BeginQuery")
 }
 
 func TestScatterConn_Case2_InTransactionNoReservedConn(t *testing.T) {
@@ -456,6 +466,9 @@ func TestScatterConn_Portal_ExistingReservedConnNoReserveReasons(t *testing.T) {
 	state := handler.NewMultigatewayConnectionState()
 	conn := newTestConn()
 	conn.SetTxnStatus(protocol.TxnStatusInBlock)
+	// Simulates a COMMIT/ROLLBACK AND CHAIN that kept this reservation active:
+	// see TestScatterConn_Case1_ExistingReservedConnection.
+	state.PendingBeginQuery = "BEGIN"
 
 	target := protoutil.NewTarget("", "tg1", "", querypb.Mode_MODE_WRITABLE)
 	state.SetReservedConnection(target, &querypb.ReservedState{
@@ -475,6 +488,8 @@ func TestScatterConn_Portal_ExistingReservedConnNoReserveReasons(t *testing.T) {
 	require.False(t, gw.streamExecuteCalled)
 	require.Equal(t, uint64(42), gw.portalOpts.GetReservedConnectionId())
 	require.Nil(t, gw.portalReservationOps, "existing reservation needs no new reasons")
+	require.Empty(t, state.PendingBeginQuery,
+		"a portal reaching the backend on the reused reservation answers it, even though it was not sent as a real BeginQuery")
 }
 
 // TestScatterConn_Portal_LogicalReplicationSlotReservesViaPortalRPC verifies
@@ -1148,6 +1163,42 @@ func TestScatterConn_CopyInitiate_ErrorPreservesReservedConn(t *testing.T) {
 	ss := state.GetMatchingShardState(target)
 	require.NotNil(t, ss, "reserved connection must survive PG-level COPY init error when other reasons remain")
 	require.Equal(t, uint64(42), ss.ReservedState.GetReservedConnectionId())
+}
+
+// TestScatterConn_CopyInitiate_ReuseReservedConnClearsPendingBeginQuery covers
+// a COPY reaching an already-reserved, already-transactional connection right
+// after a COMMIT/ROLLBACK AND CHAIN: see
+// TestScatterConn_Case1_ExistingReservedConnection for why PendingBeginQuery
+// can be non-empty here without there being a real BEGIN left to send, and why
+// it must still be cleared once this statement reaches the backend.
+func TestScatterConn_CopyInitiate_ReuseReservedConnClearsPendingBeginQuery(t *testing.T) {
+	poolerID := &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"}
+	gw := &mockGateway{
+		copyReadyReturnState: &querypb.ReservedState{
+			ReservedConnectionId: 42,
+			PoolerId:             poolerID,
+			ReservationReasons:   protoutil.ReasonTransaction,
+		},
+	}
+	sc := NewScatterConn(gw, slog.Default())
+	state := handler.NewMultigatewayConnectionState()
+	conn := newTestConn()
+	conn.SetTxnStatus(protocol.TxnStatusInBlock)
+	state.PendingBeginQuery = "BEGIN"
+
+	target := protoutil.NewTarget("", "tg1", "", querypb.Mode_MODE_WRITABLE)
+	state.SetReservedConnection(target, &querypb.ReservedState{
+		ReservedConnectionId: 42,
+		PoolerId:             poolerID,
+		ReservationReasons:   protoutil.ReasonTransaction,
+	})
+
+	_, _, err := sc.CopyInitiate(context.Background(), conn, "tg1", "", "COPY x FROM stdin", state,
+		func(_ context.Context, _ *sqltypes.Result) error { return nil })
+
+	require.NoError(t, err)
+	require.Empty(t, state.PendingBeginQuery,
+		"a statement reaching the backend on the reused reservation answers it, even though it was not sent as a real BeginQuery")
 }
 
 func TestScatterConn_CopyFinalize_SuccessStillReserved(t *testing.T) {

--- a/go/services/multipooler/internal/pools/reserved/release_finalizer_test.go
+++ b/go/services/multipooler/internal/pools/reserved/release_finalizer_test.go
@@ -49,28 +49,66 @@ func newFinalizerTestPool(t *testing.T, server *fakepgserver.Server, onRelease f
 }
 
 // TestReleaseClean_Trusted_NoReconcileSQL verifies that a clean release of a
-// trusted connection recycles the backend without issuing reconciliation SQL.
+// trusted connection recycles the backend without issuing reconciliation SQL,
+// when the gateway's settings already match connstate (the common case: real
+// gateways send their actual current SessionSettings on every release, never
+// an arbitrary placeholder).
 func TestReleaseClean_Trusted_NoReconcileSQL(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
 	server.SetNeverFail(true)
 
-	pool, _ := newFinalizerTestPool(t, server, nil)
+	pool, cache := newFinalizerTestPool(t, server, nil)
 	defer pool.Close()
 
-	cache := connstate.NewSettingsCache(10)
 	settings := cache.GetOrCreate(map[string]string{"search_path": "myschema"})
 
 	conn, err := pool.NewConn(context.Background(), settings)
 	require.NoError(t, err)
 
 	server.ResetQueryLog()
-	conn.Release(ReleaseCommit, nil)
+	conn.Release(ReleaseCommit, map[string]string{"search_path": "myschema"})
 
 	log := server.QueryLog()
 	assert.NotContains(t, log, "reset all", "trusted release must not reconcile")
 	assert.NotContains(t, log, "set_config", "trusted release must not reconcile")
 	assert.False(t, conn.IsClosed(), "trusted clean release must recycle, not close")
+	assert.Equal(t, settings, conn.Conn().Settings(), "matching gateway settings must leave connstate unchanged")
+}
+
+// TestReleaseClean_Trusted_StillSyncsFromGatewaySettings verifies the fix for
+// a real bug: a transaction-scoped SET that persists a real backend GUC
+// change (engine.ValidateSetting's Persist mode, is_local := false) never
+// marks the connection untrusted, since that flag exists for a different
+// purpose (ROLLBACK TO SAVEPOINT). Without this, a clean release right after
+// such a SET (e.g. BEGIN; SELECT 1; SET work_mem='64MB'; COMMIT;) would
+// recycle the backend with connstate still claiming the pre-SET value, even
+// though ConcludeTransaction's request already carried the confirmed one.
+// A later, unrelated session could then be handed this connection and
+// observe the leftover setting instead of getting the reset it expects.
+func TestReleaseClean_Trusted_StillSyncsFromGatewaySettings(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool, cache := newFinalizerTestPool(t, server, nil)
+	defer pool.Close()
+
+	stale := cache.GetOrCreate(map[string]string{"work_mem": "4MB"})
+	conn, err := pool.NewConn(context.Background(), stale)
+	require.NoError(t, err)
+	require.False(t, conn.SessionStateUntrusted(), "a Persist-mode SET never marks the connection untrusted")
+
+	gatewayConfirmed := map[string]string{"work_mem": "64MB"}
+
+	server.ResetQueryLog()
+	conn.Release(ReleaseCommit, gatewayConfirmed)
+
+	assert.NotContains(t, server.QueryLog(), "set_config", "sync must be cache-only, no SQL")
+	assert.False(t, conn.IsClosed(), "successful sync must recycle, not close")
+	expected := cache.GetOrCreate(gatewayConfirmed)
+	assert.Equal(t, expected, conn.Conn().Settings(),
+		"connstate must be corrected to the confirmed value even though the connection was never marked untrusted")
 }
 
 // TestReleaseClean_Untrusted_SyncsConnstateFromGateway verifies that when the

--- a/go/services/multipooler/internal/pools/reserved/reserved_pool.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_pool.go
@@ -425,16 +425,22 @@ func (p *Pool) runReleaseCleanups(rc *Conn, reason ReleaseReason, cleanups []Rel
 }
 
 // finalizeCleanRelease syncs connstate to the gateway's authoritative session
-// settings when the connection was marked untrusted (e.g. after ROLLBACK TO
-// SAVEPOINT). Gateway and backend are already aligned; only the pooler's cache
-// may lie. A trusted connection needs no work.
+// settings on every clean release, not only when the connection was marked
+// untrusted (e.g. after ROLLBACK TO SAVEPOINT). The untrusted flag exists for
+// a different purpose (forcing the heavier SQL-issuing reconciliation on the
+// next reserved statement, mid-transaction), and its absence does not mean
+// connstate is already correct: a transaction-scoped SET that persists a real
+// backend GUC change (is_local := false, see engine.ValidateSetting's Persist
+// mode) never marks the connection untrusted, yet still leaves connstate
+// stale if this sync only ran for the untrusted case. gatewaySessionSettings
+// is the same data ConcludeTransaction always sends (confirmed values on
+// COMMIT, already reverted to the pre-BEGIN snapshot on ROLLBACK, since
+// executeRollback calls RollbackTransaction before building that request), so
+// syncing from it unconditionally costs nothing beyond a cache pointer
+// assignment and is a no-op whenever the cache was already correct.
 func (p *Pool) finalizeCleanRelease(rc *Conn, gatewaySessionSettings map[string]string) error {
-	if !rc.SessionStateUntrusted() {
-		return nil
-	}
-
 	if p.config.SettingsCache == nil {
-		return errors.New("settings cache is required for untrusted release finalization")
+		return errors.New("settings cache is required for release finalization")
 	}
 
 	desired := p.config.SettingsCache.GetOrCreate(gatewaySessionSettings)


### PR DESCRIPTION
## Summary

Fixes GUC value drift between the gateway's tracked session state and PostgreSQL's real backend state for `SET`, in two steps -

- Outside an explicit transaction, `SessionSettings` (replayed onto a backend on pool rotation) now records `set_config`'s canonical confirmed value instead of the client's literal (e.g. `DateStyle 'ISO'` resolves to `'ISO, MDY'`).
- Inside an explicit transaction, once an earlier statement has already run (`state.PendingBeginQuery` empty), `SET` now goes through the same confirmed value capture instead of tracking the client's literal. Fixing the `ROLLBACK TO SAVEPOINT` drift where PostgreSQL's transactional GUC stack reverts correctly but the gateway's tracked literal didn't follow. The transaction's own first statement stays on the existing literal-based path, since routing it through a `SELECT set_config(...)` would prematurely fix a `REPEATABLE READ`/`SERIALIZABLE` snapshot one statement early.

`RESET`'s in-transaction path is unchanged: its tracking clears the override rather than recording a value, so there's nothing for confirmed-value capture to correct there. A `pg_settings` scan for `DO`/function-call GUC changes remains a separate follow-up.
