### PR TITLE
feat(multiorch): exclude cohort-ineligible poolers from failover

### DIFF
--- a/go/services/multiorch/consensus/coordinator.go
+++ b/go/services/multiorch/consensus/coordinator.go
@@ -95,6 +95,20 @@ func (c *Coordinator) AppointLeader(ctx context.Context, shardKey *clustermetada
 // that needs rewinding is not fatal — the SetPrimary path runs pg_rewind
 // before the node serves writes or replicates.
 func (c *Coordinator) runFailover(ctx context.Context, cohort []*multiorchdatapb.PoolerHealthState, reason string) error {
+	// Drop INELIGIBLE members: today raised only on a deliberate exit (graceful
+	// shutdown / admin-stopped WAL receiver), so treat them as gone — not recruited,
+	// hence never re-elected leader nor counted for quorum. No fallback. A
+	// demote-but-still-ELIGIBLE node is a different signal and stays.
+	eligible, ineligible := filterFailoverEligible(cohort)
+	if len(ineligible) > 0 {
+		c.logger.InfoContext(ctx, "excluding ineligible poolers from failover", "excluded", ineligible)
+	}
+	cohort = eligible
+	if len(cohort) == 0 {
+		return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
+			"no eligible cohort members for failover; all ineligible: %v", ineligible)
+	}
+
 	var cohortStatuses []*clustermetadatapb.ConsensusStatus
 	for _, p := range cohort {
 		if cs := p.GetConsensusStatus(); cs != nil {
@@ -116,7 +130,26 @@ func (c *Coordinator) runFailover(ctx context.Context, cohort []*multiorchdatapb
 	checkProposalPossible := func(rev *clustermetadatapb.TermRevocation, statuses []*clustermetadatapb.ConsensusStatus) error {
 		return commonconsensus.CheckProposalPossible(rev, statuses, buildProposal)
 	}
-	return c.newRuleChange(reason, tryBuildProposal, checkProposalPossible).Run(ctx, cohort, revocation)
+	if err := c.newRuleChange(reason, tryBuildProposal, checkProposalPossible).Run(ctx, cohort, revocation); err != nil {
+		if len(ineligible) > 0 {
+			return mterrors.Wrapf(err, "failover excluded ineligible members %v", ineligible)
+		}
+		return err
+	}
+	return nil
+}
+
+// filterFailoverEligible splits a failover cohort into the members that may
+// participate and the names of those advertising INELIGIBLE (see runFailover).
+func filterFailoverEligible(cohort []*multiorchdatapb.PoolerHealthState) (eligible []*multiorchdatapb.PoolerHealthState, ineligible []string) {
+	for _, p := range cohort {
+		if p.GetAvailabilityStatus().GetCohortEligibilityStatus().GetSignal() == clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE {
+			ineligible = append(ineligible, p.GetMultipooler().GetId().GetName())
+			continue
+		}
+		eligible = append(eligible, p)
+	}
+	return eligible, ineligible
 }
 
 // AppointInitialLeader orchestrates consensus leader election for a freshly

--- a/go/services/multiorch/consensus/failover_eligibility_test.go
+++ b/go/services/multiorch/consensus/failover_eligibility_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consensus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
+)
+
+// eligibilityNode builds a minimal PoolerHealthState carrying a name and cohort
+// eligibility signal. A nil AvailabilityStatus is expressed by passing setStatus=false.
+func eligibilityNode(name string, signal clustermetadatapb.CohortEligibilitySignal, setStatus bool) *multiorchdatapb.PoolerHealthState {
+	p := &multiorchdatapb.PoolerHealthState{
+		Multipooler: &clustermetadatapb.Multipooler{
+			Id: &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: name},
+		},
+	}
+	if setStatus {
+		p.AvailabilityStatus = &clustermetadatapb.AvailabilityStatus{
+			CohortEligibilityStatus: &clustermetadatapb.CohortEligibilityStatus{Signal: signal},
+		}
+	}
+	return p
+}
+
+func TestFilterFailoverEligible(t *testing.T) {
+	eligible := clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE
+	ineligible := clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE
+
+	tests := []struct {
+		name           string
+		cohort         []*multiorchdatapb.PoolerHealthState
+		wantEligible   []string
+		wantIneligible []string
+	}{
+		{
+			name: "all eligible are kept, none reported ineligible",
+			cohort: []*multiorchdatapb.PoolerHealthState{
+				eligibilityNode("mp1", eligible, true),
+				eligibilityNode("mp2", eligible, true),
+			},
+			wantEligible:   []string{"mp1", "mp2"},
+			wantIneligible: nil,
+		},
+		{
+			name: "an ineligible member is excluded and reported by name",
+			cohort: []*multiorchdatapb.PoolerHealthState{
+				eligibilityNode("mp1", eligible, true),
+				eligibilityNode("mp2", ineligible, true),
+				eligibilityNode("mp3", eligible, true),
+			},
+			wantEligible:   []string{"mp1", "mp3"},
+			wantIneligible: []string{"mp2"},
+		},
+		{
+			name: "all ineligible leaves no eligible members",
+			cohort: []*multiorchdatapb.PoolerHealthState{
+				eligibilityNode("mp1", ineligible, true),
+				eligibilityNode("mp2", ineligible, true),
+			},
+			wantEligible:   nil,
+			wantIneligible: []string{"mp1", "mp2"},
+		},
+		{
+			name: "a nil availability status is treated as eligible",
+			cohort: []*multiorchdatapb.PoolerHealthState{
+				eligibilityNode("mp1", eligible, false),
+			},
+			wantEligible:   []string{"mp1"},
+			wantIneligible: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotEligible, gotIneligible := filterFailoverEligible(tt.cohort)
+
+			var gotEligibleNames []string
+			for _, p := range gotEligible {
+				gotEligibleNames = append(gotEligibleNames, p.GetMultipooler().GetId().GetName())
+			}
+			require.Equal(t, tt.wantEligible, gotEligibleNames)
+			require.Equal(t, tt.wantIneligible, gotIneligible)
+		})
+	}
+}

--- a/go/services/multiorch/store/health_stream.go
+++ b/go/services/multiorch/store/health_stream.go
@@ -442,6 +442,8 @@ func (hs *HealthStream) applySnapshot(ctx context.Context, poolerHealth *Pooler,
 		"pooler_type", status.PoolerType,
 		"postgres_ready", status.PostgresReady,
 		"postgres_running", status.PostgresRunning,
+		"cohort_eligibility", snapshot.Status.GetAvailabilityStatus().GetCohortEligibilityStatus().GetSignal().String(),
+		"leadership_signal", snapshot.Status.GetAvailabilityStatus().GetLeadershipStatus().GetSignal().String(),
 	)
 }
 

--- a/go/services/multipooler/internal/manager/graceful_shutdown.go
+++ b/go/services/multipooler/internal/manager/graceful_shutdown.go
@@ -120,6 +120,8 @@ func (pm *MultipoolerManager) GracefulShutdown(ctx context.Context) {
 	// stopping is slow. We're favoring speed of failover rather than grace.
 	if err := pm.consensusMgr.SetCohortEligibility(lockCtx, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE); err != nil {
 		pm.logger.WarnContext(lockCtx, "failed to set cohort ineligibility during shutdown", "error", err)
+	} else {
+		pm.logger.InfoContext(lockCtx, "advertised cohort ineligibility before stopping postgres")
 	}
 
 	if err := pm.pgctldStopWithEscalation(lockCtx); err != nil {

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -139,6 +139,16 @@ func (pm *MultipoolerManager) Recruit(ctx context.Context, req *consensusdatapb.
 		"revoked_below_term", revokedBelowTerm,
 		"coordinator_id", coordinatorID.GetName())
 
+	// Refuse recruitment while cohort-ineligible. That signal is raised only on a
+	// deliberate exit (graceful shutdown / admin-stopped WAL receiver), so this node
+	// must not join the new term — otherwise it could be re-elected leader or counted
+	// for quorum while leaving. Enforcing here is synchronous and does not depend on
+	// the coordinator having observed the (health-stream) eligibility signal in time.
+	if pm.buildCohortEligibilityStatus().GetSignal() == clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE {
+		pm.logger.InfoContext(ctx, "refusing recruitment: cohort-ineligible")
+		return nil, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION, "cohort-ineligible (shutting down); refusing recruitment")
+	}
+
 	// State check — reject immediately if the node's committed WAL rule,
 	// stored revocation, or recruit position floor already conflicts with
 	// this request (the floor check matters because pg_rewind deletes back

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
 	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/servenv"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor/mock"
@@ -41,6 +42,7 @@ import (
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
+	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 )
 
 // recruitTS is a fixed coordinator_initiated_at timestamp used in Recruit test cases.
@@ -1199,6 +1201,31 @@ func TestAvailabilityStatus(t *testing.T) {
 		pm.actionLock.Release(lockCtx)
 		assert.True(t, pm.buildAvailabilityStatus().SuspectedDivergence, "reflects the in-memory flag")
 	})
+}
+
+// TestRecruitRejectsWhileCohortIneligible verifies that a node advertising
+// COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE (raised on a deliberate exit such as
+// graceful shutdown) refuses recruitment with FAILED_PRECONDITION, so a leaving
+// node is never pulled into a new term — regardless of whether the coordinator
+// observed the eligibility signal on the health stream in time.
+func TestRecruitRejectsWhileCohortIneligible(t *testing.T) {
+	pm := newTestManager(t)
+
+	lockCtx, err := pm.actionLock.Acquire(t.Context(), "seed-ineligible")
+	require.NoError(t, err)
+	require.NoError(t, pm.consensusMgr.SetCohortEligibility(lockCtx,
+		clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE))
+	pm.actionLock.Release(lockCtx)
+
+	// A non-nil TermRevocation is required to reach the eligibility guard (the
+	// nil-revocation check precedes it); its contents are irrelevant because the
+	// guard rejects before any revocation validation.
+	_, err = pm.Recruit(t.Context(), &consensusdatapb.RecruitRequest{
+		TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 7},
+	})
+	require.Error(t, err)
+	require.Equal(t, mtrpcpb.Code_FAILED_PRECONDITION, mterrors.Code(err))
+	require.ErrorContains(t, err, "cohort-ineligible")
 }
 
 // TestSetResignedLeaderAtTerm_BroadcastsOnChange verifies that setting the


### PR DESCRIPTION
Cohort-ineliglbe is set during shutdown, so we can basically treat it the same as an unreachable pooler except with higher confidence and faster reaction time

This fixes an issue where it was sometimes possible for a resigning leader on shutdown to be re-selected as the leader at the next term instead of being removed from leadership and then eventually the cohort