### PR TITLE
fix(multipooler): don't attribute in-lease backup failures to lease acquisition

### DIFF
--- a/go/services/multipooler/internal/manager/rpc_backup.go
+++ b/go/services/multipooler/internal/manager/rpc_backup.go
@@ -56,9 +56,11 @@ func (pm *MultipoolerManager) Backup(ctx context.Context, forcePrimary bool, bac
 	// If another pooler holds the lease, revoke it and acquire a new one.
 	// This ensures the most recent backup request always wins.
 	var backupID string
+	var fnStarted bool
 	health := pm.backup.Health()
 	err = pm.topoClient.WithStolenBackupLease(ctx, pm.shardKey(), pm.record.Id().Name, "backup", pm.logger, func(ctx context.Context) error {
 		// The lease is held for the duration of this function.
+		fnStarted = true
 		health.SetLeaseHeld(true)
 		defer health.SetLeaseHeld(false)
 
@@ -70,7 +72,18 @@ func (pm *MultipoolerManager) Backup(ctx context.Context, forcePrimary bool, bac
 		return backupErr
 	})
 	if err != nil {
-		return "", mterrors.Wrap(err, "failed to acquire backup lease")
+		if !fnStarted {
+			// WithStolenBackupLease returns exactly whatever fn returns once
+			// the lease is held, so an error here with fnStarted still false
+			// means fn was never invoked — the failure really is in lease
+			// acquisition (e.g. steal/revoke failed, or the post-steal
+			// grace-period wait was aborted by context cancellation).
+			return "", mterrors.Wrap(err, "failed to acquire backup lease")
+		}
+		// fn ran and failed on its own; that error (e.g. a pgbackrest
+		// failure) is already descriptive — don't relabel it as a lease
+		// problem the lease was never the issue.
+		return "", err
 	}
 	return backupID, nil
 }

--- a/go/services/multipooler/internal/manager/rpc_backup_test.go
+++ b/go/services/multipooler/internal/manager/rpc_backup_test.go
@@ -1149,7 +1149,7 @@ func TestVerifyBackups(t *testing.T) {
 // surfaces as-is — it must not be relabeled as a lease-acquisition failure,
 // since the lease was never the problem.
 func TestBackup_CallbackFailure_ErrorNotAttributedToLeaseAcquisition(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	tmpDir := t.TempDir()
 	binDir := filepath.Join(tmpDir, "bin")
 	require.NoError(t, os.MkdirAll(binDir, 0o755))
@@ -1174,4 +1174,55 @@ exit 1
 	assert.NotContains(t, err.Error(), "failed to acquire backup lease",
 		"a pgbackrest failure during the backup must not be mislabeled as a lease-acquisition failure")
 	assert.Contains(t, err.Error(), "pgbackrest backup failed")
+}
+
+// TestBackup_LeaseAcquisitionFailure_DoesNotInvokeCallback verifies that when
+// the backup lease genuinely cannot be acquired — here, the post-steal
+// grace-period wait is aborted by context cancellation before the callback
+// ever runs — the error is correctly attributed to lease acquisition.
+func TestBackup_LeaseAcquisitionFailure_DoesNotInvokeCallback(t *testing.T) {
+	ts, _ := memorytopo.NewServerAndFactory(t.Context(), "zone1")
+	defer ts.Close()
+
+	shardKey := &clustermetadatapb.ShardKey{
+		Database:   "test-database",
+		TableGroup: constants.DefaultTableGroup,
+		Shard:      constants.DefaultShard,
+	}
+
+	// Another pooler holds the lease. WithStolenBackupLease will revoke it and
+	// wait out BackupLeaseStealGracePeriod (5s) before reacquiring — Backup()
+	// below is given a context expiring in 50ms, well before that, so the
+	// grace-period wait aborts via ctx.Done() and the callback never runs.
+	_, otherUnlock, err := ts.TryLockBackup(t.Context(), shardKey, "other-pooler-backup")
+	require.NoError(t, err)
+	var otherErr error
+	defer otherUnlock(&otherErr)
+
+	poolerDir := t.TempDir()
+	pm := &MultipoolerManager{
+		state:      ManagerStateReady,
+		topoClient: ts,
+		actionLock: actionlock.NewActionLock(),
+		logger:     slog.Default(),
+		record: newRecordFromProto(&clustermetadatapb.Multipooler{
+			Id: &clustermetadatapb.ID{
+				Component: clustermetadatapb.ID_MULTIPOOLER,
+				Cell:      "zone1",
+				Name:      "test-multipooler",
+			},
+			PoolerDir: poolerDir,
+			ShardKey:  shardKey,
+		}),
+	}
+	pm.backup = backupengine.NewEngine(pm.logger, pm.runLongCommand, pm.record, backupengine.Settings{})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err = pm.Backup(ctx, false, "full", "test-job-id", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to acquire backup lease")
+	assert.True(t, errors.Is(err, context.DeadlineExceeded),
+		"expected the lease-acquisition timeout to surface as context.DeadlineExceeded, got: %v", err)
 }

--- a/go/services/multipooler/internal/manager/rpc_backup_test.go
+++ b/go/services/multipooler/internal/manager/rpc_backup_test.go
@@ -1143,3 +1143,35 @@ func TestVerifyBackups(t *testing.T) {
 		require.Contains(t, err.Error(), "pgbackrest config not found")
 	})
 }
+
+// TestBackup_CallbackFailure_ErrorNotAttributedToLeaseAcquisition verifies that
+// a pgbackrest failure occurring *after* the backup lease is already held
+// surfaces as-is — it must not be relabeled as a lease-acquisition failure,
+// since the lease was never the problem.
+func TestBackup_CallbackFailure_ErrorNotAttributedToLeaseAcquisition(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+
+	mockScript := `#!/bin/bash
+echo "ERROR: simulated backup failure" >&2
+exit 1
+`
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "pgbackrest"), []byte(mockScript), 0o755))
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	poolerDir := filepath.Join(tmpDir, "pooler")
+	require.NoError(t, os.MkdirAll(poolerDir, 0o755))
+	configPath := setupMockPgBackRestConfig(t, poolerDir)
+	pm := createTestManagerWithBackupLocation(t, poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
+	pm.backup.SetConfigPath(configPath)
+	setBackupPrimary(t, pm, "primary-pooler", "primary.local", 5432)
+	overrides := map[string]string{"pg2_path": filepath.Join(poolerDir, "pg_data")}
+
+	_, err := pm.Backup(ctx, false, "full", "test-job-id", overrides)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "failed to acquire backup lease",
+		"a pgbackrest failure during the backup must not be mislabeled as a lease-acquisition failure")
+	assert.Contains(t, err.Error(), "pgbackrest backup failed")
+}

--- a/go/services/multipooler/internal/manager/rpc_first_backup.go
+++ b/go/services/multipooler/internal/manager/rpc_first_backup.go
@@ -169,7 +169,9 @@ func (pm *MultipoolerManager) createFirstBackupAndInitializeLocked(ctx context.C
 	// everyone else will find an existing backup and skip to restore.
 	// Stanza-create runs inside the lease because it is part of the pgBackRest
 	// setup work that must complete before the backup.
+	var fnStarted bool
 	err = pm.topoClient.WithBackupLease(ctx, pm.shardKey(), pm.record.Id().Name, "create-first-backup", pm.logger, func(leaseCtx context.Context) error {
+		fnStarted = true
 		// Re-check inside the lease — another pooler may have created the backup
 		// between our outer check and acquiring the lease. A read error means
 		// the repository is unreadable (e.g. a cipher-key mismatch); abort
@@ -207,7 +209,10 @@ func (pm *MultipoolerManager) createFirstBackupAndInitializeLocked(ctx context.C
 		if errors.Is(err, &topoclient.TopoError{Code: topoclient.NodeExists}) {
 			return true, false, nil // lease held by another pooler, back off
 		}
-		return false, false, mterrors.Wrap(err, "failed during backup lease")
+		if !fnStarted {
+			return false, false, mterrors.Wrap(err, "failed during backup lease")
+		}
+		return false, false, err
 	}
 
 	pm.logger.InfoContext(ctx, "First backup created; deferred cleanup will tear down local data directory", "shard", pm.getShardID())


### PR DESCRIPTION
## Problem

A production backup failure surfaced as `failed to acquire backup lease: pgbackrest backup failed: exit status 56`, which is misleading — the lease was never the problem; pgbackrest itself failed (a `DbConnectError`, reproduced locally). `WithStolenBackupLease`/`WithBackupLease` return exactly whatever the lease-holding closure returns once the lease is acquired, so the blanket wrap conflated "lease acquisition failed" with "the work done under the lease failed," sending anyone debugging a real backup failure toward the wrong subsystem.

## Solution

Track whether the closure actually started. Only attribute the failure to lease acquisition when it didn't — the closure's own error is already descriptive and shouldn't be relabeled. Applied identically to both `Backup()` (`rpc_backup.go`) and `createFirstBackupAndInitializeLocked` (`rpc_first_backup.go`), which had the same anti-pattern with milder wording.

`rpc_first_backup.go`'s fix intentionally has no dedicated unit test: its lease closure sits behind the full bootstrap flow (sentinel handling, real postgres startup, schema creation), which the existing `go/test/endtoend/multipooler/backupfaults` integration suite already exercises and passes against.