### PR TITLE
docs(query-serving): keep file references, drop exact symbol names

### DIFF
--- a/docs/query_serving/advisory_locks_design.md
+++ b/docs/query_serving/advisory_locks_design.md
@@ -131,19 +131,12 @@ failed `try` locks, and hidden unlocks make gateway-side counting unreliable.
 
 ## Code map
 
-- Detection: `go/services/multigateway/planner/unsafe_funccall.go`
-  (`sessionAdvisoryLockAcquireFuncs`, `sessionAdvisoryLockReleaseFuncs`).
-- Routing: `planner.go` (`PlannerOptions`, `routePrimitive`),
-  `engine/advisory_lock_route.go`.
-- Reservation reason: `go/common/protoutil/reservation.go`
-  (`ReasonSessionAdvisoryLock`), `proto/multipoolerservice.proto`.
-- Gateway wiring: `scatterconn/scatter_conn.go`,
-  `handler/connection_state.go` (`PendingAdvisoryLockReservation`,
-  `PendingAdvisoryLockRecheck`).
-- Probe + scrub: `go/services/multipooler/internal/executor/executor.go`
-  (`maybeUnpinSessionAdvisoryLock`, `ReleaseReservedConnection`),
-  probe SQL in `go/common/constants/postgres.go`
-  (`PgLocksAdvisoryProbeSQL`).
-- Tests: `go/test/endtoend/queryserving/advisory_lock_test.go`,
-  `planner/advisory_lock_test.go`,
-  `multipooler/internal/executor/executor_test.go`.
+- Detection: `planner/unsafe_funccall.go`.
+- Routing: `planner/planner.go`, `engine/advisory_lock_route.go`.
+- Reservation reason: `common/protoutil/reservation.go`,
+  `proto/multipoolerservice.proto`.
+- Gateway wiring: `scatterconn/scatter_conn.go`, `handler/connection_state.go`.
+- Probe + scrub: `executor/executor.go` (multipooler), probe SQL in
+  `common/constants/postgres.go`.
+- Tests: `test/endtoend/queryserving/advisory_lock_test.go`,
+  `planner/advisory_lock_test.go`, `executor/executor_test.go` (multipooler).

--- a/docs/query_serving/multigres_version.md
+++ b/docs/query_serving/multigres_version.md
@@ -103,15 +103,15 @@ and CI stamp them.
 
 ## Code organization
 
-| File                             | Role                                                             |
-| -------------------------------- | ---------------------------------------------------------------- |
-| `common/servenv/version.go`      | `versionName` — the committed release version constant           |
-| `common/servenv/buildinfo.go`    | `Version()` (short) and `AppVersion()` (full) version strings    |
-| `common/constants/gateway.go`    | `MultigresServerVersionVariable`, `MultigresSchema`              |
-| `handler/gateway_functions.go`   | Folds `multigres.version()` into a literal                       |
-| `planner/variable_show_stmt.go`  | Intercepts `SHOW multigres.server_version`                       |
-| `engine/gateway_show_version.go` | `GatewayShowVersion` primitive; SHOW matcher and Describe helper |
-| `executor/executor.go`           | Serves the extended-protocol `Describe` for SHOW locally         |
+| File                             | Role                                                       |
+| -------------------------------- | ---------------------------------------------------------- |
+| `common/servenv/version.go`      | Committed release version constant                         |
+| `common/servenv/buildinfo.go`    | Short and full version strings                             |
+| `common/constants/gateway.go`    | Gateway-managed version variable and schema name constants |
+| `handler/gateway_functions.go`   | Folds `multigres.version()` into a literal                 |
+| `planner/variable_show_stmt.go`  | Intercepts `SHOW multigres.server_version`                 |
+| `engine/gateway_show_version.go` | SHOW matcher and Describe helper                           |
+| `executor/executor.go` (gateway) | Serves the extended-protocol `Describe` for SHOW locally   |
 
 ## Extended protocol notes
 

--- a/docs/query_serving/pgwire_io_path.md
+++ b/docs/query_serving/pgwire_io_path.md
@@ -171,43 +171,32 @@ After the fixes:
 
 ### Server
 
-- `server/packet.go` — `startPacket`, `writePacket`, in-place encoders
-  (`writeByteAt`, `writeInt16At`, `writeInt32At`, `writeStringAt`,
-  `writeBytesAt`), thin `writeMessage(msgType, body)` wrapper for the
-  body-already-materialized callers (`ParseComplete`, `BindComplete`,
-  `NoData`, `CloseComplete`), `writeRawByte` for the SSL/GSSENC
-  negotiation byte (which is not a pgwire packet), `MessageReader`,
-  read helpers.
-- `server/query.go` — concrete writers (`writeRowDescription`,
-  `writeDataRow`, `writeCommandComplete`, `writeReadyForQuery`,
-  `writeEmptyQueryResponse`, `writeParameterDescription`,
-  `writeErrorOrNotice`, `WriteCopyInResponse`).
-- `server/conn.go` — `Conn` struct, `bufMu`, `bufferedWriter`
-  lifecycle (`startWriterBuffering` / `endWriterBuffering`), async
-  notification pusher.
-- `server/listener.go` — pooled `*bufio.Writer`s and `bufPool`.
+- `server/packet.go`: packet framing and in-place body encoders shared by
+  every server-side writer, plus the raw byte write used for the SSL/GSSENC
+  negotiation byte (which isn't a pgwire packet), and read helpers.
+- `server/query.go`: the concrete message writers for the query response
+  path (row description, data rows, command completion, and friends).
+- `server/conn.go`: the connection struct, buffered-writer lifecycle, and
+  the async notification pusher.
+- `server/listener.go`: the pooled writers and buffer pool shared across
+  connections.
 
 ### Client
 
-- `client/packet.go` — package-level `bufPool`, `startPacket` (no
-  lock), `writePacket` (no flush), in-place encoders (adds
-  `writeUint32At`, `writeByteStringAt` for length-prefixed Bind
-  params), `MessageReader`, read helpers.
-- `client/query.go` — `writeQueryMessage` (simple-protocol Q,
-  self-flushing).
-- `client/extended.go` — `writeParse`, `writeBind`, `writeExecute`,
-  `writeDescribe`, `writeClose`, `writeSync`, `writeFlush`. None
-  flush; the high-level caller flushes once after the pipelined
-  sequence.
-- `client/startup.go`, `client/scram.go` — startup and SCRAM
-  messages. The startup packet has no message-type byte so it encodes
-  directly against `AvailableBuffer` rather than `startPacket`.
-- `client/conn.go` — `Conn` struct, `bufmu`, `bufferedWriter`
-  allocated in `resetConn` (held for connection lifetime),
-  `outboundPoolBuf` field, `WriteCopyData` / `Done` / `Fail`.
+- `client/packet.go`: packet framing and in-place body encoders shared by
+  every client-side writer, plus read helpers.
+- `client/query.go`: the simple-protocol query writer (self-flushing).
+- `client/extended.go`: the extended-protocol message writers; none of
+  them flush individually, the high-level caller flushes once after the
+  pipelined sequence.
+- `client/startup.go`, `client/scram.go`: startup and SCRAM messages. The
+  startup packet has no message-type byte, so it encodes directly against
+  the buffer rather than going through the shared packet framing.
+- `client/conn.go`: the connection struct, buffered-writer lifecycle
+  (allocated for the connection's lifetime), and COPY data helpers.
 
 Microbenchmarks live in `*_bench_test.go` and `*_read_bench_test.go`
-on both sides — run them before and after touching this code.
+on both sides; run them before and after touching this code.
 
 ## Pitfalls
 

--- a/docs/query_serving/setseed_pinning_design.md
+++ b/docs/query_serving/setseed_pinning_design.md
@@ -96,18 +96,13 @@ advisory-lock and logical-replication-slot detection already documents.
 
 ## Code map
 
-- Detection: `go/services/multigateway/planner/unsafe_funccall.go`
-  (`sessionSetSeedFuncs`, `CallsSetSeed`).
-- Routing: `planner.go` (`PlanOptions.PinForSetSeed`, `execInfoFromOpts`,
-  `planType`), `engine/engine.go` (`PlanExecInfo.SetSeed`), `engine/plan.go`
-  (`PlanTypeSetSeedRoute`).
-- Reservation reason: `go/common/protoutil/reservation.go` (`ReasonSetSeed`),
-  `proto/multipoolerservice.proto`
-  (`RESERVATION_REASON_SET_SEED`, `keep_sticky_reservations`).
-- Gateway wiring: `scatterconn/scatter_conn.go`
-  (`reservationReasonsForExecInfo`, `ReleaseAllReservedConnections`),
-  `engine/discard_all_primitive.go`, `executor/executor.go` (`ReleaseAll`).
-- Sticky release: `go/services/multipooler/internal/executor/executor.go`
-  (`ReleaseReservedConnection`), `go/services/multipooler/grpcpoolerservice/service.go`.
+- Detection: `planner/unsafe_funccall.go`.
+- Routing: `planner/planner.go`, `engine/engine.go`, `engine/plan.go`.
+- Reservation reason: `common/protoutil/reservation.go`,
+  `proto/multipoolerservice.proto`.
+- Gateway wiring: `scatterconn/scatter_conn.go`,
+  `engine/discard_all_primitive.go`, `executor/executor.go` (gateway).
+- Sticky release: `executor/executor.go` (multipooler),
+  `grpcpoolerservice/service.go`.
 - Tests: `planner/unsafe_funccall_test.go`, `scatterconn/scatter_conn_test.go`,
-  `multipooler/internal/executor/executor_test.go`.
+  `executor/executor_test.go` (multipooler).

--- a/docs/query_serving/statement_timeout_design.md
+++ b/docs/query_serving/statement_timeout_design.md
@@ -133,18 +133,18 @@ display format.
 
 ## File Organization
 
-| File                                  | Role                                                                                        |
-| ------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `handler/handler.go`                  | `executeWithTimeout`, `getConnectionState` init                                             |
-| `handler/statement_timeout.go`        | `ResolveStatementTimeout`, `ParsePostgresInterval`, `ParseStatementTimeoutDirective` (stub) |
-| `handler/connection_state.go`         | Connection-level timeout state, `Set`/`Reset`/`Get`/`Show`/`Init` methods                   |
-| `handler/gateway_managed_variable.go` | Generic `GatewayManagedVariable[T]` type and lifecycle interface                            |
-| `planner/variable_set_stmt.go`        | `isGatewayManagedVariable`, `planGatewayManagedVariable`                                    |
-| `planner/variable_show_stmt.go`       | Gateway-managed SHOW interception                                                           |
-| `engine/gateway_session_state.go`     | `GatewaySessionState` SET/RESET primitive                                                   |
-| `engine/gateway_show_variable.go`     | `GatewayShowVariable` SHOW primitive                                                        |
-| `engine/apply_session_state.go`       | RESET ALL support for gateway-managed vars                                                  |
-| `init.go`                             | `--statement-timeout` flag registration                                                     |
+| File                                  | Role                                                |
+| ------------------------------------- | --------------------------------------------------- |
+| `handler/handler.go`                  | Applies the timeout around statement execution      |
+| `handler/statement_timeout.go`        | Resolves and parses the timeout value/interval      |
+| `handler/connection_state.go`         | Connection-level timeout state                      |
+| `handler/gateway_managed_variable.go` | Generic gateway-managed-variable type and lifecycle |
+| `planner/variable_set_stmt.go`        | Gateway-managed SET interception and routing        |
+| `planner/variable_show_stmt.go`       | Gateway-managed SHOW interception                   |
+| `engine/gateway_session_state.go`     | SET/RESET primitive for gateway-managed variables   |
+| `engine/gateway_show_variable.go`     | SHOW primitive for gateway-managed variables        |
+| `engine/apply_session_state.go`       | RESET ALL support for gateway-managed vars          |
+| `multigateway/init.go`                | `--statement-timeout` flag registration             |
 
 ## Test Coverage
 

--- a/docs/query_serving/transaction_design.md
+++ b/docs/query_serving/transaction_design.md
@@ -298,12 +298,16 @@ conn.IsInTransaction() == true
 Connections can be reserved for multiple concurrent reasons. The
 `ReservationReasons` field is a `uint32` bitmask:
 
-| Reason              | Value | Meaning                               |
-| ------------------- | ----- | ------------------------------------- |
-| `ReasonTransaction` | `1`   | Active transaction (`BEGIN` executed) |
-| `ReasonTempTable`   | `2`   | Temporary table exists on connection  |
-| `ReasonPortal`      | `4`   | Suspended portal/cursor               |
-| `ReasonCopy`        | `8`   | Active COPY operation                 |
+| Reason                      | Value | Meaning                                                       |
+| --------------------------- | ----- | ------------------------------------------------------------- |
+| `ReasonTransaction`         | `1`   | Active transaction (`BEGIN` executed)                         |
+| `ReasonTempTable`           | `2`   | Temporary table exists on connection                          |
+| `ReasonPortal`              | `4`   | Suspended portal/cursor                                       |
+| `ReasonCopy`                | `8`   | Active COPY operation                                         |
+| `ReasonListen`              | `16`  | Active LISTEN subscription                                    |
+| `ReasonLogicalReplication`  | `32`  | Logical-replication session (owned slot or active stream)     |
+| `ReasonSessionAdvisoryLock` | `64`  | One or more session-level advisory locks held                 |
+| `ReasonSetSeed`             | `128` | `setseed()` called; backend's PRNG is seeded for this session |
 
 When a reason is removed (e.g., transaction committed), the
 connection is only released back to the pool if **all** reasons are
@@ -458,21 +462,21 @@ connection context is cancelled):
 
 | File                                  | Role                                         |
 | ------------------------------------- | -------------------------------------------- |
-| `handler/handler.go`                  | HandleQuery, HandleExecute, ConnectionClosed |
-| `handler/transaction_helpers.go`      | `executeWithImplicitTransaction`             |
+| `handler/handler.go`                  | Query/execute handling, connection lifecycle |
+| `handler/transaction_helpers.go`      | Implicit-transaction wrapping for batches    |
 | `handler/connection_state.go`         | ShardState, reservation tracking             |
 | `engine/transaction_primitive.go`     | Deferred BEGIN, COMMIT/ROLLBACK              |
 | `planner/transaction_stmt.go`         | Routes transaction statements                |
-| `scatterconn/scatter_conn.go`         | 3-case reservation, ConcludeTransaction      |
+| `scatterconn/scatter_conn.go`         | 3-case reservation, transaction conclusion   |
 | `poolergateway/grpc_query_service.go` | gRPC client for RPCs                         |
 | `poolergateway/pooler_gateway.go`     | Gateway interface                            |
 
 ### Multipooler
 
-| File                           | Role                                      |
-| ------------------------------ | ----------------------------------------- |
-| `executor/executor.go`         | ReserveStreamExecute, ConcludeTransaction |
-| `grpcpoolerservice/service.go` | gRPC server handlers                      |
+| File                           | Role                                                  |
+| ------------------------------ | ----------------------------------------------------- |
+| `executor/executor.go`         | Reserved-connection execution, transaction conclusion |
+| `grpcpoolerservice/service.go` | gRPC server handlers                                  |
 
 ### Shared
 
@@ -484,14 +488,14 @@ connection context is cancelled):
 
 ### Tests
 
-| File                                       | Coverage                         |
-| ------------------------------------------ | -------------------------------- |
-| `handler/handler_test.go`                  | Aborted state, batch handling    |
-| `handler/transaction_helpers_test.go`      | Implicit/explicit transformation |
-| `engine/transaction_primitive_test.go`     | Deferred BEGIN, COMMIT/ROLLBACK  |
-| `scatterconn/scatter_conn_test.go`         | 3-case reservation logic         |
-| `poolergateway/grpc_query_service_test.go` | gRPC client tests                |
-| `test/endtoend/.../transaction_test.go`    | End-to-end integration tests     |
+| File                                             | Coverage                         |
+| ------------------------------------------------ | -------------------------------- |
+| `handler/handler_test.go`                        | Aborted state, batch handling    |
+| `handler/transaction_helpers_test.go`            | Implicit/explicit transformation |
+| `engine/transaction_primitive_test.go`           | Deferred BEGIN, COMMIT/ROLLBACK  |
+| `scatterconn/scatter_conn_test.go`               | 3-case reservation logic         |
+| `poolergateway/grpc_query_service_test.go`       | gRPC client tests                |
+| `test/endtoend/queryserving/transaction_test.go` | End-to-end integration tests     |
 
 ## Known Limitations
 

--- a/docs/query_serving/unlogged_tables.md
+++ b/docs/query_serving/unlogged_tables.md
@@ -125,19 +125,12 @@ table falls back to the silent-empty behaviour.
 
 ## Code Map
 
-- **Create-time warning** — `UnloggedWarning` primitive (table/sequence/
-  materialized-view variants) in
-  `go/services/multigateway/engine/unlogged_warning.go`, attached ahead of the
-  CREATE route by `maybeWrapUnloggedWarning` in
-  `go/services/multigateway/planner/planner.go`.
-- **Sweep logic** — `dropUnloggedTablesAfterPromotion` in
-  `go/services/multipooler/internal/manager/manager.go`, invoked from
-  `promoteStandbyToPrimary` after the node becomes a writable primary and before
-  the topology transitions to PRIMARY/SERVING.
-- **Unit tests** — `TestPromoteDropsUnloggedTables` in
-  `go/services/multipooler/internal/manager/rpc_consensus_test.go` (verifies the
-  sweep issues the drops and that a dependency-blocked drop does not fail the
-  promotion).
-- **End-to-end test** — `TestUnloggedTablesAfterFailover` in
-  `go/test/endtoend/queryserving/unlogged_test.go` (real cluster: kills
-  the primary, waits for a new one, and asserts the dropped/empty outcomes).
+- **Create-time warning**: `engine/unlogged_warning.go`, attached ahead of
+  the CREATE route by `planner/planner.go`.
+- **Sweep logic**: `manager/manager.go`, invoked after the node becomes a
+  writable primary and before the topology transitions to PRIMARY/SERVING.
+- **Unit tests**: `manager/rpc_consensus_test.go` (verifies the sweep issues
+  the drops and that a dependency-blocked drop does not fail the promotion).
+- **End-to-end test**: `test/endtoend/queryserving/unlogged_test.go` (real
+  cluster: kills the primary, waits for a new one, and asserts the
+  dropped/empty outcomes).


### PR DESCRIPTION
## Summary

- The Code map / Files / Code organization / File Organization sections pointed at specific functions and types alongside each file. Those drift from the code without anyone noticing; the file path itself is a much more stable anchor.
- Keeps the sections but drops the parenthetical symbol names and generalizes table "Role"/"Covers" columns that named specific functions.
- Normalizes every path in these sections to be relative to the repo root, consistently. Several docs mixed full paths with short/service-relative ones in the same table, which is ambiguous without already knowing the doc's implicit base.
- Fixes a real content gap in transaction_design.md
- pgwire_io_path.md's microbenchmark note is unchanged in place; it was never part of the file/symbol index, it's testing guidance.
- serving-state-management.md's "Files changed" section is left alone: it's a historical changelog of a specific past refactor, not a "where does this live" reference, so it isn't the same kind of staleness risk.