### PR TITLE
fix(consensus): avoid rewind-readiness deadlock

### DIFF
--- a/go/common/consensus/proposals.go
+++ b/go/common/consensus/proposals.go
@@ -66,6 +66,20 @@ type RecruitmentResult struct {
 	EligibleLeaders []*clustermetadatapb.ConsensusStatus
 }
 
+// ReplicationPrimaryFromProposal builds the ReplicationPrimary a cohort
+// member should be told from a CoordinatorProposal, shared by Promote
+// (leader) and SetPrimary (followers) so they can't drift apart.
+//
+// rewindReady is explicit rather than defaulted, since a silently-omitted
+// zero value here is exactly the kind of gap this exists to prevent.
+func ReplicationPrimaryFromProposal(proposal *consensusdatapb.CoordinatorProposal, rewindReady bool) *clustermetadatapb.ReplicationPrimary {
+	return &clustermetadatapb.ReplicationPrimary{
+		Position:    proposal.GetProposedTransition(),
+		Primary:     proposal.GetProposalLeader(),
+		RewindReady: rewindReady,
+	}
+}
+
 // quorumMode controls which quorum requirements are enforced before calling
 // buildProposal. Both modes require an incoming-cohort quorum after the
 // proposal is built (so the new cohort can make durable writes); they differ

--- a/go/common/consensus/proposals_test.go
+++ b/go/common/consensus/proposals_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/multigres/multigres/go/common/topoclient"
@@ -202,6 +203,25 @@ var poolerIDs = struct {
 	zone1: newCellPoolers("zone1"),
 	zone2: newCellPoolers("zone2"),
 	zone3: newCellPoolers("zone3"),
+}
+
+func TestReplicationPrimaryFromProposal(t *testing.T) {
+	transition := &clustermetadatapb.RulePosition{
+		Decision: makeRule(ruleNum(1, 0), atLeast(2), makeID("zone1", "a")),
+		Proposal: makeRule(ruleNum(2, 0), atLeast(2), makeID("zone1", "b")),
+	}
+	leader := &clustermetadatapb.PoolerAddress{Id: makeID("zone1", "b"), Host: "hostB", PostgresPort: 5432}
+	proposal := &consensusdatapb.CoordinatorProposal{
+		ProposedTransition: transition,
+		ProposalLeader:     leader,
+	}
+
+	for _, rewindReady := range []bool{false, true} {
+		got := ReplicationPrimaryFromProposal(proposal, rewindReady)
+		assert.True(t, proto.Equal(transition, got.GetPosition()), "rewindReady=%v: position mismatch", rewindReady)
+		assert.True(t, proto.Equal(leader, got.GetPrimary()), "rewindReady=%v: primary mismatch", rewindReady)
+		assert.Equal(t, rewindReady, got.GetRewindReady())
+	}
 }
 
 func TestBuildProposalCore(t *testing.T) {

--- a/go/services/multiorch/consensus/rule_change.go
+++ b/go/services/multiorch/consensus/rule_change.go
@@ -363,12 +363,10 @@ func (r *coordinatorLedRuleChange) promote(
 		_, err := r.coordinator.rpcClient.Promote(rpcCtx, p.Multipooler, req)
 		return err
 	}
-	proposal := req.GetProposal()
+	// rewindReady is false: the leader hasn't promoted yet, so it can't have
+	// checkpointed onto its new timeline either.
 	_, err := r.coordinator.rpcClient.SetPrimary(rpcCtx, p.Multipooler, &consensusdatapb.SetPrimaryRequest{
-		ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
-			Position: proposal.GetProposedTransition(),
-			Primary:  proposal.GetProposalLeader(),
-		},
+		ReplicationPrimary: commonconsensus.ReplicationPrimaryFromProposal(req.GetProposal(), false),
 	})
 	return err
 }

--- a/go/services/multiorch/recovery/engine.go
+++ b/go/services/multiorch/recovery/engine.go
@@ -574,6 +574,13 @@ func (re *Engine) TriggerRecoveryNow(ctx context.Context, maxCycles uint32) ([]D
 		defer re.recoveryRunner.Stop()
 	}
 
+	leaderInfoWasStarted := re.leaderInfoRunner.StartWithOptions(func(ctx context.Context) {
+		re.runLeaderInfoPropagation(ctx)
+	}, timer.WithFastStart())
+	if leaderInfoWasStarted {
+		defer re.leaderInfoRunner.Stop()
+	}
+
 	// Wait for first cycle to complete before polling
 	select {
 	case <-cycleDone:

--- a/go/services/multiorch/recovery/engine.go
+++ b/go/services/multiorch/recovery/engine.go
@@ -202,6 +202,7 @@ type Engine struct {
 	// Periodic runners for background tasks
 	bookkeepingRunner *timer.PeriodicRunner
 	recoveryRunner    *timer.PeriodicRunner
+	leaderInfoRunner  *timer.PeriodicRunner
 
 	// Detected problems tracking (replaced each cycle)
 	detectedProblemsMu sync.Mutex
@@ -245,6 +246,7 @@ func NewEngine(
 		cancel:            cancel,
 		bookkeepingRunner: timer.NewPeriodicRunner(ctx, config.GetBookkeepingInterval()),
 		recoveryRunner:    timer.NewPeriodicRunner(ctx, config.GetRecoveryCycleInterval()),
+		leaderInfoRunner:  timer.NewPeriodicRunner(ctx, leaderInfoPropagationInterval),
 	}
 
 	// HealthStreamFactory is cache-agnostic — it holds no cache reference. The
@@ -326,6 +328,12 @@ func (re *Engine) Start() error {
 		re.performRecoveryCycle(ctx)
 	}, nil)
 
+	// Start the leader-info propagation runner: independent of the recovery
+	// cycle so it keeps running while an AppointLeaderAction is blocked.
+	re.leaderInfoRunner.Start(func(ctx context.Context) {
+		re.runLeaderInfoPropagation(ctx)
+	}, nil)
+
 	// Start the pooler cache (watch + sweeper) with the lifecycle hooks
 	// that drive per-pooler health streams via HealthStream.spawnStream.
 	re.poolerCache.Start(poolerCacheHooks(re.shutdownCtx, re.poolerCache, re.healthStreams, re.logger))
@@ -341,6 +349,7 @@ func (re *Engine) Shutdown() {
 	re.cancel()
 	re.bookkeepingRunner.Stop()
 	re.recoveryRunner.Stop()
+	re.leaderInfoRunner.Stop()
 	re.poolerCache.Shutdown()
 	re.healthStreams.Shutdown()
 	re.logger.Info("recovery engine stopped")
@@ -491,15 +500,18 @@ func (re *Engine) GetPoolerHealthForShard(database, tableGroup, shard string) []
 	})
 }
 
-// DisableRecovery stops the recovery loop and waits for in-flight actions to complete.
-// When this returns, no recovery actions are running and no new ones will start.
-// Intended for testing scenarios where manual control over recovery is needed.
+// DisableRecovery stops the recovery loop and the leader-info propagation
+// loop, and waits for in-flight actions to complete. When this returns, no
+// recovery actions or SetPrimary propagation are running and none will
+// start. Intended for testing scenarios where manual control over recovery
+// is needed.
 func (re *Engine) DisableRecovery() {
 	re.logger.Warn("Disabling recovery - no automatic repairs will occur")
 	re.recoveryRunner.Stop()
+	re.leaderInfoRunner.Stop()
 }
 
-// EnableRecovery resumes the recovery loop.
+// EnableRecovery resumes the recovery loop and the leader-info propagation loop.
 func (re *Engine) EnableRecovery() {
 	re.recoveryRunner.Start(func(ctx context.Context) {
 		re.performRecoveryCycle(ctx)
@@ -507,6 +519,9 @@ func (re *Engine) EnableRecovery() {
 		re.logger.Info("Enabling recovery - automatic repairs will resume")
 	},
 	)
+	re.leaderInfoRunner.Start(func(ctx context.Context) {
+		re.runLeaderInfoPropagation(ctx)
+	}, nil)
 }
 
 // IsRecoveryEnabled returns whether the recovery loop is currently running.

--- a/go/services/multiorch/recovery/leader_info_propagation.go
+++ b/go/services/multiorch/recovery/leader_info_propagation.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"context"
+	"time"
+
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
+	"github.com/multigres/multigres/go/common/topoclient"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
+	"github.com/multigres/multigres/go/services/multiorch/recovery/analysis"
+	"github.com/multigres/multigres/go/services/multiorch/store"
+)
+
+// leaderInfoPropagationInterval is deliberately much shorter than a recovery
+// cycle: telling a pooler who the leader is (or that it's rewind-ready) is
+// always safe (SetPrimary no-ops when the pooler is already current), so
+// this doesn't need recovery's grace periods or backoff.
+const leaderInfoPropagationInterval = 1 * time.Second
+
+const setPrimaryPropagationTimeout = 5 * time.Second
+
+// runLeaderInfoPropagation is a lightweight loop, independent of the
+// recovery cycle, that keeps every pooler's known leader identity and
+// rewind-readiness current via SetPrimary. It exists because AppointLeaderAction
+// can block on the leader's Promote RPC for up to RuleWriteTimeout, during
+// which the (single-flight) recovery cycle can't do anything else — including
+// re-informing a standby that the leader it's waiting on has just become
+// rewind-ready. This loop runs on its own short interval so that information
+// reaches standbys promptly regardless of what the recovery cycle is doing.
+func (re *Engine) runLeaderInfoPropagation(ctx context.Context) {
+	generator := analysis.NewAnalysisGenerator(re.poolerCache, nil)
+	for _, shardAnalysis := range generator.GenerateShardAnalyses() {
+		re.propagateLeaderInfoForShard(ctx, shardAnalysis.ShardKey)
+	}
+}
+
+// propagateLeaderInfoForShard tells every non-leader pooler in the shard
+// about the current leader and its rewind-readiness, skipping any pooler
+// that already knows both.
+func (re *Engine) propagateLeaderInfoForShard(ctx context.Context, shardKey *clustermetadatapb.ShardKey) {
+	members := store.FindShardMembers(re.poolerCache, shardKey)
+	leader := members.Leader
+	if leader == nil || members.HighestKnownPosition == nil {
+		return
+	}
+	leaderAddress := topoclient.PoolerAddressFor(leader.Health().GetMultipooler())
+	leaderRewindReady := commonconsensus.ReplicationPrimaryOrNil(leader.Health().GetConsensusStatus()).GetRewindReady()
+
+	for _, pooler := range members.Poolers {
+		if pooler == leader {
+			continue
+		}
+		rp := commonconsensus.ReplicationPrimaryOrNil(pooler.Health().GetConsensusStatus())
+		if commonconsensus.ReplicationPrimaryMatches(rp, leaderAddress, members.HighestKnownPosition) &&
+			rp.GetRewindReady() == leaderRewindReady {
+			continue // already knows everything we'd tell it
+		}
+
+		rpcCtx, cancel := context.WithTimeout(ctx, setPrimaryPropagationTimeout)
+		_, err := re.rpcClient.SetPrimary(rpcCtx, pooler.Health().GetMultipooler(), &consensusdatapb.SetPrimaryRequest{
+			ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
+				Position:    members.HighestKnownPosition,
+				Primary:     leaderAddress,
+				RewindReady: leaderRewindReady,
+			},
+		})
+		cancel()
+		if err != nil {
+			re.logger.DebugContext(ctx, "leader-info propagation: SetPrimary failed, will retry next tick",
+				"pooler", pooler.Health().GetMultipooler().GetId().GetName(), "error", err)
+		}
+	}
+}

--- a/go/services/multiorch/recovery/leader_info_propagation.go
+++ b/go/services/multiorch/recovery/leader_info_propagation.go
@@ -16,13 +16,16 @@ package recovery
 
 import (
 	"context"
+	"sync"
 	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/topoclient"
+	commontypes "github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
-	"github.com/multigres/multigres/go/services/multiorch/recovery/analysis"
 	"github.com/multigres/multigres/go/services/multiorch/store"
 )
 
@@ -34,6 +37,12 @@ const leaderInfoPropagationInterval = 1 * time.Second
 
 const setPrimaryPropagationTimeout = 5 * time.Second
 
+// leaderInfoStaleHealthThreshold skips propagation to a pooler we haven't
+// heard from recently: it's likely unreachable, and this loop's per-pooler
+// SetPrimary calls run sequentially, so waiting out setPrimaryPropagationTimeout
+// against a dead pooler would delay reaching the next (possibly live) one.
+const leaderInfoStaleHealthThreshold = 1 * time.Minute
+
 // runLeaderInfoPropagation is a lightweight loop, independent of the
 // recovery cycle, that keeps every pooler's known leader identity and
 // rewind-readiness current via SetPrimary. It exists because AppointLeaderAction
@@ -43,10 +52,27 @@ const setPrimaryPropagationTimeout = 5 * time.Second
 // rewind-ready. This loop runs on its own short interval so that information
 // reaches standbys promptly regardless of what the recovery cycle is doing.
 func (re *Engine) runLeaderInfoPropagation(ctx context.Context) {
-	generator := analysis.NewAnalysisGenerator(re.poolerCache, nil)
-	for _, shardAnalysis := range generator.GenerateShardAnalyses() {
-		re.propagateLeaderInfoForShard(ctx, shardAnalysis.ShardKey)
+	for _, shardKey := range distinctShardKeys(re.poolerCache) {
+		re.propagateLeaderInfoForShard(ctx, shardKey)
 	}
+}
+
+// distinctShardKeys returns one ShardKey per shard currently represented in
+// the pooler cache. Deliberately cheaper than analysis.GenerateShardAnalyses,
+// which builds a full per-pooler liveness analysis this loop doesn't need —
+// it only cares which shards exist, then re-derives everything else itself
+// via store.FindShardMembers.
+func distinctShardKeys(cache *store.PoolerCache) []*clustermetadatapb.ShardKey {
+	seen := make(map[commontypes.ShardKeyString]*clustermetadatapb.ShardKey)
+	for _, entry := range cache.All() {
+		key := entry.Pooler.GetShardKey()
+		seen[commontypes.FormatShardKey(key)] = key
+	}
+	keys := make([]*clustermetadatapb.ShardKey, 0, len(seen))
+	for _, key := range seen {
+		keys = append(keys, key)
+	}
+	return keys
 }
 
 // propagateLeaderInfoForShard tells every non-leader pooler in the shard
@@ -61,28 +87,77 @@ func (re *Engine) propagateLeaderInfoForShard(ctx context.Context, shardKey *clu
 	leaderAddress := topoclient.PoolerAddressFor(leader.Health().GetMultipooler())
 	leaderRewindReady := commonconsensus.ReplicationPrimaryOrNil(leader.Health().GetConsensusStatus()).GetRewindReady()
 
+	// One goroutine per pooler: each pooler appears at most once in a shard's
+	// member list, so there's never more than one in-flight SetPrimary to the
+	// same pooler. Waiting for all of them keeps a slow/unreachable pooler
+	// from delaying the next tick, without blocking this one on that pooler.
+	var wg sync.WaitGroup
 	for _, pooler := range members.Poolers {
 		if pooler == leader {
 			continue
 		}
-		rp := commonconsensus.ReplicationPrimaryOrNil(pooler.Health().GetConsensusStatus())
-		if commonconsensus.ReplicationPrimaryMatches(rp, leaderAddress, members.HighestKnownPosition) &&
-			rp.GetRewindReady() == leaderRewindReady {
-			continue // already knows everything we'd tell it
-		}
+		wg.Add(1)
+		go func(pooler *store.Pooler) {
+			defer wg.Done()
+			re.propagateLeaderInfoToPooler(ctx, pooler, leaderAddress, leaderRewindReady, members.HighestKnownPosition)
+		}(pooler)
+	}
+	wg.Wait()
+}
 
-		rpcCtx, cancel := context.WithTimeout(ctx, setPrimaryPropagationTimeout)
-		_, err := re.rpcClient.SetPrimary(rpcCtx, pooler.Health().GetMultipooler(), &consensusdatapb.SetPrimaryRequest{
-			ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
-				Position:    members.HighestKnownPosition,
-				Primary:     leaderAddress,
-				RewindReady: leaderRewindReady,
-			},
-		})
-		cancel()
-		if err != nil {
-			re.logger.DebugContext(ctx, "leader-info propagation: SetPrimary failed, will retry next tick",
-				"pooler", pooler.Health().GetMultipooler().GetId().GetName(), "error", err)
-		}
+// shouldPropagateLeaderInfo reports whether a pooler needs a SetPrimary call
+// to learn the current leader or its rewind-readiness, given rp (the
+// pooler's own last-reported ReplicationPrimary, nil if never told anything)
+// and lastSeen (its own health, nil if we've never heard from it). now is
+// passed in rather than read from the clock so this stays a pure function to
+// unit test directly, independent of the health cache and RPC client.
+func shouldPropagateLeaderInfo(
+	rp *clustermetadatapb.ReplicationPrimary,
+	lastSeen *timestamppb.Timestamp,
+	now time.Time,
+	leaderAddress *clustermetadatapb.PoolerAddress,
+	leaderRewindReady bool,
+	highestKnownPosition *clustermetadatapb.RulePosition,
+) bool {
+	if now.Sub(lastSeen.AsTime()) > leaderInfoStaleHealthThreshold {
+		return false // likely unreachable; don't let it stall the poolers behind it
+	}
+	positionMatches := commonconsensus.ReplicationPrimaryMatches(rp, leaderAddress, highestKnownPosition)
+	// rewind_ready only ever goes false -> true within a coordinator term (see
+	// RecordTermPrimary), so never tell a pooler that already believes true
+	// otherwise — even if our own cached view of the leader is stale-false.
+	if positionMatches && (rp.GetRewindReady() || rp.GetRewindReady() == leaderRewindReady) {
+		return false // already knows everything we'd tell it
+	}
+	return true
+}
+
+// propagateLeaderInfoToPooler tells a single pooler about the current leader
+// and its rewind-readiness via SetPrimary, unless it already knows both.
+func (re *Engine) propagateLeaderInfoToPooler(
+	ctx context.Context,
+	pooler *store.Pooler,
+	leaderAddress *clustermetadatapb.PoolerAddress,
+	leaderRewindReady bool,
+	highestKnownPosition *clustermetadatapb.RulePosition,
+) {
+	health := pooler.Health()
+	rp := commonconsensus.ReplicationPrimaryOrNil(health.GetConsensusStatus())
+	if !shouldPropagateLeaderInfo(rp, health.GetLastSeen(), time.Now(), leaderAddress, leaderRewindReady, highestKnownPosition) {
+		return
+	}
+
+	rpcCtx, cancel := context.WithTimeout(ctx, setPrimaryPropagationTimeout)
+	defer cancel()
+	_, err := re.rpcClient.SetPrimary(rpcCtx, health.GetMultipooler(), &consensusdatapb.SetPrimaryRequest{
+		ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
+			Position:    highestKnownPosition,
+			Primary:     leaderAddress,
+			RewindReady: leaderRewindReady,
+		},
+	})
+	if err != nil {
+		re.logger.WarnContext(ctx, "leader-info propagation: SetPrimary failed, will retry next tick",
+			"pooler", health.GetMultipooler().GetId().GetName(), "error", err)
 	}
 }

--- a/go/services/multiorch/recovery/leader_info_propagation_test.go
+++ b/go/services/multiorch/recovery/leader_info_propagation_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+)
+
+func leaderInfoTestRule(term int64) *clustermetadatapb.ShardRule {
+	return &clustermetadatapb.ShardRule{RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: term}}
+}
+
+func leaderInfoTestAddress(name string) *clustermetadatapb.PoolerAddress {
+	return &clustermetadatapb.PoolerAddress{
+		Id:           &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: name},
+		Host:         "host-" + name,
+		PostgresPort: 5432,
+	}
+}
+
+func TestShouldPropagateLeaderInfo(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	fresh := timestamppb.New(now.Add(-10 * time.Second))
+	stale := timestamppb.New(now.Add(-2 * time.Minute))
+
+	leaderAddress := leaderInfoTestAddress("leader")
+	currentPosition := &clustermetadatapb.RulePosition{Decision: leaderInfoTestRule(5)}
+	olderPosition := &clustermetadatapb.RulePosition{Decision: leaderInfoTestRule(3)}
+
+	tests := []struct {
+		name              string
+		rp                *clustermetadatapb.ReplicationPrimary
+		lastSeen          *timestamppb.Timestamp
+		leaderRewindReady bool
+		want              bool
+	}{
+		{
+			name:              "NeverToldAnything_Propagates",
+			rp:                nil,
+			lastSeen:          fresh,
+			leaderRewindReady: false,
+			want:              true,
+		},
+		{
+			name:              "StaleHealth_Skipped_EvenIfBehind",
+			rp:                nil,
+			lastSeen:          stale,
+			leaderRewindReady: true,
+			want:              false,
+		},
+		{
+			name: "PositionBehind_Propagates",
+			rp: &clustermetadatapb.ReplicationPrimary{
+				Position: olderPosition,
+				Primary:  leaderAddress,
+			},
+			lastSeen:          fresh,
+			leaderRewindReady: false,
+			want:              true,
+		},
+		{
+			name: "PositionMatches_BothRewindReadyFalse_NoOp",
+			rp: &clustermetadatapb.ReplicationPrimary{
+				Position:    currentPosition,
+				Primary:     leaderAddress,
+				RewindReady: false,
+			},
+			lastSeen:          fresh,
+			leaderRewindReady: false,
+			want:              false,
+		},
+		{
+			name: "PositionMatches_BothRewindReadyTrue_NoOp",
+			rp: &clustermetadatapb.ReplicationPrimary{
+				Position:    currentPosition,
+				Primary:     leaderAddress,
+				RewindReady: true,
+			},
+			lastSeen:          fresh,
+			leaderRewindReady: true,
+			want:              false,
+		},
+		{
+			name: "PositionMatches_FollowerAlreadyTrue_LeaderViewStaleFalse_NeverRegress",
+			rp: &clustermetadatapb.ReplicationPrimary{
+				Position:    currentPosition,
+				Primary:     leaderAddress,
+				RewindReady: true,
+			},
+			lastSeen:          fresh,
+			leaderRewindReady: false,
+			want:              false,
+		},
+		{
+			name: "PositionMatches_FollowerFalse_LeaderTrue_PropagatesGoodNews",
+			rp: &clustermetadatapb.ReplicationPrimary{
+				Position:    currentPosition,
+				Primary:     leaderAddress,
+				RewindReady: false,
+			},
+			lastSeen:          fresh,
+			leaderRewindReady: true,
+			want:              true,
+		},
+		{
+			name: "PositionMatches_DifferentPrimaryContact_Propagates",
+			rp: &clustermetadatapb.ReplicationPrimary{
+				Position:    currentPosition,
+				Primary:     leaderInfoTestAddress("stale-leader"),
+				RewindReady: true,
+			},
+			lastSeen:          fresh,
+			leaderRewindReady: true,
+			want:              true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldPropagateLeaderInfo(tt.rp, tt.lastSeen, now, leaderAddress, tt.leaderRewindReady, currentPosition)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/go/services/multipooler/internal/manager/consensus/manager.go
+++ b/go/services/multipooler/internal/manager/consensus/manager.go
@@ -352,6 +352,14 @@ func (cm *ConsensusManager) RecordTermPrimary(ctx context.Context, rp *clusterme
 	rewindReady := rp.GetRewindReady()
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
+
+	// rewind_ready belongs to the term, not to proposal-vs-decision, so
+	// deciding an already-ready proposal must not clear it.
+	if consensus.PossiblyUndecidedRule(position).GetRuleNumber().GetCoordinatorTerm() ==
+		consensus.PossiblyUndecidedRule(cm.replicationPrimary.GetPosition()).GetRuleNumber().GetCoordinatorTerm() {
+		rewindReady = rewindReady || cm.replicationPrimary.GetRewindReady()
+	}
+
 	cmp := consensus.CompareRulePosition(position, cm.replicationPrimary.GetPosition())
 	if cmp < 0 {
 		return nil

--- a/go/services/multipooler/internal/manager/consensus/manager_test.go
+++ b/go/services/multipooler/internal/manager/consensus/manager_test.go
@@ -203,6 +203,45 @@ func TestRecordTermPrimary_ReturnsCopies(t *testing.T) {
 		"mutating the returned pointer must not affect internal state")
 }
 
+// TestRecordTermPrimary_RewindReadySurvivesProposalBecomingDecision covers the
+// write-side counterpart of
+// TestStatusReplicationPrimary_RewindReadySurvivesSameTermRuleAdvance:
+// promoteLocked records its own upcoming leadership as a Proposal before its
+// rule write commits, MarkSelfRewindReady may flip rewind_ready true while
+// that write is still in flight, and a second RecordTermPrimary call then
+// upgrades the same rule from Proposal to Decision once the write succeeds.
+// That upgrade must not silently clear rewind_ready, even though
+// CompareRulePosition ranks a decision above its own term's undecided
+// proposal.
+func TestRecordTermPrimary_RewindReadySurvivesProposalBecomingDecision(t *testing.T) {
+	selfID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "p1"}
+	cm := NewManagerForTesting(t, selfID, nil, nil, nil)
+	ctx := actionLockCtx(t)
+
+	rule := ruleAt(4, 0)
+	proposedTransition := &clustermetadatapb.RulePosition{
+		Decision: ruleAt(1, 0),
+		Proposal: rule,
+	}
+	primary := primaryAt("p1", "hostA", 5432)
+
+	require.NoError(t, cm.RecordTermPrimary(ctx, &clustermetadatapb.ReplicationPrimary{
+		Position: proposedTransition,
+		Primary:  primary,
+	}))
+
+	require.True(t, cm.MarkSelfRewindReady(selfID, proposedTransition))
+
+	require.NoError(t, cm.RecordTermPrimary(ctx, &clustermetadatapb.ReplicationPrimary{
+		Position: &clustermetadatapb.RulePosition{Decision: rule},
+		Primary:  primary,
+	}))
+
+	got := cm.GetReplicationPrimary()
+	require.NotNil(t, got)
+	assert.True(t, got.GetRewindReady(), "rewind_ready must survive the proposal being decided")
+}
+
 // poolerPosAt builds a PoolerPosition with the given decision/proposal rule
 // numbers and LSN, for exercising recruitPositionFloorIfOutstanding directly.
 func poolerPosAt(decisionTerm, proposalTerm int64, lsn string) *clustermetadatapb.PoolerPosition {

--- a/go/services/multipooler/internal/manager/consensus/rule_store.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store.go
@@ -260,6 +260,15 @@ func (b *RuleUpdateBuilder) GetAcceptedMembers() []*clustermetadatapb.ID { retur
 // GetPromotionHook returns the promotion hook set on this update, if any. Exposed for tests.
 func (b *RuleUpdateBuilder) GetPromotionHook() promotionFn { return b.promotionHook }
 
+// GetPreviousRule returns the compare-and-swap rule number set via
+// WithPreviousRule, and whether one was set at all. Exposed for tests.
+func (b *RuleUpdateBuilder) GetPreviousRule() (coordinatorTerm, leaderSubterm int64, ok bool) {
+	if b.previousRule == nil {
+		return 0, 0, false
+	}
+	return b.previousRule.coordinatorTerm, b.previousRule.leaderSubterm, true
+}
+
 func NewRuleUpdate(termNumber int64, coordinatorID *clustermetadatapb.ID, eventType, reason string, createdAt time.Time) *RuleUpdateBuilder {
 	return &RuleUpdateBuilder{
 		termNumber:    termNumber,

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -391,10 +391,6 @@ func (pm *MultipoolerManager) promoteLocked(ctx context.Context, req *consensusd
 	if err := commonconsensus.ValidateRevocation(beforeStatus, revocation); err != nil {
 		return nil, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION, err.Error())
 	}
-	// PossiblyUndecidedRule, not Decision: matches what UpdateRule's own CAS
-	// compares against internally (including an outstanding proposal, so this
-	// stays consistent with propagation of a stuck proposal).
-	beforeStatusRule := commonconsensus.PossiblyUndecidedRule(beforeStatus.GetCurrentPosition().GetPosition())
 
 	// Require an explicit Recruit() for this exact term before accepting a
 	// Promote. Implicit recruitment (accepting the term here without a prior
@@ -474,9 +470,10 @@ func (pm *MultipoolerManager) promoteLocked(ctx context.Context, req *consensusd
 			}
 			return pm.promoteStandbyToPrimary(hookCtx, state, proposal.GetProposedTransition())
 		}).
+		// CAS catches drift across the whole Recruit-to-Promote window.
 		WithPreviousRule(
-			beforeStatusRule.GetRuleNumber().GetCoordinatorTerm(),
-			beforeStatusRule.GetRuleNumber().GetLeaderSubterm())
+			revocation.GetOutgoingRule().GetCoordinatorTerm(),
+			revocation.GetOutgoingRule().GetLeaderSubterm())
 	if req.GetProposal().GetSkipOutgoingQuorum() {
 		ruleUpdate.WithSkipOutgoingQuorum()
 	}

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -481,18 +481,12 @@ func (pm *MultipoolerManager) promoteLocked(ctx context.Context, req *consensusd
 		ruleUpdate.WithSkipOutgoingQuorum()
 	}
 
-	// Record optimistically, before the quorum-gated write below, as a
-	// Proposal on top of the prior Decision — otherwise SelfConsensusRole (and
-	// rewind-readiness) stays stale until that write commits, which can
-	// deadlock recovery. Comparison ranks by Decision first, so the prior
-	// decision must be carried forward or this record looks older and no-ops.
-	if err := pm.consensusMgr.RecordTermPrimary(ctx, &clustermetadatapb.ReplicationPrimary{
-		Position: &clustermetadatapb.RulePosition{
-			Decision: beforeStatus.GetCurrentPosition().GetPosition().GetDecision(),
-			Proposal: proposedRule,
-		},
-		Primary: proposalLeader,
-	}); err != nil {
+	// Record optimistically, before the quorum-gated write below, so
+	// SelfConsensusRole/rewind-readiness don't stay stale until that write
+	// commits (which can deadlock recovery).
+	if err := pm.consensusMgr.RecordTermPrimary(ctx,
+		commonconsensus.ReplicationPrimaryFromProposal(proposal, false),
+	); err != nil {
 		pm.logger.ErrorContext(ctx, "failed to record replication primary before promote", "error", err)
 	}
 

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -391,6 +391,10 @@ func (pm *MultipoolerManager) promoteLocked(ctx context.Context, req *consensusd
 	if err := commonconsensus.ValidateRevocation(beforeStatus, revocation); err != nil {
 		return nil, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION, err.Error())
 	}
+	// PossiblyUndecidedRule, not Decision: matches what UpdateRule's own CAS
+	// compares against internally (including an outstanding proposal, so this
+	// stays consistent with propagation of a stuck proposal).
+	beforeStatusRule := commonconsensus.PossiblyUndecidedRule(beforeStatus.GetCurrentPosition().GetPosition())
 
 	// Require an explicit Recruit() for this exact term before accepting a
 	// Promote. Implicit recruitment (accepting the term here without a prior
@@ -469,10 +473,29 @@ func (pm *MultipoolerManager) promoteLocked(ctx context.Context, req *consensusd
 				return mterrors.Wrap(err, "failed to clear resigned primary term")
 			}
 			return pm.promoteStandbyToPrimary(hookCtx, state, proposal.GetProposedTransition())
-		})
+		}).
+		WithPreviousRule(
+			beforeStatusRule.GetRuleNumber().GetCoordinatorTerm(),
+			beforeStatusRule.GetRuleNumber().GetLeaderSubterm())
 	if req.GetProposal().GetSkipOutgoingQuorum() {
 		ruleUpdate.WithSkipOutgoingQuorum()
 	}
+
+	// Record optimistically, before the quorum-gated write below, as a
+	// Proposal on top of the prior Decision — otherwise SelfConsensusRole (and
+	// rewind-readiness) stays stale until that write commits, which can
+	// deadlock recovery. Comparison ranks by Decision first, so the prior
+	// decision must be carried forward or this record looks older and no-ops.
+	if err := pm.consensusMgr.RecordTermPrimary(ctx, &clustermetadatapb.ReplicationPrimary{
+		Position: &clustermetadatapb.RulePosition{
+			Decision: beforeStatus.GetCurrentPosition().GetPosition().GetDecision(),
+			Proposal: proposedRule,
+		},
+		Primary: proposalLeader,
+	}); err != nil {
+		pm.logger.ErrorContext(ctx, "failed to record replication primary before promote", "error", err)
+	}
+
 	if _, err = pm.DoUpdateRule(ctx, ruleUpdate); err != nil {
 		return nil, mterrors.Wrap(err, "promote failed: could not write rule")
 	}
@@ -499,12 +522,9 @@ func (pm *MultipoolerManager) promoteLocked(ctx context.Context, req *consensusd
 		pm.logger.WarnContext(ctx, "Failed to update serving state after promote", "error", err)
 	}
 
-	// Record the (rule, primary) — this pooler IS now the primary. Stamping
-	// the published ReplicationPrimary lets the health stream advertise the
-	// new leadership immediately.
+	// Upgrade the pre-write record above from Proposal to Decision now that
+	// DoUpdateRule has committed it.
 	if err := pm.consensusMgr.RecordTermPrimary(ctx, &clustermetadatapb.ReplicationPrimary{
-		// DoUpdateRule above already committed this rule, so it is now a
-		// settled decision.
 		Position: &clustermetadatapb.RulePosition{Decision: proposedRule},
 		Primary:  proposalLeader,
 	}); err != nil {

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -484,6 +484,13 @@ func (pm *MultipoolerManager) promoteLocked(ctx context.Context, req *consensusd
 	// Record optimistically, before the quorum-gated write below, so
 	// SelfConsensusRole/rewind-readiness don't stay stale until that write
 	// commits (which can deadlock recovery).
+	//
+	// This doesn't impact multigateway routing. It only matters if the write
+	// below times out or fails partway: we'll know this pooler should be
+	// leader even though it hasn't finished acting like one, so the postgres
+	// monitor can resign (if postgres never left recovery) or reconcile
+	// serving state (if it did) — either way, orch's next recovery cycle can
+	// finish or supersede this term instead of it going undetected.
 	if err := pm.consensusMgr.RecordTermPrimary(ctx,
 		commonconsensus.ReplicationPrimaryFromProposal(proposal, false),
 	); err != nil {

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -896,6 +896,15 @@ func TestPromote(t *testing.T) {
 				assert.Nil(t, update.GetDurabilityPolicy())
 				assert.Empty(t, update.GetAcceptedMembers())
 
+				// The CAS baseline must come from the revocation's own
+				// outgoing_rule (what the coordinator asserted at Recruit
+				// time), not a local read — see rpc_consensus.go's
+				// WithPreviousRule call.
+				prevTerm, prevSubterm, ok := update.GetPreviousRule()
+				require.True(t, ok, "Promote should set a previous-rule CAS")
+				assert.Equal(t, recruitedTerm.GetOutgoingRule().GetCoordinatorTerm(), prevTerm)
+				assert.Equal(t, recruitedTerm.GetOutgoingRule().GetLeaderSubterm(), prevSubterm)
+
 				state := pm.healthStreamer.getState()
 				require.NotNil(t, state.RoutingState)
 				assert.Equal(t, clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY, state.RoutingState.GetRole())

--- a/go/test/endtoend/multiorch/quorum_blocked_rewind_test.go
+++ b/go/test/endtoend/multiorch/quorum_blocked_rewind_test.go
@@ -27,14 +27,10 @@ import (
 	"github.com/multigres/multigres/go/test/utils"
 )
 
-// TestQuorumBlockedRewindDuringDoubleFailure reproduces a suspected deadlock in
-// recovery from a double node loss: the only surviving non-leader cohort member
-// must pg_rewind against the newly promoted leader before it can supply the
-// synchronous ack the leader's own rule write is blocked on — but the leader
-// only advertises rewind-readiness once its own consensus cache reflects its
-// new leadership, which (as currently implemented) only happens after that
-// same blocked rule write succeeds. See the "rewind readiness" investigation
-// this test codifies for the full analysis.
+// TestQuorumBlockedRewindDuringDoubleFailure guards against a deadlock in
+// recovery from a double node loss: the only surviving non-leader cohort
+// member must pg_rewind against the newly promoted leader before it can
+// supply the sync-standby ack the leader's own rule write is blocked on.
 //
 // Scenario (3-node cluster, default AT_LEAST_2 durability):
 //  1. A is primary; B and C are standbys.
@@ -49,10 +45,10 @@ import (
 //     the one ack AT_LEAST_2 requires — with no other cohort member alive to
 //     ever supply it instead.
 //
-// Expected (once fixed): S2 is promoted and A rewinds + rejoins within one
-// ordinary recovery round, matching the budget already used by comparable
-// rewind-driven scenarios (TestRewindDivergedReplica's
-// RecoveryScenarioFixReplication, 30s scaled).
+// S2 should be promoted and A should rewind and rejoin within one ordinary
+// recovery round, matching the budget already used by comparable rewind-driven
+// scenarios (TestRewindDivergedReplica's RecoveryScenarioFixReplication, 30s
+// scaled).
 func TestQuorumBlockedRewindDuringDoubleFailure(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping TestQuorumBlockedRewindDuringDoubleFailure test in short mode")
@@ -208,7 +204,5 @@ func TestQuorumBlockedRewindDuringDoubleFailure(t *testing.T) {
 	resumeA()
 	t.Logf("Resumed A (%s) postgres restarts", aName)
 
-	// This is the assertion expected to currently fail (or take far longer than
-	// one recovery round): S2 promoted, A rewound and rejoined as its standby.
 	waitForNodeToRejoinAsStandby(t, setup, aName, s2Name, 0, utils.ScaleTimeout(30*time.Second))
 }

--- a/go/test/endtoend/multiorch/quorum_blocked_rewind_test.go
+++ b/go/test/endtoend/multiorch/quorum_blocked_rewind_test.go
@@ -1,0 +1,214 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiorch
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestQuorumBlockedRewindDuringDoubleFailure reproduces a suspected deadlock in
+// recovery from a double node loss: the only surviving non-leader cohort member
+// must pg_rewind against the newly promoted leader before it can supply the
+// synchronous ack the leader's own rule write is blocked on — but the leader
+// only advertises rewind-readiness once its own consensus cache reflects its
+// new leadership, which (as currently implemented) only happens after that
+// same blocked rule write succeeds. See the "rewind readiness" investigation
+// this test codifies for the full analysis.
+//
+// Scenario (3-node cluster, default AT_LEAST_2 durability):
+//  1. A is primary; B and C are standbys.
+//  2. A is given WAL that never reaches B or C (both paused), then stopped —
+//     A is now durably diverged relative to whatever B/C become.
+//  3. Orch fails over to whichever of B/C is elected (call it S1); a write
+//     through S1 advances the other standby (S2) beyond A.
+//  4. S1 is stopped too. Only A (diverged, down) and S2 (most advanced, up)
+//     remain of the original cohort.
+//  5. A's postgres is restarted (as a standby, per default behavior). Recovery
+//     now depends on promoting S2 and having A pg_rewind against it to supply
+//     the one ack AT_LEAST_2 requires — with no other cohort member alive to
+//     ever supply it instead.
+//
+// Expected (once fixed): S2 is promoted and A rewinds + rejoins within one
+// ordinary recovery round, matching the budget already used by comparable
+// rewind-driven scenarios (TestRewindDivergedReplica's
+// RecoveryScenarioFixReplication, 30s scaled).
+func TestQuorumBlockedRewindDuringDoubleFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping TestQuorumBlockedRewindDuringDoubleFailure test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("Skipping end-to-end quorum-blocked-rewind test (no postgres binaries)")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultiorchCount(1),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+	)
+	defer cleanup()
+
+	setup.StartMultiorchs(t.Context(), t)
+
+	aName := waitForShardReady(t, setup, 2, 30*time.Second)
+	t.Logf("Initial primary: %s", aName)
+
+	var standbyNames []string
+	for name := range setup.Multipoolers {
+		if name != aName {
+			standbyNames = append(standbyNames, name)
+		}
+	}
+	require.Len(t, standbyNames, 2, "expected exactly 2 standbys")
+	bName, cName := standbyNames[0], standbyNames[1]
+	t.Logf("Standbys: %s, %s", bName, cName)
+
+	aInst := setup.GetMultipoolerInstance(aName)
+	require.NotNil(t, aInst)
+	aSocketDir := filepath.Join(aInst.Pgctld.PoolerDir, "pg_sockets")
+	aDB := connectToPostgres(t, aSocketDir, aInst.Pgctld.PgPort)
+	defer aDB.Close()
+
+	bInst := setup.GetMultipoolerInstance(bName)
+	require.NotNil(t, bInst)
+	bSocketDir := filepath.Join(bInst.Pgctld.PoolerDir, "pg_sockets")
+	bDB := connectToPostgres(t, bSocketDir, bInst.Pgctld.PgPort)
+	defer bDB.Close()
+
+	cInst := setup.GetMultipoolerInstance(cName)
+	require.NotNil(t, cInst)
+	cSocketDir := filepath.Join(cInst.Pgctld.PoolerDir, "pg_sockets")
+	cDB := connectToPostgres(t, cSocketDir, cInst.Pgctld.PgPort)
+	defer cDB.Close()
+
+	_, err := aDB.Exec("CREATE TABLE IF NOT EXISTS quorum_test (id SERIAL PRIMARY KEY, data TEXT)")
+	require.NoError(t, err, "should create test table on A")
+	_, err = aDB.Exec("INSERT INTO quorum_test (data) VALUES ('baseline')")
+	require.NoError(t, err, "should write baseline data to A")
+
+	waitForRow := func(db *sql.DB, data string, timeout time.Duration, msg string) {
+		require.Eventually(t, func() bool {
+			row := db.QueryRow("SELECT COUNT(*) FROM quorum_test WHERE data = $1", data)
+			var count int
+			if err := row.Scan(&count); err != nil {
+				return false
+			}
+			return count == 1
+		}, timeout, 200*time.Millisecond, msg)
+	}
+	waitForRow(bDB, "baseline", utils.ScaleTimeout(10*time.Second), "baseline should replicate to B")
+	waitForRow(cDB, "baseline", utils.ScaleTimeout(10*time.Second), "baseline should replicate to C")
+	t.Log("Baseline data verified on B and C")
+
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioInitialSettle)
+
+	// Pause orch while we manufacture A's divergence and take it down.
+	resumeRecovery := setup.DisableRecovery(t, "multiorch")
+
+	// Pause both standbys' WAL receivers so the next write to A can never reach
+	// them — this guarantees genuine WAL divergence on A, deterministically,
+	// rather than racing on shutdown timing.
+	bClient, err := shardsetup.NewMultipoolerClient(bInst.Multipooler.GrpcPort)
+	require.NoError(t, err)
+	defer bClient.Close()
+	cClient, err := shardsetup.NewMultipoolerClient(cInst.Multipooler.GrpcPort)
+	require.NoError(t, err)
+	defer cClient.Close()
+
+	_, err = bClient.Manager.StopReplication(utils.WithTimeout(t, 10*time.Second), &multipoolermanagerdatapb.StopReplicationRequest{
+		Mode: multipoolermanagerdatapb.ReplicationPauseMode_REPLICATION_PAUSE_MODE_REPLAY_AND_RECEIVER,
+	})
+	require.NoError(t, err, "should pause replication on B")
+	_, err = cClient.Manager.StopReplication(utils.WithTimeout(t, 10*time.Second), &multipoolermanagerdatapb.StopReplicationRequest{
+		Mode: multipoolermanagerdatapb.ReplicationPauseMode_REPLICATION_PAUSE_MODE_REPLAY_AND_RECEIVER,
+	})
+	require.NoError(t, err, "should pause replication on C")
+
+	// synchronous_commit=local bypasses waiting for a standby ack for this one
+	// transaction (both standbys are paused, so a normal write would hang
+	// forever) while still durably committing the row on A alone.
+	_, err = aDB.Exec("BEGIN; SET LOCAL synchronous_commit TO local; " +
+		"INSERT INTO quorum_test (data) VALUES ('diverged_on_a'); COMMIT;")
+	require.NoError(t, err, "should write diverging data to A")
+	t.Log("Wrote diverging data to A; B and C never received it (paused)")
+
+	// Stop A's postgres (auto-restart disabled) while diverged.
+	resumeA := setup.StopPostgres(t, aName, "fast")
+	t.Logf("Stopped A (%s) postgres while diverged", aName)
+
+	// Resume B and C so the upcoming failover can proceed normally between them.
+	_, err = bClient.Manager.StartReplication(utils.WithTimeout(t, 10*time.Second), &multipoolermanagerdatapb.StartReplicationRequest{})
+	require.NoError(t, err, "should resume replication on B")
+	_, err = cClient.Manager.StartReplication(utils.WithTimeout(t, 10*time.Second), &multipoolermanagerdatapb.StartReplicationRequest{})
+	require.NoError(t, err, "should resume replication on C")
+
+	resumeRecovery()
+
+	// Orch should fail over to whichever of B/C it elects (S1); A is unreachable.
+	s1Name := shardsetup.WaitForNewPrimary(t, setup, aName, 30*time.Second)
+	require.NotEmpty(t, s1Name, "expected multiorch to elect a new primary from B/C")
+	t.Logf("First successor primary: %s", s1Name)
+
+	var s2Name string
+	if s1Name == bName {
+		s2Name = cName
+	} else {
+		s2Name = bName
+	}
+
+	// Not RequireRecovery here: A is deliberately still down at this point, so
+	// "ReplicaNotReplicating@A" never clears and a blanket wait would time out.
+	// S2 was already streaming from S1 immediately after the failover (B/C
+	// were never diverged from each other), so proceed straight to the write.
+
+	// Write through S1 so S2 advances past A.
+	s1Inst := setup.GetMultipoolerInstance(s1Name)
+	require.NotNil(t, s1Inst)
+	s1SocketDir := filepath.Join(s1Inst.Pgctld.PoolerDir, "pg_sockets")
+	s1DB := connectToPostgres(t, s1SocketDir, s1Inst.Pgctld.PgPort)
+	_, err = s1DB.Exec("INSERT INTO quorum_test (data) VALUES ('post_failover_1')")
+	require.NoError(t, err, "should write through new primary S1")
+	_ = s1DB.Close()
+
+	s2Inst := setup.GetMultipoolerInstance(s2Name)
+	require.NotNil(t, s2Inst)
+	s2SocketDir := filepath.Join(s2Inst.Pgctld.PoolerDir, "pg_sockets")
+	s2DB := connectToPostgres(t, s2SocketDir, s2Inst.Pgctld.PgPort)
+	waitForRow(s2DB, "post_failover_1", utils.ScaleTimeout(10*time.Second), "post-failover write should replicate to S2")
+	_ = s2DB.Close()
+	t.Logf("S2 (%s) confirmed ahead of A", s2Name)
+
+	// Stop S1 too — only A (diverged, down) and S2 (advanced, up) remain.
+	_ = setup.StopPostgres(t, s1Name, "fast")
+	t.Logf("Stopped S1 (%s) postgres", s1Name)
+
+	// Bring A back — restarts as a standby against its stale recorded primary;
+	// recovery must promote S2 and get A to rewind + ack.
+	resumeA()
+	t.Logf("Resumed A (%s) postgres restarts", aName)
+
+	// This is the assertion expected to currently fail (or take far longer than
+	// one recovery round): S2 promoted, A rewound and rejoined as its standby.
+	waitForNodeToRejoinAsStandby(t, setup, aName, s2Name, 0, utils.ScaleTimeout(30*time.Second))
+}


### PR DESCRIPTION
Two issues:
- The first is that a pooler should record that it's the highest known primary _before_ trying to write to WAL. This can help later if the postgres monitor loop needs to determine whether a previous promotion attempt got stuck and failed, in which case the pooler may need to resign leadership
- The second is that multiorch recovery isn't concurrent, so once a rule change is in progress it's not able to recognize the need to call `SetPrimary` to propagate rewind readiness and unblock the rule change. I tried to address this in a more principled way: `SetPrimary` simply distributes information and is idempotent, so it seems harmless to call it early and often. I've pulled it out into a separate loop so it's never blocked by recovery actions. Other options might have been to have rule change try to propagate rewind readiness itself or make recovery actions run async in the background while the recovery loop can keep running, but separating out a SetPrimary loop seemed simpler / lower risk.