### PR TITLE
fix(pgctld): reset pgbackrest pgpass during server bootstrap

### DIFF
--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -328,6 +328,11 @@ func NewPgCtldService(
 	if err := os.WriteFile(pgpassPath, []byte(pgpassContent), 0o600); err != nil {
 		return nil, fmt.Errorf("failed to write pgbackrest pgpass file: %w", err)
 	}
+	// enforce 0600 explicitly, as the operator might have changed these permissions
+	// during volume mount.
+	if err := os.Chmod(pgpassPath, 0o600); err != nil {
+		return nil, fmt.Errorf("failed to set pgbackrest pgpass file permissions: %w", err)
+	}
 	if err := os.Setenv("PGPASSFILE", pgpassPath); err != nil {
 		return nil, fmt.Errorf("failed to set PGPASSFILE: %w", err)
 	}


### PR DESCRIPTION
Trigger an explicit chmod to set pgbackrest pgpass permission during pgctld service startup, this fixes any permission modification made externally, e.g. operator setting volume permissions during PVC mount.