### PR TITLE
fix(multipooler): run post-promotion unlogged-table sweep on manager context

### DIFF
--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -1425,11 +1425,17 @@ func (pm *MultipoolerManager) promoteStandbyToPrimary(ctx context.Context, state
 		// Log but don't fail - promotion already succeeded
 	}
 
+	// Use the manager-lifetime context, not the request ctx: this goroutine
+	// outlives the promotion RPC, and the request ctx is canceled the moment
+	// that RPC returns. With the request ctx the DROPs race RPC completion and
+	// fail with "context canceled", leaving the unlogged tables in place.
+	// Mirrors the async checkpoint above.
+	sweepCtx := pm.ctx
 	go func() {
 		// After a failover PostgreSQL resets user-created unlogged tables to empty.
 		// Best-effort drop them asynchronously so clients get a clear "relation does
 		// not exist" error and rebuild instead of silently reading an empty table.
-		pm.dropUnloggedTablesAfterPromotion(ctx)
+		pm.dropUnloggedTablesAfterPromotion(sweepCtx)
 	}()
 
 	// Ensure the unlogged backend_vpid sidecar table exists before the pooler is

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -1146,6 +1146,49 @@ func TestPromoteDropsUnloggedTables(t *testing.T) {
 		require.NoError(t, err, "best-effort drop must not fail the promotion")
 		assert.NoError(t, m.ExpectationsWereMet())
 	})
+
+	// Regression for the TestUnloggedTablesAfterFailover flake: the async sweep
+	// must run on a manager-lifetime context, not the promotion request context.
+	// gRPC cancels the request context the instant Promote() returns, so a sweep
+	// bound to it aborts every DROP with "context canceled" and leaves the (already
+	// emptied) unlogged tables in place. Here we cancel the request context right
+	// after Promote returns and assert the DROP still sees a live context.
+	t.Run("sweep survives cancellation of the promotion request context", func(t *testing.T) {
+		reqCtx, cancelReq := context.WithCancel(context.Background())
+		proceed := make(chan struct{})
+		dropCtxErr := make(chan error, 1)
+
+		m := mock.NewQueryService()
+		expectLeaderPromoteMocksWithUnlogged(m, []string{"public.foo"})
+		m.AddQueryPatternWithContextCallback(`DROP TABLE public\.foo`,
+			mock.MakeQueryResult(nil, nil),
+			func(ctx context.Context, _ string) {
+				<-proceed // block until the caller has canceled the request context
+				dropCtxErr <- ctx.Err()
+			})
+
+		pm, tmpDir := setupManagerWithMockDB(t, m, &fakeRuleStore{pos: makeRulePosition(0)})
+		consensustest.SeedTerm(t, tmpDir, recruitedTerm)
+		_, err := pm.consensusMgr.Promises().Load()
+		require.NoError(t, err)
+
+		_, err = pm.Promote(reqCtx, req)
+		require.NoError(t, err)
+
+		// Mimic gRPC tearing down the request context once the RPC returns, then
+		// unblock the sweep so it issues its DROP under the (now-canceled) request
+		// context's shadow.
+		cancelReq()
+		close(proceed)
+
+		select {
+		case ctxErr := <-dropCtxErr:
+			assert.NoError(t, ctxErr,
+				"unlogged-table sweep ran on the canceled request context instead of a manager-lifetime one")
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for the post-promotion unlogged-table drop")
+		}
+	})
 }
 
 func TestAvailabilityStatus(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes the flaky `TestUnloggedTablesAfterFailover` (quarantined, ~13% failure rate) by pinning the async post-promotion unlogged-table sweep to the manager-lifetime context instead of the promotion RPC's request context.
- Adds a deterministic regression unit test that cancels the request context immediately after `Promote()` returns and asserts the sweep still runs on a live context.

## Problem

After a failover, the newly promoted primary best-effort drops user-created unlogged tables (their data is reset to empty on promotion, so dropping them surfaces a clear "relation does not exist" instead of silently returning empty results). This sweep runs in a detached goroutine, but it captured the promotion RPC's request context:

```go
go func() { pm.dropUnloggedTablesAfterPromotion(ctx) }() // ctx = request ctx
```

gRPC cancels that context the instant `Promote()` returns, so the goroutine races RPC completion. When the RPC returns first, every `DROP TABLE` aborts with `context canceled` and the unlogged tables are left in place — the observed flake. The new primary's log showed it directly:

```
Best-effort drop of unlogged table after promotion failed; table left empty
  table=public.u_dropped  error="context canceled"
```

Reproduced locally at 2/15 runs before the fix; 0 occurrences across 20 runs after.

## Solution

Detach the sweep onto `pm.ctx` (the manager-lifetime context), mirroring the async post-promotion `CHECKPOINT` goroutine immediately above it, which already uses `pm.ctx` for exactly this reason. The regression test verifies the sweep's DROP observes a live (non-canceled) context even after the request context is torn down; it fails against the old code and passes with the fix.