### PR TITLE
feat(pgctld): seed day-0 role passwords and settings at init

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,9 @@ Browse the design and reference docs by area:
   plus the HA decision log.
 - **[General](./general/)** — cross-cutting topics (e.g. serving state
   management, [logging conventions](./general/logging.md)).
+- **[pgctld init](./pgctld-init.md)** — data directory initialization: the init
+  flags, execution order, superuser password resolution, init SQL, and init
+  secrets (role passwords and database settings).
 
 ## Alpha Deployment Notes
 

--- a/docs/pgctld-init.md
+++ b/docs/pgctld-init.md
@@ -1,0 +1,161 @@
+# pgctld init
+
+`pgctld init` initializes a PostgreSQL data directory and applies any one-time,
+day-0 setup that must happen before the permanent server starts serving. It is
+the multigres equivalent of the `docker-library/postgres` entrypoint's
+first-boot behavior.
+
+Everything here runs **once**, when the data directory is empty. If the data
+directory is already initialized, `init` is a no-op and returns immediately.
+
+## What it does, in order
+
+1. **`initdb`** creates the data directory with:
+   - `--data-checksums`
+   - `--auth-local=scram-sha-256 --auth-host=scram-sha-256`
+   - `-U <pg-user>` — the superuser role
+   - `--pwfile=<resolved password file>` — sets the **superuser** password (see
+     [Superuser password](#superuser-password))
+   - any extra tokens from `--pg-initdb-args`
+2. **Generate `postgresql.conf`** from the template, appending any
+   `--pg-initdb-extra-conf` snippets verbatim (last-write-wins).
+3. **Transient server** — if any post-initdb step is requested (a non-default
+   target database, init SQL, or an init-secrets file), pgctld starts a
+   short-lived PostgreSQL instance on a **private temporary Unix socket** so it
+   is invisible to multipooler, then runs steps 4–7 against it and stops it.
+   1. **Create the target database** (only if `--pg-database` is not the default
+      `postgres`).
+   2. **Run `--pg-initdb-sql-dirs`** — bulk schema/migration directories, each
+      under `SET SESSION AUTHORIZATION <role>`. Establishes the base schema and
+      creates roles.
+   3. **Run `--pg-initdb-sql-files`** — individual files applied on top as
+      targeted overrides/patches.
+   4. **Apply `--pg-init-secrets-file`** — role passwords and database settings.
+      Runs last, after the roles it targets have been created by 3.ii/3.iii (see
+      [Init secrets](#init-secrets)).
+
+## Flags
+
+Every flag has an environment-variable equivalent; the flag takes precedence.
+
+| Flag                     | Env var                      | Default    | Purpose                                                                                                                                               |
+| ------------------------ | ---------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--pg-user`, `-U`        | `POSTGRES_USER`              | `postgres` | Superuser role created by `initdb`.                                                                                                                   |
+| `--pg-database`, `-D`    | `POSTGRES_DB`                | `postgres` | Target database. A non-default value is created on the transient instance.                                                                            |
+| `--pg-password-file`     | `POSTGRES_PASSWORD_FILE`     | —          | Path to a file holding the **superuser** password (plaintext, first line). See [Superuser password](#superuser-password).                             |
+| `--pg-initdb-args`       | `POSTGRES_INITDB_ARGS`       | —          | Extra tokens appended to the `initdb` command line.                                                                                                   |
+| `--pg-initdb-sql-dirs`   | `POSTGRES_INITDB_SQL_DIRS`   | —          | Directories of `.sql` files run after initdb, in `role:path` format. Repeatable / comma-separated. See [Init SQL directories](#init-sql-directories). |
+| `--pg-initdb-sql-files`  | `POSTGRES_INITDB_SQL_FILES`  | —          | Individual `.sql` files run after the directories, in order. Repeatable / comma-separated.                                                            |
+| `--pg-initdb-extra-conf` | `POSTGRES_INITDB_EXTRA_CONF` | —          | `postgresql.conf` snippets appended verbatim to the generated config. Repeatable; last-write-wins.                                                    |
+| `--pg-init-secrets-file` | `POSTGRES_INIT_SECRETS_FILE` | —          | JSON file of per-project role passwords and database settings. See [Init secrets](#init-secrets).                                                     |
+
+> A legacy alias `--init-db-sql-file` is normalized to `--pg-initdb-sql-files`
+> for backward compatibility.
+
+## Superuser password
+
+`initdb --pwfile` sets a password for exactly **one** role: the superuser
+(`--pg-user`). The password is resolved in order:
+
+1. `--pg-password-file` / `POSTGRES_PASSWORD_FILE` — the file path is handed to
+   `initdb --pwfile` directly, so the plaintext never lands in a temp file.
+2. `POSTGRES_PASSWORD` env var (legacy) — staged into a randomly named temp file
+   only for the duration of the `initdb` exec, then removed.
+
+Password files must be **single-line**; `initdb --pwfile` reads only the first
+line.
+
+All other roles are created **without** a password by the init SQL and must be
+seeded separately — see [Init secrets](#init-secrets).
+
+## Init SQL directories
+
+Each `--pg-initdb-sql-dirs` entry is `role:path`. pgctld reads every `.sql` file
+in `path` in lexicographic order and runs them in a single `psql` session
+wrapped in:
+
+```sql
+SET SESSION AUTHORIZATION "<role>";
+-- files, in order
+RESET SESSION AUTHORIZATION;
+```
+
+so objects are owned by `<role>`. Each script runs with `ON_ERROR_STOP=1`, so a
+failing statement aborts init. Directories run **before** `--pg-initdb-sql-files`.
+
+## Init secrets
+
+`--pg-init-secrets-file` points at a JSON file of **per-project day-0 state**
+that cannot be baked into a shared image — role login credentials and database
+settings. It is typically a mounted Kubernetes Secret, applied over the local
+transient socket during init.
+
+### Format
+
+```json
+{
+  "roles": {
+    "authenticator": "…",
+    "supabase_auth_admin": "…"
+  },
+  "database_settings": {
+    "postgres": { "app.settings.jwt_exp": "3600" }
+  }
+}
+```
+
+- **`roles`** — maps a login role (already created by the init SQL) to its
+  password. The value is **opaque**: a plaintext password (Postgres hashes it
+  per `password_encryption`) or a pre-hashed `SCRAM-SHA-256$…` verifier (stored
+  verbatim). Do **not** list the superuser here — it is set via `--pwfile`.
+- **`database_settings`** — maps a database name to GUCs applied via
+  `ALTER DATABASE <db> SET <key> TO <value>` (e.g. `app.settings.jwt_exp`).
+  Values are stored/consumed as text.
+
+Unknown top-level fields are ignored, so a newer payload does not break an older
+pgctld.
+
+### Behavior
+
+- Runs **last** in the transient phase, after roles exist. Emits
+  `ALTER ROLE … PASSWORD` and `ALTER DATABASE … SET` statements, fed to `psql`
+  over **stdin** (never argv/env) so no secret value is exposed via
+  `/proc/<pid>/cmdline`.
+- The apply session first disables statement logging
+  (`SET log_statement = 'none'`, `log_min_error_statement = 'panic'`,
+  `log_min_duration_statement = -1`) so the plaintext password in
+  `ALTER ROLE … PASSWORD` is not written to the PostgreSQL server log — the
+  generated config sets `log_statement = 'ddl'`, which would otherwise log it.
+  These `SET`s are session-local to the transient connection.
+- **Verification:** after applying role passwords, init queries
+  `pg_authid` and **fails** if any login role still has no password. This turns
+  a role omitted from the file — or created `LOGIN` by the init SQL but never
+  seeded — into a hard init failure instead of a cluster that starts up but
+  can't authenticate its services.
+  - Limitation: a password set to a _malformed_ pre-hashed verifier cannot be
+    detected here (Postgres stores a pre-hashed value verbatim without
+    validating it); the check only catches a _missing_ password.
+- Because it runs only at first init, it seeds **newly created** clusters. It
+  does not repair an already-initialized cluster.
+
+### Verifying manually
+
+```sql
+-- As the superuser: every login role should report true.
+SELECT rolname, rolpassword IS NOT NULL AS has_password
+FROM pg_authid
+WHERE rolcanlogin
+ORDER BY rolname;
+```
+
+## Security notes
+
+- Secret values are never logged: pgctld logs role names and counts only, `psql`
+  output is redacted on error, and statement logging is disabled for the apply
+  session so the plaintext never reaches the PostgreSQL server log (see
+  [Behavior](#behavior)).
+- Prefer file-based inputs (`--pg-password-file`, `--pg-init-secrets-file`) over
+  env vars so plaintext is not exposed in the process environment.
+- Mount secret files read-only (`0400`/`0600`). The init-secrets file may hold
+  credentials for multiple roles; give it the same protection as the superuser
+  password file.

--- a/go/cmd/pgctld/command/init.go
+++ b/go/cmd/pgctld/command/init.go
@@ -112,10 +112,33 @@ func InitDataDirWithResult(logger *slog.Logger, poolerDir string, cfg PgCtldServ
 	}
 
 	// Post-initdb steps that need a running server (custom DB creation, init
-	// SQL files) share a single transient PostgreSQL instance.
-	if cfg.Database != constants.DefaultPostgresDatabase || len(cfg.InitdbSQLFiles) > 0 || len(cfg.InitdbSQLDirs) > 0 {
+	// SQL files, init secrets) share a single transient PostgreSQL instance.
+	if cfg.Database != constants.DefaultPostgresDatabase || len(cfg.InitdbSQLFiles) > 0 || len(cfg.InitdbSQLDirs) > 0 || cfg.InitSecretsFile != "" {
 		if err := postInitdbSetup(logger, cfg); err != nil {
-			return nil, err
+			// initdb has already written PG_VERSION, so the data directory now
+			// reads as initialized. If we leave it, the next init no-ops past
+			// this incomplete setup (IsDataDirInitialized returns true) and a
+			// subsequent start brings up a cluster whose roles were created but
+			// never seeded — the exact failure this setup guards against. Roll
+			// the data directory back so a retry re-runs the full init.
+			//
+			// We remove the whole data directory, not just PG_VERSION: the retry
+			// re-runs initdb, which refuses to initialize a non-empty directory,
+			// so clearing only PG_VERSION would flip the gate but then fail on
+			// the leftover initdb output. initdb needs an absent (or empty)
+			// target; removing dataDir gives it that and recreates pg_data under
+			// the still-present poolerDir on retry.
+			//
+			// Removing dataDir is safe: we are past the IsDataDirInitialized
+			// early return, so this call created it (freshly-initialized, un-seeded
+			// state — never user data); and postInitdbSetup has already stopped its
+			// transient server (deferred), so it is not in use. Config artifacts
+			// outside dataDir are regenerated on retry.
+			if rmErr := os.RemoveAll(dataDir); rmErr != nil {
+				return nil, fmt.Errorf("post-initdb setup failed (%w); rolling back data directory %q also failed (%w) — manual cleanup required before retry", err, dataDir, rmErr)
+			}
+			logger.Warn("rolled back data directory after post-initdb setup failure", "data_dir", dataDir, "error", err)
+			return nil, fmt.Errorf("post-initdb setup failed; data directory rolled back for retry: %w", err)
 		}
 	}
 
@@ -126,8 +149,8 @@ func InitDataDirWithResult(logger *slog.Logger, poolerDir string, cfg PgCtldServ
 }
 
 // postInitdbSetup starts a transient PostgreSQL instance and performs any
-// post-initdb setup steps: creating a custom target database (if requested)
-// and running user-provided init SQL against the target database.
+// post-initdb setup steps: creating a custom target database (if requested) and
+// running user-provided init SQL against the target database.
 //
 // Execution order:
 //  1. Create target database (if non-default).
@@ -135,13 +158,16 @@ func InitDataDirWithResult(logger *slog.Logger, poolerDir string, cfg PgCtldServ
 //     SET SESSION AUTHORIZATION <role>. Directories establish the base schema.
 //  3. Run --pg-initdb-sql-files: individual files applied on top as targeted
 //     overrides or patches.
+//  4. Apply --pg-init-secrets-file: role passwords and database settings. Runs
+//     last, after the roles it targets have been created by steps 2/3.
 func postInitdbSetup(logger *slog.Logger, cfg PgCtldServiceConfig) error {
 	createDB := cfg.Database != constants.DefaultPostgresDatabase
 
 	logger.Info("starting Postgres transiently for post-initdb setup",
 		"create_database", createDB,
 		"init_sql_files", len(cfg.InitdbSQLFiles),
-		"init_sql_dirs", len(cfg.InitdbSQLDirs))
+		"init_sql_dirs", len(cfg.InitdbSQLDirs),
+		"init_secrets", cfg.InitSecretsFile != "")
 	pg, err := newPgInstance(logger, pgctld.PostgresDataDir(), pgctld.PostgresConfigFile(), cfg)
 	if err != nil {
 		return err
@@ -164,6 +190,11 @@ func postInitdbSetup(logger *slog.Logger, cfg PgCtldServiceConfig) error {
 		return err
 	}
 
+	// Secrets last: the roles they target are created by the dirs/files above.
+	if err := applyInitSecrets(logger, pg, cfg); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -175,7 +206,7 @@ func runInitdbSQLFiles(logger *slog.Logger, pg *pgInstance, database string, fil
 			return fmt.Errorf("init SQL file not accessible (%s): %w", file, err)
 		}
 		logger.Info("running init SQL file", "file", file, "database", database)
-		out, err := pg.psql(database, "-v", "ON_ERROR_STOP=1", "-f", file)
+		out, err := pg.psql(database, nil, "-v", "ON_ERROR_STOP=1", "-f", file)
 		if err != nil {
 			return fmt.Errorf("init SQL file failed (%s): %w\nOutput: %s", file, err, out)
 		}
@@ -213,7 +244,7 @@ func runInitdbSQLDirs(logger *slog.Logger, pg *pgInstance, database string, entr
 		}
 		args = append(args, "-c", "RESET SESSION AUTHORIZATION")
 
-		if out, err := pg.psql(database, args...); err != nil {
+		if out, err := pg.psql(database, nil, args...); err != nil {
 			return fmt.Errorf("init SQL dir failed (%s as %s): %w\nOutput: %s", dir, role, err, out)
 		}
 		logger.Info("init SQL dir applied", "dir", dir, "role", role)
@@ -276,7 +307,7 @@ func createDatabaseOnInstance(logger *slog.Logger, pg *pgInstance, database stri
 	// Use Go string formatting to build the SQL — the database name comes from
 	// operator config, not untrusted user input, so simple quoting is safe.
 	// Single quotes in the name are escaped as '' per the SQL standard.
-	checkOut, err := pg.psql(constants.DefaultPostgresDatabase,
+	checkOut, err := pg.psql(constants.DefaultPostgresDatabase, nil,
 		"-Atc", fmt.Sprintf("SELECT 1 FROM pg_database WHERE datname = '%s'",
 			strings.ReplaceAll(database, "'", "''")),
 	)
@@ -289,7 +320,7 @@ func createDatabaseOnInstance(logger *slog.Logger, pg *pgInstance, database stri
 	}
 
 	logger.Info("creating database", "database", database)
-	if out, err := pg.psql(constants.DefaultPostgresDatabase,
+	if out, err := pg.psql(constants.DefaultPostgresDatabase, nil,
 		"-c", "CREATE DATABASE "+quoteIdentifier(database),
 	); err != nil {
 		return fmt.Errorf("failed to create database %q: %w\nOutput: %s", database, err, out)

--- a/go/cmd/pgctld/command/init_secrets.go
+++ b/go/cmd/pgctld/command/init_secrets.go
@@ -1,0 +1,226 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/multigres/multigres/go/common/parser/ast"
+)
+
+// initSecrets is the day-0 state handed to pgctld at init via
+// --pg-init-secrets-file: per-project role login credentials and database
+// settings that cannot be baked into the shared image. The file is a
+// per-project Kubernetes Secret; see the MINT-60 plan for the delivery model.
+//
+// Role values are opaque: a plaintext password (Postgres hashes it per
+// password_encryption) or a pre-hashed "SCRAM-SHA-256$..." verifier (stored
+// verbatim). pgctld does not distinguish the two — it passes the value straight
+// into ALTER ROLE ... PASSWORD.
+type initSecrets struct {
+	// Roles maps additional login role names to its password/verifier. The
+	// superuser is NOT expected here and it is wrong to add it. It is set at
+	// initdb via --pwfile from its own Secret.
+	Roles map[string]string `json:"roles"`
+
+	// DatabaseSettings maps a database name to GUCs applied via
+	// ALTER DATABASE <db> SET <key> TO <value> (e.g. app.settings.jwt_exp).
+	DatabaseSettings map[string]map[string]string `json:"database_settings"`
+}
+
+// loadInitSecrets reads and parses the init-secrets JSON file. Unknown fields
+// are ignored so a newer platform payload does not break an older pgctld.
+func loadInitSecrets(path string) (*initSecrets, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read init secrets file %q: %w", path, err)
+	}
+	var s initSecrets
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("cannot parse init secrets file %q: %w", path, err)
+	}
+	return &s, nil
+}
+
+// applyInitSecrets sets role passwords and database settings from the
+// init-secrets file over the transient socket. It runs as the last step of
+// postInitdbSetup, after the init-scripts have created the roles.
+//
+// The generated SQL is fed to psql via stdin (never argv/env) so secret values
+// are not exposed through /proc. When roles are applied, a verify pass asserts
+// no login role was left passwordless, turning a missing entry into a hard init
+// failure rather than a silently-broken cluster.
+func applyInitSecrets(logger *slog.Logger, pg *pgInstance, cfg PgCtldServiceConfig) error {
+	if cfg.InitSecretsFile == "" {
+		return nil
+	}
+	secrets, err := loadInitSecrets(cfg.InitSecretsFile)
+	if err != nil {
+		return err
+	}
+	if len(secrets.Roles) == 0 && len(secrets.DatabaseSettings) == 0 {
+		logger.Info("init secrets file has no roles or settings, skipping", "file", cfg.InitSecretsFile)
+		return nil
+	}
+
+	script, err := buildInitSecretsSQL(secrets)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("applying init secrets", "file", cfg.InitSecretsFile)
+
+	// -f - reads the script from stdin so no secret value lands in argv.
+	// ON_ERROR_STOP aborts on the first failing statement.
+	if out, err := pg.psql(cfg.Database, strings.NewReader(script), "-v", "ON_ERROR_STOP=1", "-f", "-"); err != nil {
+		// Never include the script or psql output verbatim: both may echo a
+		// secret value. Report only that application failed.
+		return fmt.Errorf("failed to apply init secrets (%d role(s)): %w", len(secrets.Roles), redactPsqlOutput(out))
+	}
+
+	// Per-section summary. Role names are safe to log, but passwords are NOT, so
+	// only names/counts are printed. Database setting values ARE logged: they are
+	// non-secret configuration (e.g. app.settings.jwt_exp) — do not put secrets
+	// in database_settings.
+	if roles := sortedKeys(secrets.Roles); len(roles) > 0 {
+		logger.Info("init secrets: set role passwords", "count", len(roles), "roles", roles)
+	} else {
+		logger.Info("init secrets: no role passwords to set")
+	}
+	if len(secrets.DatabaseSettings) > 0 {
+		for _, db := range sortedKeys(secrets.DatabaseSettings) {
+			settings := secrets.DatabaseSettings[db]
+			for _, key := range sortedKeys(settings) {
+				logger.Info("init secrets: set database option",
+					"database", db, "option", key, "value", settings[key])
+			}
+		}
+	} else {
+		logger.Info("init secrets: no database options to set")
+	}
+
+	if len(secrets.Roles) > 0 {
+		if err := verifyNoPasswordlessLoginRoles(logger, pg, cfg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// buildInitSecretsSQL renders the ALTER ROLE / ALTER DATABASE statements in a
+// deterministic order (sorted by name) so output is stable and testable. Role
+// names and setting keys are identifier-quoted; values are literal-quoted.
+func buildInitSecretsSQL(secrets *initSecrets) (string, error) {
+	var sb strings.Builder
+
+	// Suppress server-side statement logging for this session before running any
+	// ALTER ROLE ... PASSWORD. The generated postgresql.conf sets
+	// log_statement = 'ddl', which would otherwise write the plaintext password
+	// to the postgres server log; log_min_error_statement / log_min_duration
+	// would leak it on error or as a "slow" statement. These SETs are
+	// session-local to this transient psql connection (superuser), and SET is
+	// not itself DDL so these lines are not logged. Keep them ahead of the
+	// generated statements in the same stdin script.
+	fmt.Fprintln(&sb, "SET log_statement = 'none';")
+	fmt.Fprintln(&sb, "SET log_min_error_statement = 'panic';")
+	fmt.Fprintln(&sb, "SET log_min_duration_statement = -1;")
+
+	for _, role := range sortedKeys(secrets.Roles) {
+		if role == "" {
+			return "", errors.New("init secrets: empty role name")
+		}
+		if secrets.Roles[role] == "" {
+			return "", fmt.Errorf("init secrets: empty password for role %q", role)
+		}
+		fmt.Fprintf(&sb, "ALTER ROLE %s PASSWORD %s;\n",
+			quoteIdentifier(role), ast.QuoteStringLiteral(secrets.Roles[role]))
+	}
+
+	for _, db := range sortedKeys(secrets.DatabaseSettings) {
+		if db == "" {
+			return "", errors.New("init secrets: empty database name in database_settings")
+		}
+		settings := secrets.DatabaseSettings[db]
+		for _, key := range sortedKeys(settings) {
+			if key == "" {
+				return "", fmt.Errorf("init secrets: empty setting key for database %q", db)
+			}
+			fmt.Fprintf(&sb, "ALTER DATABASE %s SET %s TO %s;\n",
+				quoteIdentifier(db), quoteIdentifier(key), ast.QuoteStringLiteral(settings[key]))
+		}
+	}
+
+	return sb.String(), nil
+}
+
+// verifyNoPasswordlessLoginRoles fails if any role that can log in still has no
+// password after applying the secrets. This catches both a role omitted from
+// the Secret and a role created LOGIN by the init-scripts but never seeded —
+// exactly the MINT-60 failure mode — turning it into a hard init error.
+//
+// It cannot detect a password set to the WRONG verifier (Postgres stores a
+// pre-hashed value verbatim without validation); that limit is documented.
+func verifyNoPasswordlessLoginRoles(logger *slog.Logger, pg *pgInstance, cfg PgCtldServiceConfig) error {
+	out, err := pg.psql(cfg.Database, nil, "-tAc",
+		"SELECT rolname FROM pg_authid WHERE rolcanlogin AND rolpassword IS NULL ORDER BY rolname")
+	if err != nil {
+		return fmt.Errorf("failed to verify role passwords: %w\nOutput: %s", err, out)
+	}
+	missing := strings.Fields(strings.TrimSpace(string(out)))
+	if len(missing) > 0 {
+		return fmt.Errorf("login role(s) still without a password after applying init secrets: %s",
+			strings.Join(missing, ", "))
+	}
+	logger.Info("verified all login roles have a password")
+	return nil
+}
+
+// redactPsqlOutput scrubs psql output before it goes into an error, since a
+// failing ALTER ROLE ... PASSWORD statement can echo the secret value. We keep
+// only the SQLSTATE-ish prefix lines that do not contain the statement text.
+func redactPsqlOutput(out []byte) error {
+	var kept []string
+	for line := range strings.SplitSeq(string(out), "\n") {
+		// psql error lines look like "psql:<file>:<n>: ERROR:  <msg>". Drop any
+		// line that could contain the statement (e.g. context/detail echoing the
+		// value); keep only ERROR/FATAL summary lines without a PASSWORD token.
+		if strings.Contains(line, "PASSWORD") {
+			continue
+		}
+		if strings.Contains(line, "ERROR:") || strings.Contains(line, "FATAL:") {
+			kept = append(kept, strings.TrimSpace(line))
+		}
+	}
+	if len(kept) == 0 {
+		return errors.New("psql reported an error (output redacted)")
+	}
+	return fmt.Errorf("%s", strings.Join(kept, "; "))
+}
+
+// sortedKeys returns the keys of m in ascending order.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/go/cmd/pgctld/command/init_secrets_test.go
+++ b/go/cmd/pgctld/command/init_secrets_test.go
@@ -1,0 +1,211 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// logSuppressPreamble is the statement-logging suppression that
+// buildInitSecretsSQL prepends to every script, so plaintext passwords in
+// ALTER ROLE ... PASSWORD never reach the server log (the generated config uses
+// log_statement = 'ddl'). Tests assert it precedes the data statements.
+const logSuppressPreamble = "SET log_statement = 'none';\n" +
+	"SET log_min_error_statement = 'panic';\n" +
+	"SET log_min_duration_statement = -1;\n"
+
+func TestBuildInitSecretsSQL_DeterministicAndQuoted(t *testing.T) {
+	secrets := &initSecrets{
+		Roles: map[string]string{
+			// Intentionally out of order to prove sorting.
+			"supabase_auth_admin": "pw2",
+			"authenticator":       "O'Brien", // embedded quote must be escaped
+		},
+		DatabaseSettings: map[string]map[string]string{
+			"postgres": {"app.settings.jwt_exp": "3600"},
+		},
+	}
+	sql, err := buildInitSecretsSQL(secrets)
+	require.NoError(t, err)
+
+	want := logSuppressPreamble +
+		"ALTER ROLE \"authenticator\" PASSWORD 'O''Brien';\n" +
+		"ALTER ROLE \"supabase_auth_admin\" PASSWORD 'pw2';\n" +
+		"ALTER DATABASE \"postgres\" SET \"app.settings.jwt_exp\" TO '3600';\n"
+	assert.Equal(t, want, sql)
+}
+
+func TestBuildInitSecretsSQL_VerifierStoredVerbatim(t *testing.T) {
+	verifier := "SCRAM-SHA-256$4096:c2FsdA==$c3RvcmU=:c2VydmVy"
+	secrets := &initSecrets{Roles: map[string]string{"authenticator": verifier}}
+	sql, err := buildInitSecretsSQL(secrets)
+	require.NoError(t, err)
+	assert.Equal(t, logSuppressPreamble+"ALTER ROLE \"authenticator\" PASSWORD '"+verifier+"';\n", sql)
+}
+
+// TestBuildInitSecretsSQL_EmptyCombinations covers absent/empty roles and
+// database_settings in every combination. Absent (nil map) and empty ({}) must
+// behave identically. `want` is the data statements only; every script is
+// prefixed with the log-suppression preamble, so the assertion prepends it.
+// A payload that resolves to no data statements yields just the preamble.
+func TestBuildInitSecretsSQL_EmptyCombinations(t *testing.T) {
+	const roleStmt = "ALTER ROLE \"authenticator\" PASSWORD 'pw';\n"
+	const dbStmt = "ALTER DATABASE \"postgres\" SET \"app.settings.jwt_exp\" TO '3600';\n"
+	roles := map[string]string{"authenticator": "pw"}
+	settings := map[string]map[string]string{"postgres": {"app.settings.jwt_exp": "3600"}}
+
+	tests := []struct {
+		name    string
+		secrets *initSecrets
+		want    string
+	}{
+		{"both nil", &initSecrets{}, ""},
+		{"both empty maps", &initSecrets{Roles: map[string]string{}, DatabaseSettings: map[string]map[string]string{}}, ""},
+		{"roles only, settings absent", &initSecrets{Roles: roles}, roleStmt},
+		{"roles only, settings empty", &initSecrets{Roles: roles, DatabaseSettings: map[string]map[string]string{}}, roleStmt},
+		{"settings only, roles absent", &initSecrets{DatabaseSettings: settings}, dbStmt},
+		{"settings only, roles empty", &initSecrets{Roles: map[string]string{}, DatabaseSettings: settings}, dbStmt},
+		{"settings present but inner map empty yields no statements", &initSecrets{DatabaseSettings: map[string]map[string]string{"postgres": {}}}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql, err := buildInitSecretsSQL(tt.secrets)
+			require.NoError(t, err)
+			assert.Equal(t, logSuppressPreamble+tt.want, sql)
+		})
+	}
+}
+
+func TestBuildInitSecretsSQL_Rejects(t *testing.T) {
+	tests := []struct {
+		name    string
+		secrets *initSecrets
+		errWant string
+	}{
+		{
+			name:    "empty role name",
+			secrets: &initSecrets{Roles: map[string]string{"": "pw"}},
+			errWant: "empty role name",
+		},
+		{
+			name:    "empty password",
+			secrets: &initSecrets{Roles: map[string]string{"authenticator": ""}},
+			errWant: "empty password for role",
+		},
+		{
+			name: "empty database name",
+			secrets: &initSecrets{
+				DatabaseSettings: map[string]map[string]string{"": {"k": "v"}},
+			},
+			errWant: "empty database name",
+		},
+		{
+			name: "empty setting key",
+			secrets: &initSecrets{
+				DatabaseSettings: map[string]map[string]string{"postgres": {"": "v"}},
+			},
+			errWant: "empty setting key",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := buildInitSecretsSQL(tt.secrets)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errWant)
+		})
+	}
+}
+
+func TestLoadInitSecrets(t *testing.T) {
+	t.Run("valid with unknown field ignored", func(t *testing.T) {
+		path := writeTempFile(t, `{
+			"roles": {"authenticator": "pw"},
+			"database_settings": {"postgres": {"app.settings.jwt_exp": "3600"}},
+			"future_field": "ignored"
+		}`)
+		s, err := loadInitSecrets(path)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"authenticator": "pw"}, s.Roles)
+		assert.Equal(t, "3600", s.DatabaseSettings["postgres"]["app.settings.jwt_exp"])
+	})
+
+	t.Run("missing sections yield empty maps", func(t *testing.T) {
+		path := writeTempFile(t, `{}`)
+		s, err := loadInitSecrets(path)
+		require.NoError(t, err)
+		assert.Nil(t, s.Roles)
+		assert.Nil(t, s.DatabaseSettings)
+	})
+
+	t.Run("roles only, settings absent", func(t *testing.T) {
+		path := writeTempFile(t, `{"roles": {"authenticator": "pw"}}`)
+		s, err := loadInitSecrets(path)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"authenticator": "pw"}, s.Roles)
+		assert.Nil(t, s.DatabaseSettings)
+	})
+
+	t.Run("settings only, roles absent", func(t *testing.T) {
+		path := writeTempFile(t, `{"database_settings": {"postgres": {"app.settings.jwt_exp": "3600"}}}`)
+		s, err := loadInitSecrets(path)
+		require.NoError(t, err)
+		assert.Nil(t, s.Roles)
+		assert.Equal(t, "3600", s.DatabaseSettings["postgres"]["app.settings.jwt_exp"])
+	})
+
+	t.Run("empty database_settings object is not nil-distinct", func(t *testing.T) {
+		path := writeTempFile(t, `{"roles": {"authenticator": "pw"}, "database_settings": {}}`)
+		s, err := loadInitSecrets(path)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"authenticator": "pw"}, s.Roles)
+		assert.Empty(t, s.DatabaseSettings)
+	})
+
+	t.Run("malformed JSON errors", func(t *testing.T) {
+		path := writeTempFile(t, `{"roles": `)
+		_, err := loadInitSecrets(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot parse init secrets file")
+	})
+
+	t.Run("missing file errors", func(t *testing.T) {
+		_, err := loadInitSecrets(filepath.Join(t.TempDir(), "nope.json"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot read init secrets file")
+	})
+}
+
+func TestRedactPsqlOutput_DropsPasswordLines(t *testing.T) {
+	out := []byte("psql:<stdin>:1: ERROR:  syntax error\n" +
+		"LINE 1: ALTER ROLE \"authenticator\" PASSWORD 'supersecret';\n" +
+		"                                            ^")
+	err := redactPsqlOutput(out)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "supersecret")
+	assert.NotContains(t, err.Error(), "PASSWORD")
+	assert.Contains(t, err.Error(), "syntax error")
+}
+
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "init-secrets.json")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}

--- a/go/cmd/pgctld/command/pg_instance.go
+++ b/go/cmd/pgctld/command/pg_instance.go
@@ -17,6 +17,7 @@ package command
 import (
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -142,9 +143,10 @@ func (p *pgInstance) stop() {
 }
 
 // psql runs a psql command against this instance connected to database,
-// appending args after the standard -h/-p/-U/-d connection flags.
-// Returns combined stdout+stderr and any error.
-func (p *pgInstance) psql(database string, args ...string) ([]byte, error) {
+// appending args after the standard -h/-p/-U/-d connection flags. Returns
+// combined stdout+stderr and any error. You can pass in a Reader representing
+// the stdin if necessary. A value of nil means do not set Stdin.
+func (p *pgInstance) psql(database string, stdin io.Reader, args ...string) ([]byte, error) {
 	baseArgs := []string{
 		"-h", p.socketDir,
 		"-p", strconv.Itoa(p.port),
@@ -152,6 +154,10 @@ func (p *pgInstance) psql(database string, args ...string) ([]byte, error) {
 		"-d", database,
 	}
 	cmd := exec.Command("psql", append(baseArgs, args...)...)
+	if stdin != nil {
+		cmd.Stdin = stdin
+	}
+
 	// pg_hba.conf requires scram-sha-256 for every connection including the
 	// local socket, so psql needs the password and we pass it via PGPASSWORD.
 	// Embedding it in a connection URI would expose it via /proc/<pid>/cmdline.

--- a/go/cmd/pgctld/command/root.go
+++ b/go/cmd/pgctld/command/root.go
@@ -65,6 +65,7 @@ type PgCtlCommand struct {
 	pgInitdbSQLFiles   viperutil.Value[[]string]
 	pgInitdbSQLDirs    viperutil.Value[[]string]
 	pgInitdbExtraConf  viperutil.Value[[]string]
+	pgInitSecretsFile  viperutil.Value[string]
 
 	vc        *viperutil.ViperConfig
 	lg        *servenv.Logger
@@ -156,6 +157,12 @@ func GetRootCommand() (*cobra.Command, *PgCtlCommand) {
 			EnvVars:  []string{constants.PgInitdbExtraConfEnvVar},
 			Dynamic:  false,
 		}),
+		pgInitSecretsFile: viperutil.Configure(reg, "pg-init-secrets-file", viperutil.Options[string]{
+			Default:  "",
+			FlagName: "pg-init-secrets-file",
+			EnvVars:  []string{constants.PgInitSecretsFileEnvVar},
+			Dynamic:  false,
+		}),
 		vc:        viperutil.NewViperConfig(reg),
 		lg:        servenv.NewLogger(reg, telemetry),
 		telemetry: telemetry,
@@ -216,6 +223,7 @@ management for PostgreSQL servers.`,
 	root.PersistentFlags().StringSlice("pg-initdb-sql-files", pc.pgInitdbSQLFiles.Default(), "Path to an .sql file to run against the target database after data directory initialization. Repeat the flag to run multiple files in order (overrides "+constants.PgInitdbSQLFilesEnvVar+" env var).")
 	root.PersistentFlags().StringSlice("pg-initdb-sql-dirs", pc.pgInitdbSQLDirs.Default(), "Directory of .sql files to run after initdb, in role:path format. Files run in lexicographic order under SET SESSION AUTHORIZATION <role>. Repeat for multiple directories (overrides "+constants.PgInitdbSQLDirsEnvVar+" env var).")
 	root.PersistentFlags().StringSlice("pg-initdb-extra-conf", pc.pgInitdbExtraConf.Default(), "Path to a postgresql.conf snippet live-included (via include_if_exists) at the end of the generated config. The file is re-read on every start and reload, so edits to it take effect on restart. Repeat the flag to include multiple files in order; postgres applies last-write-wins (overrides "+constants.PgInitdbExtraConfEnvVar+" env var).")
+	root.PersistentFlags().String("pg-init-secrets-file", pc.pgInitSecretsFile.Default(), "Path to a JSON file of per-project day-0 state (role passwords/verifiers and database settings) applied during the transient init phase, after init SQL runs. See init_secrets.go for the format (overrides "+constants.PgInitSecretsFileEnvVar+" env var).")
 
 	// Backwards-compat alias: --init-db-sql-file → --pg-initdb-sql-files.
 	// Remove once downstream users have migrated.
@@ -244,6 +252,7 @@ management for PostgreSQL servers.`,
 		pc.pgInitdbSQLFiles,
 		pc.pgInitdbSQLDirs,
 		pc.pgInitdbExtraConf,
+		pc.pgInitSecretsFile,
 	)
 
 	// Save the persistent flag set so GetPostgresPassword can use
@@ -339,6 +348,7 @@ func (pc *PgCtlCommand) buildServiceConfig() (PgCtldServiceConfig, error) {
 		InitdbSQLFiles:       pc.pgInitdbSQLFiles.Get(),
 		InitdbSQLDirs:        pc.pgInitdbSQLDirs.Get(),
 		InitdbExtraConfFiles: pc.pgInitdbExtraConf.Get(),
+		InitSecretsFile:      pc.pgInitSecretsFile.Get(),
 	}, nil
 }
 

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -254,6 +254,10 @@ type PgCtldServiceConfig struct {
 	InitdbSQLFiles       []string
 	InitdbSQLDirs        []string
 	InitdbExtraConfFiles []string
+	// InitSecretsFile is the path to a mounted JSON file of per-project day-0
+	// state (role passwords/verifiers and database settings) applied during the
+	// transient init phase. Empty when the feature is unused.
+	InitSecretsFile string
 }
 
 // PgCtldService implements the pgctld gRPC service

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -54,6 +54,11 @@ const (
 	// Multiple entries are comma-separated, each in role:path format.
 	PgInitdbSQLDirsEnvVar = "POSTGRES_INITDB_SQL_DIRS"
 
+	// PgInitSecretsFileEnvVar names an environment variable that points at a JSON
+	// file of per-project day-0 state (role passwords/verifiers and database
+	// settings) applied during the transient init phase.
+	PgInitSecretsFileEnvVar = "POSTGRES_INIT_SECRETS_FILE" //nolint:gosec // env var name, not a credential
+
 	// PgInitdbExtraConfEnvVar is the environment variable for extra postgresql.conf
 	// files live-included (via include_if_exists) at the end of the generated
 	// config. Multiple files are comma-separated. Postgres applies

--- a/go/test/endtoend/pgctld/init_secrets_test.go
+++ b/go/test/endtoend/pgctld/init_secrets_test.go
@@ -1,0 +1,237 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgctld
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
+	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/test/utils"
+	"github.com/multigres/multigres/go/tools/executil"
+)
+
+// assertNoLogLeak fails if any of the given secret values appears in any *.log
+// file under poolerDir (notably the transient server's pg_data/setup.log).
+// Setting or modifying a password over psql must never write the plaintext to a
+// PostgreSQL server log, even though the generated config sets
+// log_statement = 'ddl'. Any test that seeds or changes a password must call it.
+func assertNoLogLeak(t *testing.T, poolerDir string, secrets ...string) {
+	t.Helper()
+	scanned := 0
+	err := filepath.WalkDir(poolerDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".log") {
+			return nil
+		}
+		data, rerr := os.ReadFile(path) //nolint:gosec // path is from WalkDir over a test-owned temp dir
+		if rerr != nil {
+			return rerr
+		}
+		scanned++
+		for _, s := range secrets {
+			assert.NotContainsf(t, string(data), s, "plaintext password leaked into log file %s", path)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Positive(t, scanned, "expected at least one .log file under %s to scan for leaks", poolerDir)
+}
+
+// runPsqlAs connects to the running instance over its Unix socket as user with
+// password and runs a single SQL statement, returning trimmed output. Unlike
+// setupTestEnv it sets PGPASSWORD to the given password so a seeded (non-super)
+// role can be exercised.
+func runPsqlAs(t *testing.T, poolerDir string, port int, user, password, sql string) (string, error) {
+	t.Helper()
+	socketDir := filepath.Join(poolerDir, "pg_sockets")
+	cmd := executil.Command(t.Context(), "psql",
+		"-h", socketDir,
+		"-p", strconv.Itoa(port),
+		"-U", user,
+		"-d", "postgres",
+		"-Atc", sql,
+	)
+	env := append(utils.BaseTestEnv(),
+		"PGCONNECT_TIMEOUT=5",
+		constants.PgDataDirEnvVar+"="+filepath.Join(poolerDir, "pg_data"),
+		"PGPASSWORD="+password,
+	)
+	if runtime.GOOS == "darwin" {
+		env = append(env, "LC_ALL=en_US.UTF-8")
+	}
+	cmd.SetEnv(env)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// TestInitSecrets_SeedsRolePasswordsAndSettings verifies the happy path: a
+// login role created without a password by the init SQL is seeded from
+// --pg-init-secrets-file, can then authenticate over SCRAM, and a day-0
+// database setting from the same file is applied.
+func TestInitSecrets_SeedsRolePasswordsAndSettings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+	if !utils.HasPostgreSQLBinaries() {
+		t.Skip("PostgreSQL binaries not found, skipping real PostgreSQL test")
+	}
+
+	tempDir, cleanup := testutil.TempDir(t, "pgctld_init_secrets_test")
+	t.Cleanup(cleanup)
+	poolerDir := filepath.Join(tempDir, "data")
+
+	// init-scripts create a LOGIN role with no password, mirroring how the image
+	// creates service roles (e.g. authenticator) that are seeded separately.
+	scriptsDir := filepath.Join(tempDir, "init-scripts")
+	require.NoError(t, os.MkdirAll(scriptsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(scriptsDir, "00-roles.sql"),
+		[]byte("CREATE ROLE authenticator LOGIN NOINHERIT;\n"), 0o644))
+
+	// Distinctive token so the log-leak scan is unambiguous.
+	const authPassword = "authpw_D0NOTLOG_a1b2c3"
+	secretsFile := filepath.Join(tempDir, "init-secrets.json")
+	require.NoError(t, os.WriteFile(secretsFile, []byte(
+		`{"roles": {"authenticator": "`+authPassword+`"}, `+
+			`"database_settings": {"postgres": {"app.settings.jwt_exp": "3600"}}}`), 0o600))
+
+	port := utils.GetFreePort(t)
+	initCmd := executil.Command(t.Context(), "pgctld", "init",
+		"--pooler-dir", poolerDir,
+		"--pg-port", strconv.Itoa(port),
+		"--pg-initdb-sql-dirs", "postgres:"+scriptsDir,
+		"--pg-init-secrets-file", secretsFile,
+	)
+	setupTestEnv(initCmd, poolerDir)
+	initOut, err := initCmd.CombinedOutput()
+	require.NoError(t, err, "pgctld init failed: %s", string(initOut))
+
+	startCmd := executil.Command(t.Context(), "pgctld", "start",
+		"--pooler-dir", poolerDir, "--pg-port", strconv.Itoa(port))
+	setupTestEnv(startCmd, poolerDir)
+	startOut, err := startCmd.CombinedOutput()
+	require.NoError(t, err, "pgctld start failed: %s", string(startOut))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		stopCmd := executil.Command(ctx, "pgctld", "stop",
+			"--pooler-dir", poolerDir, "--pg-port", strconv.Itoa(port))
+		setupTestEnv(stopCmd, poolerDir)
+		_ = stopCmd.Run()
+	})
+
+	// 1. The seeded role can authenticate over SCRAM with its password.
+	out, err := runPsqlAs(t, poolerDir, port, "authenticator", authPassword, "SELECT 1")
+	require.NoError(t, err, "authenticator login should succeed: %s", out)
+	assert.Equal(t, "1", out)
+
+	// 2. Wrong password is rejected — proves the password is actually enforced.
+	_, err = runPsqlAs(t, poolerDir, port, "authenticator", "wrongpw", "SELECT 1")
+	require.Error(t, err, "authenticator login with wrong password should fail")
+
+	// 3. pg_authid confirms the role now has a password.
+	out, err = runPsqlAs(t, poolerDir, port, "postgres", "test-password",
+		"SELECT rolpassword IS NOT NULL FROM pg_authid WHERE rolname = 'authenticator'")
+	require.NoError(t, err, "pg_authid query failed: %s", out)
+	assert.Equal(t, "t", out)
+
+	// 4. The day-0 database setting from the same file was applied.
+	out, err = runPsqlAs(t, poolerDir, port, "postgres", "test-password", `SHOW "app.settings.jwt_exp"`)
+	require.NoError(t, err, "SHOW app.settings.jwt_exp failed: %s", out)
+	assert.Equal(t, "3600", out)
+
+	// 5. The plaintext password must not have leaked into any server log
+	// (the generated config sets log_statement = 'ddl').
+	assertNoLogLeak(t, poolerDir, authPassword)
+}
+
+// TestInitSecrets_FailsWhenLoginRoleLeftPasswordless verifies the drift-catch:
+// if the init SQL creates a LOGIN role that the secrets file does not seed, the
+// post-apply pg_authid check fails init rather than letting the cluster come up
+// with a passwordless login role.
+func TestInitSecrets_FailsWhenLoginRoleLeftPasswordless(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+	if !utils.HasPostgreSQLBinaries() {
+		t.Skip("PostgreSQL binaries not found, skipping real PostgreSQL test")
+	}
+
+	tempDir, cleanup := testutil.TempDir(t, "pgctld_init_secrets_fail_test")
+	t.Cleanup(cleanup)
+	poolerDir := filepath.Join(tempDir, "data")
+
+	// Two LOGIN roles created; the secrets file seeds only one.
+	scriptsDir := filepath.Join(tempDir, "init-scripts")
+	require.NoError(t, os.MkdirAll(scriptsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(scriptsDir, "00-roles.sql"),
+		[]byte("CREATE ROLE role_a LOGIN;\nCREATE ROLE role_b LOGIN;\n"), 0o644))
+
+	// Distinctive tokens so the log-leak scan is unambiguous.
+	const pwA = "pw_a_D0NOTLOG_11aa"
+	const pwB = "pw_b_D0NOTLOG_22bb"
+	secretsFile := filepath.Join(tempDir, "init-secrets.json")
+	require.NoError(t, os.WriteFile(secretsFile, []byte(`{"roles": {"role_a": "`+pwA+`"}}`), 0o600))
+
+	port := utils.GetFreePort(t)
+	initCmd := executil.Command(t.Context(), "pgctld", "init",
+		"--pooler-dir", poolerDir,
+		"--pg-port", strconv.Itoa(port),
+		"--pg-initdb-sql-dirs", "postgres:"+scriptsDir,
+		"--pg-init-secrets-file", secretsFile,
+	)
+	setupTestEnv(initCmd, poolerDir)
+	initOut, err := initCmd.CombinedOutput()
+	require.Error(t, err, "init should fail when a login role is left passwordless; output: %s", string(initOut))
+	assert.Contains(t, string(initOut), "without a password")
+	assert.Contains(t, string(initOut), "role_b")
+
+	// Retry-safety: the failed init must have rolled back the data directory so
+	// it does not read as initialized. Otherwise a retry would no-op and start
+	// would bring up a cluster with passwordless roles.
+	_, statErr := os.Stat(filepath.Join(poolerDir, "pg_data", "PG_VERSION"))
+	require.True(t, os.IsNotExist(statErr),
+		"data dir should be rolled back after failed init (PG_VERSION should not exist), stat err: %v", statErr)
+
+	// A corrected retry (now seeding both roles) succeeds against the same dir,
+	// proving the rollback left a clean slate.
+	require.NoError(t, os.WriteFile(secretsFile,
+		[]byte(`{"roles": {"role_a": "`+pwA+`", "role_b": "`+pwB+`"}}`), 0o600))
+	retryCmd := executil.Command(t.Context(), "pgctld", "init",
+		"--pooler-dir", poolerDir,
+		"--pg-port", strconv.Itoa(port),
+		"--pg-initdb-sql-dirs", "postgres:"+scriptsDir,
+		"--pg-init-secrets-file", secretsFile,
+	)
+	setupTestEnv(retryCmd, poolerDir)
+	retryOut, err := retryCmd.CombinedOutput()
+	require.NoError(t, err, "corrected retry should succeed after rollback; output: %s", string(retryOut))
+
+	// Neither password may leak into a server log from the ALTER ROLE apply.
+	assertNoLogLeak(t, poolerDir, pwA, pwB)
+}


### PR DESCRIPTION
## Summary

Service roles created by the init SQL (e.g. `authenticator`, `supabase_auth_admin`) are
created **without** passwords. Today those passwords are set only by a post-boot control-plane
write over the gateway; on a freshly provisioned cluster that write can fail (e.g. the gateway
is unreachable during the first minutes) with no retry, leaving the roles passwordless and the
dependent services unable to authenticate.

This adds an **init-time** path so a newborn cluster is usable with no post-boot network write.

## What's in this PR

- **`--pg-init-secrets-file`** (`POSTGRES_INIT_SECRETS_FILE`): a JSON file of per-project day-0
  state — role passwords and per-database settings:

  ```json
  {
    "roles": { "authenticator": "…", "supabase_auth_admin": "…" },
    "database_settings": { "postgres": { "app.settings.jwt_exp": "3600" } }
  }
  ```

- **`applyInitSecrets`** runs as the last step of `postInitdbSetup`, after the init SQL has
  created the roles. It emits `ALTER ROLE … PASSWORD` / `ALTER DATABASE … SET`, fed to `psql`
  over **stdin** so secret values never appear in argv or `/proc/<pid>/cmdline`.
- **Verify-and-fail:** after applying, it queries `pg_authid` and fails init if any login role
  is still passwordless, so the cluster never comes up "healthy but passwordless".
- **Retry-safe rollback:** `initdb` writes `PG_VERSION` before this step, so a failed setup
  would otherwise read as initialized and a retry would no-op past it. On any `postInitdbSetup`
  failure the data directory is now removed, so a retry re-runs the full init — transient
  failures (e.g. the Secret not yet mounted) self-heal, persistent ones stay loud.
- **Log-safe:** the apply session disables statement logging (`SET log_statement = 'none'`,
  `log_min_error_statement = 'panic'`, `log_min_duration_statement = -1`) so the plaintext
  password isn't written to the PostgreSQL server log — the generated config uses
  `log_statement = 'ddl'`, which would otherwise capture it.
- **Docs:** `docs/pgctld-init.md` documents the init flags, execution order, superuser password
  resolution, and init secrets.

Role values are plaintext (Postgres hashes per `password_encryption`); the code is
value-agnostic — a pre-hashed `SCRAM-SHA-256$…` verifier would apply verbatim — but plaintext
is the supported input mode.

## Testing

- **Unit:** SQL builder (deterministic sorted output, identifier/literal quoting, rejects empty
  role/password/db/key, absent/empty role and settings combinations), loader (parse + edge
  cases), and error-output redaction.
- **E2E (real PostgreSQL, verified on 18):** a seeded role authenticates over SCRAM, a wrong
  password is rejected, `pg_authid` shows the password set, and `app.settings.jwt_exp` is
  applied; an unseeded login role fails init; a failed init rolls back the data dir and a
  corrected retry succeeds; and the plaintext password does not leak into any server log.

## Context

Part of MINT-60 (provisioning leaves service roles without passwords, auth/postgrest). This is
the pgctld/multigres piece only — it does not on its own close MINT-60: the multigres-operator
still needs to mount the per-project `init-secrets` Secret into the pgctld init step, and the
control plane needs to materialize it. Those are tracked separately.
