### PR TITLE
feat(multipooler): add promotion phase eventlog events

### DIFF
--- a/go/common/eventlog/events.go
+++ b/go/common/eventlog/events.go
@@ -162,3 +162,22 @@ func (ConsensusSetPrimary) EventType() string { return "consensus.set_primary" }
 func (e ConsensusSetPrimary) LogAttrs() []slog.Attr {
 	return []slog.Attr{slog.String("rule", e.Rule)}
 }
+
+// PromotionWalReplay is emitted by the multipooler leader node while it waits
+// for postgres to leave recovery mode (complete WAL replay) after pg_promote().
+// Started fires when the polling loop begins; Success fires when
+// pg_is_in_recovery() first returns false; Failed fires on context cancellation
+// or a query error.
+type PromotionWalReplay struct{}
+
+func (PromotionWalReplay) EventType() string     { return "promotion.wal_replay" }
+func (PromotionWalReplay) LogAttrs() []slog.Attr { return nil }
+
+// PromotionPostgresReady is emitted by the multipooler leader node while it
+// waits for postgres to start accepting connections after WAL replay completes.
+// Started fires when pg_is_in_recovery() first returns false; Success fires
+// when pg_isready succeeds; Failed fires on context cancellation.
+type PromotionPostgresReady struct{}
+
+func (PromotionPostgresReady) EventType() string     { return "promotion.postgres_ready" }
+func (PromotionPostgresReady) LogAttrs() []slog.Attr { return nil }

--- a/go/common/eventlog/events.go
+++ b/go/common/eventlog/events.go
@@ -163,6 +163,19 @@ func (e ConsensusSetPrimary) LogAttrs() []slog.Attr {
 	return []slog.Attr{slog.String("rule", e.Rule)}
 }
 
+// ConsensusRulePropose is emitted when the rule store writes the proposal row
+// and blocks waiting for a sync-standby WAL acknowledgement. This is the
+// dominant latency step in a promotion: for promotion writes the ack only
+// arrives after standbys have reconnected and optionally completed pg_rewind.
+type ConsensusRulePropose struct {
+	Rule string
+}
+
+func (ConsensusRulePropose) EventType() string { return "consensus.rule_propose" }
+func (e ConsensusRulePropose) LogAttrs() []slog.Attr {
+	return []slog.Attr{slog.String("rule", e.Rule)}
+}
+
 // PromotionWalReplay is emitted by the multipooler leader node while it waits
 // for postgres to leave recovery mode (complete WAL replay) after pg_promote().
 // Started fires when the polling loop begins; Success fires when

--- a/go/services/multipooler/internal/manager/consensus/rule_store.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/multigres/multigres/go/common/consensus"
+	"github.com/multigres/multigres/go/common/eventlog"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/timeouts"
 	"github.com/multigres/multigres/go/common/topoclient"
@@ -946,7 +947,14 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 	// recover from.
 	// writeRuleProposal caches the resulting position itself, so its return
 	// value isn't needed here.
-	if _, err := rs.writeRuleProposal(ctx, ruleProposalWriteParams{
+	proposeEvent := eventlog.ConsensusRulePropose{
+		Rule: consensus.FormatRuleNumber(&clustermetadatapb.RuleNumber{
+			CoordinatorTerm: update.termNumber,
+			LeaderSubterm:   nextSubterm,
+		}),
+	}
+	eventlog.Emit(ctx, rs.logger, eventlog.Started, proposeEvent)
+	_, writeErr := rs.writeRuleProposal(ctx, ruleProposalWriteParams{
 		casTerm:          currentTerm,
 		casSubterm:       currentSubterm,
 		newTerm:          update.termNumber,
@@ -964,9 +972,12 @@ func (rs *ruleStore) UpdateRule(ctx context.Context, update *RuleUpdateBuilder) 
 		acceptedMembers:  acceptedParam,
 		coordinatorIDStr: coordinatorIDStr,
 		isPromotion:      isPromotion,
-	}); err != nil {
-		return nil, err
+	})
+	if writeErr != nil {
+		eventlog.Emit(ctx, rs.logger, eventlog.Failed, proposeEvent, "error", writeErr)
+		return nil, writeErr
 	}
+	eventlog.Emit(ctx, rs.logger, eventlog.Success, proposeEvent)
 
 	// Finalize: promote the just-written proposal to decision.
 	pos, err := rs.markProposalAsDecision(ctx, update.termNumber, nextSubterm, coordinatorIDStr, update.createdAt)

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/multigres/multigres/go/common/backup"
 	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/common/eventlog"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/servenv"
@@ -1558,11 +1559,17 @@ func (pm *MultipoolerManager) waitForPromotionComplete(ctx context.Context) erro
 	promotionCtx, cancel := context.WithTimeout(ctx, promotionTimeout)
 	defer cancel()
 
+	eventlog.Emit(ctx, pm.logger, eventlog.Started, eventlog.PromotionWalReplay{})
 	promotedFromRecovery := false
 	for {
 		select {
 		case <-promotionCtx.Done():
 			pm.logger.ErrorContext(ctx, "Timeout waiting for promotion to complete")
+			if promotedFromRecovery {
+				eventlog.Emit(ctx, pm.logger, eventlog.Failed, eventlog.PromotionPostgresReady{}, "error", promotionCtx.Err())
+			} else {
+				eventlog.Emit(ctx, pm.logger, eventlog.Failed, eventlog.PromotionWalReplay{}, "error", promotionCtx.Err())
+			}
 			return mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED,
 				fmt.Sprintf("timeout waiting for promotion to complete after %v", promotionTimeout))
 
@@ -1571,16 +1578,20 @@ func (pm *MultipoolerManager) waitForPromotionComplete(ctx context.Context) erro
 				pgMode, err := pm.postgresMode(promotionCtx)
 				if err != nil {
 					pm.logger.ErrorContext(ctx, "Failed to check recovery status during promotion", "error", err)
+					eventlog.Emit(ctx, pm.logger, eventlog.Failed, eventlog.PromotionWalReplay{}, "error", err)
 					return mterrors.Wrap(err, "failed to check recovery status")
 				}
 				if pgMode.OutOfRecovery() {
 					pm.logger.InfoContext(ctx, "Postgres left recovery mode, waiting for connections to be accepted")
+					eventlog.Emit(ctx, pm.logger, eventlog.Success, eventlog.PromotionWalReplay{})
+					eventlog.Emit(ctx, pm.logger, eventlog.Started, eventlog.PromotionPostgresReady{})
 					promotedFromRecovery = true
 				}
 			}
 
 			if promotedFromRecovery && pm.isPostgresReady(promotionCtx) {
 				pm.logger.InfoContext(ctx, "Promotion completed successfully - node is now primary and accepting connections")
+				eventlog.Emit(ctx, pm.logger, eventlog.Success, eventlog.PromotionPostgresReady{})
 				return nil
 			}
 		}


### PR DESCRIPTION
## Summary

Adds eventlog instrumentation across the full leader-side promotion path, making every phase observable through structured logs.

### New event types (`go/common/eventlog/events.go`)

| Event | Where | Semantics |
|---|---|---|
| `promotion.wal_replay` | `waitForPromotionComplete` | Started/Success/Failed around `pg_is_in_recovery()` polling |
| `promotion.postgres_ready` | `waitForPromotionComplete` | Started/Success/Failed around `pg_isready` polling |
| `consensus.rule_propose` | `ruleStore.UpdateRule` | Started/Success/Failed around the sync-rep WAL ack wait |

### Event sequence on a successful promotion

```
consensus.promote          Started
  promotion.wal_replay     Started → Success
  promotion.postgres_ready Started → Success
  consensus.rule_propose   Started → Success   ← new; closes the sync-rep gap
consensus.promote          Success
```

`consensus.rule_propose` fills the previously dark gap between postgres accepting connections and the rule commit completing. For promotions this step blocks until standbys reconnect and optionally complete pg_rewind — it is the dominant latency step and the most useful one to observe independently.

These pair with the existing `consensus.recruit` and `consensus.set_primary` events that bracket the other two RPC handlers.

## Test plan

- [ ] `go test -count=1 -run TestPromote ./go/services/multipooler/internal/manager/...`
- [ ] `go build ./go/common/eventlog/... ./go/services/multipooler/...`