### PR TITLE
refactor(pgctld): move PostgresCtlConfig helpers onto PgCtldService

### DIFF
--- a/go/cmd/pgctld/command/crash_recovery.go
+++ b/go/cmd/pgctld/command/crash_recovery.go
@@ -17,14 +17,11 @@ package command
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
 	"github.com/multigres/multigres/go/common/constants"
-	"github.com/multigres/multigres/go/services/pgctld"
 	"github.com/multigres/multigres/go/tools/executil"
 	"github.com/multigres/multigres/go/tools/retry"
 )
@@ -39,8 +36,8 @@ var postgresAlreadyRunningPattern = regexp.MustCompile(`lock file ".*" already e
 
 // isPostgresCleanlyStopped checks if PostgreSQL is in a clean shutdown state.
 // Returns true if state is "shut down" or "shut down in recovery", false otherwise.
-func isPostgresCleanlyStopped(ctx context.Context) (bool, error) {
-	cmd := executil.Command(ctx, "pg_controldata", pgctld.PostgresDataDir())
+func (s *PgCtldService) isPostgresCleanlyStopped(ctx context.Context) (bool, error) {
+	cmd := executil.Command(ctx, "pg_controldata", s.pgConfig.PostgresDataDir)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return false, fmt.Errorf("pg_controldata failed: %w (output: %s)", err, string(output))
@@ -72,51 +69,12 @@ func extractClusterState(output string) string {
 
 // crashRecoveryNeeded reports whether PostgreSQL is not cleanly shut down and so
 // must be crash recovered before it can start again.
-func crashRecoveryNeeded(ctx context.Context) (bool, error) {
-	cleanlyStopped, err := isPostgresCleanlyStopped(ctx)
+func (s *PgCtldService) crashRecoveryNeeded(ctx context.Context) (bool, error) {
+	cleanlyStopped, err := s.isPostgresCleanlyStopped(ctx)
 	if err != nil {
 		return false, err
 	}
 	return !cleanlyStopped, nil
-}
-
-// standbySignalPath returns the path to the standby.signal marker file inside dataDir.
-func standbySignalPath(dataDir string) string {
-	return filepath.Join(dataDir, constants.StandbySignalFile)
-}
-
-// hasStandbySignal reports whether a standby.signal marker file is present, i.e.
-// PostgreSQL is configured to start in standby mode.
-func hasStandbySignal() bool {
-	_, err := os.Stat(standbySignalPath(pgctld.PostgresDataDir()))
-	return err == nil
-}
-
-// createStandbySignal creates an empty standby.signal file in dataDir so that
-// PostgreSQL comes up in recovery (standby) mode instead of as a writable
-// primary. The write truncates any existing file, so it is idempotent.
-func createStandbySignal(logger *slog.Logger, dataDir string) (string, error) {
-	path := standbySignalPath(dataDir)
-	if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
-		return path, fmt.Errorf("failed to create standby.signal: %w", err)
-	}
-	logger.Info("standby.signal created successfully", "path", path)
-	return path, nil
-}
-
-// removeStandbySignal removes standby.signal from dataDir so that PostgreSQL
-// starts as a writable primary instead of recovering as a standby. A no-op if
-// the file does not exist.
-func removeStandbySignal(logger *slog.Logger, dataDir string) (string, error) {
-	path := standbySignalPath(dataDir)
-	if err := os.Remove(path); err != nil {
-		if os.IsNotExist(err) {
-			return path, nil
-		}
-		return path, fmt.Errorf("failed to remove standby.signal: %w", err)
-	}
-	logger.Info("standby.signal removed successfully", "path", path)
-	return path, nil
 }
 
 // runCrashRecovery performs crash recovery in single-user mode (postgres --single),
@@ -129,50 +87,50 @@ func removeStandbySignal(logger *slog.Logger, dataDir string) (string, error) {
 // cleaned up via single-user recovery — e.g. one wedged by an early pg_rewind that
 // stamped minRecoveryPoint onto the wrong timeline — is handled consistently
 // (notably, this lets a re-issued pg_rewind clean-shut-down such a node).
-func runCrashRecovery(ctx context.Context, logger *slog.Logger) error {
+func (s *PgCtldService) runCrashRecovery(ctx context.Context) error {
 	r := retry.New(constants.CrashRecoveryRetryDelay, constants.CrashRecoveryRetryDelay)
-	return runCrashRecoveryInDir(ctx, logger, pgctld.PostgresDataDir(), runSingleUserPostgres, r)
+	return s.runCrashRecoveryInDir(ctx, s.runSingleUserPostgres, r)
 }
 
-// runCrashRecoveryInDir is runCrashRecovery with the data directory and single-user
-// runner injected, so the standby.signal save/restore can be unit-tested without a
-// real postgres. Extracted for testing.
-func runCrashRecoveryInDir(
+// runCrashRecoveryInDir is runCrashRecovery with the single-user runner
+// injected, so the standby.signal save/restore can be unit-tested against a
+// PgCtldService pointed at a temp dir, without a real postgres. Extracted for
+// testing.
+func (s *PgCtldService) runCrashRecoveryInDir(
 	ctx context.Context,
-	logger *slog.Logger,
-	dataDir string,
 	run func(context.Context) ([]byte, error),
 	r *retry.Retry,
 ) error {
-	signalPath := standbySignalPath(dataDir)
+	logger := s.logger
+	signalPath := s.standbySignalPath()
 	if _, err := os.Stat(signalPath); err == nil {
 		logger.InfoContext(ctx, "Temporarily removing standby.signal for single-user crash recovery",
 			"path", signalPath)
-		if _, rmErr := removeStandbySignal(logger, dataDir); rmErr != nil {
+		if _, rmErr := s.removeStandbySignal(); rmErr != nil {
 			return fmt.Errorf("failed to remove standby.signal before crash recovery: %w", rmErr)
 		}
 		// Recreate even if recovery fails, so the node is not silently converted
 		// from a standby into a primary on the next start.
 		defer func() {
-			if _, wErr := createStandbySignal(logger, dataDir); wErr != nil {
+			if _, wErr := s.createStandbySignal(); wErr != nil {
 				logger.ErrorContext(ctx, "failed to recreate standby.signal after crash recovery", "error", wErr, "path", signalPath)
 			}
 		}()
 	}
 
-	return runCrashRecoveryAttempts(ctx, logger, run, r)
+	return s.runCrashRecoveryAttempts(ctx, run, r)
 }
 
 // runCrashRecoveryAttempts retries `postgres --single` while the lock file is held.
 // During the orphan-cleanup window after a postmaster crash, the lock will eventually
 // release; if it does not within the retry window, postgres is genuinely running and
 // we preserve the historical no-op behavior. Extracted for unit-test injection.
-func runCrashRecoveryAttempts(
+func (s *PgCtldService) runCrashRecoveryAttempts(
 	ctx context.Context,
-	logger *slog.Logger,
 	run func(context.Context) ([]byte, error),
 	r *retry.Retry,
 ) error {
+	logger := s.logger
 	logger.InfoContext(ctx, "Starting single-user crash recovery")
 
 	var lastOutput string
@@ -215,8 +173,8 @@ func runCrashRecoveryAttempts(
 // runSingleUserPostgres runs `postgres --single` once and returns its combined
 // output and exit error. /dev/null on stdin causes single-user mode to perform
 // recovery and exit on EOF.
-func runSingleUserPostgres(ctx context.Context) ([]byte, error) {
-	cmd := executil.Command(ctx, "postgres", "--single", "-D", pgctld.PostgresDataDir(), "template1")
+func (s *PgCtldService) runSingleUserPostgres(ctx context.Context) ([]byte, error) {
+	cmd := executil.Command(ctx, "postgres", "--single", "-D", s.pgConfig.PostgresDataDir, "template1")
 
 	devNull, err := os.Open("/dev/null")
 	if err != nil {

--- a/go/cmd/pgctld/command/crash_recovery_test.go
+++ b/go/cmd/pgctld/command/crash_recovery_test.go
@@ -26,8 +26,19 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/services/pgctld"
 	"github.com/multigres/multigres/go/tools/retry"
 )
+
+// testPgCtldService builds a minimal PgCtldService for exercising crash-recovery
+// helpers directly, without the full NewPgCtldService setup (ports, pgbackrest, etc.)
+// that production callers need but these unit tests don't.
+func testPgCtldService(dataDir string) *PgCtldService {
+	return &PgCtldService{
+		logger:   testLogger(),
+		pgConfig: &pgctld.PostgresCtlConfig{PostgresDataDir: dataDir},
+	}
+}
 
 // fastRetry returns a retry.Retry whose delays are short enough to make tests
 // effectively instant while still exercising the iterator-driven control flow.
@@ -91,6 +102,7 @@ HINT:  Is another postmaster (PID 12345) running in data directory "/data"?`)
 // release it. Recovery should succeed once the lock clears.
 func TestRunCrashRecovery_RetriesDuringOrphanCleanupWindow(t *testing.T) {
 	const holdAttempts = 3
+	s := testPgCtldService("")
 
 	calls := 0
 	runner := func(ctx context.Context) ([]byte, error) {
@@ -101,7 +113,7 @@ func TestRunCrashRecovery_RetriesDuringOrphanCleanupWindow(t *testing.T) {
 		return []byte("recovery complete"), nil
 	}
 
-	err := runCrashRecoveryAttempts(context.Background(), testLogger(), runner, fastRetry())
+	err := s.runCrashRecoveryAttempts(context.Background(), runner, fastRetry())
 	require.NoError(t, err)
 	assert.Equal(t, holdAttempts+1, calls,
 		"runner should be retried until the lock clears, then succeed")
@@ -112,12 +124,13 @@ func TestRunCrashRecovery_RetriesDuringOrphanCleanupWindow(t *testing.T) {
 // and return nil rather than surfacing an error.
 func TestRunCrashRecovery_LockNeverClearsReturnsNil(t *testing.T) {
 	calls := 0
+	s := testPgCtldService("")
 	runner := func(ctx context.Context) ([]byte, error) {
 		calls++
 		return lockHeldOutput, errors.New("exit status 1")
 	}
 
-	err := runCrashRecoveryAttempts(context.Background(), testLogger(), runner, fastRetry())
+	err := s.runCrashRecoveryAttempts(context.Background(), runner, fastRetry())
 	require.NoError(t, err)
 	assert.Equal(t, constants.CrashRecoveryMaxAttempts, calls,
 		"runner should be retried up to the max-attempts bound")
@@ -127,12 +140,13 @@ func TestRunCrashRecovery_LockNeverClearsReturnsNil(t *testing.T) {
 // no retries, no sleeps.
 func TestRunCrashRecovery_FirstAttemptSucceeds(t *testing.T) {
 	calls := 0
+	s := testPgCtldService("")
 	runner := func(ctx context.Context) ([]byte, error) {
 		calls++
 		return []byte("recovery complete"), nil
 	}
 
-	err := runCrashRecoveryAttempts(context.Background(), testLogger(), runner, fastRetry())
+	err := s.runCrashRecoveryAttempts(context.Background(), runner, fastRetry())
 	require.NoError(t, err)
 	assert.Equal(t, 1, calls)
 }
@@ -141,13 +155,14 @@ func TestRunCrashRecovery_FirstAttemptSucceeds(t *testing.T) {
 // errors fail fast and do not consume the retry budget — only the orphan-cleanup
 // race should trigger retries.
 func TestRunCrashRecovery_NonLockErrorReturnsImmediately(t *testing.T) {
+	s := testPgCtldService("")
 	calls := 0
 	runner := func(ctx context.Context) ([]byte, error) {
 		calls++
 		return []byte("FATAL:  could not access data directory"), errors.New("exit status 1")
 	}
 
-	err := runCrashRecoveryAttempts(context.Background(), testLogger(), runner, fastRetry())
+	err := s.runCrashRecoveryAttempts(context.Background(), runner, fastRetry())
 	require.Error(t, err)
 	assert.Equal(t, 1, calls, "non-lock errors must not be retried")
 }
@@ -155,6 +170,7 @@ func TestRunCrashRecovery_NonLockErrorReturnsImmediately(t *testing.T) {
 // TestRunCrashRecovery_ContextCancelledDuringBackoff verifies that a cancelled
 // context aborts the retry loop without further runner invocations.
 func TestRunCrashRecovery_ContextCancelledDuringBackoff(t *testing.T) {
+	s := testPgCtldService("")
 	ctx, cancel := context.WithCancel(context.Background())
 
 	calls := 0
@@ -164,7 +180,7 @@ func TestRunCrashRecovery_ContextCancelledDuringBackoff(t *testing.T) {
 		return lockHeldOutput, errors.New("exit status 1")
 	}
 
-	err := runCrashRecoveryAttempts(ctx, testLogger(), runner, retry.New(time.Hour, time.Hour))
+	err := s.runCrashRecoveryAttempts(ctx, runner, retry.New(time.Hour, time.Hour))
 	require.ErrorIs(t, err, context.Canceled)
 	assert.Equal(t, 1, calls)
 }
@@ -180,8 +196,8 @@ func fileExists(t *testing.T, path string) bool {
 // refuses to start with one present) and is recreated afterwards so the node
 // stays a standby.
 func TestRunCrashRecoveryInDir_RemovesAndRestoresStandbySignal(t *testing.T) {
-	dir := t.TempDir()
-	signalPath, err1 := createStandbySignal(testLogger(), dir)
+	s := testPgCtldService(t.TempDir())
+	signalPath, err1 := s.createStandbySignal()
 	require.NoError(t, err1)
 
 	var signalPresentDuringRun bool
@@ -190,7 +206,7 @@ func TestRunCrashRecoveryInDir_RemovesAndRestoresStandbySignal(t *testing.T) {
 		return []byte("recovery complete"), nil
 	}
 
-	err := runCrashRecoveryInDir(context.Background(), testLogger(), dir, runner, fastRetry())
+	err := s.runCrashRecoveryInDir(context.Background(), runner, fastRetry())
 	require.NoError(t, err)
 	assert.False(t, signalPresentDuringRun, "standby.signal must be removed while postgres --single runs")
 	assert.True(t, fileExists(t, signalPath), "standby.signal must be recreated after recovery")
@@ -200,15 +216,15 @@ func TestRunCrashRecoveryInDir_RemovesAndRestoresStandbySignal(t *testing.T) {
 // recreated even when recovery fails, so a failed recovery does not silently
 // convert a standby into a primary on its next start.
 func TestRunCrashRecoveryInDir_RestoresStandbySignalOnFailure(t *testing.T) {
-	dir := t.TempDir()
-	signalPath, err1 := createStandbySignal(testLogger(), dir)
+	s := testPgCtldService(t.TempDir())
+	signalPath, err1 := s.createStandbySignal()
 	require.NoError(t, err1)
 
 	runner := func(ctx context.Context) ([]byte, error) {
 		return []byte("FATAL:  could not access data directory"), errors.New("exit status 1")
 	}
 
-	err := runCrashRecoveryInDir(context.Background(), testLogger(), dir, runner, fastRetry())
+	err := s.runCrashRecoveryInDir(context.Background(), runner, fastRetry())
 	require.Error(t, err)
 	assert.True(t, fileExists(t, signalPath), "standby.signal must be recreated even when recovery fails")
 }
@@ -216,8 +232,9 @@ func TestRunCrashRecoveryInDir_RestoresStandbySignalOnFailure(t *testing.T) {
 // TestRunCrashRecoveryInDir_NoStandbySignal_LeavesNoneBehind verifies a primary
 // (no standby.signal) is crash-recovered without a spurious signal being created.
 func TestRunCrashRecoveryInDir_NoStandbySignal_LeavesNoneBehind(t *testing.T) {
-	dir := t.TempDir()
-	signalPath := standbySignalPath(dir)
+	s := testPgCtldService(t.TempDir())
+
+	signalPath := s.standbySignalPath()
 
 	calls := 0
 	runner := func(ctx context.Context) ([]byte, error) {
@@ -225,7 +242,7 @@ func TestRunCrashRecoveryInDir_NoStandbySignal_LeavesNoneBehind(t *testing.T) {
 		return []byte("recovery complete"), nil
 	}
 
-	err := runCrashRecoveryInDir(context.Background(), testLogger(), dir, runner, fastRetry())
+	err := s.runCrashRecoveryInDir(context.Background(), runner, fastRetry())
 	require.NoError(t, err)
 	assert.Equal(t, 1, calls)
 	assert.False(t, fileExists(t, signalPath), "no standby.signal should be created for a non-standby node")
@@ -237,8 +254,9 @@ func TestRunCrashRecoveryInDir_NoStandbySignal_LeavesNoneBehind(t *testing.T) {
 // un-removable by making it a non-empty directory, so os.Stat sees it present
 // but os.Remove fails.
 func TestRunCrashRecoveryInDir_RemoveFailureSkipsRecovery(t *testing.T) {
-	dir := t.TempDir()
-	signalPath := standbySignalPath(dir)
+	s := testPgCtldService(t.TempDir())
+
+	signalPath := s.standbySignalPath()
 	require.NoError(t, os.Mkdir(signalPath, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(signalPath, "child"), []byte(""), 0o644))
 
@@ -248,7 +266,7 @@ func TestRunCrashRecoveryInDir_RemoveFailureSkipsRecovery(t *testing.T) {
 		return []byte("recovery complete"), nil
 	}
 
-	err := runCrashRecoveryInDir(context.Background(), testLogger(), dir, runner, fastRetry())
+	err := s.runCrashRecoveryInDir(context.Background(), runner, fastRetry())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to remove standby.signal")
 	assert.False(t, called, "recovery must not run when standby.signal could not be removed")

--- a/go/cmd/pgctld/command/restart.go
+++ b/go/cmd/pgctld/command/restart.go
@@ -16,9 +16,7 @@ package command
 
 import (
 	"fmt"
-	"log/slog"
 
-	"github.com/multigres/multigres/go/services/pgctld"
 	"github.com/multigres/multigres/go/tools/viperutil"
 
 	"github.com/spf13/cobra"
@@ -95,8 +93,10 @@ Examples:
 }
 
 // RestartPostgreSQLWithResult restarts PostgreSQL with the given configuration and returns detailed result information
-func RestartPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtlConfig, mode string, asStandby bool) (*RestartResult, error) {
+func (s *PgCtldService) RestartPostgreSQLWithResult(mode string, asStandby bool) (*RestartResult, error) {
 	result := &RestartResult{}
+	logger := s.logger
+	config := s.pgConfig
 
 	if asStandby {
 		logger.Info("Restarting PostgreSQL server as standby", "data_dir", config.PostgresDataDir, "mode", mode)
@@ -107,7 +107,7 @@ func RestartPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtl
 	// Stop the server if it's running
 	if isPostgreSQLRunning(config.PostgresDataDir) {
 		logger.Info("Stopping PostgreSQL server")
-		stopResult, err := StopPostgreSQLWithResult(logger, config, mode)
+		stopResult, err := s.StopPostgreSQLWithResult(mode)
 		if err != nil {
 			return nil, fmt.Errorf("failed to stop PostgreSQL during restart: %w", err)
 		}
@@ -119,7 +119,7 @@ func RestartPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtl
 
 	// Create standby.signal if restarting as standby
 	if asStandby {
-		if _, err := createStandbySignal(logger, config.PostgresDataDir); err != nil {
+		if _, err := s.createStandbySignal(); err != nil {
 			return nil, err
 		}
 	}
@@ -135,7 +135,7 @@ func RestartPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtl
 		logger.Info("Starting PostgreSQL server")
 	}
 
-	startResult, err := StartPostgreSQLWithResult(logger, config)
+	startResult, err := s.StartPostgreSQLWithResult()
 	if err != nil {
 		// Enhanced error logging for standby mode
 		if asStandby {
@@ -165,7 +165,8 @@ func (r *PgCtlRestartCmd) runRestart(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	result, err := RestartPostgreSQLWithResult(r.pgCtlCmd.lg.GetLogger(), config, r.mode.Get(), r.asStandby.Get())
+	svc := &PgCtldService{logger: r.pgCtlCmd.lg.GetLogger(), pgConfig: config}
+	result, err := svc.RestartPostgreSQLWithResult(r.mode.Get(), r.asStandby.Get())
 	if err != nil {
 		return err
 	}

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -389,6 +389,47 @@ func NewPgCtldService(
 	}, nil
 }
 
+// standbySignalPath returns the path to the standby.signal marker file inside
+// the service's configured PostgreSQL data directory.
+func (s *PgCtldService) standbySignalPath() string {
+	return filepath.Join(s.pgConfig.PostgresDataDir, constants.StandbySignalFile)
+}
+
+// hasStandbySignal reports whether a standby.signal marker file is present, i.e.
+// PostgreSQL is configured to start in standby mode.
+func (s *PgCtldService) hasStandbySignal() bool {
+	_, err := os.Stat(s.standbySignalPath())
+	return err == nil
+}
+
+// createStandbySignal creates an empty standby.signal file in the configured
+// data directory so that PostgreSQL comes up in recovery (standby) mode
+// instead of as a writable primary. The write truncates any existing file, so
+// it is idempotent.
+func (s *PgCtldService) createStandbySignal() (string, error) {
+	path := s.standbySignalPath()
+	if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+		return path, fmt.Errorf("failed to create standby.signal: %w", err)
+	}
+	s.logger.Info("standby.signal created successfully", "path", path)
+	return path, nil
+}
+
+// removeStandbySignal removes standby.signal from the configured data
+// directory so that PostgreSQL starts as a writable primary instead of
+// recovering as a standby. A no-op if the file does not exist.
+func (s *PgCtldService) removeStandbySignal() (string, error) {
+	path := s.standbySignalPath()
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return path, nil
+		}
+		return path, fmt.Errorf("failed to remove standby.signal: %w", err)
+	}
+	s.logger.Info("standby.signal removed successfully", "path", path)
+	return path, nil
+}
+
 // setPgBackRestStatus updates the pgBackRest status thread-safely and returns the current restart count
 func (s *PgCtldService) setPgBackRestStatus(running bool, errorMessage string, incrementRestart bool) int32 {
 	s.statusMu.Lock()
@@ -562,13 +603,12 @@ func (s *PgCtldService) Start(ctx context.Context, req *pb.StartRequest) (*pb.St
 	// writable start. Sequenced before crash recovery below so a written
 	// standby.signal is preserved through single-user recovery (which removes and
 	// recreates it), and an as_primary start clears any leftover signal.
-	dataDir := pgctld.PostgresDataDir()
 	if req.GetAsPrimary() {
-		if _, err := removeStandbySignal(s.logger, dataDir); err != nil {
+		if _, err := s.removeStandbySignal(); err != nil {
 			return nil, err
 		}
 	} else {
-		if _, err := createStandbySignal(s.logger, dataDir); err != nil {
+		if _, err := s.createStandbySignal(); err != nil {
 			return nil, err
 		}
 	}
@@ -579,7 +619,7 @@ func (s *PgCtldService) Start(ctx context.Context, req *pb.StartRequest) (*pb.St
 	// caller can treat it as evidence the node was not cleanly shut down.
 	var crashRecoveryRan bool
 	if req.GetAllowCrashRecovery() {
-		needed, nErr := crashRecoveryNeeded(ctx)
+		needed, nErr := s.crashRecoveryNeeded(ctx)
 		if nErr != nil {
 			s.logger.WarnContext(ctx, "could not determine clean-shutdown state before start (continuing)", "error", nErr)
 		} else if needed {
@@ -593,8 +633,8 @@ func (s *PgCtldService) Start(ctx context.Context, req *pb.StartRequest) (*pb.St
 			// standby.signal blocking the postmaster's own recovery, is why the
 			// explicit step is gated on standby.signal).
 			crashRecoveryRan = true
-			if hasStandbySignal() {
-				if rcErr := runCrashRecovery(ctx, s.logger); rcErr != nil {
+			if s.hasStandbySignal() {
+				if rcErr := s.runCrashRecovery(ctx); rcErr != nil {
 					// Best effort: the start below may still surface a clearer error.
 					s.logger.WarnContext(ctx, "standby crash recovery before start failed (continuing)", "error", rcErr)
 				}
@@ -603,7 +643,7 @@ func (s *PgCtldService) Start(ctx context.Context, req *pb.StartRequest) (*pb.St
 	}
 
 	// Use the pre-configured PostgreSQL config for start operation
-	result, err := StartPostgreSQLWithResult(s.logger, s.pgConfig)
+	result, err := s.StartPostgreSQLWithResult()
 	if err != nil {
 		return nil, fmt.Errorf("failed to start PostgreSQL: %w", err)
 	}
@@ -630,7 +670,7 @@ func (s *PgCtldService) Stop(ctx context.Context, req *pb.StopRequest) (*pb.Stop
 	}
 
 	// Use the pre-configured PostgreSQL config for stop operation
-	result, err := StopPostgreSQLWithResult(s.logger, s.pgConfig, req.Mode)
+	result, err := s.StopPostgreSQLWithResult(req.Mode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to stop PostgreSQL: %w", err)
 	}
@@ -650,7 +690,7 @@ func (s *PgCtldService) Restart(ctx context.Context, req *pb.RestartRequest) (*p
 	}
 
 	// Use the pre-configured PostgreSQL config for restart operation
-	result, err := RestartPostgreSQLWithResult(s.logger, s.pgConfig, req.Mode, req.AsStandby)
+	result, err := s.RestartPostgreSQLWithResult(req.Mode, req.AsStandby)
 	if err != nil {
 		return nil, fmt.Errorf("failed to restart PostgreSQL: %w", err)
 	}
@@ -780,13 +820,13 @@ func (s *PgCtldService) PgRewind(ctx context.Context, req *pb.PgRewindRequest) (
 	// If not, try crash recovery - this is needed for rewind dry-run to work
 	// This check is best effort. It's not harmful to try the pg_rewind if
 	// crash recovery fails, the dry run is just unlikely to succeed in that case.
-	cleanlyStopped, err := isPostgresCleanlyStopped(ctx)
+	cleanlyStopped, err := s.isPostgresCleanlyStopped(ctx)
 	if err != nil {
 		s.logger.WarnContext(ctx, "Failed to check postgres state (continuing anyway)", "error", err)
 	} else if !cleanlyStopped {
 		// Try to run crash recovery.
 		// It's not harmful to do this if postgres is already running.
-		if err := runCrashRecovery(ctx, s.logger); err != nil {
+		if err := s.runCrashRecovery(ctx); err != nil {
 			s.logger.WarnContext(ctx, "Crash recovery failed (continuing anyway)", "error", err)
 		}
 	}

--- a/go/cmd/pgctld/command/start.go
+++ b/go/cmd/pgctld/command/start.go
@@ -112,7 +112,8 @@ func (s *PgCtlStartCmd) runStart(cmd *cobra.Command, args []string) error {
 	}
 	config.Password = password
 
-	result, err := StartPostgreSQLWithResult(s.pgCtlCmd.lg.GetLogger(), config)
+	svc := &PgCtldService{logger: s.pgCtlCmd.lg.GetLogger(), pgConfig: config}
+	result, err := svc.StartPostgreSQLWithResult()
 	if err != nil {
 		return err
 	}
@@ -128,8 +129,10 @@ func (s *PgCtlStartCmd) runStart(cmd *cobra.Command, args []string) error {
 }
 
 // StartPostgreSQLWithResult starts PostgreSQL with the given configuration and returns detailed result information
-func StartPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtlConfig) (*StartResult, error) {
+func (s *PgCtldService) StartPostgreSQLWithResult() (*StartResult, error) {
 	result := &StartResult{}
+	logger := s.logger
+	config := s.pgConfig
 
 	// Check if PostgreSQL is already running
 	if isPostgreSQLRunning(config.PostgresDataDir) {
@@ -183,8 +186,9 @@ func StartPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtlCo
 }
 
 // StartPostgreSQLWithConfig starts PostgreSQL with the given configuration
-func StartPostgreSQLWithConfig(logger *slog.Logger, config *pgctld.PostgresCtlConfig) error {
-	result, err := StartPostgreSQLWithResult(logger, config)
+func (s *PgCtldService) StartPostgreSQLWithConfig() error {
+	logger := s.logger
+	result, err := s.StartPostgreSQLWithResult()
 	if err != nil {
 		return err
 	}

--- a/go/cmd/pgctld/command/stop.go
+++ b/go/cmd/pgctld/command/stop.go
@@ -16,7 +16,6 @@ package command
 
 import (
 	"fmt"
-	"log/slog"
 	"os"
 	"os/exec"
 	"strconv"
@@ -109,7 +108,8 @@ func (s *PgCtlStopCmd) runStop(cmd *cobra.Command, args []string) error {
 	// TODO: Consider removing the CHECKPOINT command in the stop flow since
 	// it's not strictly necessary and adds complexity (requires password, can
 	// fail if PostgreSQL is already in a bad state, etc.)
-	result, err := StopPostgreSQLWithResult(s.pgCtlCmd.lg.GetLogger(), config, s.mode.Get())
+	svc := &PgCtldService{logger: s.pgCtlCmd.lg.GetLogger(), pgConfig: config}
+	result, err := svc.StopPostgreSQLWithResult(s.mode.Get())
 	if err != nil {
 		return err
 	}
@@ -125,8 +125,10 @@ func (s *PgCtlStopCmd) runStop(cmd *cobra.Command, args []string) error {
 }
 
 // StopPostgreSQLWithResult stops PostgreSQL with the given configuration and returns detailed result information
-func StopPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtlConfig, mode string) (*StopResult, error) {
+func (s *PgCtldService) StopPostgreSQLWithResult(mode string) (*StopResult, error) {
 	result := &StopResult{}
+	config := s.pgConfig
+	logger := s.logger
 
 	// Default mode to "fast" if not specified
 	if mode == "" {
@@ -144,7 +146,7 @@ func StopPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtlCon
 	result.WasRunning = true
 	logger.Info("Stopping PostgreSQL server", "data_dir", config.PostgresDataDir, "mode", mode)
 
-	if err := stopPostgreSQLWithConfig(logger, config, mode); err != nil {
+	if err := s.stopPostgreSQLWithConfig(mode); err != nil {
 		return nil, fmt.Errorf("failed to stop PostgreSQL: %w", err)
 	}
 
@@ -154,8 +156,9 @@ func StopPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtlCon
 }
 
 // StopPostgreSQLWithConfig stops PostgreSQL with the given configuration and mode
-func StopPostgreSQLWithConfig(logger *slog.Logger, config *pgctld.PostgresCtlConfig, mode string) error {
-	result, err := StopPostgreSQLWithResult(logger, config, mode)
+func (s *PgCtldService) StopPostgreSQLWithConfig(mode string) error {
+	logger := s.logger
+	result, err := s.StopPostgreSQLWithResult(mode)
 	if err != nil {
 		return err
 	}
@@ -168,18 +171,22 @@ func StopPostgreSQLWithConfig(logger *slog.Logger, config *pgctld.PostgresCtlCon
 	return nil
 }
 
-func stopPostgreSQLWithConfig(logger *slog.Logger, config *pgctld.PostgresCtlConfig, mode string) error {
+func (s *PgCtldService) stopPostgreSQLWithConfig(mode string) error {
+	logger := s.logger
 	// First try using pg_ctl
-	if err := stopWithPgCtlWithConfig(logger, config, mode); err != nil {
+	if err := s.stopWithPgCtlWithConfig(mode); err != nil {
 		logger.Error("pg_ctl stop failed,", "error", err)
 		return err
 	}
 	return nil
 }
 
-func stopWithPgCtlWithConfig(logger *slog.Logger, config *pgctld.PostgresCtlConfig, mode string) error {
+func (s *PgCtldService) stopWithPgCtlWithConfig(mode string) error {
+	config := s.pgConfig
+	logger := s.logger
+
 	// Take a checkpoint before stopping PostgreSQL for clean shutdown
-	if err := takeCheckpoint(logger, config); err != nil {
+	if err := s.takeCheckpoint(); err != nil {
 		logger.Warn("Failed to take checkpoint before stop", "error", err, "data_dir", config.PostgresDataDir)
 		// Continue with stop even if checkpoint fails - it's not critical
 	}
@@ -199,7 +206,9 @@ func stopWithPgCtlWithConfig(logger *slog.Logger, config *pgctld.PostgresCtlConf
 }
 
 // takeCheckpoint executes a CHECKPOINT command to ensure all data is written to disk before shutdown
-func takeCheckpoint(logger *slog.Logger, config *pgctld.PostgresCtlConfig) error {
+func (s *PgCtldService) takeCheckpoint() error {
+	config := s.pgConfig
+	logger := s.logger
 	logger.Info("Taking checkpoint before stopping PostgreSQL", "data_dir", config.PostgresDataDir)
 
 	// Use Unix socket connection for psql

--- a/go/cmd/pgctld/command/stop_test.go
+++ b/go/cmd/pgctld/command/stop_test.go
@@ -125,7 +125,8 @@ func TestStopPostgreSQLWithResult(t *testing.T) {
 			require.NoError(t, err)
 
 			logger := slog.New(slog.DiscardHandler)
-			result, err := StopPostgreSQLWithResult(logger, config, tt.mode)
+			svc := &PgCtldService{logger: logger, pgConfig: config}
+			result, err := svc.StopPostgreSQLWithResult(tt.mode)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -304,7 +305,8 @@ func TestStopPostgreSQLWithConfig(t *testing.T) {
 			require.NoError(t, err)
 
 			logger := slog.New(slog.DiscardHandler)
-			err = StopPostgreSQLWithConfig(logger, config, tt.mode)
+			svc := &PgCtldService{logger: logger, pgConfig: config}
+			err = svc.StopPostgreSQLWithConfig(tt.mode)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -372,7 +374,8 @@ func TestTakeCheckpoint(t *testing.T) {
 			}
 
 			logger := slog.New(slog.DiscardHandler)
-			err := takeCheckpoint(logger, tt.config(baseDir))
+			svc := &PgCtldService{logger: logger, pgConfig: tt.config(baseDir)}
+			err := svc.takeCheckpoint()
 
 			if tt.expectError {
 				assert.Error(t, err)


### PR DESCRIPTION
## Summary

- `standbySignalPath`, `hasStandbySignal`, `createStandbySignal`, `removeStandbySignal`, `isPostgresCleanlyStopped`, `crashRecoveryNeeded`, `runSingleUserPostgres`, `runCrashRecovery`, `runCrashRecoveryInDir`, `runCrashRecoveryAttempts`, `StartPostgreSQLWithResult`, `StartPostgreSQLWithConfig`, `StopPostgreSQLWithResult`, `StopPostgreSQLWithConfig`, `stopPostgreSQLWithConfig`, `stopWithPgCtlWithConfig`, `takeCheckpoint`, and `RestartPostgreSQLWithResult` all took a bare `dataDir`/`logger`/`config` parameter set even though every caller already had a `PgCtldService` in hand. Made them methods on `PgCtldService` so they read `pgConfig` and `logger` off the receiver instead of threading both through every call site.
- Fixes a latent inconsistency: `runSingleUserPostgres` read `PGDATA` from the environment directly while the rest of the crash-recovery path used `pgConfig.PostgresDataDir`. The two happened to agree in production only because `pgConfig.PostgresDataDir` is seeded from `PGDATA` once at startup — nothing enforced it, and a `PgCtldService` built with a different data dir (as tests now do) would have silently run recovery against the wrong directory.
- The CLI command handlers (`runStart`, `runStop`, `runRestart`) build their `PostgresCtlConfig` from flags rather than owning a `PgCtldService`, so each now constructs a throwaway `PgCtldService` to call these methods on.

## Test plan

- [x] `go build ./go/...`
- [x] `go vet ./go/cmd/pgctld/...`
- [x] `go test -short ./go/cmd/pgctld/...`
- [x] `golangci-lint run ./go/cmd/pgctld/command/...` (v2.12.2, matching CI)
