### PR TITLE
feat(multipooler): add ReloadConfig RPC

### DIFF
--- a/go/common/rpcclient/client.go
+++ b/go/common/rpcclient/client.go
@@ -205,6 +205,14 @@ type MultipoolerClient interface {
 	SetPostgresRestartsEnabled(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse, error)
 
 	//
+	// Manager Service Methods - PostgreSQL Configuration Reload
+	//
+
+	// ReloadConfig triggers a PostgreSQL configuration reload on a pooler and
+	// confirms it took effect, returning the advanced pg_conf_load_time().
+	ReloadConfig(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.ReloadConfigRequest) (*multipoolermanagerdatapb.ReloadConfigResponse, error)
+
+	//
 	// Manager Service Methods - Health Streaming
 	//
 

--- a/go/common/rpcclient/fake_client.go
+++ b/go/common/rpcclient/fake_client.go
@@ -74,6 +74,7 @@ type FakeClient struct {
 	GetBackupsResponses                 map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupsResponse
 	GetBackupByJobIdResponses           map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupByJobIdResponse
 	SetPostgresRestartsEnabledResponses map[topoclient.ComponentID]*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse
+	ReloadConfigResponses               map[topoclient.ComponentID]*multipoolermanagerdatapb.ReloadConfigResponse
 
 	// Errors to return - keyed by pooler ID
 	Errors map[topoclient.ComponentID]error
@@ -116,6 +117,7 @@ func NewFakeClient() *FakeClient {
 		GetBackupsResponses:                 make(map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupsResponse),
 		GetBackupByJobIdResponses:           make(map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupByJobIdResponse),
 		SetPostgresRestartsEnabledResponses: make(map[topoclient.ComponentID]*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse),
+		ReloadConfigResponses:               make(map[topoclient.ComponentID]*multipoolermanagerdatapb.ReloadConfigResponse),
 		Errors:                              make(map[topoclient.ComponentID]error),
 		RecruitDelays:                       make(map[topoclient.ComponentID]time.Duration),
 		RecruitGates:                        make(map[topoclient.ComponentID]chan struct{}),
@@ -481,6 +483,26 @@ func (f *FakeClient) SetPostgresRestartsEnabled(ctx context.Context, pooler *clu
 		return resp, nil
 	}
 	return &multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse{}, nil
+}
+
+//
+// Manager Service Methods - PostgreSQL Configuration Reload
+//
+
+func (f *FakeClient) ReloadConfig(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.ReloadConfigRequest) (*multipoolermanagerdatapb.ReloadConfigResponse, error) {
+	poolerID := f.getPoolerID(pooler)
+	f.logCall("ReloadConfig", poolerID)
+
+	if err := f.checkError(poolerID); err != nil {
+		return nil, err
+	}
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if resp, ok := f.ReloadConfigResponses[poolerID]; ok {
+		return resp, nil
+	}
+	return &multipoolermanagerdatapb.ReloadConfigResponse{}, nil
 }
 
 //

--- a/go/common/rpcclient/grpc_client.go
+++ b/go/common/rpcclient/grpc_client.go
@@ -268,6 +268,23 @@ func (c *Client) SetPostgresRestartsEnabled(ctx context.Context, pooler *cluster
 }
 
 //
+// Manager Service Methods - PostgreSQL Configuration Reload
+//
+
+// ReloadConfig triggers a PostgreSQL configuration reload on a pooler and verifies the result.
+func (c *Client) ReloadConfig(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.ReloadConfigRequest) (*multipoolermanagerdatapb.ReloadConfigResponse, error) {
+	conn, closer, err := c.dialPersistent(ctx, pooler)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = closer()
+	}()
+
+	return conn.managerClient.ReloadConfig(ctx, request)
+}
+
+//
 // Manager Service Methods - Health Streaming
 //
 

--- a/go/pb/multipoolermanager/multipoolermanagerconnect/multipoolermanagerservice.connect.go
+++ b/go/pb/multipoolermanager/multipoolermanagerconnect/multipoolermanagerservice.connect.go
@@ -78,6 +78,9 @@ const (
 	// MultipoolerManagerSetPostgresRestartsEnabledProcedure is the fully-qualified name of the
 	// MultipoolerManager's SetPostgresRestartsEnabled RPC.
 	MultipoolerManagerSetPostgresRestartsEnabledProcedure = "/multipoolermanager.MultipoolerManager/SetPostgresRestartsEnabled"
+	// MultipoolerManagerReloadConfigProcedure is the fully-qualified name of the MultipoolerManager's
+	// ReloadConfig RPC.
+	MultipoolerManagerReloadConfigProcedure = "/multipoolermanager.MultipoolerManager/ReloadConfig"
 	// MultipoolerManagerManagerHealthStreamProcedure is the fully-qualified name of the
 	// MultipoolerManager's ManagerHealthStream RPC.
 	MultipoolerManagerManagerHealthStreamProcedure = "/multipoolermanager.MultipoolerManager/ManagerHealthStream"
@@ -112,6 +115,11 @@ type MultipoolerManagerClient interface {
 	// PostgreSQL instance. Used by tests and demos to prevent premature restarts during
 	// controlled failovers.
 	SetPostgresRestartsEnabled(context.Context, *connect.Request[multipoolermanagerdata.SetPostgresRestartsEnabledRequest]) (*connect.Response[multipoolermanagerdata.SetPostgresRestartsEnabledResponse], error)
+	// ReloadConfig triggers a PostgreSQL configuration reload (SIGHUP via pgctld)
+	// on this multipooler's local PostgreSQL and confirms it took effect by
+	// waiting for pg_conf_load_time() to advance. The returned config_load_time
+	// lets the caller verify its config-file change was re-read.
+	ReloadConfig(context.Context, *connect.Request[multipoolermanagerdata.ReloadConfigRequest]) (*connect.Response[multipoolermanagerdata.ReloadConfigResponse], error)
 	// ManagerHealthStream is a bidirectional health stream between orchestrator
 	// and pooler.
 	//
@@ -200,6 +208,12 @@ func NewMultipoolerManagerClient(httpClient connect.HTTPClient, baseURL string, 
 			connect.WithSchema(multipoolerManagerMethods.ByName("SetPostgresRestartsEnabled")),
 			connect.WithClientOptions(opts...),
 		),
+		reloadConfig: connect.NewClient[multipoolermanagerdata.ReloadConfigRequest, multipoolermanagerdata.ReloadConfigResponse](
+			httpClient,
+			baseURL+MultipoolerManagerReloadConfigProcedure,
+			connect.WithSchema(multipoolerManagerMethods.ByName("ReloadConfig")),
+			connect.WithClientOptions(opts...),
+		),
 		managerHealthStream: connect.NewClient[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse](
 			httpClient,
 			baseURL+MultipoolerManagerManagerHealthStreamProcedure,
@@ -221,6 +235,7 @@ type multipoolerManagerClient struct {
 	expireBackups              *connect.Client[multipoolermanagerdata.ExpireBackupsRequest, multipoolermanagerdata.ExpireBackupsResponse]
 	verifyBackups              *connect.Client[multipoolermanagerdata.VerifyBackupsRequest, multipoolermanagerdata.VerifyBackupsResponse]
 	setPostgresRestartsEnabled *connect.Client[multipoolermanagerdata.SetPostgresRestartsEnabledRequest, multipoolermanagerdata.SetPostgresRestartsEnabledResponse]
+	reloadConfig               *connect.Client[multipoolermanagerdata.ReloadConfigRequest, multipoolermanagerdata.ReloadConfigResponse]
 	managerHealthStream        *connect.Client[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse]
 }
 
@@ -275,6 +290,11 @@ func (c *multipoolerManagerClient) SetPostgresRestartsEnabled(ctx context.Contex
 	return c.setPostgresRestartsEnabled.CallUnary(ctx, req)
 }
 
+// ReloadConfig calls multipoolermanager.MultipoolerManager.ReloadConfig.
+func (c *multipoolerManagerClient) ReloadConfig(ctx context.Context, req *connect.Request[multipoolermanagerdata.ReloadConfigRequest]) (*connect.Response[multipoolermanagerdata.ReloadConfigResponse], error) {
+	return c.reloadConfig.CallUnary(ctx, req)
+}
+
 // ManagerHealthStream calls multipoolermanager.MultipoolerManager.ManagerHealthStream.
 func (c *multipoolerManagerClient) ManagerHealthStream(ctx context.Context) *connect.BidiStreamForClient[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse] {
 	return c.managerHealthStream.CallBidiStream(ctx)
@@ -310,6 +330,11 @@ type MultipoolerManagerHandler interface {
 	// PostgreSQL instance. Used by tests and demos to prevent premature restarts during
 	// controlled failovers.
 	SetPostgresRestartsEnabled(context.Context, *connect.Request[multipoolermanagerdata.SetPostgresRestartsEnabledRequest]) (*connect.Response[multipoolermanagerdata.SetPostgresRestartsEnabledResponse], error)
+	// ReloadConfig triggers a PostgreSQL configuration reload (SIGHUP via pgctld)
+	// on this multipooler's local PostgreSQL and confirms it took effect by
+	// waiting for pg_conf_load_time() to advance. The returned config_load_time
+	// lets the caller verify its config-file change was re-read.
+	ReloadConfig(context.Context, *connect.Request[multipoolermanagerdata.ReloadConfigRequest]) (*connect.Response[multipoolermanagerdata.ReloadConfigResponse], error)
 	// ManagerHealthStream is a bidirectional health stream between orchestrator
 	// and pooler.
 	//
@@ -394,6 +419,12 @@ func NewMultipoolerManagerHandler(svc MultipoolerManagerHandler, opts ...connect
 		connect.WithSchema(multipoolerManagerMethods.ByName("SetPostgresRestartsEnabled")),
 		connect.WithHandlerOptions(opts...),
 	)
+	multipoolerManagerReloadConfigHandler := connect.NewUnaryHandler(
+		MultipoolerManagerReloadConfigProcedure,
+		svc.ReloadConfig,
+		connect.WithSchema(multipoolerManagerMethods.ByName("ReloadConfig")),
+		connect.WithHandlerOptions(opts...),
+	)
 	multipoolerManagerManagerHealthStreamHandler := connect.NewBidiStreamHandler(
 		MultipoolerManagerManagerHealthStreamProcedure,
 		svc.ManagerHealthStream,
@@ -422,6 +453,8 @@ func NewMultipoolerManagerHandler(svc MultipoolerManagerHandler, opts ...connect
 			multipoolerManagerVerifyBackupsHandler.ServeHTTP(w, r)
 		case MultipoolerManagerSetPostgresRestartsEnabledProcedure:
 			multipoolerManagerSetPostgresRestartsEnabledHandler.ServeHTTP(w, r)
+		case MultipoolerManagerReloadConfigProcedure:
+			multipoolerManagerReloadConfigHandler.ServeHTTP(w, r)
 		case MultipoolerManagerManagerHealthStreamProcedure:
 			multipoolerManagerManagerHealthStreamHandler.ServeHTTP(w, r)
 		default:
@@ -471,6 +504,10 @@ func (UnimplementedMultipoolerManagerHandler) VerifyBackups(context.Context, *co
 
 func (UnimplementedMultipoolerManagerHandler) SetPostgresRestartsEnabled(context.Context, *connect.Request[multipoolermanagerdata.SetPostgresRestartsEnabledRequest]) (*connect.Response[multipoolermanagerdata.SetPostgresRestartsEnabledResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("multipoolermanager.MultipoolerManager.SetPostgresRestartsEnabled is not implemented"))
+}
+
+func (UnimplementedMultipoolerManagerHandler) ReloadConfig(context.Context, *connect.Request[multipoolermanagerdata.ReloadConfigRequest]) (*connect.Response[multipoolermanagerdata.ReloadConfigResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("multipoolermanager.MultipoolerManager.ReloadConfig is not implemented"))
 }
 
 func (UnimplementedMultipoolerManagerHandler) ManagerHealthStream(context.Context, *connect.BidiStream[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse]) error {

--- a/go/pb/multipoolermanager/multipoolermanagerservice.pb.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice.pb.go
@@ -39,7 +39,8 @@ var File_multipoolermanagerservice_proto protoreflect.FileDescriptor
 
 const file_multipoolermanagerservice_proto_rawDesc = "" +
 	"\n" +
-	"\x1fmultipoolermanagerservice.proto\x12\x12multipoolermanager\x1a\x1cmultipoolermanagerdata.proto2\xef\t\n" +
+	"\x1fmultipoolermanagerservice.proto\x12\x12multipoolermanager\x1a\x1cmultipoolermanagerdata.proto2\xda\n" +
+	"\n" +
 	"\x12MultipoolerManager\x12c\n" +
 	"\n" +
 	"WaitForLSN\x12).multipoolermanagerdata.WaitForLSNRequest\x1a*.multipoolermanagerdata.WaitForLSNResponse\x12u\n" +
@@ -52,7 +53,8 @@ const file_multipoolermanagerservice_proto_rawDesc = "" +
 	"\x10GetBackupByJobId\x12/.multipoolermanagerdata.GetBackupByJobIdRequest\x1a0.multipoolermanagerdata.GetBackupByJobIdResponse\x12l\n" +
 	"\rExpireBackups\x12,.multipoolermanagerdata.ExpireBackupsRequest\x1a-.multipoolermanagerdata.ExpireBackupsResponse\x12l\n" +
 	"\rVerifyBackups\x12,.multipoolermanagerdata.VerifyBackupsRequest\x1a-.multipoolermanagerdata.VerifyBackupsResponse\x12\x93\x01\n" +
-	"\x1aSetPostgresRestartsEnabled\x129.multipoolermanagerdata.SetPostgresRestartsEnabledRequest\x1a:.multipoolermanagerdata.SetPostgresRestartsEnabledResponse\x12\x88\x01\n" +
+	"\x1aSetPostgresRestartsEnabled\x129.multipoolermanagerdata.SetPostgresRestartsEnabledRequest\x1a:.multipoolermanagerdata.SetPostgresRestartsEnabledResponse\x12i\n" +
+	"\fReloadConfig\x12+.multipoolermanagerdata.ReloadConfigRequest\x1a,.multipoolermanagerdata.ReloadConfigResponse\x12\x88\x01\n" +
 	"\x13ManagerHealthStream\x128.multipoolermanagerdata.ManagerHealthStreamClientMessage\x1a3.multipoolermanagerdata.ManagerHealthStreamResponse(\x010\x01B9Z7github.com/multigres/multigres/go/pb/multipoolermanagerb\x06proto3"
 
 var file_multipoolermanagerservice_proto_goTypes = []any{
@@ -66,18 +68,20 @@ var file_multipoolermanagerservice_proto_goTypes = []any{
 	(*multipoolermanagerdata.ExpireBackupsRequest)(nil),               // 7: multipoolermanagerdata.ExpireBackupsRequest
 	(*multipoolermanagerdata.VerifyBackupsRequest)(nil),               // 8: multipoolermanagerdata.VerifyBackupsRequest
 	(*multipoolermanagerdata.SetPostgresRestartsEnabledRequest)(nil),  // 9: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	(*multipoolermanagerdata.ManagerHealthStreamClientMessage)(nil),   // 10: multipoolermanagerdata.ManagerHealthStreamClientMessage
-	(*multipoolermanagerdata.WaitForLSNResponse)(nil),                 // 11: multipoolermanagerdata.WaitForLSNResponse
-	(*multipoolermanagerdata.StartReplicationResponse)(nil),           // 12: multipoolermanagerdata.StartReplicationResponse
-	(*multipoolermanagerdata.StopReplicationResponse)(nil),            // 13: multipoolermanagerdata.StopReplicationResponse
-	(*multipoolermanagerdata.StatusResponse)(nil),                     // 14: multipoolermanagerdata.StatusResponse
-	(*multipoolermanagerdata.BackupResponse)(nil),                     // 15: multipoolermanagerdata.BackupResponse
-	(*multipoolermanagerdata.GetBackupsResponse)(nil),                 // 16: multipoolermanagerdata.GetBackupsResponse
-	(*multipoolermanagerdata.GetBackupByJobIdResponse)(nil),           // 17: multipoolermanagerdata.GetBackupByJobIdResponse
-	(*multipoolermanagerdata.ExpireBackupsResponse)(nil),              // 18: multipoolermanagerdata.ExpireBackupsResponse
-	(*multipoolermanagerdata.VerifyBackupsResponse)(nil),              // 19: multipoolermanagerdata.VerifyBackupsResponse
-	(*multipoolermanagerdata.SetPostgresRestartsEnabledResponse)(nil), // 20: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	(*multipoolermanagerdata.ManagerHealthStreamResponse)(nil),        // 21: multipoolermanagerdata.ManagerHealthStreamResponse
+	(*multipoolermanagerdata.ReloadConfigRequest)(nil),                // 10: multipoolermanagerdata.ReloadConfigRequest
+	(*multipoolermanagerdata.ManagerHealthStreamClientMessage)(nil),   // 11: multipoolermanagerdata.ManagerHealthStreamClientMessage
+	(*multipoolermanagerdata.WaitForLSNResponse)(nil),                 // 12: multipoolermanagerdata.WaitForLSNResponse
+	(*multipoolermanagerdata.StartReplicationResponse)(nil),           // 13: multipoolermanagerdata.StartReplicationResponse
+	(*multipoolermanagerdata.StopReplicationResponse)(nil),            // 14: multipoolermanagerdata.StopReplicationResponse
+	(*multipoolermanagerdata.StatusResponse)(nil),                     // 15: multipoolermanagerdata.StatusResponse
+	(*multipoolermanagerdata.BackupResponse)(nil),                     // 16: multipoolermanagerdata.BackupResponse
+	(*multipoolermanagerdata.GetBackupsResponse)(nil),                 // 17: multipoolermanagerdata.GetBackupsResponse
+	(*multipoolermanagerdata.GetBackupByJobIdResponse)(nil),           // 18: multipoolermanagerdata.GetBackupByJobIdResponse
+	(*multipoolermanagerdata.ExpireBackupsResponse)(nil),              // 19: multipoolermanagerdata.ExpireBackupsResponse
+	(*multipoolermanagerdata.VerifyBackupsResponse)(nil),              // 20: multipoolermanagerdata.VerifyBackupsResponse
+	(*multipoolermanagerdata.SetPostgresRestartsEnabledResponse)(nil), // 21: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	(*multipoolermanagerdata.ReloadConfigResponse)(nil),               // 22: multipoolermanagerdata.ReloadConfigResponse
+	(*multipoolermanagerdata.ManagerHealthStreamResponse)(nil),        // 23: multipoolermanagerdata.ManagerHealthStreamResponse
 }
 var file_multipoolermanagerservice_proto_depIdxs = []int32{
 	0,  // 0: multipoolermanager.MultipoolerManager.WaitForLSN:input_type -> multipoolermanagerdata.WaitForLSNRequest
@@ -90,20 +94,22 @@ var file_multipoolermanagerservice_proto_depIdxs = []int32{
 	7,  // 7: multipoolermanager.MultipoolerManager.ExpireBackups:input_type -> multipoolermanagerdata.ExpireBackupsRequest
 	8,  // 8: multipoolermanager.MultipoolerManager.VerifyBackups:input_type -> multipoolermanagerdata.VerifyBackupsRequest
 	9,  // 9: multipoolermanager.MultipoolerManager.SetPostgresRestartsEnabled:input_type -> multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	10, // 10: multipoolermanager.MultipoolerManager.ManagerHealthStream:input_type -> multipoolermanagerdata.ManagerHealthStreamClientMessage
-	11, // 11: multipoolermanager.MultipoolerManager.WaitForLSN:output_type -> multipoolermanagerdata.WaitForLSNResponse
-	12, // 12: multipoolermanager.MultipoolerManager.StartReplication:output_type -> multipoolermanagerdata.StartReplicationResponse
-	13, // 13: multipoolermanager.MultipoolerManager.StopReplication:output_type -> multipoolermanagerdata.StopReplicationResponse
-	14, // 14: multipoolermanager.MultipoolerManager.Status:output_type -> multipoolermanagerdata.StatusResponse
-	15, // 15: multipoolermanager.MultipoolerManager.Backup:output_type -> multipoolermanagerdata.BackupResponse
-	16, // 16: multipoolermanager.MultipoolerManager.GetBackups:output_type -> multipoolermanagerdata.GetBackupsResponse
-	17, // 17: multipoolermanager.MultipoolerManager.GetBackupByJobId:output_type -> multipoolermanagerdata.GetBackupByJobIdResponse
-	18, // 18: multipoolermanager.MultipoolerManager.ExpireBackups:output_type -> multipoolermanagerdata.ExpireBackupsResponse
-	19, // 19: multipoolermanager.MultipoolerManager.VerifyBackups:output_type -> multipoolermanagerdata.VerifyBackupsResponse
-	20, // 20: multipoolermanager.MultipoolerManager.SetPostgresRestartsEnabled:output_type -> multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	21, // 21: multipoolermanager.MultipoolerManager.ManagerHealthStream:output_type -> multipoolermanagerdata.ManagerHealthStreamResponse
-	11, // [11:22] is the sub-list for method output_type
-	0,  // [0:11] is the sub-list for method input_type
+	10, // 10: multipoolermanager.MultipoolerManager.ReloadConfig:input_type -> multipoolermanagerdata.ReloadConfigRequest
+	11, // 11: multipoolermanager.MultipoolerManager.ManagerHealthStream:input_type -> multipoolermanagerdata.ManagerHealthStreamClientMessage
+	12, // 12: multipoolermanager.MultipoolerManager.WaitForLSN:output_type -> multipoolermanagerdata.WaitForLSNResponse
+	13, // 13: multipoolermanager.MultipoolerManager.StartReplication:output_type -> multipoolermanagerdata.StartReplicationResponse
+	14, // 14: multipoolermanager.MultipoolerManager.StopReplication:output_type -> multipoolermanagerdata.StopReplicationResponse
+	15, // 15: multipoolermanager.MultipoolerManager.Status:output_type -> multipoolermanagerdata.StatusResponse
+	16, // 16: multipoolermanager.MultipoolerManager.Backup:output_type -> multipoolermanagerdata.BackupResponse
+	17, // 17: multipoolermanager.MultipoolerManager.GetBackups:output_type -> multipoolermanagerdata.GetBackupsResponse
+	18, // 18: multipoolermanager.MultipoolerManager.GetBackupByJobId:output_type -> multipoolermanagerdata.GetBackupByJobIdResponse
+	19, // 19: multipoolermanager.MultipoolerManager.ExpireBackups:output_type -> multipoolermanagerdata.ExpireBackupsResponse
+	20, // 20: multipoolermanager.MultipoolerManager.VerifyBackups:output_type -> multipoolermanagerdata.VerifyBackupsResponse
+	21, // 21: multipoolermanager.MultipoolerManager.SetPostgresRestartsEnabled:output_type -> multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	22, // 22: multipoolermanager.MultipoolerManager.ReloadConfig:output_type -> multipoolermanagerdata.ReloadConfigResponse
+	23, // 23: multipoolermanager.MultipoolerManager.ManagerHealthStream:output_type -> multipoolermanagerdata.ManagerHealthStreamResponse
+	12, // [12:24] is the sub-list for method output_type
+	0,  // [0:12] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/go/pb/multipoolermanager/multipoolermanagerservice.pb.gw.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice.pb.gw.go
@@ -306,6 +306,33 @@ func local_request_MultipoolerManager_SetPostgresRestartsEnabled_0(ctx context.C
 	return msg, metadata, err
 }
 
+func request_MultipoolerManager_ReloadConfig_0(ctx context.Context, marshaler runtime.Marshaler, client MultipoolerManagerClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq multipoolermanagerdata.ReloadConfigRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ReloadConfig(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MultipoolerManager_ReloadConfig_0(ctx context.Context, marshaler runtime.Marshaler, server MultipoolerManagerServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq multipoolermanagerdata.ReloadConfigRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ReloadConfig(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_MultipoolerManager_ManagerHealthStream_0(ctx context.Context, marshaler runtime.Marshaler, client MultipoolerManagerClient, req *http.Request, pathParams map[string]string) (MultipoolerManager_ManagerHealthStreamClient, runtime.ServerMetadata, error) {
 	var metadata runtime.ServerMetadata
 	stream, err := client.ManagerHealthStream(ctx)
@@ -555,6 +582,26 @@ func RegisterMultipoolerManagerHandlerServer(ctx context.Context, mux *runtime.S
 		}
 		forward_MultipoolerManager_SetPostgresRestartsEnabled_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultipoolerManager_ReloadConfig_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/multipoolermanager.MultipoolerManager/ReloadConfig", runtime.WithHTTPPathPattern("/multipoolermanager.MultipoolerManager/ReloadConfig"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MultipoolerManager_ReloadConfig_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultipoolerManager_ReloadConfig_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 
 	mux.Handle(http.MethodPost, pattern_MultipoolerManager_ManagerHealthStream_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		err := status.Error(codes.Unimplemented, "streaming calls are not yet supported in the in-process transport")
@@ -772,6 +819,23 @@ func RegisterMultipoolerManagerHandlerClient(ctx context.Context, mux *runtime.S
 		}
 		forward_MultipoolerManager_SetPostgresRestartsEnabled_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultipoolerManager_ReloadConfig_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/multipoolermanager.MultipoolerManager/ReloadConfig", runtime.WithHTTPPathPattern("/multipoolermanager.MultipoolerManager/ReloadConfig"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MultipoolerManager_ReloadConfig_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultipoolerManager_ReloadConfig_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_MultipoolerManager_ManagerHealthStream_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -803,6 +867,7 @@ var (
 	pattern_MultipoolerManager_ExpireBackups_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultipoolerManager", "ExpireBackups"}, ""))
 	pattern_MultipoolerManager_VerifyBackups_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultipoolerManager", "VerifyBackups"}, ""))
 	pattern_MultipoolerManager_SetPostgresRestartsEnabled_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultipoolerManager", "SetPostgresRestartsEnabled"}, ""))
+	pattern_MultipoolerManager_ReloadConfig_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultipoolerManager", "ReloadConfig"}, ""))
 	pattern_MultipoolerManager_ManagerHealthStream_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultipoolerManager", "ManagerHealthStream"}, ""))
 )
 
@@ -817,5 +882,6 @@ var (
 	forward_MultipoolerManager_ExpireBackups_0              = runtime.ForwardResponseMessage
 	forward_MultipoolerManager_VerifyBackups_0              = runtime.ForwardResponseMessage
 	forward_MultipoolerManager_SetPostgresRestartsEnabled_0 = runtime.ForwardResponseMessage
+	forward_MultipoolerManager_ReloadConfig_0               = runtime.ForwardResponseMessage
 	forward_MultipoolerManager_ManagerHealthStream_0        = runtime.ForwardResponseStream
 )

--- a/go/pb/multipoolermanager/multipoolermanagerservice_grpc.pb.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice_grpc.pb.go
@@ -44,6 +44,7 @@ const (
 	MultipoolerManager_ExpireBackups_FullMethodName              = "/multipoolermanager.MultipoolerManager/ExpireBackups"
 	MultipoolerManager_VerifyBackups_FullMethodName              = "/multipoolermanager.MultipoolerManager/VerifyBackups"
 	MultipoolerManager_SetPostgresRestartsEnabled_FullMethodName = "/multipoolermanager.MultipoolerManager/SetPostgresRestartsEnabled"
+	MultipoolerManager_ReloadConfig_FullMethodName               = "/multipoolermanager.MultipoolerManager/ReloadConfig"
 	MultipoolerManager_ManagerHealthStream_FullMethodName        = "/multipoolermanager.MultipoolerManager/ManagerHealthStream"
 )
 
@@ -80,6 +81,11 @@ type MultipoolerManagerClient interface {
 	// PostgreSQL instance. Used by tests and demos to prevent premature restarts during
 	// controlled failovers.
 	SetPostgresRestartsEnabled(ctx context.Context, in *multipoolermanagerdata.SetPostgresRestartsEnabledRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.SetPostgresRestartsEnabledResponse, error)
+	// ReloadConfig triggers a PostgreSQL configuration reload (SIGHUP via pgctld)
+	// on this multipooler's local PostgreSQL and confirms it took effect by
+	// waiting for pg_conf_load_time() to advance. The returned config_load_time
+	// lets the caller verify its config-file change was re-read.
+	ReloadConfig(ctx context.Context, in *multipoolermanagerdata.ReloadConfigRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.ReloadConfigResponse, error)
 	// ManagerHealthStream is a bidirectional health stream between orchestrator
 	// and pooler.
 	//
@@ -205,6 +211,16 @@ func (c *multipoolerManagerClient) SetPostgresRestartsEnabled(ctx context.Contex
 	return out, nil
 }
 
+func (c *multipoolerManagerClient) ReloadConfig(ctx context.Context, in *multipoolermanagerdata.ReloadConfigRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.ReloadConfigResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(multipoolermanagerdata.ReloadConfigResponse)
+	err := c.cc.Invoke(ctx, MultipoolerManager_ReloadConfig_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *multipoolerManagerClient) ManagerHealthStream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &MultipoolerManager_ServiceDesc.Streams[0], MultipoolerManager_ManagerHealthStream_FullMethodName, cOpts...)
@@ -251,6 +267,11 @@ type MultipoolerManagerServer interface {
 	// PostgreSQL instance. Used by tests and demos to prevent premature restarts during
 	// controlled failovers.
 	SetPostgresRestartsEnabled(context.Context, *multipoolermanagerdata.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdata.SetPostgresRestartsEnabledResponse, error)
+	// ReloadConfig triggers a PostgreSQL configuration reload (SIGHUP via pgctld)
+	// on this multipooler's local PostgreSQL and confirms it took effect by
+	// waiting for pg_conf_load_time() to advance. The returned config_load_time
+	// lets the caller verify its config-file change was re-read.
+	ReloadConfig(context.Context, *multipoolermanagerdata.ReloadConfigRequest) (*multipoolermanagerdata.ReloadConfigResponse, error)
 	// ManagerHealthStream is a bidirectional health stream between orchestrator
 	// and pooler.
 	//
@@ -305,6 +326,9 @@ func (UnimplementedMultipoolerManagerServer) VerifyBackups(context.Context, *mul
 }
 func (UnimplementedMultipoolerManagerServer) SetPostgresRestartsEnabled(context.Context, *multipoolermanagerdata.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdata.SetPostgresRestartsEnabledResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SetPostgresRestartsEnabled not implemented")
+}
+func (UnimplementedMultipoolerManagerServer) ReloadConfig(context.Context, *multipoolermanagerdata.ReloadConfigRequest) (*multipoolermanagerdata.ReloadConfigResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReloadConfig not implemented")
 }
 func (UnimplementedMultipoolerManagerServer) ManagerHealthStream(grpc.BidiStreamingServer[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse]) error {
 	return status.Errorf(codes.Unimplemented, "method ManagerHealthStream not implemented")
@@ -510,6 +534,24 @@ func _MultipoolerManager_SetPostgresRestartsEnabled_Handler(srv interface{}, ctx
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MultipoolerManager_ReloadConfig_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(multipoolermanagerdata.ReloadConfigRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MultipoolerManagerServer).ReloadConfig(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MultipoolerManager_ReloadConfig_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MultipoolerManagerServer).ReloadConfig(ctx, req.(*multipoolermanagerdata.ReloadConfigRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _MultipoolerManager_ManagerHealthStream_Handler(srv interface{}, stream grpc.ServerStream) error {
 	return srv.(MultipoolerManagerServer).ManagerHealthStream(&grpc.GenericServerStream[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse]{ServerStream: stream})
 }
@@ -563,6 +605,10 @@ var MultipoolerManager_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SetPostgresRestartsEnabled",
 			Handler:    _MultipoolerManager_SetPostgresRestartsEnabled_Handler,
+		},
+		{
+			MethodName: "ReloadConfig",
+			Handler:    _MultipoolerManager_ReloadConfig_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -2714,6 +2714,96 @@ func (*SetPostgresRestartsEnabledResponse) Descriptor() ([]byte, []int) {
 	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{33}
 }
 
+// ReloadConfigRequest asks the multipooler to trigger a PostgreSQL
+// configuration reload (SIGHUP) on its local PostgreSQL. It carries no
+// parameters: the caller writes the config file, then calls this to reload it.
+type ReloadConfigRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReloadConfigRequest) Reset() {
+	*x = ReloadConfigRequest{}
+	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReloadConfigRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReloadConfigRequest) ProtoMessage() {}
+
+func (x *ReloadConfigRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReloadConfigRequest.ProtoReflect.Descriptor instead.
+func (*ReloadConfigRequest) Descriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{34}
+}
+
+// ReloadConfigResponse reports the outcome of a configuration reload.
+type ReloadConfigResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The pg_conf_load_time() observed after the reload, confirmed to have
+	// advanced past the moment the reload was triggered. A value newer than when
+	// the caller wrote its config change proves PostgreSQL re-read the file.
+	//
+	// Unset means PostgreSQL was not running, so no reload happened (pgctld could
+	// not deliver the signal); the caller should treat that as retryable.
+	ConfigLoadTime *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=config_load_time,json=configLoadTime,proto3" json:"config_load_time,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *ReloadConfigResponse) Reset() {
+	*x = ReloadConfigResponse{}
+	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReloadConfigResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReloadConfigResponse) ProtoMessage() {}
+
+func (x *ReloadConfigResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReloadConfigResponse.ProtoReflect.Descriptor instead.
+func (*ReloadConfigResponse) Descriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *ReloadConfigResponse) GetConfigLoadTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ConfigLoadTime
+	}
+	return nil
+}
+
 var File_multipoolermanagerdata_proto protoreflect.FileDescriptor
 
 const file_multipoolermanagerdata_proto_rawDesc = "" +
@@ -2869,7 +2959,10 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\bCOMPLETE\x10\x02\"=\n" +
 	"!SetPostgresRestartsEnabledRequest\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\"$\n" +
-	"\"SetPostgresRestartsEnabledResponse*\xa4\x01\n" +
+	"\"SetPostgresRestartsEnabledResponse\"\x15\n" +
+	"\x13ReloadConfigRequest\"\\\n" +
+	"\x14ReloadConfigResponse\x12D\n" +
+	"\x10config_load_time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x0econfigLoadTime*\xa4\x01\n" +
 	"\x0ePostgresStatus\x12\x1b\n" +
 	"\x17POSTGRES_STATUS_UNKNOWN\x10\x00\x12\x1c\n" +
 	"\x18POSTGRES_STATUS_STARTING\x10\x01\x12\x1b\n" +
@@ -2919,7 +3012,7 @@ func file_multipoolermanagerdata_proto_rawDescGZIP() []byte {
 }
 
 var file_multipoolermanagerdata_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
+var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
 var file_multipoolermanagerdata_proto_goTypes = []any{
 	(PostgresStatus)(0),                         // 0: multipoolermanagerdata.PostgresStatus
 	(PostgresAction)(0),                         // 1: multipoolermanagerdata.PostgresAction
@@ -2963,71 +3056,74 @@ var file_multipoolermanagerdata_proto_goTypes = []any{
 	(*BackupMetadata)(nil),                      // 39: multipoolermanagerdata.BackupMetadata
 	(*SetPostgresRestartsEnabledRequest)(nil),   // 40: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
 	(*SetPostgresRestartsEnabledResponse)(nil),  // 41: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	nil,                             // 42: multipoolermanagerdata.BackupRequest.OverridesEntry
-	nil,                             // 43: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	(*durationpb.Duration)(nil),     // 44: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),   // 45: google.protobuf.Timestamp
-	(*clustermetadata.ID)(nil),      // 46: clustermetadata.ID
-	(clustermetadata.PoolerType)(0), // 47: clustermetadata.PoolerType
-	(*clustermetadata.AvailabilityStatus)(nil), // 48: clustermetadata.AvailabilityStatus
-	(*clustermetadata.ConsensusStatus)(nil),    // 49: clustermetadata.ConsensusStatus
-	(*clustermetadata.RuleNumber)(nil),         // 50: clustermetadata.RuleNumber
-	(clustermetadata.RoutingRole)(0),           // 51: clustermetadata.RoutingRole
+	(*ReloadConfigRequest)(nil),                 // 42: multipoolermanagerdata.ReloadConfigRequest
+	(*ReloadConfigResponse)(nil),                // 43: multipoolermanagerdata.ReloadConfigResponse
+	nil,                                         // 44: multipoolermanagerdata.BackupRequest.OverridesEntry
+	nil,                                         // 45: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	(*durationpb.Duration)(nil),                 // 46: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),               // 47: google.protobuf.Timestamp
+	(*clustermetadata.ID)(nil),                  // 48: clustermetadata.ID
+	(clustermetadata.PoolerType)(0),             // 49: clustermetadata.PoolerType
+	(*clustermetadata.AvailabilityStatus)(nil),  // 50: clustermetadata.AvailabilityStatus
+	(*clustermetadata.ConsensusStatus)(nil),     // 51: clustermetadata.ConsensusStatus
+	(*clustermetadata.RuleNumber)(nil),          // 52: clustermetadata.RuleNumber
+	(clustermetadata.RoutingRole)(0),            // 53: clustermetadata.RoutingRole
 }
 var file_multipoolermanagerdata_proto_depIdxs = []int32{
-	44, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
+	46, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
 	8,  // 1: multipoolermanagerdata.StandbyReplicationStatus.primary_conn_info:type_name -> multipoolermanagerdata.PrimaryConnInfo
-	45, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
-	44, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
-	44, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
-	45, // 5: multipoolermanagerdata.StandbyReplicationStatus.last_receive_lsn_advance_time:type_name -> google.protobuf.Timestamp
-	44, // 6: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
+	47, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
+	46, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
+	46, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
+	47, // 5: multipoolermanagerdata.StandbyReplicationStatus.last_receive_lsn_advance_time:type_name -> google.protobuf.Timestamp
+	46, // 6: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
 	3,  // 7: multipoolermanagerdata.StopReplicationRequest.mode:type_name -> multipoolermanagerdata.ReplicationPauseMode
 	9,  // 8: multipoolermanagerdata.StopReplicationResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
 	6,  // 9: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
 	4,  // 10: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
-	46, // 11: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
-	46, // 12: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
+	48, // 11: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
+	48, // 12: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
 	16, // 13: multipoolermanagerdata.PrimaryStatus.sync_replication_config:type_name -> multipoolermanagerdata.SynchronousReplicationConfiguration
-	47, // 14: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
+	49, // 14: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
 	17, // 15: multipoolermanagerdata.Status.primary_status:type_name -> multipoolermanagerdata.PrimaryStatus
 	9,  // 16: multipoolermanagerdata.Status.replication_status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
 	0,  // 17: multipoolermanagerdata.Status.postgres_status:type_name -> multipoolermanagerdata.PostgresStatus
 	1,  // 18: multipoolermanagerdata.Status.postgres_action:type_name -> multipoolermanagerdata.PostgresAction
-	44, // 19: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
+	46, // 19: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
 	18, // 20: multipoolermanagerdata.StatusResponse.status:type_name -> multipoolermanagerdata.Status
-	48, // 21: multipoolermanagerdata.StatusResponse.availability_status:type_name -> clustermetadata.AvailabilityStatus
-	49, // 22: multipoolermanagerdata.StatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	50, // 21: multipoolermanagerdata.StatusResponse.availability_status:type_name -> clustermetadata.AvailabilityStatus
+	51, // 22: multipoolermanagerdata.StatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
 	22, // 23: multipoolermanagerdata.ManagerHealthStreamClientMessage.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartRequest
 	23, // 24: multipoolermanagerdata.ManagerHealthStreamClientMessage.poll:type_name -> multipoolermanagerdata.ManagerHealthStreamPollRequest
-	44, // 25: multipoolermanagerdata.ManagerHealthStreamStartRequest.snapshot_interval:type_name -> google.protobuf.Duration
-	44, // 26: multipoolermanagerdata.ManagerHealthStreamStartRequest.staleness_timeout:type_name -> google.protobuf.Duration
-	44, // 27: multipoolermanagerdata.ManagerHealthStreamStartResponse.snapshot_interval:type_name -> google.protobuf.Duration
-	44, // 28: multipoolermanagerdata.ManagerHealthStreamStartResponse.staleness_timeout:type_name -> google.protobuf.Duration
+	46, // 25: multipoolermanagerdata.ManagerHealthStreamStartRequest.snapshot_interval:type_name -> google.protobuf.Duration
+	46, // 26: multipoolermanagerdata.ManagerHealthStreamStartRequest.staleness_timeout:type_name -> google.protobuf.Duration
+	46, // 27: multipoolermanagerdata.ManagerHealthStreamStartResponse.snapshot_interval:type_name -> google.protobuf.Duration
+	46, // 28: multipoolermanagerdata.ManagerHealthStreamStartResponse.staleness_timeout:type_name -> google.protobuf.Duration
 	24, // 29: multipoolermanagerdata.ManagerHealthStreamResponse.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartResponse
 	26, // 30: multipoolermanagerdata.ManagerHealthStreamResponse.snapshot:type_name -> multipoolermanagerdata.ManagerHealthSnapshot
 	20, // 31: multipoolermanagerdata.ManagerHealthSnapshot.status:type_name -> multipoolermanagerdata.StatusResponse
-	44, // 32: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
+	46, // 32: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
 	2,  // 33: multipoolermanagerdata.ManagerHealthSnapshot.trigger:type_name -> multipoolermanagerdata.SnapshotTrigger
-	45, // 34: multipoolermanagerdata.ManagerHealthSnapshot.captured_at:type_name -> google.protobuf.Timestamp
+	47, // 34: multipoolermanagerdata.ManagerHealthSnapshot.captured_at:type_name -> google.protobuf.Timestamp
 	5,  // 35: multipoolermanagerdata.UpdateConsensusRuleRequest.operation:type_name -> multipoolermanagerdata.CohortUpdateOperation
-	46, // 36: multipoolermanagerdata.UpdateConsensusRuleRequest.standby_ids:type_name -> clustermetadata.ID
-	50, // 37: multipoolermanagerdata.UpdateConsensusRuleRequest.expected_outgoing_rule:type_name -> clustermetadata.RuleNumber
-	46, // 38: multipoolermanagerdata.UpdateConsensusRuleRequest.coordinator_id:type_name -> clustermetadata.ID
-	42, // 39: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
+	48, // 36: multipoolermanagerdata.UpdateConsensusRuleRequest.standby_ids:type_name -> clustermetadata.ID
+	52, // 37: multipoolermanagerdata.UpdateConsensusRuleRequest.expected_outgoing_rule:type_name -> clustermetadata.RuleNumber
+	48, // 38: multipoolermanagerdata.UpdateConsensusRuleRequest.coordinator_id:type_name -> clustermetadata.ID
+	44, // 39: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
 	39, // 40: multipoolermanagerdata.GetBackupsResponse.backups:type_name -> multipoolermanagerdata.BackupMetadata
 	39, // 41: multipoolermanagerdata.GetBackupByJobIdResponse.backup:type_name -> multipoolermanagerdata.BackupMetadata
-	43, // 42: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	44, // 43: multipoolermanagerdata.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
+	45, // 42: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	46, // 43: multipoolermanagerdata.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
 	7,  // 44: multipoolermanagerdata.BackupMetadata.status:type_name -> multipoolermanagerdata.BackupMetadata.Status
-	51, // 45: multipoolermanagerdata.BackupMetadata.routing_role:type_name -> clustermetadata.RoutingRole
-	45, // 46: multipoolermanagerdata.BackupMetadata.start_timestamp:type_name -> google.protobuf.Timestamp
-	45, // 47: multipoolermanagerdata.BackupMetadata.stop_timestamp:type_name -> google.protobuf.Timestamp
-	48, // [48:48] is the sub-list for method output_type
-	48, // [48:48] is the sub-list for method input_type
-	48, // [48:48] is the sub-list for extension type_name
-	48, // [48:48] is the sub-list for extension extendee
-	0,  // [0:48] is the sub-list for field type_name
+	53, // 45: multipoolermanagerdata.BackupMetadata.routing_role:type_name -> clustermetadata.RoutingRole
+	47, // 46: multipoolermanagerdata.BackupMetadata.start_timestamp:type_name -> google.protobuf.Timestamp
+	47, // 47: multipoolermanagerdata.BackupMetadata.stop_timestamp:type_name -> google.protobuf.Timestamp
+	47, // 48: multipoolermanagerdata.ReloadConfigResponse.config_load_time:type_name -> google.protobuf.Timestamp
+	49, // [49:49] is the sub-list for method output_type
+	49, // [49:49] is the sub-list for method input_type
+	49, // [49:49] is the sub-list for extension type_name
+	49, // [49:49] is the sub-list for extension extendee
+	0,  // [0:49] is the sub-list for field type_name
 }
 
 func init() { file_multipoolermanagerdata_proto_init() }
@@ -3049,7 +3145,7 @@ func file_multipoolermanagerdata_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_multipoolermanagerdata_proto_rawDesc), len(file_multipoolermanagerdata_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   36,
+			NumMessages:   38,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/services/multipooler/grpcmanagerservice/service.go
+++ b/go/services/multipooler/grpcmanagerservice/service.go
@@ -151,6 +151,15 @@ func (s *managerService) SetPostgresRestartsEnabled(ctx context.Context, req *mu
 	return s.manager.SetPostgresRestartsEnabled(ctx, req)
 }
 
+// ReloadConfig triggers a PostgreSQL configuration reload and confirms it took effect.
+func (s *managerService) ReloadConfig(ctx context.Context, req *multipoolermanagerdatapb.ReloadConfigRequest) (*multipoolermanagerdatapb.ReloadConfigResponse, error) {
+	resp, err := s.manager.ReloadConfig(ctx)
+	if err != nil {
+		return nil, mterrors.ToGRPC(err)
+	}
+	return resp, nil
+}
+
 // ManagerHealthStream is the bidirectional health stream implementation.
 //
 // The orchestrator sends a start message (optionally carrying snapshot_interval

--- a/go/services/multipooler/internal/manager/consensus/shared_helpers_test.go
+++ b/go/services/multipooler/internal/manager/consensus/shared_helpers_test.go
@@ -82,22 +82,23 @@ func (f *failingSyncStandbyManager) NeedsApply(_ context.Context, _ commonconsen
 }
 
 // expectReloadConfig sets up the mock query expectations for one successful call
-// to MultipoolerManager.reloadPostgresConfig: read pg_conf_load_time (pre), run
-// pg_reload_conf, then read pg_conf_load_time (post) returning a different value
-// so the wait loop exits on the first poll.
+// to MultipoolerManager.reloadPostgresConfig: read the config load time (pre),
+// run pg_reload_conf, then read it (post) returning a different value so the
+// wait loop exits on the first poll. The load time is read as a Unix epoch
+// (see readConfLoadTime), so the mock returns epoch-second values.
 func expectReloadConfig(m *mock.QueryService) {
-	m.AddQueryPatternOnce("SELECT pg_conf_load_time",
-		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"2026-01-01 00:00:00+00"}}))
+	m.AddQueryPatternOnce("pg_conf_load_time",
+		mock.MakeQueryResult([]string{"date_part"}, [][]any{{"1767225600"}}))
 	m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil))
-	m.AddQueryPatternOnce("SELECT pg_conf_load_time",
-		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"2026-01-01 00:00:01+00"}}))
+	m.AddQueryPatternOnce("pg_conf_load_time",
+		mock.MakeQueryResult([]string{"date_part"}, [][]any{{"1767225601"}}))
 }
 
 // expectReloadConfigFailure sets up the mock query expectations for a call to
 // MultipoolerManager.reloadPostgresConfig where pg_reload_conf itself fails.
 // The wait loop is never entered.
 func expectReloadConfigFailure(m *mock.QueryService, reloadErr error) {
-	m.AddQueryPatternOnce("SELECT pg_conf_load_time",
-		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"2026-01-01 00:00:00+00"}}))
+	m.AddQueryPatternOnce("pg_conf_load_time",
+		mock.MakeQueryResult([]string{"date_part"}, [][]any{{"1767225600"}}))
 	m.AddQueryPatternOnceWithError("SELECT pg_reload_conf", reloadErr)
 }

--- a/go/services/multipooler/internal/manager/consensus/sync_standby_names.go
+++ b/go/services/multipooler/internal/manager/consensus/sync_standby_names.go
@@ -160,13 +160,9 @@ func ReloadPostgresConfig(ctx context.Context, logger *slog.Logger, qs executor.
 
 	loadTimeCtx, loadTimeCancel := context.WithTimeout(ctx, timeouts.PostgresConfigTimeout)
 	defer loadTimeCancel()
-	result, err := qs.Query(loadTimeCtx, "SELECT pg_conf_load_time()")
+	loadTimeBefore, err := readConfLoadTime(loadTimeCtx, qs)
 	if err != nil {
 		return mterrors.Wrap(err, "failed to read pg_conf_load_time before reload")
-	}
-	var loadTimeBefore string
-	if err := executor.ScanSingleRow(result, &loadTimeBefore); err != nil {
-		return mterrors.Wrap(err, "failed to scan pg_conf_load_time before reload")
 	}
 
 	logger.InfoContext(ctx, "reloading Postgres configuration")
@@ -177,31 +173,70 @@ func ReloadPostgresConfig(ctx context.Context, logger *slog.Logger, qs executor.
 		return mterrors.Wrap(err, "failed to reload PostgreSQL configuration")
 	}
 
-	// Poll pg_conf_load_time() until it advances. retry.New uses "do work, then
-	// back off" semantics, so the backoff timer starts after the previous query
-	// finishes — a slow query under load doesn't cause back-to-back hammering.
+	// Confirm the reload landed by waiting for pg_conf_load_time() to change
+	// from the value read before the reload.
+	if _, err := WaitForConfigReload(ctx, qs, func(loadTime time.Time) bool {
+		return !loadTime.Equal(loadTimeBefore)
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// WaitForConfigReload polls PostgreSQL's config load time until isReloaded
+// reports that the observed value reflects a completed reload, and returns that
+// load time. It backs off between polls — retry.New uses "do work, then back
+// off" semantics, so the backoff timer starts after the previous query finishes
+// and a slow query under load does not cause back-to-back hammering — and
+// returns DEADLINE_EXCEEDED if no reload is observed within the budget.
+//
+// The isReloaded predicate lets each caller define "reloaded" against its own
+// baseline: a SQL pg_reload_conf() caller (ReloadPostgresConfig) waits for the
+// load time to differ from the value it read beforehand, while a SIGHUP caller
+// waits for it to reach a wall-clock moment captured before the signal.
+func WaitForConfigReload(ctx context.Context, qs executor.InternalQueryService, isReloaded func(loadTime time.Time) bool) (time.Time, error) {
+	if qs == nil {
+		return time.Time{}, errors.New("internal query service not available")
+	}
+
 	waitCtx, waitCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer waitCancel()
 	r := retry.New(1*time.Millisecond, 20*time.Millisecond)
 	for _, attemptErr := range r.Attempts(waitCtx) {
 		if attemptErr != nil {
-			return mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED,
-				"timeout waiting for pg_conf_load_time to advance after pg_reload_conf")
+			return time.Time{}, mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED,
+				"timeout waiting for pg_conf_load_time to advance after reload")
 		}
 		queryCtx, queryCancel := context.WithTimeout(waitCtx, timeouts.PostgresConfigTimeout)
-		result, err := qs.Query(queryCtx, "SELECT pg_conf_load_time()")
+		loadTime, err := readConfLoadTime(queryCtx, qs)
 		queryCancel()
 		if err != nil {
-			return mterrors.Wrap(err, "failed to poll pg_conf_load_time after reload")
+			return time.Time{}, err
 		}
-		var loadTimeAfter string
-		if err := executor.ScanSingleRow(result, &loadTimeAfter); err != nil {
-			return mterrors.Wrap(err, "failed to scan pg_conf_load_time after reload")
-		}
-		if loadTimeAfter != loadTimeBefore {
-			return nil
+		if isReloaded(loadTime) {
+			return loadTime, nil
 		}
 	}
 	// Unreachable: r.Attempts only exits via the ctx-cancelled branch above.
-	return mterrors.New(mtrpcpb.Code_INTERNAL, "reload polling loop exited unexpectedly")
+	return time.Time{}, mterrors.New(mtrpcpb.Code_INTERNAL, "reload polling loop exited unexpectedly")
+}
+
+// readConfLoadTime reads PostgreSQL's configuration load time. It selects the
+// value as a Unix epoch (extract(epoch from ...)) rather than the default text
+// rendering so the result is timezone-independent: pg_conf_load_time() text is
+// formatted in the session's TimeZone, whose offset can carry minutes (e.g.
+// +05:30) that the text-timestamp scanner does not parse. The epoch is an
+// absolute instant, safe to compare across callers and sessions.
+func readConfLoadTime(ctx context.Context, qs executor.InternalQueryService) (time.Time, error) {
+	result, err := qs.Query(ctx, "SELECT extract(epoch from pg_conf_load_time())")
+	if err != nil {
+		return time.Time{}, mterrors.Wrap(err, "failed to read pg_conf_load_time")
+	}
+	var epoch float64
+	if err := executor.ScanSingleRow(result, &epoch); err != nil {
+		return time.Time{}, mterrors.Wrap(err, "failed to scan pg_conf_load_time")
+	}
+	sec := int64(epoch)
+	nsec := int64((epoch - float64(sec)) * 1e9)
+	return time.Unix(sec, nsec).UTC(), nil
 }

--- a/go/services/multipooler/internal/manager/pg_replication_test.go
+++ b/go/services/multipooler/internal/manager/pg_replication_test.go
@@ -35,23 +35,24 @@ import (
 )
 
 // expectReloadConfig sets up the mock query expectations for one successful call
-// to MultipoolerManager.reloadPostgresConfig: read pg_conf_load_time (pre), run
-// pg_reload_conf, then read pg_conf_load_time (post) returning a different value
-// so the wait loop exits on the first poll.
+// to MultipoolerManager.reloadPostgresConfig: read the config load time (pre),
+// run pg_reload_conf, then read it (post) returning a different value so the
+// wait loop exits on the first poll. The load time is read as a Unix epoch
+// (see readConfLoadTime), so the mock returns epoch-second values.
 func expectReloadConfig(m *mock.QueryService) {
-	m.AddQueryPatternOnce("SELECT pg_conf_load_time",
-		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"2026-01-01 00:00:00+00"}}))
+	m.AddQueryPatternOnce("pg_conf_load_time",
+		mock.MakeQueryResult([]string{"date_part"}, [][]any{{"1767225600"}}))
 	m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil))
-	m.AddQueryPatternOnce("SELECT pg_conf_load_time",
-		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"2026-01-01 00:00:01+00"}}))
+	m.AddQueryPatternOnce("pg_conf_load_time",
+		mock.MakeQueryResult([]string{"date_part"}, [][]any{{"1767225601"}}))
 }
 
 // expectReloadConfigFailure sets up the mock query expectations for a call to
 // MultipoolerManager.reloadPostgresConfig where pg_reload_conf itself fails.
 // The wait loop is never entered.
 func expectReloadConfigFailure(m *mock.QueryService, reloadErr error) {
-	m.AddQueryPatternOnce("SELECT pg_conf_load_time",
-		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"2026-01-01 00:00:00+00"}}))
+	m.AddQueryPatternOnce("pg_conf_load_time",
+		mock.MakeQueryResult([]string{"date_part"}, [][]any{{"1767225600"}}))
 	m.AddQueryPatternOnceWithError("SELECT pg_reload_conf", reloadErr)
 }
 

--- a/go/services/multipooler/internal/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/internal/manager/rpc_initialization_test.go
@@ -333,13 +333,15 @@ func TestPromotion_PublishesSelfLeadership(t *testing.T) {
 
 // Mock pgctld client for testing
 type mockPgctldClient struct {
-	statusResponse *pgctldpb.StatusResponse
-	statusError    error
-	startResponse  *pgctldpb.StartResponse
-	startCalled    bool
-	startError     error
-	restartCalled  bool
-	restartError   error
+	statusResponse     *pgctldpb.StatusResponse
+	statusError        error
+	startResponse      *pgctldpb.StartResponse
+	startCalled        bool
+	startError         error
+	restartCalled      bool
+	restartError       error
+	reloadConfigCalled bool
+	reloadConfigError  error
 }
 
 func (m *mockPgctldClient) Status(ctx context.Context, req *pgctldpb.StatusRequest, opts ...grpc.CallOption) (*pgctldpb.StatusResponse, error) {
@@ -382,6 +384,10 @@ func (m *mockPgctldClient) InitDataDir(ctx context.Context, req *pgctldpb.InitDa
 }
 
 func (m *mockPgctldClient) ReloadConfig(ctx context.Context, req *pgctldpb.ReloadConfigRequest, opts ...grpc.CallOption) (*pgctldpb.ReloadConfigResponse, error) {
+	m.reloadConfigCalled = true
+	if m.reloadConfigError != nil {
+		return nil, m.reloadConfigError
+	}
 	return &pgctldpb.ReloadConfigResponse{}, nil
 }
 

--- a/go/services/multipooler/internal/manager/rpc_manager_test.go
+++ b/go/services/multipooler/internal/manager/rpc_manager_test.go
@@ -71,12 +71,14 @@ func expectRewindPositionFloorMocks(m *mock.QueryService) {
 	replStatusRow := [][]any{{nil, nil, true, "paused", nil, "", nil, nil, nil, nil}}
 
 	// pauseReplication(REPLAY_AND_RECEIVER): resetPrimaryConnInfo, then reload.
+	// The reload reads the config load time as a Unix epoch (see readConfLoadTime),
+	// so the before/after mocks return distinct epoch seconds.
 	m.AddQueryPattern("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
-	m.AddQueryPatternOnce("SELECT pg_conf_load_time",
-		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"1970-01-01 00:00:00"}}))
+	m.AddQueryPatternOnce("pg_conf_load_time",
+		mock.MakeQueryResult([]string{"date_part"}, [][]any{{"0"}}))
 	m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult([]string{"pg_reload_conf"}, [][]any{{true}}))
-	m.AddQueryPatternOnce("SELECT pg_conf_load_time",
-		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"1970-01-01 00:00:01"}}))
+	m.AddQueryPatternOnce("pg_conf_load_time",
+		mock.MakeQueryResult([]string{"date_part"}, [][]any{{"1"}}))
 
 	// restartAsStandbyLocked clears restore_command before the replay-completion
 	// wait (a rewinding cohort member must replay only local WAL / stream from the
@@ -85,11 +87,11 @@ func expectRewindPositionFloorMocks(m *mock.QueryService) {
 	// consumed in execution order. (stopRestoreCommand goes through the mock pgctld
 	// gRPC server, so it needs no SQL mock here.)
 	m.AddQueryPattern("ALTER SYSTEM RESET restore_command", mock.MakeQueryResult(nil, nil))
-	m.AddQueryPatternOnce("SELECT pg_conf_load_time",
-		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"1970-01-01 00:00:02"}}))
+	m.AddQueryPatternOnce("pg_conf_load_time",
+		mock.MakeQueryResult([]string{"date_part"}, [][]any{{"2"}}))
 	m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult([]string{"pg_reload_conf"}, [][]any{{true}}))
-	m.AddQueryPatternOnce("SELECT pg_conf_load_time",
-		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"1970-01-01 00:00:03"}}))
+	m.AddQueryPatternOnce("pg_conf_load_time",
+		mock.MakeQueryResult([]string{"date_part"}, [][]any{{"3"}}))
 
 	// ConsensusStatus -> Rules().ObservePosition -> readCurrentRule's SELECT.
 	// Column shape mirrors consensus.mockDecidedReadResult (a decided rule,
@@ -1125,15 +1127,15 @@ func TestRestartAsStandby_RestoresPrimaryConnInfo(t *testing.T) {
 		mock.MakeQueryResult(nil, nil),
 		func(query string) { primaryConnInfoSet = query },
 	)
-	// pg_conf_load_time before reload (consumed once)
-	mockQueryService.AddQueryPatternOnce("SELECT pg_conf_load_time",
-		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"2024-01-01 00:00:00"}}))
+	// config load time before reload, read as a Unix epoch (consumed once)
+	mockQueryService.AddQueryPatternOnce("pg_conf_load_time",
+		mock.MakeQueryResult([]string{"date_part"}, [][]any{{"1704067200"}}))
 	// pg_reload_conf
 	mockQueryService.AddQueryPattern("SELECT pg_reload_conf",
 		mock.MakeQueryResult([]string{"pg_reload_conf"}, [][]any{{true}}))
-	// pg_conf_load_time after reload (different value signals reload completed)
-	mockQueryService.AddQueryPattern("SELECT pg_conf_load_time",
-		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"2024-01-01 00:00:01"}}))
+	// config load time after reload (different value signals reload completed)
+	mockQueryService.AddQueryPattern("pg_conf_load_time",
+		mock.MakeQueryResult([]string{"date_part"}, [][]any{{"1704067201"}}))
 
 	config := &Config{
 		TopoClient: ts,
@@ -1246,12 +1248,12 @@ func TestRestartAsStandby_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
 		mock.MakeQueryResult(nil, nil),
 		func(query string) { primaryConnInfoSet = query },
 	)
-	mockQueryService.AddQueryPatternOnce("SELECT pg_conf_load_time",
-		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"2024-01-01 00:00:00"}}))
+	mockQueryService.AddQueryPatternOnce("pg_conf_load_time",
+		mock.MakeQueryResult([]string{"date_part"}, [][]any{{"1704067200"}}))
 	mockQueryService.AddQueryPattern("SELECT pg_reload_conf",
 		mock.MakeQueryResult([]string{"pg_reload_conf"}, [][]any{{true}}))
-	mockQueryService.AddQueryPattern("SELECT pg_conf_load_time",
-		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"2024-01-01 00:00:01"}}))
+	mockQueryService.AddQueryPattern("pg_conf_load_time",
+		mock.MakeQueryResult([]string{"date_part"}, [][]any{{"1704067201"}}))
 
 	config := &Config{
 		TopoClient: ts,

--- a/go/services/multipooler/internal/manager/rpc_reload_config.go
+++ b/go/services/multipooler/internal/manager/rpc_reload_config.go
@@ -21,12 +21,9 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/multigres/multigres/go/common/mterrors"
-	"github.com/multigres/multigres/go/common/timeouts"
-	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
-	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
-	"github.com/multigres/multigres/go/tools/retry"
+	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
 )
 
 // ReloadConfig triggers a PostgreSQL configuration reload on this multipooler's
@@ -78,8 +75,12 @@ func (pm *MultipoolerManager) ReloadConfig(ctx context.Context) (*multipoolerman
 	}
 
 	// Confirm the reload took effect by waiting for pg_conf_load_time() to
-	// advance past the baseline.
-	loadTime, err := pm.waitForConfigReload(ctx, baseline)
+	// advance to at or after the baseline captured before the trigger. This
+	// reuses the same poll helper as the SQL-triggered consensus reload path,
+	// supplying a baseline predicate instead of a before/after comparison.
+	loadTime, err := consensus.WaitForConfigReload(ctx, pm.internalQueryService(), func(loadTime time.Time) bool {
+		return !loadTime.Before(baseline)
+	})
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to confirm configuration reload")
 	}
@@ -87,41 +88,4 @@ func (pm *MultipoolerManager) ReloadConfig(ctx context.Context) (*multipoolerman
 	return &multipoolermanagerdatapb.ReloadConfigResponse{
 		ConfigLoadTime: timestamppb.New(loadTime),
 	}, nil
-}
-
-// waitForConfigReload polls pg_conf_load_time() until it reports a time at or
-// after baseline, returning that time. It backs off between polls and gives up
-// with a DEADLINE_EXCEEDED error if the reload is not observed within the
-// budget (e.g. the SIGHUP never reached the backend).
-func (pm *MultipoolerManager) waitForConfigReload(ctx context.Context, baseline time.Time) (time.Time, error) {
-	waitCtx, waitCancel := context.WithTimeout(ctx, 5*time.Second)
-	defer waitCancel()
-
-	// retry.New uses "do work, then back off" semantics, so the backoff timer
-	// starts after the previous query finishes — a slow query under load does
-	// not cause back-to-back hammering.
-	r := retry.New(1*time.Millisecond, 20*time.Millisecond)
-	for _, attemptErr := range r.Attempts(waitCtx) {
-		if attemptErr != nil {
-			return time.Time{}, mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED,
-				"timeout waiting for pg_conf_load_time to advance after reload")
-		}
-
-		queryCtx, queryCancel := context.WithTimeout(waitCtx, timeouts.PostgresConfigTimeout)
-		result, err := pm.query(queryCtx, "SELECT pg_conf_load_time()")
-		queryCancel()
-		if err != nil {
-			return time.Time{}, mterrors.Wrap(err, "failed to poll pg_conf_load_time")
-		}
-
-		var loadTime time.Time
-		if err := executor.ScanSingleRow(result, &loadTime); err != nil {
-			return time.Time{}, mterrors.Wrap(err, "failed to scan pg_conf_load_time")
-		}
-		if !loadTime.Before(baseline) {
-			return loadTime, nil
-		}
-	}
-	// Unreachable: r.Attempts only exits via the ctx-cancelled branch above.
-	return time.Time{}, mterrors.New(mtrpcpb.Code_INTERNAL, "reload polling loop exited unexpectedly")
 }

--- a/go/services/multipooler/internal/manager/rpc_reload_config.go
+++ b/go/services/multipooler/internal/manager/rpc_reload_config.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/timeouts"
+	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
+	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
+	"github.com/multigres/multigres/go/tools/retry"
+)
+
+// ReloadConfig triggers a PostgreSQL configuration reload on this multipooler's
+// local PostgreSQL and confirms it took effect.
+//
+// It issues the reload via pgctld (which sends SIGHUP), then waits for
+// pg_conf_load_time() to advance past the moment the reload was triggered. The
+// returned config_load_time is that confirmed-advanced value: a caller that
+// wrote its config change before calling this can trust that a config_load_time
+// newer than its write means PostgreSQL re-read the file.
+//
+// Triggering the reload through pgctld (an OS signal) rather than SQL
+// pg_reload_conf() avoids needing a superuser connection; reading
+// pg_conf_load_time() needs no elevated privilege.
+//
+// Contract:
+//   - Operates on the local PostgreSQL only.
+//   - If PostgreSQL is not running, pgctld's reload fails; this returns
+//     reloaded=false with no error so the caller can treat it as retryable.
+//   - Idempotent: calling it when nothing changed is a harmless reload + read.
+func (pm *MultipoolerManager) ReloadConfig(ctx context.Context) (*multipoolermanagerdatapb.ReloadConfigResponse, error) {
+	if err := pm.checkReady(); err != nil {
+		return nil, err
+	}
+
+	// pgctld's ReloadConfig is a state-changing operation and requires the
+	// action lock (enforced by protectedPgctldClient). Acquire it so we don't
+	// race the monitor or another manual operation.
+	ctx, err := pm.actionLock.Acquire(ctx, "ReloadConfig")
+	if err != nil {
+		return nil, err
+	}
+	defer pm.actionLock.Release(ctx)
+
+	// Capture a baseline on the local clock before triggering. multipooler and
+	// PostgreSQL are colocated, so pg_conf_load_time() (server clock) is
+	// comparable to this: any load time >= baseline reflects a reload at or
+	// after our trigger, while every prior reload is strictly in the past. This
+	// absolute reference is why a pooled poll is safe — backends that have not
+	// yet processed our SIGHUP report their previous (pre-baseline) load time.
+	baseline := time.Now()
+
+	// Trigger the SIGHUP via pgctld. When PostgreSQL is not running pgctld
+	// returns an error; surface that as an empty response (nil config_load_time)
+	// rather than failing hard so the caller can retry.
+	if _, err := pm.pgctldClient.ReloadConfig(ctx, &pgctldpb.ReloadConfigRequest{}); err != nil {
+		pm.logger.WarnContext(ctx, "pgctld ReloadConfig failed, reporting not reloaded", "error", err)
+		return &multipoolermanagerdatapb.ReloadConfigResponse{}, nil
+	}
+
+	// Confirm the reload took effect by waiting for pg_conf_load_time() to
+	// advance past the baseline.
+	loadTime, err := pm.waitForConfigReload(ctx, baseline)
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to confirm configuration reload")
+	}
+
+	return &multipoolermanagerdatapb.ReloadConfigResponse{
+		ConfigLoadTime: timestamppb.New(loadTime),
+	}, nil
+}
+
+// waitForConfigReload polls pg_conf_load_time() until it reports a time at or
+// after baseline, returning that time. It backs off between polls and gives up
+// with a DEADLINE_EXCEEDED error if the reload is not observed within the
+// budget (e.g. the SIGHUP never reached the backend).
+func (pm *MultipoolerManager) waitForConfigReload(ctx context.Context, baseline time.Time) (time.Time, error) {
+	waitCtx, waitCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer waitCancel()
+
+	// retry.New uses "do work, then back off" semantics, so the backoff timer
+	// starts after the previous query finishes — a slow query under load does
+	// not cause back-to-back hammering.
+	r := retry.New(1*time.Millisecond, 20*time.Millisecond)
+	for _, attemptErr := range r.Attempts(waitCtx) {
+		if attemptErr != nil {
+			return time.Time{}, mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED,
+				"timeout waiting for pg_conf_load_time to advance after reload")
+		}
+
+		queryCtx, queryCancel := context.WithTimeout(waitCtx, timeouts.PostgresConfigTimeout)
+		result, err := pm.query(queryCtx, "SELECT pg_conf_load_time()")
+		queryCancel()
+		if err != nil {
+			return time.Time{}, mterrors.Wrap(err, "failed to poll pg_conf_load_time")
+		}
+
+		var loadTime time.Time
+		if err := executor.ScanSingleRow(result, &loadTime); err != nil {
+			return time.Time{}, mterrors.Wrap(err, "failed to scan pg_conf_load_time")
+		}
+		if !loadTime.Before(baseline) {
+			return loadTime, nil
+		}
+	}
+	// Unreachable: r.Attempts only exits via the ctx-cancelled branch above.
+	return time.Time{}, mterrors.New(mtrpcpb.Code_INTERNAL, "reload polling loop exited unexpectedly")
+}

--- a/go/services/multipooler/internal/manager/rpc_reload_config_test.go
+++ b/go/services/multipooler/internal/manager/rpc_reload_config_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/services/multipooler/internal/executor/mock"
+	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
+)
+
+// pg_conf_load_time() text values used to drive the poll loop. The baseline the
+// RPC captures is time.Now(), so "future" always counts as advanced and "past"
+// always counts as stale, independent of when the test runs.
+const (
+	futureConfLoadTime = "2100-01-01 00:00:00+00"
+	pastConfLoadTime   = "2000-01-01 00:00:00+00"
+)
+
+// newReloadConfigTestManager builds a MultipoolerManager wired with a mock
+// query service and a mock pgctld client, ready for ReloadConfig tests.
+func newReloadConfigTestManager(t *testing.T, pgctld *mockPgctldClient) (*MultipoolerManager, *mock.QueryService) {
+	t.Helper()
+	mockQueryService := mock.NewQueryService()
+	multipooler := &clustermetadatapb.Multipooler{
+		ShardKey: &clustermetadatapb.ShardKey{TableGroup: "default", Shard: "0-inf"},
+	}
+	pm := &MultipoolerManager{
+		logger:       slog.New(slog.DiscardHandler),
+		qsc:          &mockPoolerController{queryService: mockQueryService},
+		config:       &Config{},
+		record:       newRecordFromProto(multipooler),
+		serviceID:    &clustermetadatapb.ID{Cell: "test-cell", Name: "test-pooler"},
+		state:        ManagerStateReady,
+		actionLock:   actionlock.NewActionLock(),
+		pgctldClient: pgctld,
+	}
+	return pm, mockQueryService
+}
+
+// TestReloadConfig_Success verifies that a reload triggers pgctld and returns
+// the advanced pg_conf_load_time() once observed.
+func TestReloadConfig_Success(t *testing.T) {
+	pgctld := &mockPgctldClient{}
+	pm, qs := newReloadConfigTestManager(t, pgctld)
+
+	qs.AddQueryPattern("SELECT pg_conf_load_time",
+		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{futureConfLoadTime}}))
+
+	resp, err := pm.ReloadConfig(context.Background())
+	require.NoError(t, err)
+
+	assert.True(t, pgctld.reloadConfigCalled, "pgctld ReloadConfig should be triggered")
+	require.NotNil(t, resp.ConfigLoadTime, "config_load_time should be set on success")
+	assert.Equal(t, 2100, resp.GetConfigLoadTime().AsTime().Year())
+}
+
+// TestReloadConfig_WaitsForAdvance verifies that the poll loop keeps reading
+// pg_conf_load_time() until it advances past the trigger baseline, ignoring a
+// stale pre-reload value.
+func TestReloadConfig_WaitsForAdvance(t *testing.T) {
+	pgctld := &mockPgctldClient{}
+	pm, qs := newReloadConfigTestManager(t, pgctld)
+
+	// First poll observes the stale (pre-reload) value; second observes the
+	// advanced one. The loop must skip the first and return the second.
+	qs.AddQueryPatternOnce("SELECT pg_conf_load_time",
+		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{pastConfLoadTime}}))
+	qs.AddQueryPatternOnce("SELECT pg_conf_load_time",
+		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{futureConfLoadTime}}))
+
+	resp, err := pm.ReloadConfig(context.Background())
+	require.NoError(t, err)
+
+	require.NotNil(t, resp.ConfigLoadTime)
+	assert.Equal(t, 2100, resp.GetConfigLoadTime().AsTime().Year(), "should return the advanced value, not the stale one")
+	require.NoError(t, qs.ExpectationsWereMet(), "both polls should be consumed")
+}
+
+// TestReloadConfig_PostgresNotRunning verifies that when pgctld's reload fails
+// (e.g. PostgreSQL not running), ReloadConfig returns an empty response (nil
+// config_load_time) without a hard error and does not read pg_conf_load_time().
+func TestReloadConfig_PostgresNotRunning(t *testing.T) {
+	pgctld := &mockPgctldClient{
+		reloadConfigError: errors.New("PostgreSQL is not running"),
+	}
+	pm, qs := newReloadConfigTestManager(t, pgctld)
+
+	resp, err := pm.ReloadConfig(context.Background())
+	require.NoError(t, err, "not-running should be surfaced as an empty response, not an error")
+
+	assert.True(t, pgctld.reloadConfigCalled)
+	assert.Nil(t, resp.ConfigLoadTime, "no timestamp when the reload was not delivered")
+	// No pg_conf_load_time query should have been registered/consumed.
+	require.NoError(t, qs.ExpectationsWereMet())
+}
+
+// TestReloadConfig_ConfLoadTimeQueryFails verifies that when the reload signal
+// succeeds but reading pg_conf_load_time() fails, the error is surfaced.
+func TestReloadConfig_ConfLoadTimeQueryFails(t *testing.T) {
+	pgctld := &mockPgctldClient{}
+	pm, qs := newReloadConfigTestManager(t, pgctld)
+
+	qs.AddQueryPatternWithError("SELECT pg_conf_load_time", errors.New("connection refused"))
+
+	_, err := pm.ReloadConfig(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "confirm configuration reload")
+}

--- a/go/services/multipooler/internal/manager/rpc_reload_config_test.go
+++ b/go/services/multipooler/internal/manager/rpc_reload_config_test.go
@@ -28,12 +28,13 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
 )
 
-// pg_conf_load_time() text values used to drive the poll loop. The baseline the
-// RPC captures is time.Now(), so "future" always counts as advanced and "past"
-// always counts as stale, independent of when the test runs.
+// Config load times are read as Unix epoch seconds (see readConfLoadTime). The
+// baseline the RPC captures is time.Now(), so the year-2100 epoch always counts
+// as advanced and the year-2000 epoch always counts as stale, independent of
+// when the test runs.
 const (
-	futureConfLoadTime = "2100-01-01 00:00:00+00"
-	pastConfLoadTime   = "2000-01-01 00:00:00+00"
+	futureConfLoadTime = "4102444800" // 2100-01-01 00:00:00 UTC
+	pastConfLoadTime   = "946684800"  // 2000-01-01 00:00:00 UTC
 )
 
 // newReloadConfigTestManager builds a MultipoolerManager wired with a mock
@@ -63,8 +64,8 @@ func TestReloadConfig_Success(t *testing.T) {
 	pgctld := &mockPgctldClient{}
 	pm, qs := newReloadConfigTestManager(t, pgctld)
 
-	qs.AddQueryPattern("SELECT pg_conf_load_time",
-		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{futureConfLoadTime}}))
+	qs.AddQueryPattern("pg_conf_load_time",
+		mock.MakeQueryResult([]string{"date_part"}, [][]any{{futureConfLoadTime}}))
 
 	resp, err := pm.ReloadConfig(context.Background())
 	require.NoError(t, err)
@@ -83,10 +84,10 @@ func TestReloadConfig_WaitsForAdvance(t *testing.T) {
 
 	// First poll observes the stale (pre-reload) value; second observes the
 	// advanced one. The loop must skip the first and return the second.
-	qs.AddQueryPatternOnce("SELECT pg_conf_load_time",
-		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{pastConfLoadTime}}))
-	qs.AddQueryPatternOnce("SELECT pg_conf_load_time",
-		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{futureConfLoadTime}}))
+	qs.AddQueryPatternOnce("pg_conf_load_time",
+		mock.MakeQueryResult([]string{"date_part"}, [][]any{{pastConfLoadTime}}))
+	qs.AddQueryPatternOnce("pg_conf_load_time",
+		mock.MakeQueryResult([]string{"date_part"}, [][]any{{futureConfLoadTime}}))
 
 	resp, err := pm.ReloadConfig(context.Background())
 	require.NoError(t, err)
@@ -120,7 +121,7 @@ func TestReloadConfig_ConfLoadTimeQueryFails(t *testing.T) {
 	pgctld := &mockPgctldClient{}
 	pm, qs := newReloadConfigTestManager(t, pgctld)
 
-	qs.AddQueryPatternWithError("SELECT pg_conf_load_time", errors.New("connection refused"))
+	qs.AddQueryPatternWithError("pg_conf_load_time", errors.New("connection refused"))
 
 	_, err := pm.ReloadConfig(context.Background())
 	require.Error(t, err)

--- a/go/test/endtoend/multipooler/rpc_manager_api_test.go
+++ b/go/test/endtoend/multipooler/rpc_manager_api_test.go
@@ -72,6 +72,33 @@ func TestManagerStatus_NodeIdentityAndConsensus(t *testing.T) {
 	})
 }
 
+// TestManagerReloadConfig verifies that MultipoolerManager.ReloadConfig triggers
+// a PostgreSQL config reload and confirms it took effect by returning a
+// pg_conf_load_time() that advanced past the moment the call was made.
+func TestManagerReloadConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+
+	setup := getSharedTestSetup(t)
+	setupPoolerTest(t, setup, WithoutReplication())
+	waitForManagerReady(t, setup, setup.PrimaryMultipooler)
+
+	primaryClient, err := shardsetup.NewMultipoolerClient(setup.PrimaryMultipooler.GrpcPort)
+	require.NoError(t, err)
+	t.Cleanup(func() { primaryClient.Close() })
+
+	before := time.Now().Add(-time.Second) // small allowance for clock granularity
+	resp, err := primaryClient.Manager.ReloadConfig(utils.WithShortDeadline(t),
+		&multipoolermanagerdatapb.ReloadConfigRequest{})
+	require.NoError(t, err, "ReloadConfig should succeed while postgres is running")
+	require.NotNil(t, resp)
+
+	require.NotNil(t, resp.GetConfigLoadTime(), "config_load_time should be set while postgres is running")
+	assert.False(t, resp.GetConfigLoadTime().AsTime().Before(before),
+		"config_load_time should reflect a reload at/after the call")
+}
+
 // TestMultipoolerPrimaryLSN verifies that a primary pooler reports a valid WAL position
 // via the manager Status RPC.
 func TestMultipoolerPrimaryLSN(t *testing.T) {

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -596,3 +596,24 @@ message SetPostgresRestartsEnabledRequest {
 message SetPostgresRestartsEnabledResponse {
   // Empty - success indicated by no error
 }
+
+// =============================================================================
+// PostgreSQL Configuration Reload API
+// =============================================================================
+
+// ReloadConfigRequest asks the multipooler to trigger a PostgreSQL
+// configuration reload (SIGHUP) on its local PostgreSQL. It carries no
+// parameters: the caller writes the config file, then calls this to reload it.
+message ReloadConfigRequest {
+}
+
+// ReloadConfigResponse reports the outcome of a configuration reload.
+message ReloadConfigResponse {
+  // The pg_conf_load_time() observed after the reload, confirmed to have
+  // advanced past the moment the reload was triggered. A value newer than when
+  // the caller wrote its config change proves PostgreSQL re-read the file.
+  //
+  // Unset means PostgreSQL was not running, so no reload happened (pgctld could
+  // not deliver the signal); the caller should treat that as retryable.
+  google.protobuf.Timestamp config_load_time = 1;
+}

--- a/proto/multipoolermanagerservice.proto
+++ b/proto/multipoolermanagerservice.proto
@@ -84,6 +84,17 @@ service MultipoolerManager {
   rpc SetPostgresRestartsEnabled(multipoolermanagerdata.SetPostgresRestartsEnabledRequest)
       returns (multipoolermanagerdata.SetPostgresRestartsEnabledResponse);
 
+  //
+  // PostgreSQL Configuration Reload
+  //
+
+  // ReloadConfig triggers a PostgreSQL configuration reload (SIGHUP via pgctld)
+  // on this multipooler's local PostgreSQL and confirms it took effect by
+  // waiting for pg_conf_load_time() to advance. The returned config_load_time
+  // lets the caller verify its config-file change was re-read.
+  rpc ReloadConfig(multipoolermanagerdata.ReloadConfigRequest)
+      returns (multipoolermanagerdata.ReloadConfigResponse);
+
   // ManagerHealthStream is a bidirectional health stream between orchestrator
   // and pooler.
   //

--- a/web/multiadmin/lib/api/generated/multipoolermanagerdata_pb.ts
+++ b/web/multiadmin/lib/api/generated/multipoolermanagerdata_pb.ts
@@ -2285,3 +2285,84 @@ export class SetPostgresRestartsEnabledResponse extends Message<SetPostgresResta
   }
 }
 
+/**
+ * ReloadConfigRequest asks the multipooler to trigger a PostgreSQL
+ * configuration reload (SIGHUP) on its local PostgreSQL. It carries no
+ * parameters: the caller writes the config file, then calls this to reload it.
+ *
+ * @generated from message multipoolermanagerdata.ReloadConfigRequest
+ */
+export class ReloadConfigRequest extends Message<ReloadConfigRequest> {
+  constructor(data?: PartialMessage<ReloadConfigRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "multipoolermanagerdata.ReloadConfigRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ReloadConfigRequest {
+    return new ReloadConfigRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ReloadConfigRequest {
+    return new ReloadConfigRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ReloadConfigRequest {
+    return new ReloadConfigRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ReloadConfigRequest | PlainMessage<ReloadConfigRequest> | undefined, b: ReloadConfigRequest | PlainMessage<ReloadConfigRequest> | undefined): boolean {
+    return proto3.util.equals(ReloadConfigRequest, a, b);
+  }
+}
+
+/**
+ * ReloadConfigResponse reports the outcome of a configuration reload.
+ *
+ * @generated from message multipoolermanagerdata.ReloadConfigResponse
+ */
+export class ReloadConfigResponse extends Message<ReloadConfigResponse> {
+  /**
+   * The pg_conf_load_time() observed after the reload, confirmed to have
+   * advanced past the moment the reload was triggered. A value newer than when
+   * the caller wrote its config change proves PostgreSQL re-read the file.
+   *
+   * Unset means PostgreSQL was not running, so no reload happened (pgctld could
+   * not deliver the signal); the caller should treat that as retryable.
+   *
+   * @generated from field: google.protobuf.Timestamp config_load_time = 1;
+   */
+  configLoadTime?: Timestamp;
+
+  constructor(data?: PartialMessage<ReloadConfigResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "multipoolermanagerdata.ReloadConfigResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "config_load_time", kind: "message", T: Timestamp },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ReloadConfigResponse {
+    return new ReloadConfigResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ReloadConfigResponse {
+    return new ReloadConfigResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ReloadConfigResponse {
+    return new ReloadConfigResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ReloadConfigResponse | PlainMessage<ReloadConfigResponse> | undefined, b: ReloadConfigResponse | PlainMessage<ReloadConfigResponse> | undefined): boolean {
+    return proto3.util.equals(ReloadConfigResponse, a, b);
+  }
+}
+


### PR DESCRIPTION
## Summary

- Adds a `ReloadConfig` RPC to the multipooler manager service that triggers a PostgreSQL config reload and confirms it took effect, so the operator can apply reload-safe GUC changes without recreating the pod.
- The reload is triggered via pgctld (SIGHUP, no superuser needed) and confirmed by waiting for `pg_conf_load_time()` to advance past a baseline captured before the trigger.
- Wires the RPC through the gRPC service, the `rpcclient.MultipoolerClient` interface (real client + fake), and adds unit + endtoend coverage.

## Description

The multigres-operator needs a single per-pod RPC to apply reload-safe PostgreSQL config changes (sighup/user/superuser-context GUCs) via SIGHUP instead of a rolling restart, and to verify the reload actually landed. multipooler is the right home: the operator already dials it, and it already holds both a pgctld client and a live PostgreSQL connection. pgctld's own `ReloadConfig` only delivers the signal and can't verify, so the new RPC reuses it to trigger and then reads PostgreSQL to confirm.

The response is a single `config_load_time` timestamp. Set means the reload was confirmed; unset means PostgreSQL was not running so nothing reloaded (the caller treats that as retryable). A hard gRPC error means a genuine failure (the reload fired but `pg_conf_load_time()` never advanced within the budget, or the read failed). The caller verifies its config-file change was re-read by comparing the returned time against its own write — no GUC values cross the wire, and reload-vs-restart classification stays entirely with the caller.

Confirmation uses a `time.Now()` baseline captured before the SIGHUP and accepts any `pg_conf_load_time()` at or after it. Because that is an absolute reference, every prior reload is strictly in the past, so a pooled poll that lands on a backend which has not yet processed the signal simply reports its old value and the loop keeps polling. This relies on multipooler and PostgreSQL sharing a clock, which holds since they are colocated in the pod.

This assumes the separate pgctld change that includes the operator-provided extra config file (so a SIGHUP re-reads updated values) rather than copying it into `postgresql.conf` at startup. No ALTER SYSTEM path and no classification logic are included here.