### PR TITLE
fix(multipooler): back off failed heartbeat writes

### DIFF
--- a/go/services/multipooler/internal/heartbeat/writer.go
+++ b/go/services/multipooler/internal/heartbeat/writer.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
+	"github.com/multigres/multigres/go/tools/retry"
 	"github.com/multigres/multigres/go/tools/timer"
 )
 
@@ -31,6 +32,8 @@ import (
 var (
 	defaultHeartbeatInterval = 1 * time.Second
 )
+
+const maxHeartbeatWriteBackoff = 30 * time.Second
 
 // Writer runs on primary databases and writes heartbeats to the heartbeat
 // table at regular intervals.
@@ -42,7 +45,9 @@ type Writer struct {
 	interval     time.Duration
 	now          func() time.Time
 
-	runner *timer.PeriodicRunner
+	runner  *timer.PeriodicRunner
+	backoff *retry.ExponentialBackoff
+	retryAt time.Time
 
 	writes      atomic.Int64
 	writeErrors atomic.Int64
@@ -56,7 +61,6 @@ func NewWriter(queryService executor.InternalQueryService, logger *slog.Logger, 
 	if intervalMs <= 0 {
 		interval = defaultHeartbeatInterval
 	}
-	runner := timer.NewPeriodicRunner(context.TODO(), interval)
 	return &Writer{
 		queryService: queryService,
 		logger:       logger,
@@ -64,14 +68,18 @@ func NewWriter(queryService executor.InternalQueryService, logger *slog.Logger, 
 		poolerID:     poolerID,
 		interval:     interval,
 		now:          time.Now,
-		runner:       runner,
+		runner:       timer.NewPeriodicRunner(context.TODO(), interval),
+		backoff:      retry.NewExponentialBackoff(interval, max(interval, maxHeartbeatWriteBackoff)),
 	}
 }
 
 // Open starts the heartbeat writer.
 func (w *Writer) Open() {
 	w.logger.Info("Heartbeat Writer: opening")
-	w.runner.Start(w.writeHeartbeat, nil)
+	w.runner.Start(w.writeHeartbeat, func() {
+		w.backoff.Reset()
+		w.retryAt = time.Time{}
+	})
 }
 
 // Close stops the heartbeat writer. After Close returns, no more heartbeat
@@ -89,14 +97,22 @@ func (w *Writer) IsOpen() bool {
 
 // writeHeartbeat updates the heartbeat row with the current time in nanoseconds.
 func (w *Writer) writeHeartbeat(ctx context.Context) {
+	if !w.retryAt.IsZero() && w.now().Before(w.retryAt) {
+		return
+	}
+
 	writeCtx, cancel := context.WithTimeout(ctx, w.interval)
 	defer cancel()
 
 	err := w.write(writeCtx)
 	if err != nil {
-		w.logger.ErrorContext(ctx, "Failed to write heartbeat", "error", err)
+		delay := max(w.backoff.NextDelay(), w.interval)
+		w.retryAt = w.now().Add(delay)
+		w.logger.ErrorContext(ctx, "Failed to write heartbeat", "error", err, "retry_in", delay)
 		w.writeErrors.Add(1)
 	} else {
+		w.backoff.Reset()
+		w.retryAt = time.Time{}
 		w.writes.Add(1)
 		w.logger.DebugContext(ctx, "Heartbeat written",
 			"shard_id", w.shardID,

--- a/go/services/multipooler/internal/heartbeat/writer_test.go
+++ b/go/services/multipooler/internal/heartbeat/writer_test.go
@@ -93,6 +93,33 @@ func TestWriteHeartbeatError(t *testing.T) {
 	assert.EqualValues(t, 1, tw.WriteErrors())
 }
 
+func TestWriteHeartbeatBackoffAndReset(t *testing.T) {
+	queryService := mock.NewQueryService()
+	now := time.Now()
+	tw := newTestWriter(t, queryService, &now)
+
+	// The first attempt fails and starts the backoff.
+	tw.writeHeartbeat(t.Context())
+	assert.EqualValues(t, 1, tw.WriteErrors())
+
+	queryService.AddQueryPattern("\\s*INSERT INTO multigres\\.heartbeat.*", mock.MakeQueryResult([]string{}, [][]any{}))
+
+	// Calls before the retry deadline do not touch PostgreSQL.
+	tw.writeHeartbeat(t.Context())
+	now = now.Add(tw.interval - time.Nanosecond)
+	tw.writeHeartbeat(t.Context())
+	assert.EqualValues(t, 0, tw.Writes())
+	assert.EqualValues(t, 1, tw.WriteErrors())
+
+	// The deadline permits another attempt; success clears the backoff so the
+	// following call can write immediately.
+	now = now.Add(time.Nanosecond)
+	tw.writeHeartbeat(t.Context())
+	tw.writeHeartbeat(t.Context())
+	assert.EqualValues(t, 2, tw.Writes())
+	assert.EqualValues(t, 1, tw.WriteErrors())
+}
+
 // TestOpenClose tests the basic open/close lifecycle.
 func TestOpenClose(t *testing.T) {
 	queryService := mock.NewQueryService()


### PR DESCRIPTION
## Summary

- Apply exponential backoff with full jitter after failed heartbeat writes.
- Cap retry delay at approximately 30 seconds and reset it after success or writer restart.
- Add fake-time coverage for retry suppression and reset behaviour.

## Problem

The heartbeat writer normally runs once per second. When PostgreSQL refuses connections, each interval starts another write attempt, adding connection work while the server is already saturated. 

In a local test setup, observed 4,684 heartbeat failures on the saturated primary, 2,293 on the busy zone2 node, and none on the idle zone3 node.

Current main already addresses two related concerns: heartbeat queries use the existing regular connection pool, whose physical connections are recycled, and `ReplTracker` runs the writer only when the live routing role is writable. The existing `TestReplTrackerOnStateChangeGating` covers that primary-only behaviour.

## Solution

A failed write now advances the existing shared exponential-backoff implementation and suppresses database attempts until the retry deadline. The normal heartbeat interval is the minimum delay, full jitter spreads retries, and the delay is capped at 30 seconds. A successful write or a genuine writer restart clears the backoff.

No dedicated connection or additional role signal is introduced because the current pooled query path and writable routing state already provide those behaviours.

## Testing

- All unit tests
- Heartbeat unit tests with the race detector
- Multipooler integration tests, run sequentially
- `go build ./...`
- `make build`
- Pre-commit golangci-lint: 0 issues
