### PR TITLE
fix(multipooler): detect missing passfile in primary_conninfo drift check

### DIFF
--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -501,7 +501,11 @@ type PrimaryConnInfo struct {
 	// Application name for this standby
 	ApplicationName string `protobuf:"bytes,4,opt,name=application_name,json=applicationName,proto3" json:"application_name,omitempty"`
 	// Raw connection string (includes all parameters)
-	Raw           string `protobuf:"bytes,5,opt,name=raw,proto3" json:"raw,omitempty"`
+	Raw string `protobuf:"bytes,5,opt,name=raw,proto3" json:"raw,omitempty"`
+	// Path to the libpq password file (passfile=) the standby uses to
+	// authenticate to the primary. Empty when the conninfo carries no passfile
+	// clause. Not a secret (it is a filesystem path, not the password itself).
+	Passfile      string `protobuf:"bytes,6,opt,name=passfile,proto3" json:"passfile,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -567,6 +571,13 @@ func (x *PrimaryConnInfo) GetApplicationName() string {
 func (x *PrimaryConnInfo) GetRaw() string {
 	if x != nil {
 		return x.Raw
+	}
+	return ""
+}
+
+func (x *PrimaryConnInfo) GetPassfile() string {
+	if x != nil {
+		return x.Passfile
 	}
 	return ""
 }
@@ -2707,13 +2718,14 @@ var File_multipoolermanagerdata_proto protoreflect.FileDescriptor
 
 const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\n" +
-	"\x1cmultipoolermanagerdata.proto\x12\x16multipoolermanagerdata\x1a\x15clustermetadata.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x8a\x01\n" +
+	"\x1cmultipoolermanagerdata.proto\x12\x16multipoolermanagerdata\x1a\x15clustermetadata.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa6\x01\n" +
 	"\x0fPrimaryConnInfo\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
 	"\x04port\x18\x02 \x01(\x05R\x04port\x12\x12\n" +
 	"\x04user\x18\x03 \x01(\tR\x04user\x12)\n" +
 	"\x10application_name\x18\x04 \x01(\tR\x0fapplicationName\x12\x10\n" +
-	"\x03raw\x18\x05 \x01(\tR\x03raw\"\x97\x06\n" +
+	"\x03raw\x18\x05 \x01(\tR\x03raw\x12\x1a\n" +
+	"\bpassfile\x18\x06 \x01(\tR\bpassfile\"\x97\x06\n" +
 	"\x18StandbyReplicationStatus\x12&\n" +
 	"\x0flast_replay_lsn\x18\x01 \x01(\tR\rlastReplayLsn\x12(\n" +
 	"\x10last_receive_lsn\x18\x02 \x01(\tR\x0elastReceiveLsn\x12/\n" +

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -1084,6 +1084,15 @@ func (pm *MultipoolerManager) loadShardConfigFromGlobalTopo() {
 	}
 }
 
+// pgpassFilePath returns the path to the libpq password file written at
+// startup, or "" if it has not been set yet. Reads under pm.mu because the
+// value is populated asynchronously by loadShardConfigFromGlobalTopo.
+func (pm *MultipoolerManager) pgpassFilePath() string {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	return pm.pgpassPath
+}
+
 // checkDemotionState checks the current state to determine what steps remain
 func (pm *MultipoolerManager) checkDemotionState(ctx context.Context) (*demotionState, error) {
 	state := &demotionState{}

--- a/go/services/multipooler/internal/manager/pg_config.go
+++ b/go/services/multipooler/internal/manager/pg_config.go
@@ -172,6 +172,8 @@ func parseAndRedactPrimaryConnInfo(connInfoStr string) (*multipoolermanagerdata.
 			connInfo.User = value
 		case "application_name":
 			connInfo.ApplicationName = value
+		case "passfile":
+			connInfo.Passfile = value
 		}
 	}
 

--- a/go/services/multipooler/internal/manager/pg_config_test.go
+++ b/go/services/multipooler/internal/manager/pg_config_test.go
@@ -379,6 +379,7 @@ func TestParseAndRedactPrimaryConnInfo(t *testing.T) {
 				Port:            5432,
 				User:            "postgres",
 				ApplicationName: "",
+				Passfile:        "/home/user/.pgpass",
 				Raw:             "host=localhost port=5432 user=postgres passfile=/home/user/.pgpass",
 			},
 		},

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -422,11 +422,39 @@ func (pm *MultipoolerManager) setMonitorReason(ctx context.Context, reason, mess
 	}
 }
 
+// matchesRecorded reports whether ci's contact info matches target: host,
+// port, AND the passfile clause. A conninfo that points at the right primary
+// but lacks a usable passfile= (e.g. it was written before pgpassPath was
+// known) leaves the walreceiver unable to authenticate, so passfile is part
+// of the match too — this lets the reconcile paths self-heal that case
+// instead of freezing a passwordless conninfo in place forever.
+//
+// The passfile comparison is asymmetric: pgpassFilePath() returns "" until
+// pgpassPath is known, and setPrimaryConnInfoLocked cannot append a passfile
+// in that state. Treating "" as "expect no passfile" would flag drift we
+// can't fix and reconcile in a loop that keeps producing the same
+// passwordless conninfo, so an unknown expected path is treated as a match
+// (nothing to reconcile toward yet) regardless of what ci carries.
+//
+// ci may be nil (absent/unparsable conninfo), which never matches.
+func (pm *MultipoolerManager) matchesRecorded(target *clustermetadatapb.PoolerAddress, ci *multipoolermanagerdatapb.PrimaryConnInfo) bool {
+	if ci == nil {
+		return false
+	}
+	if ci.GetHost() != target.GetHost() || ci.GetPort() != target.GetPostgresPort() {
+		return false
+	}
+	expectedPassfile := pm.pgpassFilePath()
+	return expectedPassfile == "" || ci.GetPassfile() == expectedPassfile
+}
+
 // primaryConnInfoDiffersFromRecorded returns true when this pooler has been
 // informed about a primary (via SetPrimary or Promote) and the live primary_conninfo
 // in postgres doesn't match the recorded primary's contact info. Returns false
 // when there's nothing to compare against, when we couldn't read the GUC, or
 // when the recorded primary names this pooler itself.
+//
+// "Contact info" is host, port, and the passfile clause — see matchesRecorded.
 //
 // Returns false when the recorded primary's rule is revoked by our recorded
 // revocation: a Recruit that's already advanced revoked_below_term has
@@ -472,38 +500,31 @@ func (pm *MultipoolerManager) primaryConnInfoDiffersFromRecorded(ctx context.Con
 	if commonconsensus.IsRuleRevoked(rp.GetPosition(), pm.consensusMgr.Promises().GetInconsistentRevocation()) {
 		return false
 	}
-	targetHost := target.GetHost()
-	targetPort := target.GetPostgresPort()
-	if targetHost == "" || targetPort == 0 {
+	if target.GetHost() == "" || target.GetPostgresPort() == 0 {
 		return false
 	}
 
-	// Fast path: primary_conninfo was already read into state this tick — compare
-	// directly rather than re-querying. An empty/absent conninfo parses to a
-	// zero-value struct, so its host/port won't match the (non-empty) target and
-	// it reads as drift, matching the read path below.
-	if connInfo != nil {
-		return connInfo.GetHost() != targetHost || connInfo.GetPort() != targetPort
+	if connInfo == nil {
+		// No pre-read snapshot (RPC path, or the tick's read failed): read the GUC.
+		// Use a short deadline so a slow query never blocks the monitor tick.
+		ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		defer cancel()
+		connInfoStr, err := pm.readPrimaryConnInfo(ctx)
+		if err != nil {
+			// Conservative: don't trigger reconciliation we can't verify.
+			return false
+		}
+		if connInfoStr == "" {
+			return true
+		}
+		parsed, err := parseAndRedactPrimaryConnInfo(connInfoStr)
+		if err != nil || parsed == nil {
+			// Unparsable conninfo is itself drift worth fixing.
+			return true
+		}
+		connInfo = parsed
 	}
-
-	// No pre-read snapshot (RPC path, or the tick's read failed): read the GUC.
-	// Use a short deadline so a slow query never blocks the monitor tick.
-	ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-	connInfoStr, err := pm.readPrimaryConnInfo(ctx)
-	if err != nil {
-		// Conservative: don't trigger reconciliation we can't verify.
-		return false
-	}
-	if connInfoStr == "" {
-		return true
-	}
-	parsed, err := parseAndRedactPrimaryConnInfo(connInfoStr)
-	if err != nil || parsed == nil {
-		// Unparsable conninfo is itself drift worth fixing.
-		return true
-	}
-	return parsed.GetHost() != targetHost || parsed.GetPort() != targetPort
+	return !pm.matchesRecorded(target, connInfo)
 }
 
 // reconcilePrimaryConnInfoToRecorded re-applies primary_conninfo so it points

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -1599,7 +1599,11 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 		seedManualStop bool
 		// mockConnInfo controls what readPrimaryConnInfo returns. Empty string
 		// means NULL; mockReadError takes precedence and triggers a query error.
-		mockConnInfo  string
+		mockConnInfo string
+		// matchPassfile, when true, appends " passfile=<pm.pgpassFilePath()>" to
+		// mockConnInfo at runtime so the live conninfo carries the passfile the
+		// manager expects (host/port alone are not enough to be drift-free).
+		matchPassfile bool
 		mockReadError bool
 		// expectQuery is true when readPrimaryConnInfo is expected to run; the
 		// early-exit branches don't issue the SQL.
@@ -1709,9 +1713,36 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 				Position: &clustermetadatapb.RulePosition{Decision: mkRule(5, recordedID)},
 				Primary:  mkAddress(recordedHost, recordedPort),
 			},
+			expectQuery:   true,
+			mockConnInfo:  "host=primary.example.com port=5432 user=replicator",
+			matchPassfile: true,
+			want:          false,
+		},
+		{
+			// Host/port point at the recorded primary, but the conninfo carries
+			// no passfile= clause (written before pgpassPath was known). This is
+			// the "fe_sendauth: no password supplied" incident: without the
+			// passfile check this reads as no-drift and the standby stays stuck.
+			name: "LiveConnInfoMissingPassfile_Drifts",
+			seedRP: &clustermetadatapb.ReplicationPrimary{
+				Position: &clustermetadatapb.RulePosition{Decision: mkRule(5, recordedID)},
+				Primary:  mkAddress(recordedHost, recordedPort),
+			},
 			expectQuery:  true,
 			mockConnInfo: "host=primary.example.com port=5432 user=replicator",
-			want:         false,
+			want:         true,
+		},
+		{
+			// Host/port match and a passfile is present, but it points at a stale
+			// path (e.g. carried over from a different layout) -> fixable drift.
+			name: "LiveConnInfoStalePassfile_Drifts",
+			seedRP: &clustermetadatapb.ReplicationPrimary{
+				Position: &clustermetadatapb.RulePosition{Decision: mkRule(5, recordedID)},
+				Primary:  mkAddress(recordedHost, recordedPort),
+			},
+			expectQuery:  true,
+			mockConnInfo: "host=primary.example.com port=5432 user=replicator passfile=/stale/path/pgpass",
+			want:         true,
 		},
 		{
 			name: "LiveConnInfoHostMismatch",
@@ -1738,24 +1769,32 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockQueryService := mock.NewQueryService()
+			pm, tmpDir := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(0)})
+
+			// Register the primary_conninfo mock after setup so matchPassfile can
+			// append the passfile path the manager actually resolved at startup.
+			// Setup's startup does not read primary_conninfo, so the once-pattern
+			// is consumed only by the explicit call below.
 			if tt.expectQuery {
 				if tt.mockReadError {
 					mockQueryService.AddQueryPatternOnceWithError(
 						"current_setting.*primary_conninfo", assert.AnError)
 				} else {
+					connInfo := tt.mockConnInfo
+					if tt.matchPassfile {
+						connInfo += " passfile=" + pm.pgpassFilePath()
+					}
 					var row [][]any
-					if tt.mockConnInfo == "" {
+					if connInfo == "" {
 						row = [][]any{{nil}}
 					} else {
-						row = [][]any{{tt.mockConnInfo}}
+						row = [][]any{{connInfo}}
 					}
 					mockQueryService.AddQueryPatternOnce(
 						"current_setting.*primary_conninfo",
 						mock.MakeQueryResult([]string{"current_setting"}, row))
 				}
 			}
-
-			pm, tmpDir := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(0)})
 
 			if tt.seedRP != nil {
 				lockCtx, err := pm.actionLock.Acquire(t.Context(), "test-seed")

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -151,8 +151,16 @@ func (pm *MultipoolerManager) setPrimaryConnInfoLocked(ctx context.Context, host
 	}
 	connInfo := fmt.Sprintf("host=%s port=%d user=%s application_name=%s",
 		host, port, user, appName.AppName())
-	if pm.pgpassPath != "" {
-		connInfo += " passfile=" + pm.pgpassPath
+	if pgpass := pm.pgpassFilePath(); pgpass != "" {
+		connInfo += " passfile=" + pgpass
+	} else {
+		// Writing a conninfo with no passfile: the walreceiver will fail SCRAM
+		// with "fe_sendauth: no password supplied" until pgpassPath is known and
+		// the drift check (primaryConnInfoDiffersFromRecorded) self-heals it.
+		// Surface it so a stuck standby is diagnosable from the pooler log rather
+		// than only the postgres log.
+		pm.logger.WarnContext(ctx, "writing primary_conninfo without passfile (pgpassPath not set yet); standby cannot authenticate to primary until reconciled",
+			"host", host, "port", port)
 	}
 
 	// Set primary_conninfo using ALTER SYSTEM

--- a/go/test/endtoend/multipooler/postgres_monitor_test.go
+++ b/go/test/endtoend/multipooler/postgres_monitor_test.go
@@ -291,3 +291,103 @@ func TestPostgresMonitor_FixesPrimaryConnInfoDrift(t *testing.T) {
 
 	t.Logf("MonitorPostgres restored primary_conninfo from the bogus override back to the recorded primary")
 }
+
+// TestPostgresMonitor_FixesMissingPassfileDrift reproduces the original bug
+// fixed by this change: a primary_conninfo that already points at the right
+// host/port but carries no passfile= clause used to read as "no drift"
+// because primaryConnInfoDiffersFromRecorded only compared host and port.
+// That left the walreceiver unable to authenticate ("fe_sendauth: no
+// password supplied") with no self-heal in sight.
+//
+//  1. Establish replication on the standby (which populates the recorded
+//     ReplicationPrimary and, since pgpassPath is known by then, writes a
+//     conninfo that includes passfile=).
+//  2. Externally clobber primary_conninfo to the same host/port but with the
+//     passfile= clause stripped out.
+//  3. Wait for the monitor (5s tick) to detect the passfile drift via
+//     primaryConnInfoDiffersFromRecorded/matchesRecorded and rewrite
+//     primary_conninfo to restore it.
+func TestPostgresMonitor_FixesMissingPassfileDrift(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+
+	setup := getSharedTestSetup(t)
+	// Use WithoutReplication so this test owns the SetPrimaryConnInfo call
+	// below — that's how we both establish replication AND populate the
+	// recorded ReplicationPrimary the monitor reads from.
+	setupPoolerTest(t, setup, WithoutReplication())
+
+	waitForManagerReady(t, setup, setup.StandbyMultipooler)
+
+	standbyClient, err := shardsetup.NewMultipoolerClient(setup.StandbyMultipooler.GrpcPort)
+	require.NoError(t, err)
+	t.Cleanup(func() { standbyClient.Close() })
+
+	// Configure replication AND record the (rule, primary) tuple. SetPrimary
+	// populates ReplicationPrimary, which is what the monitor reads.
+	primaryID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      setup.CellName,
+		Name:      setup.PrimaryMultipooler.Name,
+	}
+	primaryHost := "localhost"
+	primaryPort := int32(setup.PrimaryPgctld.PgPort)
+	// Use a high coordinator term so the supplied rule is strictly higher than
+	// whatever the standby has observed, forcing SetPrimary's standby
+	// branch to apply.
+	_, err = standbyClient.Consensus.SetPrimary(t.Context(), &consensusdatapb.SetPrimaryRequest{
+		ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
+			Position: &clustermetadatapb.RulePosition{
+				Decision: &clustermetadatapb.ShardRule{
+					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1 << 30},
+					LeaderId:   primaryID,
+				},
+			},
+			Primary: &clustermetadatapb.PoolerAddress{
+				Id:           primaryID,
+				Host:         primaryHost,
+				PostgresPort: primaryPort,
+			},
+		},
+	})
+	require.NoError(t, err, "SetPrimary should succeed on standby")
+
+	standbyDB := connectToPostgresViaSocket(t,
+		getPostgresSocketPath(setup.StandbyPgctld.PoolerDir),
+		setup.StandbyPgctld.PgPort)
+	t.Cleanup(func() { standbyDB.Close() })
+
+	readConnInfo := func() string {
+		var connInfo string
+		err := standbyDB.QueryRow(`SELECT current_setting('primary_conninfo', true)`).Scan(&connInfo)
+		require.NoError(t, err, "should read primary_conninfo")
+		return connInfo
+	}
+	originalConnInfo := readConnInfo()
+	require.NotEmpty(t, originalConnInfo, "primary_conninfo must be set after SetPrimaryConnInfo")
+	require.Contains(t, originalConnInfo, "passfile=",
+		"sanity check: the pooler-written conninfo should carry a passfile clause once pgpassPath is known")
+
+	// Clobber primary_conninfo with the same host/port but no passfile= clause —
+	// the exact shape a conninfo written before pgpassPath was known would have.
+	// ALTER SYSTEM does not accept query parameters, so the value is inlined;
+	// pg_reload_conf makes the new value visible to subsequent reads.
+	clobbered := fmt.Sprintf("host=%s port=%d user=replicator application_name=passfile_drift_test",
+		primaryHost, primaryPort)
+	_, err = standbyDB.Exec(fmt.Sprintf(`ALTER SYSTEM SET primary_conninfo = '%s'`, clobbered))
+	require.NoError(t, err, "ALTER SYSTEM SET primary_conninfo should succeed")
+	_, err = standbyDB.Exec(`SELECT pg_reload_conf()`)
+	require.NoError(t, err, "pg_reload_conf should succeed")
+	time.Sleep(10 * time.Millisecond)
+
+	// Monitor ticks every 5s; allow up to ~30s for the heal to converge over
+	// 4-5 cycles even with scheduling jitter.
+	require.Eventually(t, func() bool {
+		current := readConnInfo()
+		return strings.Contains(current, "passfile=") &&
+			strings.Contains(current, "host="+primaryHost)
+	}, 30*time.Second, 500*time.Millisecond, "monitor should self-heal the missing passfile clause back onto primary_conninfo")
+
+	t.Logf("MonitorPostgres restored the passfile clause stripped from primary_conninfo")
+}

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -38,6 +38,11 @@ message PrimaryConnInfo {
 
   // Raw connection string (includes all parameters)
   string raw = 5;
+
+  // Path to the libpq password file (passfile=) the standby uses to
+  // authenticate to the primary. Empty when the conninfo carries no passfile
+  // clause. Not a secret (it is a filesystem path, not the password itself).
+  string passfile = 6;
 }
 
 // StandbyReplicationStatus PostgreSQL replication status information

--- a/web/multiadmin/lib/api/generated/multipoolermanagerdata_pb.ts
+++ b/web/multiadmin/lib/api/generated/multipoolermanagerdata_pb.ts
@@ -355,6 +355,15 @@ export class PrimaryConnInfo extends Message<PrimaryConnInfo> {
    */
   raw = "";
 
+  /**
+   * Path to the libpq password file (passfile=) the standby uses to
+   * authenticate to the primary. Empty when the conninfo carries no passfile
+   * clause. Not a secret (it is a filesystem path, not the password itself).
+   *
+   * @generated from field: string passfile = 6;
+   */
+  passfile = "";
+
   constructor(data?: PartialMessage<PrimaryConnInfo>) {
     super();
     proto3.util.initPartial(data, this);
@@ -368,6 +377,7 @@ export class PrimaryConnInfo extends Message<PrimaryConnInfo> {
     { no: 3, name: "user", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 4, name: "application_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 5, name: "raw", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 6, name: "passfile", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): PrimaryConnInfo {


### PR DESCRIPTION
## Summary

- A standby whose `primary_conninfo` was written before `pgpassPath` was known carries no `passfile=` clause, so its walreceiver can't authenticate to the primary (`fe_sendauth: no password supplied`). The drift check only compared host/port, so this read as "no drift" and froze the passwordless conninfo in place forever, with the monitor then misdiagnosing the stuck standby as WAL divergence and routing to a needless `pg_rewind`.
- Add a `passfile` field to `PrimaryConnInfo` and fold it into drift detection (`matchesRecorded`) so the existing self-heal paths (the `SetPrimary` no-op branch and the `MonitorPostgres` tick) fix it instead of freezing it.
- Also warn when a conninfo is written without a passfile, so a stuck standby is diagnosable from the pooler log rather than only the postgres log.

Fixes MUL-1193

## Sequence of events that led to the failure

1. A standby is provisioned / restarted. The multipooler starts and kicks off `loadShardConfigFromGlobalTopo` **asynchronously** (retry + backoff); `pm.pgpassPath` is still `""`.
2. Before that goroutine finishes, `primary_conninfo` is written — via early `SetPrimary`/`restartAsStandby` during bring-up — while `pgpassPath == ""`. The conninfo is `host=… port=… user=… application_name=…` with **no `passfile=`** clause.
3. `ALTER SYSTEM SET primary_conninfo = …` persists that passwordless value into `postgresql.auto.conf`.
4. `loadShardConfigFromGlobalTopo` completes, writes the pgpass file, and sets `pm.pgpassPath`. But nothing rebuilds the already-written conninfo.
5. The walreceiver starts, reads the passwordless conninfo, and libpq has no password to send. The primary (pg_hba `scram-sha-256` for replication) demands SCRAM → libpq aborts with `fe_sendauth: no password supplied`. Replication never establishes.
6. The standby keeps up only via archive replay (`restore_command`), reaching consistent recovery, then waits for WAL that must come via streaming.
7. multiorch issues `SetPrimary`, but the consensus position hasn't advanced → it hits the **no-op gate**. The no-op branch tries to self-heal, but calls `primaryConnInfoDiffersFromRecorded`, which sees host/port already correct → reports **no drift** → returns without rewriting.
8. The `MonitorPostgres` periodic tick runs the **same** host/port-only drift check → same result → no rewrite.
9. With every rewrite path gated on a check blind to the missing passfile, the passwordless conninfo is **frozen in place**. The standby is permanently stuck; a restart re-loads the same `postgresql.auto.conf` and reproduces the state (step 5 onward).

## Test plan

Unit (`./go/services/multipooler/internal/manager`, run with `-race`):

- [x] `TestPrimaryConnInfoDiffersFromRecorded` — all subtests, including the new missing/stale passfile cases and the `LiveConnInfoMatchesRecorded` control.
- [x] Red-before-green: with the passfile comparison reverted to host/port-only, `LiveConnInfoMissingPassfile_Drifts` and `LiveConnInfoStalePassfile_Drifts` both fail (`expected: true, actual: false`) while the control stays green; both pass with the fix.

End-to-end (`./go/test/endtoend/multipooler`, PostgreSQL 17):

- [x] `TestPostgresMonitor_FixesMissingPassfileDrift` — red-before-green verified on this commit: fails without the fix (times out at ~50s, "monitor should self-heal the missing passfile clause"), passes with it (~21s).
- [x] `TestPostgresMonitor_FixesPrimaryConnInfoDrift` (existing host/port drift self-heal) passes.
- [x] Full `./go/test/endtoend/...` suite green on an earlier revision of this change; the passfile-specific e2e re-verified on the final squashed commit.
