### PR TITLE
fix(multigateway): buffer when no writable primary exists

### DIFF
--- a/go/services/multigateway/poolergateway/availability_errors.go
+++ b/go/services/multigateway/poolergateway/availability_errors.go
@@ -15,6 +15,8 @@
 package poolergateway
 
 import (
+	"errors"
+
 	"github.com/multigres/multigres/go/common/mterrors"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 )
@@ -31,12 +33,21 @@ func newUnavailablePgError(message, internalFormat string, args ...any) error {
 	)
 }
 
+type noWritablePrimaryError struct{ error }
+
+func (e *noWritablePrimaryError) Unwrap() error { return e.error }
+
 func newNoWritablePrimaryError(internalFormat string, args ...any) error {
-	return newUnavailablePgError(
+	return &noWritablePrimaryError{newUnavailablePgError(
 		"no writable primary is currently available",
 		internalFormat,
 		args...,
-	)
+	)}
+}
+
+func isNoWritablePrimaryError(err error) bool {
+	var target *noWritablePrimaryError
+	return errors.As(err, &target)
 }
 
 // isCredentialSourceUnavailable recognizes only errors that occur before the

--- a/go/services/multigateway/poolergateway/pooler_gateway.go
+++ b/go/services/multigateway/poolergateway/pooler_gateway.go
@@ -86,6 +86,7 @@ const transactionReadOnlyOptionName = "transaction_read_only"
 
 // classifyError determines whether an error is eligible for failover buffering.
 // Only PRIMARY traffic is buffered, and only for:
+//   - no writable primary in the gateway's current routing view
 //   - MTF01: multipooler signals planned failover (SERVING_RDONLY)
 //   - 25006 when the request is safe to replay: a single autocommit query, or
 //     the first statement of a deferred explicit transaction that was not
@@ -94,7 +95,7 @@ func classifyError(err error, target *query.Target, retryReadOnlyError bool) err
 	if !modeRequiresLeader(target.GetMode()) {
 		return actionFail
 	}
-	if mterrors.IsErrorCode(err, mterrors.MTF01.ID) {
+	if isNoWritablePrimaryError(err) || mterrors.IsErrorCode(err, mterrors.MTF01.ID) {
 		return actionBuffer
 	}
 	if retryReadOnlyError && mterrors.IsErrorCode(err, mterrors.PgSSReadOnlyTransaction) {

--- a/go/services/multigateway/poolergateway/pooler_gateway_test.go
+++ b/go/services/multigateway/poolergateway/pooler_gateway_test.go
@@ -67,6 +67,18 @@ func TestClassifyError(t *testing.T) {
 			want:   actionFail,
 		},
 		{
+			name:   "no writable primary buffers leader traffic",
+			err:    newNoWritablePrimaryError("no leader observed"),
+			target: primaryTarget,
+			want:   actionBuffer,
+		},
+		{
+			name:   "no writable primary does not buffer replica traffic",
+			err:    newNoWritablePrimaryError("no leader observed"),
+			target: replicaTarget,
+			want:   actionFail,
+		},
+		{
 			name:   "generic error on PRIMARY does not buffer",
 			err:    errors.New("connection refused"),
 			target: primaryTarget,
@@ -112,6 +124,60 @@ func TestClassifyError(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestPoolerGateway_QuietGatewayBuffersUntilPrimaryAppears(t *testing.T) {
+	bufferConfig := gatewaybuffer.NewConfig(viperutil.NewRegistry())
+	bufferConfig.Enabled.Set(true)
+	bufferConfig.Window.Set(5 * time.Second)
+	bufferConfig.Size.Set(10)
+	bufferConfig.MaxFailoverDuration.Set(5 * time.Second)
+	bufferConfig.MinTimeBetweenFailovers.Set(0)
+	bufferConfig.DrainConcurrency.Set(1)
+	logger := slog.New(slog.DiscardHandler)
+	failoverBuffer := gatewaybuffer.New(t.Context(), bufferConfig, logger)
+	t.Cleanup(failoverBuffer.Shutdown)
+
+	lb := newTestLBWithLeaderServing(t, "zone1", failoverBuffer.StopBuffering)
+	pg := &PoolerGateway{loadBalancer: lb, buffer: failoverBuffer, logger: logger}
+	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, constants.DefaultShard, query.Mode_MODE_WRITABLE)
+
+	requestCtx, cancelRequest := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancelRequest()
+	selected := make(chan *poolerConnection, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- pg.withBuffering(requestCtx, target, true, false, func(conn *poolerConnection) error {
+			selected <- conn
+			return nil
+		})
+	}()
+
+	// This gateway saw no query during the drain. Its first arrival must arm the
+	// buffer on the load balancer's no-primary result instead of failing fast.
+	for {
+		select {
+		case err := <-done:
+			t.Fatalf("request returned before a primary appeared: %v", err)
+		default:
+		}
+		probeCtx, cancel := context.WithCancel(requestCtx)
+		cancel()
+		_, err := failoverBuffer.WaitIfAlreadyBuffering(probeCtx, target.GetShardKey())
+		if errors.Is(err, context.Canceled) {
+			break
+		}
+		require.NoError(t, err)
+		time.Sleep(time.Millisecond)
+	}
+
+	primary := createTestMultipooler("primary", "zone1", constants.DefaultTableGroup, constants.DefaultShard, clustermetadatapb.PoolerType_PRIMARY)
+	addPoolerForTest(t, lb, primary)
+	simulateHealthUpdate(connForTest(t, lb, primary), clustermetadatapb.PoolerServingStatus_SERVING,
+		primary.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
+
+	require.NoError(t, <-done)
+	assert.Equal(t, poolerID(primary), (<-selected).ID())
 }
 
 func TestGetAuthCredentials_InfrastructureFailureCarriesCannotConnectNow(t *testing.T) {


### PR DESCRIPTION
Title: fix(multigateway): buffer when no writable primary exists

## Summary

- Mark the load balancer's canonical no-writable-primary error so buffering can distinguish it from unrelated failures.
- Buffer WRITABLE and CONSISTENT requests when the gateway's routing view has no primary, using the existing bounded failover window and drain path.
- Add a quiet-gateway regression test that starts with no buffered traffic, submits a new write during the primary gap, and verifies it resumes on the newly serving primary.

## Problem

Failover buffering currently starts only after a request observes MTF01 or a replay-safe 25006 from the demoting primary. A gateway with no request in flight during that drain does not arm its buffer. Its first request in the 2–4s demote-to-promote gap instead receives `FATAL: no writable primary is currently available`.

## Solution

The load balancer already retracts a demoted primary from each gateway's routing view, and the existing health-stream callback calls `StopBuffering` only after a replacement reports itself PRIMARY and SERVING. The missing piece is classification: the routing-generated no-writable-primary error was UNAVAILABLE/57P03 but was not one of the errors accepted by `classifyError`.

This change gives only that canonical routing error an internal marker and classifies it as buffer-worthy for leader-routed traffic. The first arrival on an otherwise quiet gateway therefore creates the shard buffer, waits within the existing request window and maximum failover duration, then retries after the replacement is routable. Replica traffic and unrelated errors still fail as before.

An out-of-band failover flag in topology was considered but not chosen. Gateways already receive the two facts needed through pooler health streams—no writable primary now, and a PRIMARY/SERVING replacement later—so another distributed state transition would add ordering and cleanup cases without closing a larger gap. If maintainers want proactive buffering before the old primary disappears, that signal can be added separately; it is not required for the reported quiet-gateway window.

## Testing

- `go test -short -count=1 ./go/services/multigateway/poolergateway`
- `go test -short -count=10 -run '^TestPoolerGateway_QuietGatewayBuffersUntilPrimaryAppears$' ./go/services/multigateway/poolergateway`
- `go build ./...`
