### PR TITLE
fix(pgctld): live-include extra postgresql.conf instead of copying at initdb

### DIFF
--- a/go/cmd/pgctld/command/root.go
+++ b/go/cmd/pgctld/command/root.go
@@ -215,7 +215,7 @@ management for PostgreSQL servers.`,
 	root.PersistentFlags().String("pg-initdb-args", pc.pgInitdbArgs.Default(), "Extra arguments passed to initdb (overrides "+constants.PgInitdbArgsEnvVar+" env var)")
 	root.PersistentFlags().StringSlice("pg-initdb-sql-files", pc.pgInitdbSQLFiles.Default(), "Path to an .sql file to run against the target database after data directory initialization. Repeat the flag to run multiple files in order (overrides "+constants.PgInitdbSQLFilesEnvVar+" env var).")
 	root.PersistentFlags().StringSlice("pg-initdb-sql-dirs", pc.pgInitdbSQLDirs.Default(), "Directory of .sql files to run after initdb, in role:path format. Files run in lexicographic order under SET SESSION AUTHORIZATION <role>. Repeat for multiple directories (overrides "+constants.PgInitdbSQLDirsEnvVar+" env var).")
-	root.PersistentFlags().StringSlice("pg-initdb-extra-conf", pc.pgInitdbExtraConf.Default(), "Path to a postgresql.conf snippet appended verbatim onto the generated config at init time. Repeat the flag to append multiple files in order; postgres applies last-write-wins (overrides "+constants.PgInitdbExtraConfEnvVar+" env var).")
+	root.PersistentFlags().StringSlice("pg-initdb-extra-conf", pc.pgInitdbExtraConf.Default(), "Path to a postgresql.conf snippet live-included (via include_if_exists) at the end of the generated config. The file is re-read on every start and reload, so edits to it take effect on restart. Repeat the flag to include multiple files in order; postgres applies last-write-wins (overrides "+constants.PgInitdbExtraConfEnvVar+" env var).")
 
 	// Backwards-compat alias: --init-db-sql-file → --pg-initdb-sql-files.
 	// Remove once downstream users have migrated.

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -55,9 +55,12 @@ const (
 	PgInitdbSQLDirsEnvVar = "POSTGRES_INITDB_SQL_DIRS"
 
 	// PgInitdbExtraConfEnvVar is the environment variable for extra postgresql.conf
-	// files appended verbatim onto the generated config at init time.
-	// Multiple files are comma-separated. Postgres applies last-write-wins, so
-	// extras override values from the templated defaults.
+	// files live-included (via include_if_exists) at the end of the generated
+	// config. Multiple files are comma-separated. Postgres applies
+	// last-write-wins, so extras override values from the templated defaults.
+	// The referenced files are re-read on every server start and reload, so
+	// editing them (e.g. an operator-managed ConfigMap) takes effect on restart
+	// rather than being frozen at first initdb.
 	PgInitdbExtraConfEnvVar = "POSTGRES_INITDB_EXTRA_CONF"
 
 	// PgConfigTemplateEnvVar is the environment variable for the path to a
@@ -67,7 +70,7 @@ const (
 	// images -- e.g. shared_preload_libraries for extensions a custom base
 	// image bundles (supautils, pgaudit, pg_cron, ...) -- can be set
 	// correctly here instead. Unlike PgInitdbExtraConfEnvVar (which is
-	// appended verbatim, unrendered), this file is rendered through the same
+	// live-included unrendered), this file is rendered through the same
 	// template engine as the embedded default, so it must use the same
 	// {{.Field}} placeholders (see PostgresServerConfig's template fields).
 	PgConfigTemplateEnvVar = "POSTGRES_CONFIG_TEMPLATE_PATH"

--- a/go/services/pgctld/postgresconfig_gen.go
+++ b/go/services/pgctld/postgresconfig_gen.go
@@ -162,10 +162,10 @@ func (cnf *PostgresServerConfig) appendExtraConfFiles(paths []string) error {
 	for _, p := range paths {
 		abs, err := ExpandToAbsolutePath(p)
 		if err != nil {
-			return fmt.Errorf("resolving extra postgres config %q: %w", p, err)
+			return fmt.Errorf("failed when resolving extra postgres config %q: %w", p, err)
 		}
 		if _, err := fmt.Fprintf(f, "include_if_exists %s\n", quoteConfValue(abs)); err != nil {
-			return fmt.Errorf("appending include for %q: %w", p, err)
+			return fmt.Errorf("failed to append include for %q: %w", p, err)
 		}
 	}
 	return nil

--- a/go/services/pgctld/postgresconfig_gen.go
+++ b/go/services/pgctld/postgresconfig_gen.go
@@ -49,7 +49,8 @@ func ExpandToAbsolutePath(dir string) (string, error) {
 }
 
 // GeneratePostgresServerConfig writes postgresql.conf from the embedded template,
-// appends extraConfFiles verbatim (postgres last-write-wins), then reads it back.
+// appends include_if_exists directives for extraConfFiles (postgres
+// last-write-wins), then reads it back.
 func GeneratePostgresServerConfig(poolerDir string, pgUser string, extraConfFiles []string) (*PostgresServerConfig, error) {
 	// Create minimal config for template generation
 	if poolerDir == "" {
@@ -132,9 +133,18 @@ func GeneratePostgresServerConfig(poolerDir string, pgUser string, extraConfFile
 	return ReadPostgresServerConfig(cnf, 0)
 }
 
-// appendExtraConfFiles concatenates each path onto postgresql.conf. The
-// "## <path>" header before each block lets readers attribute lines back to
-// their source file.
+// appendExtraConfFiles appends an `include_if_exists '<absolute path>'`
+// directive for each path to the END of postgresql.conf, in order. Postgres
+// re-reads the referenced files on every server start and every
+// pg_reload_conf() SIGHUP, so a file that changes on disk (e.g. an operator
+// ConfigMap remounted read-only into the pod) takes effect on the next restart
+// or reload — unlike copying the bytes at init time, which baked a stale
+// snapshot into PGDATA/postgresql.conf.
+//
+// Emitting these after the generated template preserves postgres' last-write-
+// wins precedence, so the extra conf still overrides the template. include_if_exists
+// (not include) means a missing/unmounted file is silently skipped instead of
+// failing startup.
 func (cnf *PostgresServerConfig) appendExtraConfFiles(paths []string) error {
 	if len(paths) == 0 {
 		return nil
@@ -146,24 +156,25 @@ func (cnf *PostgresServerConfig) appendExtraConfFiles(paths []string) error {
 	}
 	defer f.Close()
 
+	if _, err := f.WriteString("\n# Live-included extra config (edit the referenced file and reload/restart to apply).\n"); err != nil {
+		return fmt.Errorf("appending extra config header: %w", err)
+	}
 	for _, p := range paths {
-		data, err := os.ReadFile(p)
+		abs, err := ExpandToAbsolutePath(p)
 		if err != nil {
-			return fmt.Errorf("reading extra postgres config %q: %w", p, err)
+			return fmt.Errorf("resolving extra postgres config %q: %w", p, err)
 		}
-		if _, err := fmt.Fprintf(f, "\n## %s\n", p); err != nil {
-			return fmt.Errorf("appending %q: %w", p, err)
-		}
-		if _, err := f.Write(data); err != nil {
-			return fmt.Errorf("appending %q: %w", p, err)
-		}
-		if len(data) > 0 && data[len(data)-1] != '\n' {
-			if _, err := f.WriteString("\n"); err != nil {
-				return fmt.Errorf("appending %q: %w", p, err)
-			}
+		if _, err := fmt.Fprintf(f, "include_if_exists %s\n", quoteConfValue(abs)); err != nil {
+			return fmt.Errorf("appending include for %q: %w", p, err)
 		}
 	}
 	return nil
+}
+
+// quoteConfValue wraps a value in single quotes and escapes embedded single
+// quotes by doubling them, per postgresql.conf string syntax.
+func quoteConfValue(v string) string {
+	return "'" + strings.ReplaceAll(v, "'", "''") + "'"
 }
 
 // generateConfigFile creates the postgresql.conf file using the embedded template

--- a/go/services/pgctld/postgresconfig_gen_test.go
+++ b/go/services/pgctld/postgresconfig_gen_test.go
@@ -208,18 +208,49 @@ func TestGeneratePostgresServerConfigExtraConfFiles(t *testing.T) {
 	require.NoError(t, err)
 	content := string(raw)
 
-	// Source-attribution headers are present in append order.
-	idxA := strings.Index(content, "## "+extraA)
-	idxB := strings.Index(content, "## "+extraB)
-	require.GreaterOrEqual(t, idxA, 0, "extra A header should be present")
-	require.GreaterOrEqual(t, idxB, 0, "extra B header should be present")
-	assert.Greater(t, idxB, idxA, "extra B should be appended after extra A")
+	// The extra files are live-included (not copied). include_if_exists
+	// directives point at the absolute file paths, in order.
+	idxA := strings.Index(content, "include_if_exists '"+extraA+"'")
+	idxB := strings.Index(content, "include_if_exists '"+extraB+"'")
+	require.GreaterOrEqual(t, idxA, 0, "extra A include should be present")
+	require.GreaterOrEqual(t, idxB, 0, "extra B include should be present")
+	assert.Greater(t, idxB, idxA, "extra B should be included after extra A")
 
-	// Last-write-wins: the in-memory struct reflects the value postgres will see.
+	// The bytes are NOT copied into postgresql.conf — only the includes are.
+	assert.NotContains(t, content, "log_min_duration_statement = 500",
+		"extra file contents must not be copied into postgresql.conf")
+
+	// Last-write-wins: the in-memory struct (which follows the includes)
+	// reflects the value postgres will see.
 	assert.Equal(t, "256MB", cfg.SharedBuffers)
+}
 
-	// Settings absent from the template still land in the file.
-	assert.Contains(t, content, "log_min_duration_statement = 500")
+// TestGeneratePostgresServerConfigExtraConfIsLive verifies the whole point of
+// live-including: editing the referenced file after config generation and
+// re-reading (as a restart or SIGHUP reload would) reflects the new value,
+// without regenerating postgresql.conf.
+func TestGeneratePostgresServerConfigExtraConfIsLive(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv(constants.PgDataDirEnvVar, tempDir+"/pg_data")
+
+	extraDir := t.TempDir()
+	extra := filepath.Join(extraDir, "extra.conf")
+	require.NoError(t, os.WriteFile(extra, []byte("max_connections = 111\n"), 0o644))
+
+	cfg, err := GeneratePostgresServerConfig(tempDir, "postgres", []string{extra})
+	require.NoError(t, err)
+	assert.Equal(t, 111, cfg.MaxConnections)
+
+	// Change the referenced file, as an operator would by updating a mounted
+	// ConfigMap. postgresql.conf is untouched.
+	require.NoError(t, os.WriteFile(extra, []byte("max_connections = 222\n"), 0o644))
+
+	// Re-reading the same postgresql.conf (what a restart/reload does) follows
+	// the include and picks up the new value.
+	reread, err := ReadPostgresServerConfig(&PostgresServerConfig{Path: cfg.Path}, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 222, reread.MaxConnections,
+		"edits to the live-included file must be visible on re-read")
 }
 
 func TestGeneratePostgresServerConfigExtraConfFollowsInclude(t *testing.T) {
@@ -241,11 +272,18 @@ func TestGeneratePostgresServerConfigExtraConfFollowsInclude(t *testing.T) {
 	assert.Equal(t, "512MB", cfg.SharedBuffers)
 }
 
+// A missing/unmounted extra file must not fail generation or startup: we emit
+// include_if_exists, which postgres silently skips when the target is absent.
+// This matters because the operator mounts the file from a ConfigMap that may
+// not exist yet on first boot.
 func TestGeneratePostgresServerConfigExtraConfFileMissing(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv(constants.PgDataDirEnvVar, tempDir+"/pg_data")
 
-	_, err := GeneratePostgresServerConfig(tempDir, "postgres", []string{"/does/not/exist.conf"})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "/does/not/exist.conf")
+	cfg, err := GeneratePostgresServerConfig(tempDir, "postgres", []string{"/does/not/exist.conf"})
+	require.NoError(t, err)
+
+	raw, err := os.ReadFile(cfg.Path)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "include_if_exists '/does/not/exist.conf'")
 }

--- a/go/test/endtoend/pgctld/pgctld_test.go
+++ b/go/test/endtoend/pgctld/pgctld_test.go
@@ -514,6 +514,126 @@ func TestPgInitdbExtraConfWithInclude(t *testing.T) {
 	assert.Equal(t, "on", show("track_io_timing"))
 }
 
+// TestPgInitdbExtraConfLiveReload verifies that the file passed via
+// --pg-initdb-extra-conf is live-included, not copied into
+// PGDATA/postgresql.conf at initdb: editing the file in place and refreshing
+// postgres picks up the new value. This mirrors the multigres-operator flow,
+// where the extra file is a mounted ConfigMap the operator edits then expects a
+// reload or restart to apply.
+//
+// Two refresh mechanisms are checked against a running server:
+//   - reload: change a SIGHUP-context GUC (work_mem) in the file, pg_reload_conf(),
+//     and observe the new value.
+//   - restart: change a postmaster-context GUC (max_connections) in the file,
+//     `pgctld restart`, and observe the new value.
+func TestPgInitdbExtraConfLiveReload(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	if !utils.HasPostgreSQLBinaries() {
+		t.Fatal("PostgreSQL binaries not found, make sure to install PostgreSQL and add it to the PATH")
+	}
+
+	tempDir, cleanup := testutil.TempDir(t, "pgctld_extra_conf_live_test")
+	t.Cleanup(cleanup)
+
+	dataDir := filepath.Join(tempDir, "data")
+	extraDir := filepath.Join(tempDir, "extras")
+	require.NoError(t, os.MkdirAll(extraDir, 0o755))
+
+	// This is the operator-managed file. We rewrite it in place below, exactly
+	// as the operator rewrites a mounted ConfigMap.
+	extra := filepath.Join(extraDir, "postgresql.conf")
+	writeExtra := func(contents string) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(extra, []byte(contents), 0o644))
+	}
+	writeExtra("work_mem = 8MB\nmax_connections = 111\n")
+
+	port := utils.GetFreePort(t)
+
+	initCmd := executil.Command(t.Context(), "pgctld", "init",
+		"--pooler-dir", dataDir,
+		"--pg-port", strconv.Itoa(port),
+		"--pg-initdb-extra-conf", extra,
+	)
+	setupTestEnv(initCmd, dataDir)
+	initOut, err := initCmd.CombinedOutput()
+	require.NoError(t, err, "pgctld init failed: %s", string(initOut))
+
+	startCmd := executil.Command(t.Context(), "pgctld", "start",
+		"--pooler-dir", dataDir,
+		"--pg-port", strconv.Itoa(port),
+	)
+	setupTestEnv(startCmd, dataDir)
+	startOut, err := startCmd.CombinedOutput()
+	require.NoError(t, err, "pgctld start failed: %s", string(startOut))
+
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		stopCmd := executil.Command(cleanupCtx, "pgctld", "stop",
+			"--pooler-dir", dataDir,
+			"--pg-port", strconv.Itoa(port),
+		)
+		setupTestEnv(stopCmd, dataDir)
+		_ = stopCmd.Run()
+	})
+
+	socketDir := filepath.Join(dataDir, "pg_sockets")
+	query := func(sql string) string {
+		t.Helper()
+		cmd := executil.Command(t.Context(), "psql",
+			"-h", socketDir,
+			"-p", strconv.Itoa(port),
+			"-U", "postgres",
+			"-d", "postgres",
+			"-Atc", sql,
+		)
+		setupTestEnv(cmd, dataDir)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "psql query failed (%s): %s", sql, string(out))
+		return strings.TrimSpace(string(out))
+	}
+	show := func(setting string) string {
+		t.Helper()
+		return query("SHOW " + setting)
+	}
+
+	// The live-included file is effective at first init.
+	require.Equal(t, "8MB", show("work_mem"))
+	require.Equal(t, "111", show("max_connections"))
+
+	// Reload path: edit the mounted file, SIGHUP via pg_reload_conf(). Under the
+	// old copy-the-bytes behaviour PGDATA/postgresql.conf still held work_mem=8MB,
+	// so this stayed stale.
+	writeExtra("work_mem = 16MB\nmax_connections = 111\n")
+	require.Equal(t, "t", query("SELECT pg_reload_conf()"))
+	require.Eventually(t, func() bool {
+		return show("work_mem") == "16MB"
+	}, 10*time.Second, 100*time.Millisecond,
+		"work_mem edit in the live-included file must take effect after SIGHUP")
+
+	// Restart path: max_connections is postmaster context, so it needs a full
+	// restart. Edit the mounted file, then `pgctld restart`.
+	writeExtra("work_mem = 16MB\nmax_connections = 122\n")
+	restartCmd := executil.Command(t.Context(), "pgctld", "restart",
+		"--pooler-dir", dataDir,
+		"--pg-port", strconv.Itoa(port),
+	)
+	setupTestEnv(restartCmd, dataDir)
+	restartOut, err := restartCmd.CombinedOutput()
+	require.NoError(t, err, "pgctld restart failed: %s", string(restartOut))
+
+	require.Eventually(t, func() bool {
+		return show("max_connections") == "122"
+	}, 10*time.Second, 100*time.Millisecond,
+		"max_connections edit in the live-included file must take effect after restart")
+
+	// The reloaded work_mem survives the restart too (still sourced from the file).
+	assert.Equal(t, "16MB", show("work_mem"))
+}
+
 // TestPostgreSQLAcceptsScaledWalSettingsWithCustomSegmentSize checks that the
 // scaled-down WAL settings for a 1 GiB volume actually start a real PostgreSQL
 // initialized with non-default WAL segments. Unit tests already cover how the

--- a/go/test/endtoend/shardsetup/process.go
+++ b/go/test/endtoend/shardsetup/process.go
@@ -92,8 +92,9 @@ type ProcessInstance struct {
 	// under SET SESSION AUTHORIZATION <role> after initdb (pgctld --pg-initdb-sql-dirs).
 	InitdbSQLDirs []string
 
-	// PgInitdbExtraConfFiles is a list of postgresql.conf snippets appended to
-	// the generated config at init time (pgctld --pg-initdb-extra-conf).
+	// PgInitdbExtraConfFiles is a list of postgresql.conf snippets live-included
+	// (include_if_exists) at the end of the generated config (pgctld
+	// --pg-initdb-extra-conf).
 	// Populated by WithMultipoolerPGTLS to enable ssl on the postgres side.
 	PgInitdbExtraConfFiles []string
 

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -90,7 +90,7 @@ type SetupConfig struct {
 	InitdbSQLFiles                     []string // Paths to .sql files executed on each pgctld after initdb against the target database
 	InitdbSQLDirs                      []string // role:path entries; each dir's .sql files run under SET SESSION AUTHORIZATION <role> after initdb
 	PgInitdbArgs                       string   // Extra args forwarded to pgctld --pg-initdb-args (e.g., "--no-locale --encoding=SQL_ASCII" for pgregress)
-	PgInitdbExtraConfFiles             []string // postgresql.conf snippets appended at init time via --pg-initdb-extra-conf (e.g., locale overrides for pgregress)
+	PgInitdbExtraConfFiles             []string // postgresql.conf snippets live-included via --pg-initdb-extra-conf (e.g., locale overrides for pgregress)
 }
 
 // SetupOption is a function that configures setup creation.
@@ -350,9 +350,10 @@ func WithPgInitdbArgs(args string) SetupOption {
 }
 
 // WithPgInitdbExtraConfFiles appends the given postgresql.conf snippet paths
-// to every pgctld via --pg-initdb-extra-conf. Files are concatenated onto the
-// generated postgresql.conf at init time; postgres applies last-write-wins so
-// settings here override the template defaults. Used by the pgregress harness
+// to every pgctld via --pg-initdb-extra-conf. The generated postgresql.conf
+// live-includes each file (include_if_exists) at its end; postgres applies
+// last-write-wins so settings here override the template defaults. Used by the
+// pgregress harness
 // to force `lc_messages/lc_monetary/lc_numeric/lc_time = 'C'` (the template
 // otherwise hard-codes en_US.UTF-8, which makes locale-sensitive output
 // diverge from upstream `pg_regress --no-locale` expected fixtures).
@@ -624,7 +625,7 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 		inst.Multipooler.ExtraArgs = append(inst.Multipooler.ExtraArgs, config.MultipoolerExtraArgs...)
 		if config.EnableMultipoolerPGTLS {
 			paths := setup.MultipoolerPGTLSCertPaths
-			// Append SSL config to postgresql.conf at init time.
+			// Live-include SSL config into the generated postgresql.conf.
 			inst.Pgctld.PgInitdbExtraConfFiles = append(inst.Pgctld.PgInitdbExtraConfFiles, paths.ExtraConfFile)
 			// Use a permissive pg_hba template that trusts 127.0.0.1 over TLS so
 			// the multipooler's per-user pools (which dial password="" without


### PR DESCRIPTION
## Summary

- `--pg-initdb-extra-conf` files are now live-included into `postgresql.conf` via `include_if_exists` directives instead of having their bytes copied in at initdb, so edits to those files take effect on restart/reload.
- This fixes the multigres-operator flow where a per-shard config ConfigMap is mounted read-only into the pod and updated in place: the change is now picked up on the next restart or `pg_reload_conf()` SIGHUP.
- Adds an e2e test (plus unit-test updates) that edits the referenced file in place and confirms the new value applies via both SIGHUP reload and a full restart.

## Problem

`GeneratePostgresServerConfig` runs only from `pgctld init`, which early-returns when the data dir is already initialized. `appendExtraConfFiles` copied the *contents* of each extra-conf file into `PGDATA/postgresql.conf` on the persistent data volume. So the operator's config was baked into `PGDATA/postgresql.conf` once, at first initdb. On a later restart the data dir already exists → init is skipped → the mounted file (now holding new content) is never re-read, and postgres loads the stale copy. A `pg_reload_conf()` SIGHUP has the same problem — postgres reads `PGDATA`, not the mount. Config changes therefore applied only at first cluster creation.

## Solution

`appendExtraConfFiles` now writes an `include_if_exists '<absolute path>'` directive per file, in order, at the end of `PGDATA/postgresql.conf`, instead of copying the bytes. `postgresql.conf` then points at the live mounted file(s): every server start and every `pg_reload_conf()` SIGHUP re-reads the current content.

- Precedence is preserved — includes are emitted after the generated template, one per file in order, so extras still override the template (same last-write-wins as before).
- `include_if_exists` (not `include`) means a missing/unmounted file is silently skipped rather than failing startup. Paths are absolute and quoted per postgresql.conf syntax.
- `ReadPostgresServerConfig`/`parseConfigInto` already follow `include_if_exists`, so pgctld's in-memory struct still resolves the values correctly (covered by existing + updated tests), and the values remain effective at first initdb (postgres reads `postgresql.conf` → follows the include → mounted file).
- Flag help and env-var docs updated: the file is now live-included, not appended verbatim at init time. The `--pg-initdb-extra-conf` / `POSTGRES_INITDB_EXTRA_CONF` name is kept as-is.

## Testing

- Unit: `postgresconfig_gen_test.go` now asserts the `include_if_exists` directives are written (and contents are *not* copied), a missing file no longer errors, and a new liveness case confirms re-reading reflects an edited file.
- E2e: `TestPgInitdbExtraConfLiveReload` starts real postgres, edits the referenced file in place, and verifies the new value applies via both `pg_reload_conf()` (SIGHUP, `work_mem`) and `pgctld restart` (`max_connections`). Verified red against the old copy-the-bytes behavior and green with the fix.