### PR TITLE
fix(pgctld): raise default max connections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       # container as a drop-in PostgreSQL on the default port (e.g. for a setup
       # that hardcodes 5432). Keep ports/healthcheck below in sync.
       MULTIGRES_GATEWAY_PG_PORT: "15432"
-      # PostgreSQL max_connections (default 60). Raising it also sizes the
+      # PostgreSQL max_connections (default 110). Setting it also sizes the
       # connection pooler to this value minus 10. Forwarded from the host env so
       # CI / callers can override it without editing this file; empty = default.
       MULTIGRES_PG_MAX_CONNECTIONS: "${MULTIGRES_PG_MAX_CONNECTIONS:-}"

--- a/docker/README.md
+++ b/docker/README.md
@@ -53,8 +53,8 @@ healthcheck in `docker-compose.yml` in sync with this value.
 
 ### Max connections (`MULTIGRES_PG_MAX_CONNECTIONS`)
 
-The bundled PostgreSQL defaults to `max_connections = 60`. Set
-`MULTIGRES_PG_MAX_CONNECTIONS` to raise it:
+The bundled PostgreSQL defaults to `max_connections = 110`. Set
+`MULTIGRES_PG_MAX_CONNECTIONS` to change it:
 
 ```bash
 MULTIGRES_PG_MAX_CONNECTIONS=100 docker compose up --build

--- a/docker/cluster-entrypoint.sh
+++ b/docker/cluster-entrypoint.sh
@@ -45,7 +45,7 @@ NUM_CELLS="${MULTIGRES_NUM_CELLS:-2}"
 # `5432`). Additional cells use consecutive ports (base+1, base+2).
 GATEWAY_PG_PORT="${MULTIGRES_GATEWAY_PG_PORT:-15432}"
 
-# PostgreSQL max_connections. The bundled default is 60.
+# PostgreSQL max_connections. The bundled default is 110.
 # Setting this raises PostgreSQL's ceiling AND sizes the connection pooler to
 # match: the pooler's global capacity is set to this value minus POOL_RESERVE,
 # leaving headroom for superuser logins, replication, and the pooler's own admin

--- a/docs/query_serving/benchmarking/pgbench.md
+++ b/docs/query_serving/benchmarking/pgbench.md
@@ -108,7 +108,7 @@ the test is skipped.
 | `PGBENCH_PROTOCOLS`          | `simple,extended` | Comma-separated subset of `simple,extended`                                                      |
 | `PGBENCH_NO_CHURN`           | (unset)           | Set to `1` to skip the connection-churn (`-C`) variants                                          |
 | `PGBENCH_TARGETS`            | `multigateway`    | Comma-separated subset of `postgres,multigateway,pgbouncer`                                      |
-| `PGBENCH_PG_MAX_CONNECTIONS` | (unset)           | Bump postgres `max_connections` to this value and restart pgctld (needed for direct ≥ 60 client) |
+| `PGBENCH_PG_MAX_CONNECTIONS` | (unset)           | Set postgres `max_connections` to this value and restart pgctld for direct client benchmark runs |
 | `CAPTURE_PPROF`              | (unset)           | Set to `1` to capture CPU profiles from multigateway and primary multipooler during each run     |
 | `CAPTURE_HEAP`               | (unset)           | Set to `1` to capture heap, allocs and goroutine snapshots before+after each scenario            |
 

--- a/go/services/pgctld/postgresconfig_gen.go
+++ b/go/services/pgctld/postgresconfig_gen.go
@@ -75,7 +75,7 @@ func GeneratePostgresServerConfig(poolerDir string, pgUser string, extraConfFile
 
 	// Set Multigres default values tuned for a small instance.
 	// These can be changed in the future based on instance size/requirements
-	cnf.MaxConnections = 60
+	cnf.MaxConnections = 110
 	cnf.SharedBuffers = "64MB"
 	cnf.MaintenanceWorkMem = "16MB"
 	cnf.WorkMem = "1092kB"

--- a/go/services/pgctld/postgresconfig_gen_test.go
+++ b/go/services/pgctld/postgresconfig_gen_test.go
@@ -108,7 +108,7 @@ func TestMakePostgresConf(t *testing.T) {
 		{
 			name:     "max connections template",
 			template: "max_connections = {{.MaxConnections}}",
-			want:     []string{"max_connections = 60"},
+			want:     []string{"max_connections = 110"},
 		},
 		{
 			name: "complex template",
@@ -117,7 +117,7 @@ max_connections = {{.MaxConnections}}
 data_directory = '{{.DataDir}}'
 cluster_name = '{{.ClusterName}}'`,
 			want: []string{
-				"max_connections = 60",
+				"max_connections = 110",
 				"data_directory = '" + tempDir + "/pg_data'",
 				"cluster_name = 'main'",
 				"# PostgreSQL Configuration",

--- a/go/test/endtoend/queryserving/benchmarking/pg_config.go
+++ b/go/test/endtoend/queryserving/benchmarking/pg_config.go
@@ -32,7 +32,7 @@ import (
 // pgctld so the new value takes effect.
 //
 // Required when running pgbench with more clients than the default
-// postgres max_connections (60).
+// postgres max_connections (110).
 func bumpPostgresMaxConnections(ctx context.Context, t *testing.T, setup *shardsetup.ShardSetup, n int) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- Raise generated PostgreSQL `max_connections` from 60 to 110.
- Leave ten slots above the multipooler's default 100 user connections for its admin pool and PostgreSQL access headroom.
- Update affected tests and documentation.

## Problem

pgctld generated `max_connections = 60`, while multipooler can manage 100 regular and reserved user connections plus a separate five-connection admin pool. Under load, PostgreSQL could therefore refuse connections before the pooler reached its configured capacity.

## Solution

The generated PostgreSQL default is now 110: 100 user-pool connections, five admin-pool connections, and five remaining slots that include PostgreSQL's reserved access capacity.

This PR intentionally does not add another configuration knob. Existing template and extra-configuration overrides remain available. A follow-up can read PostgreSQL's live connection settings and cap multipooler automatically so unsafe configuration divergence is impossible.

## Testing

- `go test -short -count=1 ./go/services/pgctld/...`
- `go build ./...`
- Prettier and markdownlint for the changed Markdown
- Pre-commit golangci-lint: 0 issues
