### PR TITLE
fix(multiorch): defer repair on unknown replication status

### DIFF
--- a/go/services/multiorch/recovery/actions/fix_replication.go
+++ b/go/services/multiorch/recovery/actions/fix_replication.go
@@ -259,8 +259,8 @@ func (a *FixReplicationAction) verifyReplicaNotReplicating(
 		return false, nil, err
 	}
 	if status == nil {
-		// No status means we can't determine state, assume problem exists
-		return true, nil, nil
+		return false, nil, mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
+			"replication status unavailable for replica %s", replica.Health().GetMultipooler().GetId().GetName())
 	}
 
 	// Check if primary_conninfo is configured

--- a/go/services/multiorch/recovery/actions/fix_replication_test.go
+++ b/go/services/multiorch/recovery/actions/fix_replication_test.go
@@ -56,6 +56,31 @@ func TestFixReplicationAction_RequiresHealthyLeader(t *testing.T) {
 	assert.True(t, action.RequiresHealthyLeader())
 }
 
+func TestFixReplicationAction_DefersWhenReplicationStatusUnavailable(t *testing.T) {
+	replicaID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "replica"}
+	primaryID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary"}
+	replica := store.NewPooler(&multiorchdatapb.PoolerHealthState{
+		Multipooler: &clustermetadatapb.Multipooler{Id: replicaID},
+	}, nil)
+	primary := store.NewPooler(&multiorchdatapb.PoolerHealthState{
+		Multipooler: &clustermetadatapb.Multipooler{Id: primaryID},
+	}, nil)
+	client := &rpcclient.FakeClient{
+		StatusResponses: map[topoclient.ComponentID]*rpcclient.ResponseWithDelay[*multipoolermanagerdatapb.StatusResponse]{
+			topoclient.ComponentIDString(replicaID): {
+				Response: &multipoolermanagerdatapb.StatusResponse{Status: &multipoolermanagerdatapb.Status{}},
+			},
+		},
+	}
+	action := NewFixReplicationAction(config.NewTestConfig(), client, nil, slog.Default())
+
+	needsFix, status, err := action.verifyReplicaNotReplicating(t.Context(), replica, primary)
+	require.Error(t, err)
+	assert.False(t, needsFix)
+	assert.Nil(t, status)
+	assert.Equal(t, mtrpcpb.Code_UNAVAILABLE, mterrors.Code(err))
+}
+
 func TestFixReplicationAction_ExecuteReplicaNotFound(t *testing.T) {
 	ctx := context.Background()
 	ts, _ := memorytopo.NewServerAndFactory(ctx, "cell1")

--- a/go/services/multiorch/recovery/analysis/replica_not_replicating_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/replica_not_replicating_analyzer.go
@@ -57,6 +57,17 @@ func (a *ReplicaNotReplicatingAnalyzer) analyzePooler(sa *ShardAnalysis, pa *sto
 		return nil, nil
 	}
 
+	// ReplicationStatus is populated only when the snapshot's live postgres query
+	// succeeds. LastSeen advances whenever a snapshot arrives, so a fresh snapshot
+	// may still be partial. Stale snapshots and nil ReplicationStatus while postgres
+	// is running are unknown, not evidence that replication is broken. A fresh
+	// PostgresRunning=false observation remains actionable.
+	status := pa.Health().GetStatus()
+	if !observationFresh(pa, sa.Now, sa.Policy.FollowerStreamFreshness) ||
+		(status.GetReplicationStatus() == nil && status.GetPostgresRunning()) {
+		return nil, nil
+	}
+
 	// Skip unless we know where to point the replica: the shard must have a known
 	// consensus leader (HighestShardRule) whose host/port we actually have (Leader
 	// health present). A leader we have no address for is not actionable.

--- a/go/services/multiorch/recovery/analysis/replica_not_replicating_analyzer_test.go
+++ b/go/services/multiorch/recovery/analysis/replica_not_replicating_analyzer_test.go
@@ -73,12 +73,17 @@ func TestReplicaNotReplicatingAnalyzer_Analyze(t *testing.T) {
 		h := &multiorchdatapb.PoolerHealthState{
 			Multipooler:      &clustermetadatapb.Multipooler{Id: id, ShardKey: shardKey},
 			IsLastCheckValid: true,
-			Status:           &multipoolermanagerdatapb.Status{IsInitialized: initialized},
+			LastSeen:         timestamppb.Now(),
+			Status: &multipoolermanagerdatapb.Status{
+				IsInitialized:   initialized,
+				PostgresRunning: true,
+			},
 		}
 		if selfLeader {
 			h.ConsensusStatus = primaryConsensusStatus(id, 1)
-		}
-		if primaryHost != "" || walReplayPaused || walReceiverStatus != "" {
+		} else {
+			// A non-nil value means the pooler's live replication-status query
+			// succeeded, even when primary_conninfo and receiver status are empty.
 			h.Status.ReplicationStatus = &multipoolermanagerdatapb.StandbyReplicationStatus{
 				IsWalReplayPaused: walReplayPaused,
 				PrimaryConnInfo:   &multipoolermanagerdatapb.PrimaryConnInfo{Host: primaryHost},
@@ -130,6 +135,62 @@ func TestReplicaNotReplicatingAnalyzer_Analyze(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, problems, 1)
 		require.Equal(t, types.ProblemReplicaNotReplicating, problems[0].Code)
+	})
+
+	t.Run("ignores missing replication observation", func(t *testing.T) {
+		replica := pooler(replicaID, false, true, "", false, "")
+		replica.Mutate(func(h *multiorchdatapb.PoolerHealthState) {
+			h.Status.ReplicationStatus = nil
+		})
+		sa := &ShardAnalysis{
+			ShardKey: shardKey,
+			Leader:   leaderHealth(),
+			Analyses: []*store.Pooler{replica},
+			Now:      time.Now(),
+			Policy:   DefaultAvailabilityPolicy(),
+		}
+
+		problems, err := analyzer.Analyze(sa)
+		require.NoError(t, err)
+		require.Empty(t, problems)
+	})
+
+	t.Run("retains problem while postgres is known stopped", func(t *testing.T) {
+		replica := pooler(replicaID, false, true, "", false, "")
+		replica.Mutate(func(h *multiorchdatapb.PoolerHealthState) {
+			h.Status.PostgresRunning = false
+			h.Status.ReplicationStatus = nil
+		})
+		sa := &ShardAnalysis{
+			ShardKey: shardKey,
+			Leader:   leaderHealth(),
+			Analyses: []*store.Pooler{replica},
+			Now:      time.Now(),
+			Policy:   DefaultAvailabilityPolicy(),
+		}
+
+		problems, err := analyzer.Analyze(sa)
+		require.NoError(t, err)
+		require.Len(t, problems, 1)
+	})
+
+	t.Run("ignores stale negative replication observation", func(t *testing.T) {
+		now := time.Now()
+		replica := pooler(replicaID, false, true, "", false, "")
+		replica.Mutate(func(h *multiorchdatapb.PoolerHealthState) {
+			h.LastSeen = timestamppb.New(now.Add(-time.Minute))
+		})
+		sa := &ShardAnalysis{
+			ShardKey: shardKey,
+			Leader:   leaderHealth(),
+			Analyses: []*store.Pooler{replica},
+			Now:      now,
+			Policy:   DefaultAvailabilityPolicy(),
+		}
+
+		problems, err := analyzer.Analyze(sa)
+		require.NoError(t, err)
+		require.Empty(t, problems)
 	})
 
 	// Skip the problem when we have no health for the leader (Leader is nil), so

--- a/go/services/multiorch/recovery/analysis/shard_analysis.go
+++ b/go/services/multiorch/recovery/analysis/shard_analysis.go
@@ -96,9 +96,8 @@ func poolerID(p *store.Pooler) *clustermetadatapb.ID {
 }
 
 // walReplayNotPaused reports whether the standby's WAL replay is active. A
-// pooler with no replication status (e.g. a primary, or one we haven't observed
-// replicating) returns false, so an unpopulated state errs toward repair rather
-// than assuming health.
+// pooler with no replication status returns false; callers that distinguish an
+// unavailable observation from a negative one must check for nil first.
 func walReplayNotPaused(p *store.Pooler) bool {
 	rs := p.Health().GetStatus().GetReplicationStatus()
 	if rs == nil {


### PR DESCRIPTION
## Summary

- Treat missing or stale standby replication observations as unknown instead of `ReplicaNotReplicating`.
- Require the action's live status recheck to succeed before changing replication configuration.
- Cover missing and stale analyzer input plus an unavailable live recheck.

## Problem

Under sustained failover load, a multipooler that could not query its own PostgreSQL returned a partial health snapshot with no replication details. `ReplicaNotReplicatingAnalyzer` interpreted that absence as a negative result. 

In a local repeated failover test which revealed the reported incident, PostgreSQL showed only 0.000165s of replay lag on replicas that orchestration refused to use, while `TriggerRecoveryNow` continued returning two `ReplicaNotReplicating` problems. The resulting all-REPLICA/no-primary state survived a cluster stop and restart.

## Solution

Current main already provides the evidence timestamp needed here: every manager health snapshot is freshly rebuilt by `Status`, the orchestrator stamps its receipt in `LastSeen`, and `Status.ReplicationStatus` is populated only when that snapshot's live PostgreSQL query succeeds. Replication details are not retained from an older successful query. This change therefore reuses the existing snapshot timestamp instead of adding another protobuf field: stale follower snapshots are ignored, and a missing replication status is treated as unknown while pgctld still reports the PostgreSQL process running. A fresh process-down observation remains actionable so recovery does not report success while a replica is restarting or rewinding. A fresh, non-nil status with empty `primary_conninfo` or an inactive WAL receiver also remains negative evidence and still schedules repair.

The action performs a second live `Status` RPC before mutating the replica. A partial response now returns `UNAVAILABLE` and defers to the next recovery cycle rather than treating unknown as confirmation. Recovery analysis already reruns continuously, and `TriggerRecoveryNow` polls for new snapshots, so the problem clears automatically when introspection resumes.

A direct orchestrator-to-PostgreSQL verification path was considered but not chosen: it would duplicate the pooler's existing live query and require PostgreSQL connectivity and credentials in multiorch. An operator-only verdict reset was also left out because this verdict is recomputed, not persisted; once unknown observations stop being classified as failures, the existing re-analysis path is the escape hatch.

## Testing

- `go test -short -count=1 ./go/services/multiorch/recovery/...`
- `go test -count=1 -run '^Test(RewindDivergedReplica|DemoteStalePrimary_GracefulShutdown)$' ./go/test/endtoend/multiorch/...`
- `go build ./...`
