### PR TITLE
feat(multipooler): access multigres schema via admin pool

### DIFF
--- a/go/services/multipooler/internal/executor/admin_query.go
+++ b/go/services/multipooler/internal/executor/admin_query.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"context"
+
+	"github.com/multigres/multigres/go/common/sqltypes"
+)
+
+// The QueryAdmin* methods are the InternalQueryService access path for the
+// locked-down multigres sidecar schema. They share the run* helpers with the
+// regular Query* methods and differ only in the borrower: they run on the admin
+// pool, which authenticates as the true PostgreSQL superuser. The multigres
+// schema is created and owned by that superuser and is not reachable by customer
+// roles through their per-user regular pool (they get only USAGE on the schema
+// and SELECT on multigres.backend_vpid), so any internal read/write of a
+// multigres.* table must go through these methods or it would fail once the
+// regular pool's role is not the schema owner.
+
+// borrowAdmin borrows a connection from the admin (true-superuser) pool.
+func (e *Executor) borrowAdmin(ctx context.Context) (pooledQueryConn, func(), error) {
+	conn, err := e.poolManager.GetAdminConn(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn.Conn, conn.Recycle, nil
+}
+
+// QueryAdmin implements InternalQueryService on the admin pool.
+func (e *Executor) QueryAdmin(ctx context.Context, queryStr string) (*sqltypes.Result, error) {
+	return runSingleQuery(ctx, e.borrowAdmin, queryStr)
+}
+
+// QueryAdminArgs implements InternalQueryService on the admin pool.
+func (e *Executor) QueryAdminArgs(ctx context.Context, sql string, args ...any) (*sqltypes.Result, error) {
+	return runSingleQueryArgs(ctx, e.borrowAdmin, sql, args...)
+}
+
+// QueryAdminMultiStatement implements InternalQueryService on the admin pool.
+func (e *Executor) QueryAdminMultiStatement(ctx context.Context, queryStr string) error {
+	return runMultiStatement(ctx, e.borrowAdmin, queryStr)
+}

--- a/go/services/multipooler/internal/executor/admin_query_test.go
+++ b/go/services/multipooler/internal/executor/admin_query_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/fakepgserver"
+)
+
+// The QueryAdmin* methods are the access path for the locked-down multigres
+// sidecar schema. These tests exercise them against a real connpoolmanager.Manager
+// (whose admin pool dials the fake server), the same wiring production uses.
+
+func TestQueryAdmin(t *testing.T) {
+	server := fakepgserver.New(t)
+	server.SetNeverFail(true)
+
+	e := newInternalQueryTestExecutor(t, server)
+	ctx := context.Background()
+
+	res, err := e.QueryAdmin(ctx, "SELECT 1 FROM multigres.heartbeat")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, 1, server.GetQueryCalledNum("SELECT 1 FROM multigres.heartbeat"))
+}
+
+func TestQueryAdminArgs(t *testing.T) {
+	server := fakepgserver.New(t)
+	server.SetNeverFail(true)
+
+	e := newInternalQueryTestExecutor(t, server)
+	ctx := context.Background()
+
+	res, err := e.QueryAdminArgs(ctx, "SELECT oid FROM multigres.tablegroup WHERE name = $1", "default")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+}
+
+func TestQueryAdminMultiStatement(t *testing.T) {
+	server := fakepgserver.New(t)
+	server.SetNeverFail(true)
+
+	e := newInternalQueryTestExecutor(t, server)
+	ctx := context.Background()
+
+	err := e.QueryAdminMultiStatement(ctx, "CREATE SCHEMA multigres; GRANT USAGE ON SCHEMA multigres TO PUBLIC")
+	require.NoError(t, err)
+	assert.Equal(t, 1, server.GetQueryCalledNum("CREATE SCHEMA multigres; GRANT USAGE ON SCHEMA multigres TO PUBLIC"))
+}

--- a/go/services/multipooler/internal/executor/internal_query.go
+++ b/go/services/multipooler/internal/executor/internal_query.go
@@ -28,23 +28,48 @@ import (
 // already been committed or rolled back.
 var errTxFinished = errors.New("transaction already finished")
 
-// InternalQueryService provides a simplified query interface for internal multipooler
-// components. It uses the admin connection pool, which authenticates as the configured
-// superuser (POSTGRES_USER / POSTGRES_PASSWORD).
+// InternalQueryService provides a simplified query interface for internal
+// multipooler components. It exposes two families of methods over two connection
+// pools:
+//
+//   - Query / QueryArgs / QueryMultiStatement / Begin run on the regular pool (as
+//     the configured PgUser). Use for pure system queries — pg_is_in_recovery(),
+//     ALTER SYSTEM, WAL LSN reads, SELECT 1 — so the small admin pool is not
+//     exhausted by high-volume polling.
+//   - QueryAdmin / QueryAdminArgs / QueryAdminMultiStatement run on the admin
+//     (true-superuser) pool. Use for every read/write of the locked-down multigres
+//     sidecar schema, which is owned by the true superuser and which customer
+//     roles on the regular pool cannot reach.
+//
+// Choosing the pool at the call site (by method name) keeps "this touches the
+// locked-down schema" visible where the query is written.
 type InternalQueryService interface {
-	// Query executes a query and returns the result.
+	// Query executes a query on the regular pool and returns the result.
 	Query(ctx context.Context, query string) (*sqltypes.Result, error)
 
-	// QueryArgs executes a query with arguments and returns the result.
-	// This is a convenience method that accepts Go values as arguments and converts
-	// them to the appropriate text format for PostgreSQL.
+	// QueryArgs executes a query with arguments on the regular pool and returns
+	// the result. This is a convenience method that accepts Go values as arguments
+	// and converts them to the appropriate text format for PostgreSQL.
 	// Supported argument types: nil, string, []byte, int, int32, int64, *int64, uint32, uint64,
 	// float32, float64, bool, and time.Time.
 	QueryArgs(ctx context.Context, query string, args ...any) (*sqltypes.Result, error)
 
 	// QueryMultiStatement executes a multi-statement query (e.g. "BEGIN; ...; COMMIT;")
-	// using the simple query protocol. Unlike Query, it does not require exactly one result set.
+	// on the regular pool using the simple query protocol. Unlike Query, it does
+	// not require exactly one result set.
 	QueryMultiStatement(ctx context.Context, query string) error
+
+	// QueryAdmin executes a query on the admin (true-superuser) pool and returns
+	// the single result. Use for reads/writes of the multigres sidecar schema.
+	QueryAdmin(ctx context.Context, query string) (*sqltypes.Result, error)
+
+	// QueryAdminArgs is QueryAdmin with arguments; it accepts the same Go argument
+	// types as QueryArgs.
+	QueryAdminArgs(ctx context.Context, query string, args ...any) (*sqltypes.Result, error)
+
+	// QueryAdminMultiStatement is QueryMultiStatement on the admin pool. Use for
+	// the multigres schema DDL that grants privileges alongside CREATE.
+	QueryAdminMultiStatement(ctx context.Context, query string) error
 
 	// Begin starts a transaction on a reserved connection and returns a handle
 	// for issuing queries within it. Reserved connections are the mechanism for
@@ -100,27 +125,49 @@ var _ InternalTx = (*internalTx)(nil)
 // Compile-time check that Executor implements InternalQueryService.
 var _ InternalQueryService = (*Executor)(nil)
 
-// Query implements InternalQueryService for simple internal queries.
-//
-// It executes a query using the regular connection pool and returns the first
-// result. We use the regular connection pool rather than the admin pool because
-// we do not want to exhaust the admin pool.
-//
-// Internal queries include SQL text in trace spans since they use system
-// functions.
-func (e *Executor) Query(ctx context.Context, queryStr string) (*sqltypes.Result, error) {
-	// Enable SQL text in trace spans for internal queries (safe - no user data)
-	ctx = client.WithQueryTracing(ctx, client.QueryTracingConfig{
-		IncludeQueryText: true,
-	})
+// pooledQueryConn is the subset of a borrowed pool connection the internal query
+// helpers use. Both *regular.Conn and *admin.Conn satisfy it, which lets the
+// regular and admin query methods share the run* helpers below and differ only
+// in the borrower they pass.
+type pooledQueryConn interface {
+	QueryWithRetry(ctx context.Context, sql string) ([]*sqltypes.Result, error)
+	QueryArgsWithRetry(ctx context.Context, sql string, args ...any) ([]*sqltypes.Result, error)
+}
 
+// connBorrower acquires a pool connection and returns it with a release function
+// the caller must invoke when finished. The Query/QueryAdmin pairs differ only in
+// which borrower they pass: borrowRegular (per-user regular pool) vs borrowAdmin
+// (admin true-superuser pool).
+type connBorrower func(ctx context.Context) (conn pooledQueryConn, release func(), err error)
+
+// borrowRegular borrows a connection from the per-user regular pool as the
+// configured PgUser. We use the regular pool for system queries rather than the
+// admin pool so as not to exhaust the small admin pool.
+func (e *Executor) borrowRegular(ctx context.Context) (pooledQueryConn, func(), error) {
 	conn, err := e.poolManager.GetRegularConn(ctx, e.poolManager.PgUser(), nil, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn.Conn, conn.Recycle, nil
+}
+
+// withInternalQueryTracing enables SQL text in trace spans for internal queries
+// (safe - no user data, and they use system functions).
+func withInternalQueryTracing(ctx context.Context) context.Context {
+	return client.WithQueryTracing(ctx, client.QueryTracingConfig{IncludeQueryText: true})
+}
+
+// runSingleQuery runs a query on a borrowed connection and returns its single
+// result set, erroring if the query did not produce exactly one.
+func runSingleQuery(ctx context.Context, borrow connBorrower, queryStr string) (*sqltypes.Result, error) {
+	ctx = withInternalQueryTracing(ctx)
+	conn, release, err := borrow(ctx)
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Recycle()
+	defer release()
 
-	results, err := conn.Conn.QueryWithRetry(ctx, queryStr)
+	results, err := conn.QueryWithRetry(ctx, queryStr)
 	if err != nil {
 		return nil, err
 	}
@@ -130,49 +177,58 @@ func (e *Executor) Query(ctx context.Context, queryStr string) (*sqltypes.Result
 	return results[0], nil
 }
 
-// QueryMultiStatement implements InternalQueryService for multi-statement queries.
-// It executes a query using the simple query protocol and does not check the number of result sets.
-func (e *Executor) QueryMultiStatement(ctx context.Context, queryStr string) error {
-	ctx = client.WithQueryTracing(ctx, client.QueryTracingConfig{
-		IncludeQueryText: true,
-	})
+// runSingleQueryArgs is runSingleQuery for a parameterized query.
+func runSingleQueryArgs(ctx context.Context, borrow connBorrower, sql string, args ...any) (*sqltypes.Result, error) {
+	ctx = withInternalQueryTracing(ctx)
+	conn, release, err := borrow(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 
-	conn, err := e.poolManager.GetRegularConn(ctx, e.poolManager.PgUser(), nil, nil)
+	results, err := conn.QueryArgsWithRetry(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) != 1 {
+		return nil, errors.New("unexpected number of results")
+	}
+	return results[0], nil
+}
+
+// runMultiStatement runs a multi-statement query on a borrowed connection using
+// the simple query protocol, without checking the number of result sets.
+func runMultiStatement(ctx context.Context, borrow connBorrower, queryStr string) error {
+	ctx = withInternalQueryTracing(ctx)
+	conn, release, err := borrow(ctx)
 	if err != nil {
 		return err
 	}
-	defer conn.Recycle()
+	defer release()
 
-	_, err = conn.Conn.QueryWithRetry(ctx, queryStr)
+	_, err = conn.QueryWithRetry(ctx, queryStr)
 	return err
 }
 
-// QueryArgs implements InternalQueryService for simple internal queries.
-// This is a convenience method that accepts Go values as arguments and converts
-// them to the appropriate text format for PostgreSQL.
-// Supported argument types: nil, string, []byte, int, int32, int64, *int64, uint32, uint64,
-// float32, float64, bool, and time.Time.
-// Internal queries include SQL text in trace spans since they use system functions.
+// Query implements InternalQueryService for simple internal queries on the
+// regular pool.
+func (e *Executor) Query(ctx context.Context, queryStr string) (*sqltypes.Result, error) {
+	return runSingleQuery(ctx, e.borrowRegular, queryStr)
+}
+
+// QueryMultiStatement implements InternalQueryService for multi-statement queries
+// on the regular pool.
+func (e *Executor) QueryMultiStatement(ctx context.Context, queryStr string) error {
+	return runMultiStatement(ctx, e.borrowRegular, queryStr)
+}
+
+// QueryArgs implements InternalQueryService for simple parameterized queries on
+// the regular pool. It accepts Go values as arguments and converts them to the
+// appropriate text format for PostgreSQL. Supported argument types: nil, string,
+// []byte, int, int32, int64, *int64, uint32, uint64, float32, float64, bool, and
+// time.Time.
 func (e *Executor) QueryArgs(ctx context.Context, sql string, args ...any) (*sqltypes.Result, error) {
-	// Enable SQL text in trace spans for internal queries (safe - no user data)
-	ctx = client.WithQueryTracing(ctx, client.QueryTracingConfig{
-		IncludeQueryText: true,
-	})
-
-	conn, err := e.poolManager.GetRegularConn(ctx, e.poolManager.PgUser(), nil, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer conn.Recycle()
-
-	results, err := conn.Conn.QueryArgsWithRetry(ctx, sql, args...)
-	if err != nil {
-		return nil, err
-	}
-	if len(results) != 1 {
-		return nil, errors.New("unexpected number of results")
-	}
-	return results[0], nil
+	return runSingleQueryArgs(ctx, e.borrowRegular, sql, args...)
 }
 
 // Begin implements InternalQueryService. It reserves a connection (via the

--- a/go/services/multipooler/internal/executor/mock/mock_querier.go
+++ b/go/services/multipooler/internal/executor/mock/mock_querier.go
@@ -185,6 +185,24 @@ func (m *QueryService) QueryArgs(ctx context.Context, queryStr string, args ...a
 	return m.Query(ctx, queryStr)
 }
 
+// QueryAdmin implements executor.InternalQueryService.
+// The mock records admin-pool queries through the same pattern matcher as Query;
+// tests assert on the query string regardless of which pool it targets.
+func (m *QueryService) QueryAdmin(ctx context.Context, queryStr string) (*sqltypes.Result, error) {
+	return m.Query(ctx, queryStr)
+}
+
+// QueryAdminArgs implements executor.InternalQueryService (delegates to Query).
+func (m *QueryService) QueryAdminArgs(ctx context.Context, queryStr string, args ...any) (*sqltypes.Result, error) {
+	return m.Query(ctx, queryStr)
+}
+
+// QueryAdminMultiStatement implements executor.InternalQueryService (delegates to Query).
+func (m *QueryService) QueryAdminMultiStatement(ctx context.Context, queryStr string) error {
+	_, err := m.Query(ctx, queryStr)
+	return err
+}
+
 // SetBeginError configures Begin to fail with the given error. Pass nil to clear.
 // Useful for exercising transaction-start failure paths.
 func (m *QueryService) SetBeginError(err error) {

--- a/go/services/multipooler/internal/heartbeat/reader.go
+++ b/go/services/multipooler/internal/heartbeat/reader.go
@@ -176,7 +176,7 @@ func (r *Reader) readHeartbeat(ctx context.Context) {
 // restore_command/archive replay), so its advancement is a "the primary is
 // streaming new WAL to this standby" signal.
 func (r *Reader) fetchMostRecentHeartbeat(ctx context.Context) (tsNano int64, receiveLSN pgutil.LSN, haveReceiveLSN bool, err error) {
-	result, err := r.queryService.QueryArgs(ctx,
+	result, err := r.queryService.QueryAdminArgs(ctx,
 		"SELECT ts, pg_last_wal_receive_lsn()::text FROM multigres.heartbeat WHERE shard_id = $1",
 		r.shardID)
 	if err != nil {
@@ -243,7 +243,7 @@ func (r *Reader) GetLeadershipView() (*LeadershipView, error) {
 	ctx, cancel := context.WithTimeout(context.TODO(), r.interval)
 	defer cancel()
 
-	result, err := r.queryService.QueryArgs(ctx,
+	result, err := r.queryService.QueryAdminArgs(ctx,
 		"SELECT leader_id, ts FROM multigres.heartbeat WHERE shard_id = $1",
 		r.shardID)
 	if err != nil {

--- a/go/services/multipooler/internal/heartbeat/writer.go
+++ b/go/services/multipooler/internal/heartbeat/writer.go
@@ -109,7 +109,7 @@ func (w *Writer) writeHeartbeat(ctx context.Context) {
 func (w *Writer) write(ctx context.Context) error {
 	tsNano := w.now().UnixNano()
 
-	_, err := w.queryService.QueryArgs(ctx, `
+	_, err := w.queryService.QueryAdminArgs(ctx, `
 		INSERT INTO multigres.heartbeat (shard_id, leader_id, ts)
 		VALUES ($1, $2, $3)
 		ON CONFLICT (shard_id) DO UPDATE

--- a/go/services/multipooler/internal/manager/consensus/rule_store.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store.go
@@ -366,7 +366,7 @@ func (rs *ruleStore) CreateRuleTables(ctx context.Context, policy *clustermetada
 	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
 
-	if _, err := rs.queryService.Query(execCtx, `CREATE TABLE multigres.current_rule (
+	if _, err := rs.queryService.QueryAdmin(execCtx, `CREATE TABLE multigres.current_rule (
 		shard_id                           BYTEA PRIMARY KEY,
 		decision_coordinator_term          BIGINT NOT NULL,
 		decision_leader_subterm            BIGINT NOT NULL,
@@ -389,7 +389,7 @@ func (rs *ruleStore) CreateRuleTables(ctx context.Context, policy *clustermetada
 		return mterrors.Wrap(err, "failed to create current_rule table")
 	}
 
-	if _, err := rs.queryService.QueryArgs(execCtx, `
+	if _, err := rs.queryService.QueryAdminArgs(execCtx, `
 		INSERT INTO multigres.current_rule
 		  (shard_id, decision_coordinator_term, decision_leader_subterm, coordinator_id, cohort_members,
 		   durability_policy_name, durability_quorum_type, durability_required_count, created_at)
@@ -408,7 +408,7 @@ func (rs *ruleStore) CreateRuleTables(ctx context.Context, policy *clustermetada
 	// when a proposal is first written and is later UPDATEd to true once confirmed, rather than
 	// getting a second row — that's Step 3's two-phase write; every write today still inserts
 	// decided=true directly, since there is no proposal phase yet.
-	if _, err := rs.queryService.Query(execCtx, `CREATE TABLE multigres.rule_history (
+	if _, err := rs.queryService.QueryAdmin(execCtx, `CREATE TABLE multigres.rule_history (
 		coordinator_term          BIGINT NOT NULL,
 		leader_subterm            BIGINT NOT NULL,
 		event_type                TEXT NOT NULL,
@@ -458,7 +458,7 @@ func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clus
 	if forUpdate {
 		suffix = " FOR UPDATE NOWAIT"
 	}
-	result, err := rs.queryService.QueryArgs(ctx, `
+	result, err := rs.queryService.QueryAdminArgs(ctx, `
 		SELECT decision_coordinator_term, decision_leader_subterm, leader_id, coordinator_id, cohort_members,
 		       durability_policy_name, durability_quorum_type, durability_required_count,
 		       created_at,
@@ -997,7 +997,7 @@ func (rs *ruleStore) markProposalAsDecision(
 	execCtx, cancel := context.WithTimeout(ctx, timeouts.RuleWriteTimeout)
 	defer cancel()
 
-	result, err := rs.queryService.QueryArgs(execCtx, `
+	result, err := rs.queryService.QueryAdminArgs(execCtx, `
 		WITH
 		  params AS (
 		    SELECT $1::bytea       AS shard_id,
@@ -1155,7 +1155,7 @@ func (rs *ruleStore) writeRuleProposal(ctx context.Context, p ruleProposalWriteP
 		defer ackSpan.End()
 	}
 
-	result, err := rs.queryService.QueryArgs(execCtx, `
+	result, err := rs.queryService.QueryAdminArgs(execCtx, `
 		WITH
 		  params AS (
 		    -- Name all query parameters once so the rest of the CTE references them by name.
@@ -1330,7 +1330,7 @@ func (rs *ruleStore) confirmProposalQuorum(ctx context.Context, expectedTerm, ex
 	execCtx, cancel := context.WithTimeout(ctx, timeouts.RuleWriteTimeout)
 	defer cancel()
 
-	result, err := rs.queryService.QueryArgs(execCtx, `
+	result, err := rs.queryService.QueryAdminArgs(execCtx, `
 		WITH
 		  params AS (
 		    SELECT $1::bytea  AS shard_id,
@@ -1373,7 +1373,7 @@ func (rs *ruleStore) queryRuleHistory(ctx context.Context, limit int) ([]ruleHis
 	queryCtx, cancel := context.WithTimeout(ctx, timeouts.RuleReadTimeout)
 	defer cancel()
 
-	result, err := rs.queryService.QueryArgs(queryCtx, `
+	result, err := rs.queryService.QueryAdminArgs(queryCtx, `
 		SELECT coordinator_term, leader_subterm, event_type, leader_id, coordinator_id,
 		       wal_position, operation, reason, cohort_members, accepted_members,
 		       durability_policy_name, durability_quorum_type, durability_required_count,

--- a/go/services/multipooler/internal/manager/consensus/rule_store_pg_test.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store_pg_test.go
@@ -111,6 +111,21 @@ func (s *connQueryService) QueryMultiStatement(ctx context.Context, query string
 	return err
 }
 
+// The admin variants run on the same test connection (already the superuser), so
+// they delegate to the regular methods.
+
+func (s *connQueryService) QueryAdmin(ctx context.Context, query string) (*sqltypes.Result, error) {
+	return s.Query(ctx, query)
+}
+
+func (s *connQueryService) QueryAdminArgs(ctx context.Context, query string, args ...any) (*sqltypes.Result, error) {
+	return s.QueryArgs(ctx, query, args...)
+}
+
+func (s *connQueryService) QueryAdminMultiStatement(ctx context.Context, query string) error {
+	return s.QueryMultiStatement(ctx, query)
+}
+
 func (s *connQueryService) Begin(ctx context.Context) (executor.InternalTx, error) {
 	if _, err := s.conn.Query(ctx, "BEGIN"); err != nil {
 		return nil, err

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -471,6 +471,41 @@ func (pm *MultipoolerManager) execArgs(ctx context.Context, sql string, args ...
 	return err
 }
 
+// adminQuery executes a query on the admin (true-superuser) pool via the
+// InternalQueryService's QueryAdmin method and returns the result. Use for
+// reads/writes of the multigres sidecar schema.
+func (pm *MultipoolerManager) adminQuery(ctx context.Context, sql string) (*sqltypes.Result, error) {
+	queryService := pm.internalQueryService()
+	if queryService == nil {
+		return nil, errors.New("internal query service not available")
+	}
+	return queryService.QueryAdmin(ctx, sql)
+}
+
+// adminExec executes a command that doesn't return rows on the admin
+// (true-superuser) pool. Use for multigres sidecar schema DDL/DML.
+func (pm *MultipoolerManager) adminExec(ctx context.Context, sql string) error {
+	_, err := pm.adminQuery(ctx, sql)
+	return err
+}
+
+// adminQueryArgs executes a parameterized query on the admin (true-superuser)
+// pool and returns the result. Use for reads/writes of the multigres sidecar schema.
+func (pm *MultipoolerManager) adminQueryArgs(ctx context.Context, sql string, args ...any) (*sqltypes.Result, error) {
+	queryService := pm.internalQueryService()
+	if queryService == nil {
+		return nil, errors.New("internal query service not available")
+	}
+	return queryService.QueryAdminArgs(ctx, sql, args...)
+}
+
+// adminExecArgs executes a parameterized command that doesn't return rows on the
+// admin (true-superuser) pool. Use for multigres sidecar schema DDL/DML.
+func (pm *MultipoolerManager) adminExecArgs(ctx context.Context, sql string, args ...any) error {
+	_, err := pm.adminQueryArgs(ctx, sql, args...)
+	return err
+}
+
 // Open opens the database connections and starts background operations, then
 // transitions the pooler to SERVING. This is the entry point for first-time
 // startup; resume-from-Pause goes through openLocked directly so it can

--- a/go/services/multipooler/internal/manager/pg_multischema.go
+++ b/go/services/multipooler/internal/manager/pg_multischema.go
@@ -128,11 +128,22 @@ func (pm *MultipoolerManager) initializeMultischemaData(ctx context.Context) err
 	return nil
 }
 
-// createSchema creates the multigres schema if it doesn't exist
+// createSchema creates the multigres sidecar schema under the admin
+// (true-superuser) connection, so the schema is owned by the true superuser and
+// customer roles cannot drop or alter it. It grants only USAGE on the schema to
+// PUBLIC — the minimum that lets customer roles resolve the one object they are
+// permitted to read (multigres.backend_vpid, whose SELECT grant is applied when
+// that table is created). No object privileges are implied by USAGE, so every
+// other sidecar table remains reachable only through the admin pool.
 func (pm *MultipoolerManager) createSchema(ctx context.Context) error {
+	queryService := pm.internalQueryService()
+	if queryService == nil {
+		return mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE, "internal query service unavailable for multigres schema creation")
+	}
 	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	if err := pm.exec(execCtx, "CREATE SCHEMA multigres"); err != nil {
+	if err := queryService.QueryAdminMultiStatement(execCtx, `CREATE SCHEMA multigres;
+GRANT USAGE ON SCHEMA multigres TO PUBLIC`); err != nil {
 		return mterrors.Wrap(err, "failed to create multigres schema")
 	}
 	return nil
@@ -146,7 +157,7 @@ func (pm *MultipoolerManager) createSchema(ctx context.Context) error {
 func (pm *MultipoolerManager) createHeartbeatTable(ctx context.Context) error {
 	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	if err := pm.exec(execCtx, `CREATE TABLE multigres.heartbeat (
+	if err := pm.adminExec(execCtx, `CREATE TABLE multigres.heartbeat (
 		shard_id BYTEA PRIMARY KEY,
 		leader_id TEXT NOT NULL,
 		ts BIGINT NOT NULL
@@ -165,7 +176,11 @@ func (pm *MultipoolerManager) createBackendVpidTable(ctx context.Context) error 
 	}
 	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	if err := queryService.QueryMultiStatement(execCtx, `CREATE UNLOGGED TABLE IF NOT EXISTS multigres.backend_vpid (
+	// backend_vpid is the one sidecar table customer roles may read: writes go
+	// through the admin pool, so PUBLIC gets only SELECT (USAGE on the schema is
+	// granted in createSchema). The REVOKE ALL first line is belt-and-suspenders
+	// against any inherited default privileges before the narrow SELECT grant.
+	if err := queryService.QueryAdminMultiStatement(execCtx, `CREATE UNLOGGED TABLE IF NOT EXISTS multigres.backend_vpid (
 	backend_pid integer PRIMARY KEY,
 	vpid bigint NOT NULL,
 	updated_at timestamptz NOT NULL DEFAULT now()
@@ -176,7 +191,6 @@ ALTER TABLE multigres.backend_vpid SET (
 	autovacuum_analyze_scale_factor = 0,
 	autovacuum_analyze_threshold = 100
 );
-GRANT USAGE ON SCHEMA multigres TO PUBLIC;
 REVOKE ALL PRIVILEGES ON TABLE multigres.backend_vpid FROM PUBLIC;
 GRANT SELECT ON TABLE multigres.backend_vpid TO PUBLIC`); err != nil {
 		return mterrors.Wrap(err, "failed to create backend_vpid table")
@@ -192,7 +206,7 @@ GRANT SELECT ON TABLE multigres.backend_vpid TO PUBLIC`); err != nil {
 func (pm *MultipoolerManager) createTablegroup(ctx context.Context) error {
 	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	if err := pm.exec(execCtx, `CREATE TABLE multigres.tablegroup (
+	if err := pm.adminExec(execCtx, `CREATE TABLE multigres.tablegroup (
 		oid BIGSERIAL PRIMARY KEY,
 		name TEXT NOT NULL UNIQUE,
 		type TEXT NOT NULL
@@ -206,7 +220,7 @@ func (pm *MultipoolerManager) createTablegroup(ctx context.Context) error {
 func (pm *MultipoolerManager) createTablegroupTable(ctx context.Context) error {
 	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	if err := pm.exec(execCtx, `CREATE TABLE multigres.tablegroup_table (
+	if err := pm.adminExec(execCtx, `CREATE TABLE multigres.tablegroup_table (
 		oid BIGSERIAL PRIMARY KEY,
 		tablegroup_oid BIGINT NOT NULL REFERENCES multigres.tablegroup(oid),
 		name TEXT NOT NULL,
@@ -221,7 +235,7 @@ func (pm *MultipoolerManager) createTablegroupTable(ctx context.Context) error {
 func (pm *MultipoolerManager) createShard(ctx context.Context) error {
 	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	if err := pm.exec(execCtx, `CREATE TABLE multigres.shard (
+	if err := pm.adminExec(execCtx, `CREATE TABLE multigres.shard (
 		oid BIGSERIAL PRIMARY KEY,
 		tablegroup_oid BIGINT NOT NULL REFERENCES multigres.tablegroup(oid),
 		shard_name TEXT NOT NULL,
@@ -245,7 +259,7 @@ func (pm *MultipoolerManager) insertTablegroup(ctx context.Context, name string)
 	pm.logger.InfoContext(ctx, "Inserting tablegroup", "name", name)
 	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	err := pm.execArgs(execCtx, `INSERT INTO multigres.tablegroup (name, type)
+	err := pm.adminExecArgs(execCtx, `INSERT INTO multigres.tablegroup (name, type)
 		VALUES ($1, 'unsharded')
 		ON CONFLICT (name) DO NOTHING`, name)
 	if err != nil {
@@ -263,7 +277,7 @@ func (pm *MultipoolerManager) insertShard(ctx context.Context, tablegroupName st
 	// First, fetch the tablegroup oid
 	queryCtx, queryCancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer queryCancel()
-	result, err := pm.queryArgs(queryCtx, "SELECT oid FROM multigres.tablegroup WHERE name = $1", tablegroupName)
+	result, err := pm.adminQueryArgs(queryCtx, "SELECT oid FROM multigres.tablegroup WHERE name = $1", tablegroupName)
 	if err != nil {
 		return mterrors.Wrap(err, "failed to find tablegroup: "+tablegroupName)
 	}
@@ -276,7 +290,7 @@ func (pm *MultipoolerManager) insertShard(ctx context.Context, tablegroupName st
 	// Insert the shard
 	execCtx, execCancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer execCancel()
-	err = pm.execArgs(execCtx, `INSERT INTO multigres.shard (tablegroup_oid, shard_name)
+	err = pm.adminExecArgs(execCtx, `INSERT INTO multigres.shard (tablegroup_oid, shard_name)
 		VALUES ($1, $2)
 		ON CONFLICT (tablegroup_oid, shard_name) DO NOTHING`, tablegroupOid, shardName)
 	if err != nil {

--- a/go/services/multipooler/internal/manager/pgbackrest_repos.go
+++ b/go/services/multipooler/internal/manager/pgbackrest_repos.go
@@ -64,7 +64,7 @@ func (pm *MultipoolerManager) createPgBackRestReposTable(ctx context.Context) er
 	}
 	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	if err := queryService.QueryMultiStatement(execCtx, `CREATE TABLE IF NOT EXISTS multigres.pgbackrest_repos (
+	if err := queryService.QueryAdminMultiStatement(execCtx, `CREATE TABLE IF NOT EXISTS multigres.pgbackrest_repos (
 	generation BIGINT PRIMARY KEY,
 	repo_number BIGINT NOT NULL UNIQUE CHECK (repo_number >= 1),
 	encrypted BOOLEAN NOT NULL,
@@ -94,7 +94,7 @@ func (pm *MultipoolerManager) insertInitialPgBackRestRepo(ctx context.Context) e
 		"generation", repo.Generation, "repo_number", repo.RepoNumber, "key_fingerprint", repo.KeyFingerprint, "encrypted", repo.Encrypted)
 	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	err := pm.execArgs(execCtx, `INSERT INTO multigres.pgbackrest_repos (generation, repo_number, encrypted, key_fingerprint, state, authoritative)
+	err := pm.adminExecArgs(execCtx, `INSERT INTO multigres.pgbackrest_repos (generation, repo_number, encrypted, key_fingerprint, state, authoritative)
 		VALUES ($1, $2, $3, $4, $5, TRUE)`,
 		repo.Generation, repo.RepoNumber, repo.Encrypted, repo.KeyFingerprint, repo.State)
 	if err != nil {

--- a/go/services/multipooler/internal/poolerserver/controller.go
+++ b/go/services/multipooler/internal/poolerserver/controller.go
@@ -85,7 +85,8 @@ type PoolerController interface {
 
 	// InternalQueryService returns an InternalQueryService for simple internal queries.
 	// This is used by internal components like heartbeat that need to execute
-	// queries using the connection pool.
+	// queries using the connection pool. The service's QueryAdmin* methods route
+	// multigres sidecar schema access to the admin (true-superuser) pool.
 	InternalQueryService() executor.InternalQueryService
 
 	// RegisterGRPCServices registers gRPC services with the server.


### PR DESCRIPTION
## Summary

- Create and access the `multigres` sidecar schema exclusively through the admin pool (the true PostgreSQL superuser), so the schema is owned by the superuser and customer roles cannot drop, alter, or read it.
- `PUBLIC` gets only `USAGE` on the schema plus `SELECT` on `multigres.backend_vpid`; every other sidecar table is owner-only.
- Route all `multigres.*` reads/writes (schema and table DDL, heartbeat, consensus rules, tablegroup/shard, `pgbackrest_repos`) through the admin pool; pure system queries stay on the regular pool.

## Description

`InternalQueryService` gains `QueryAdmin` / `QueryAdminArgs` / `QueryAdminMultiStatement` alongside the existing regular-pool methods. Both families share internal `run*` helpers and differ only in which pool they borrow from (`borrowRegular` vs `borrowAdmin`), so there is one interface and one `Executor` implementation — the pool is chosen by method name at the call site.

Previously every `multigres.*` operation went through the regular pool as `PgUser` (despite a doc comment claiming otherwise); only `backend_vpid` writes already used the admin pool. Now the schema DDL, heartbeat reader/writer, consensus rule store, tablegroup/shard inserts, and `pgbackrest_repos` provisioning all use the `QueryAdmin*` variants. Pure system queries (`pg_is_in_recovery`, `ALTER SYSTEM`, WAL LSN reads, `SELECT 1`, the sync-standby manager) stay on the regular pool so the intentionally small admin pool is not exhausted by high-volume polling.

The `USAGE` grant is what lets customer sessions reach `backend_vpid` at all (schema access in PostgreSQL requires both `USAGE` on the schema and a privilege on the object); without it the `SELECT` grant on `backend_vpid` would be dead and the isolation-test lock-wait probe, which runs as the client role, would fail.