### PR TITLE
test(queryserving): fix ctx-budget flake in TestCopyInterruptedByBackendCrash

### DIFF
--- a/go/test/endtoend/queryserving/pgbouncertests/copy_fault_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/copy_fault_test.go
@@ -97,16 +97,25 @@ func TestCopyInterruptedByBackendCrash(t *testing.T) {
 	waitForPostgresReady(t, setup, 60*time.Second)
 	t.Log("postgres auto-restarted by the monitor")
 
+	// The post-recovery assertions get their own fresh context. The top-level
+	// ctx above shares a single 120s budget across a chain of internal waits
+	// (up to 30s for the killed COPY to fail, up to 60s for postgres to
+	// auto-restart, up to 30s in the recovery Eventually below). On a slow
+	// runner those waits can burn nearly the whole budget, leaving the final
+	// count check with an already-exhausted deadline. A fresh context ensures a
+	// slow-but-successful recovery still has time to verify the outcome.
+	recoveryCtx := utils.WithTimeout(t, 30*time.Second)
+
 	// A fresh connection must serve queries again after recovery.
-	conn2 := connectGateway(t, ctx, gatewayDSN)
-	defer conn2.Close(ctx)
+	conn2 := connectGateway(t, recoveryCtx, gatewayDSN)
+	defer conn2.Close(recoveryCtx)
 
 	// Disable statement_timeout on the recovery connection. This test isn't
 	// exercising timeout behavior — it just needs the post-restart queries to
 	// complete. Under coverage-instrumented binaries (which run ~2-3x slower) a
 	// query issued right after crash recovery can otherwise exceed the gateway's
 	// default statement_timeout and fail with SQLSTATE 57014.
-	_, err = conn2.Exec(ctx, "SET statement_timeout = 0")
+	_, err = conn2.Exec(recoveryCtx, "SET statement_timeout = 0")
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
@@ -118,7 +127,7 @@ func TestCopyInterruptedByBackendCrash(t *testing.T) {
 	// COPY FROM is all-or-nothing: the interrupted stream committed nothing, so
 	// the (durable, pre-crash) table survived crash recovery with zero rows.
 	var rows int
-	require.NoError(t, conn2.QueryRow(ctx, "SELECT count(*) FROM copy_fault").Scan(&rows))
+	require.NoError(t, conn2.QueryRow(recoveryCtx, "SELECT count(*) FROM copy_fault").Scan(&rows))
 	require.Zerof(t, rows, "an interrupted COPY must commit nothing; found %d rows", rows)
 }
 


### PR DESCRIPTION
## Problem

`TestCopyInterruptedByBackendCrash` intermittently fails on the "Run full integration test suite" CI job with:

```
copy_fault_test.go: Error: Received unexpected error: timeout: context deadline exceeded
Test: TestCopyInterruptedByBackendCrash
```

This is a pre-existing environmental/timing flake, not a regression.

## Root cause

The test creates a single 120s context near the top of the test and then reuses that *same* context for the post-recovery assertions, including the final `SELECT count(*) FROM copy_fault`. Between creation and that final check, the test deliberately burns through a chain of internal waits that sum to essentially the entire budget:

- up to **30s** waiting for the killed COPY to fail
- up to **60s** waiting for postgres to auto-restart (`waitForPostgresReady`)
- up to **30s** in the recovery `require.Eventually`

So ~120s of internal waits share a single 120s deadline. On a slow runner the sum creeps past 120s, and the final query — still using the now-exhausted context — trips the deadline.

## Fix

Give the post-recovery phase its own fresh 30s context (`recoveryCtx`) for the recovery connection, the `SET statement_timeout = 0`, and the final count check. This mirrors what the recovery `require.Eventually` block already does with `utils.WithShortDeadline(t)`, so a slow-but-successful recovery no longer leaves zero budget for verifying the outcome. `utils.WithTimeout` also auto-scales under coverage instrumentation, giving coverage-slowed runs proportionally more headroom.

No production code changes — test-only.

## Verification

Stress-run locally with real Postgres (Homebrew `postgresql@18`) via the `/mt-dev` integration workflow: the test passes repeatedly under `-count`.
