### PR TITLE
fix(multiorch): cache successful SetPrimary target to stop redundant re-sends

### DIFF
--- a/go/common/consensus/compare.go
+++ b/go/common/consensus/compare.go
@@ -264,6 +264,53 @@ func ReplicationPrimaryMatches(rp *clustermetadatapb.ReplicationPrimary, target 
 	return true
 }
 
+// ReplicationPrimaryReplaces reports whether candidate is at least as
+// advanced as current: a higher rule position, or the same position with an
+// improved rewind_ready (false -> true, never the reverse) or a changed
+// primary contact address. nil current is always replaceable; nil candidate
+// never replaces.
+func ReplicationPrimaryReplaces(candidate, current *clustermetadatapb.ReplicationPrimary) bool {
+	if candidate == nil {
+		return false
+	}
+	if current == nil {
+		return true
+	}
+	cmp := CompareRulePosition(candidate.GetPosition(), current.GetPosition())
+	if cmp > 0 {
+		return true
+	}
+	if cmp < 0 {
+		return false
+	}
+	if candidate.GetRewindReady() && !current.GetRewindReady() {
+		return true
+	}
+	return !primaryAddressEqual(candidate.GetPrimary(), current.GetPrimary())
+}
+
+// FoldReplicationPrimary sets cs's ReplicationPrimary to candidate if it
+// ReplicationPrimaryReplaces the current one. Allocates cs if nil. Use this
+// instead of assigning ConsensusStatus.ReplicationPrimary directly (enforced
+// by ruleguard outside this package).
+func FoldReplicationPrimary(cs *clustermetadatapb.ConsensusStatus, candidate *clustermetadatapb.ReplicationPrimary) *clustermetadatapb.ConsensusStatus {
+	if cs == nil {
+		cs = &clustermetadatapb.ConsensusStatus{}
+	}
+	if ReplicationPrimaryReplaces(candidate, ReplicationPrimaryOrNil(cs)) {
+		cs.ReplicationPrimary = candidate
+	}
+	return cs
+}
+
+// primaryAddressEqual reports whether two PoolerAddresses name the same
+// pooler at the same contact info (id, host, postgres port).
+func primaryAddressEqual(a, b *clustermetadatapb.PoolerAddress) bool {
+	return idsEqual(a.GetId(), b.GetId()) &&
+		a.GetHost() == b.GetHost() &&
+		a.GetPostgresPort() == b.GetPostgresPort()
+}
+
 func idsEqual(a, b *clustermetadatapb.ID) bool {
 	return a.GetComponent() == b.GetComponent() &&
 		a.GetCell() == b.GetCell() &&

--- a/go/common/consensus/compare.go
+++ b/go/common/consensus/compare.go
@@ -18,6 +18,8 @@ package consensus
 import (
 	"fmt"
 
+	"google.golang.org/protobuf/proto"
+
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/tools/pgutil"
 )
@@ -264,43 +266,48 @@ func ReplicationPrimaryMatches(rp *clustermetadatapb.ReplicationPrimary, target 
 	return true
 }
 
-// ReplicationPrimaryReplaces reports whether candidate is at least as
-// advanced as current: a higher rule position, or the same position with an
-// improved rewind_ready (false -> true, never the reverse) or a changed
-// primary contact address. nil current is always replaceable; nil candidate
-// never replaces.
-func ReplicationPrimaryReplaces(candidate, current *clustermetadatapb.ReplicationPrimary) bool {
-	if candidate == nil {
-		return false
+// MergeReplicationPrimary folds a newly observed candidate into the
+// previously recorded current value. It returns the ReplicationPrimary that
+// should be recorded now and whether that's actually different from current
+// (false if candidate carries no rule or isn't at least as advanced).
+//
+// This is a merge, not a replace: primary keeps current's contact info when
+// candidate doesn't supply one, and rewind_ready is carried forward
+// (false -> true, never the reverse) whenever candidate and current share a
+// coordinator_term — including when candidate's position is a decision
+// replacing current's still-outstanding proposal at that same term, which
+// CompareRulePosition ranks as strictly more advanced. Folding rewind_ready
+// only within cmp==0 would miss exactly that transition and silently
+// regress a rewind_ready flip already observed.
+func MergeReplicationPrimary(current, candidate *clustermetadatapb.ReplicationPrimary) (result *clustermetadatapb.ReplicationPrimary, changed bool) {
+	if PossiblyUndecidedRule(candidate.GetPosition()) == nil {
+		return current, false
 	}
-	if current == nil {
-		return true
+	rewindReady := candidate.GetRewindReady()
+	if PossiblyUndecidedRule(candidate.GetPosition()).GetRuleNumber().GetCoordinatorTerm() ==
+		PossiblyUndecidedRule(current.GetPosition()).GetRuleNumber().GetCoordinatorTerm() {
+		rewindReady = rewindReady || current.GetRewindReady()
 	}
 	cmp := CompareRulePosition(candidate.GetPosition(), current.GetPosition())
-	if cmp > 0 {
-		return true
-	}
 	if cmp < 0 {
-		return false
+		return current, false
 	}
-	if candidate.GetRewindReady() && !current.GetRewindReady() {
-		return true
+	primary := current.GetPrimary()
+	if candidate.GetPrimary() != nil {
+		primary = proto.Clone(candidate.GetPrimary()).(*clustermetadatapb.PoolerAddress)
 	}
-	return !primaryAddressEqual(candidate.GetPrimary(), current.GetPrimary())
-}
-
-// FoldReplicationPrimary sets cs's ReplicationPrimary to candidate if it
-// ReplicationPrimaryReplaces the current one. Allocates cs if nil. Use this
-// instead of assigning ConsensusStatus.ReplicationPrimary directly (enforced
-// by ruleguard outside this package).
-func FoldReplicationPrimary(cs *clustermetadatapb.ConsensusStatus, candidate *clustermetadatapb.ReplicationPrimary) *clustermetadatapb.ConsensusStatus {
-	if cs == nil {
-		cs = &clustermetadatapb.ConsensusStatus{}
+	if cmp == 0 && primaryAddressEqual(primary, current.GetPrimary()) && rewindReady == current.GetRewindReady() {
+		return current, false
 	}
-	if ReplicationPrimaryReplaces(candidate, ReplicationPrimaryOrNil(cs)) {
-		cs.ReplicationPrimary = candidate
+	position := current.GetPosition()
+	if cmp > 0 {
+		position = proto.Clone(candidate.GetPosition()).(*clustermetadatapb.RulePosition)
 	}
-	return cs
+	return &clustermetadatapb.ReplicationPrimary{
+		Position:    position,
+		Primary:     primary,
+		RewindReady: rewindReady,
+	}, true
 }
 
 // primaryAddressEqual reports whether two PoolerAddresses name the same

--- a/go/common/consensus/compare_test.go
+++ b/go/common/consensus/compare_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
@@ -231,6 +232,104 @@ func TestReplicationPrimaryMatches(t *testing.T) {
 		// "no older than" means published >= target.
 		rp := mkRP(mkRule(5), target)
 		assert.True(t, ReplicationPrimaryMatches(rp, target, targetPosition))
+	})
+}
+
+func TestReplicationPrimaryReplaces(t *testing.T) {
+	mkRP := func(term int64, rewindReady bool) *clustermetadatapb.ReplicationPrimary {
+		return &clustermetadatapb.ReplicationPrimary{
+			Position:    &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: rn(term, 0)}},
+			RewindReady: rewindReady,
+		}
+	}
+	mkRPWithAddr := func(term int64, host string, port int32) *clustermetadatapb.ReplicationPrimary {
+		rp := mkRP(term, false)
+		rp.Primary = &clustermetadatapb.PoolerAddress{
+			Id:           &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "p1"},
+			Host:         host,
+			PostgresPort: port,
+		}
+		return rp
+	}
+
+	t.Run("nil candidate never replaces", func(t *testing.T) {
+		assert.False(t, ReplicationPrimaryReplaces(nil, mkRP(5, false)))
+		assert.False(t, ReplicationPrimaryReplaces(nil, nil))
+	})
+
+	t.Run("nil current is always replaceable", func(t *testing.T) {
+		assert.True(t, ReplicationPrimaryReplaces(mkRP(5, false), nil))
+	})
+
+	t.Run("higher position replaces", func(t *testing.T) {
+		assert.True(t, ReplicationPrimaryReplaces(mkRP(5, false), mkRP(3, false)))
+	})
+
+	t.Run("lower position never replaces", func(t *testing.T) {
+		assert.False(t, ReplicationPrimaryReplaces(mkRP(3, false), mkRP(5, false)))
+	})
+
+	t.Run("same position, rewind_ready false to true replaces", func(t *testing.T) {
+		assert.True(t, ReplicationPrimaryReplaces(mkRP(5, true), mkRP(5, false)))
+	})
+
+	t.Run("same position, rewind_ready true to false never regresses", func(t *testing.T) {
+		assert.False(t, ReplicationPrimaryReplaces(mkRP(5, false), mkRP(5, true)))
+	})
+
+	t.Run("same position, both unchanged does not replace", func(t *testing.T) {
+		assert.False(t, ReplicationPrimaryReplaces(mkRP(5, false), mkRP(5, false)))
+		assert.False(t, ReplicationPrimaryReplaces(mkRP(5, true), mkRP(5, true)))
+	})
+
+	t.Run("same position, different host replaces", func(t *testing.T) {
+		assert.True(t, ReplicationPrimaryReplaces(mkRPWithAddr(5, "host-b", 5432), mkRPWithAddr(5, "host-a", 5432)))
+	})
+
+	t.Run("same position, different port replaces", func(t *testing.T) {
+		assert.True(t, ReplicationPrimaryReplaces(mkRPWithAddr(5, "host-a", 5433), mkRPWithAddr(5, "host-a", 5432)))
+	})
+
+	t.Run("same position, same address does not replace", func(t *testing.T) {
+		assert.False(t, ReplicationPrimaryReplaces(mkRPWithAddr(5, "host-a", 5432), mkRPWithAddr(5, "host-a", 5432)))
+	})
+}
+
+func TestFoldReplicationPrimary(t *testing.T) {
+	mkRP := func(term int64) *clustermetadatapb.ReplicationPrimary {
+		return &clustermetadatapb.ReplicationPrimary{
+			Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: rn(term, 0)}},
+		}
+	}
+
+	t.Run("nil ConsensusStatus is allocated and folded into", func(t *testing.T) {
+		candidate := mkRP(5)
+		cs := FoldReplicationPrimary(nil, candidate)
+		require.NotNil(t, cs)
+		assert.Same(t, candidate, cs.GetReplicationPrimary())
+	})
+
+	t.Run("higher candidate replaces", func(t *testing.T) {
+		cs := &clustermetadatapb.ConsensusStatus{ReplicationPrimary: mkRP(3)}
+		candidate := mkRP(5)
+		cs = FoldReplicationPrimary(cs, candidate)
+		assert.Same(t, candidate, cs.GetReplicationPrimary())
+	})
+
+	t.Run("lower candidate does not replace", func(t *testing.T) {
+		current := mkRP(5)
+		cs := &clustermetadatapb.ConsensusStatus{ReplicationPrimary: current}
+		cs = FoldReplicationPrimary(cs, mkRP(3))
+		assert.Same(t, current, cs.GetReplicationPrimary())
+	})
+
+	t.Run("reads through the phantom-0/0-safe accessor, not the raw field", func(t *testing.T) {
+		// A phantom 0/0 "current" must be treated as absent, so even a
+		// lower-looking real candidate (term 1) replaces it.
+		cs := &clustermetadatapb.ConsensusStatus{ReplicationPrimary: mkRP(0)}
+		candidate := mkRP(1)
+		cs = FoldReplicationPrimary(cs, candidate)
+		assert.Same(t, candidate, cs.GetReplicationPrimary())
 	})
 }
 

--- a/go/common/consensus/compare_test.go
+++ b/go/common/consensus/compare_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
@@ -235,7 +236,7 @@ func TestReplicationPrimaryMatches(t *testing.T) {
 	})
 }
 
-func TestReplicationPrimaryReplaces(t *testing.T) {
+func TestMergeReplicationPrimary(t *testing.T) {
 	mkRP := func(term int64, rewindReady bool) *clustermetadatapb.ReplicationPrimary {
 		return &clustermetadatapb.ReplicationPrimary{
 			Position:    &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: rn(term, 0)}},
@@ -252,84 +253,93 @@ func TestReplicationPrimaryReplaces(t *testing.T) {
 		return rp
 	}
 
-	t.Run("nil candidate never replaces", func(t *testing.T) {
-		assert.False(t, ReplicationPrimaryReplaces(nil, mkRP(5, false)))
-		assert.False(t, ReplicationPrimaryReplaces(nil, nil))
+	t.Run("nil candidate never changes anything", func(t *testing.T) {
+		current := mkRP(5, false)
+		result, changed := MergeReplicationPrimary(current, nil)
+		assert.False(t, changed)
+		assert.Same(t, current, result)
 	})
 
 	t.Run("nil current is always replaceable", func(t *testing.T) {
-		assert.True(t, ReplicationPrimaryReplaces(mkRP(5, false), nil))
+		candidate := mkRP(5, false)
+		result, changed := MergeReplicationPrimary(nil, candidate)
+		assert.True(t, changed)
+		assert.True(t, proto.Equal(candidate, result))
 	})
 
 	t.Run("higher position replaces", func(t *testing.T) {
-		assert.True(t, ReplicationPrimaryReplaces(mkRP(5, false), mkRP(3, false)))
+		result, changed := MergeReplicationPrimary(mkRP(3, false), mkRP(5, false))
+		assert.True(t, changed)
+		assert.True(t, proto.Equal(mkRP(5, false), result))
 	})
 
 	t.Run("lower position never replaces", func(t *testing.T) {
-		assert.False(t, ReplicationPrimaryReplaces(mkRP(3, false), mkRP(5, false)))
+		current := mkRP(5, false)
+		result, changed := MergeReplicationPrimary(current, mkRP(3, false))
+		assert.False(t, changed)
+		assert.Same(t, current, result)
 	})
 
 	t.Run("same position, rewind_ready false to true replaces", func(t *testing.T) {
-		assert.True(t, ReplicationPrimaryReplaces(mkRP(5, true), mkRP(5, false)))
+		result, changed := MergeReplicationPrimary(mkRP(5, false), mkRP(5, true))
+		assert.True(t, changed)
+		assert.True(t, result.GetRewindReady())
 	})
 
 	t.Run("same position, rewind_ready true to false never regresses", func(t *testing.T) {
-		assert.False(t, ReplicationPrimaryReplaces(mkRP(5, false), mkRP(5, true)))
+		result, changed := MergeReplicationPrimary(mkRP(5, true), mkRP(5, false))
+		assert.False(t, changed)
+		assert.True(t, result.GetRewindReady())
 	})
 
 	t.Run("same position, both unchanged does not replace", func(t *testing.T) {
-		assert.False(t, ReplicationPrimaryReplaces(mkRP(5, false), mkRP(5, false)))
-		assert.False(t, ReplicationPrimaryReplaces(mkRP(5, true), mkRP(5, true)))
+		_, changed := MergeReplicationPrimary(mkRP(5, false), mkRP(5, false))
+		assert.False(t, changed)
+		_, changed = MergeReplicationPrimary(mkRP(5, true), mkRP(5, true))
+		assert.False(t, changed)
 	})
 
 	t.Run("same position, different host replaces", func(t *testing.T) {
-		assert.True(t, ReplicationPrimaryReplaces(mkRPWithAddr(5, "host-b", 5432), mkRPWithAddr(5, "host-a", 5432)))
+		_, changed := MergeReplicationPrimary(mkRPWithAddr(5, "host-a", 5432), mkRPWithAddr(5, "host-b", 5432))
+		assert.True(t, changed)
 	})
 
 	t.Run("same position, different port replaces", func(t *testing.T) {
-		assert.True(t, ReplicationPrimaryReplaces(mkRPWithAddr(5, "host-a", 5433), mkRPWithAddr(5, "host-a", 5432)))
+		_, changed := MergeReplicationPrimary(mkRPWithAddr(5, "host-a", 5432), mkRPWithAddr(5, "host-a", 5433))
+		assert.True(t, changed)
 	})
 
 	t.Run("same position, same address does not replace", func(t *testing.T) {
-		assert.False(t, ReplicationPrimaryReplaces(mkRPWithAddr(5, "host-a", 5432), mkRPWithAddr(5, "host-a", 5432)))
+		_, changed := MergeReplicationPrimary(mkRPWithAddr(5, "host-a", 5432), mkRPWithAddr(5, "host-a", 5432))
+		assert.False(t, changed)
 	})
-}
 
-func TestFoldReplicationPrimary(t *testing.T) {
-	mkRP := func(term int64) *clustermetadatapb.ReplicationPrimary {
-		return &clustermetadatapb.ReplicationPrimary{
-			Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: rn(term, 0)}},
+	t.Run("rewind_ready carries forward when a decision replaces its own term's proposal", func(t *testing.T) {
+		// CompareRulePosition ranks a decision strictly above its own term's
+		// undecided proposal (cmp > 0, not cmp == 0), so this exercises the
+		// carry-forward on the advance path, not just the same-position path.
+		proposal := &clustermetadatapb.ReplicationPrimary{
+			Position: &clustermetadatapb.RulePosition{
+				Decision: &clustermetadatapb.ShardRule{RuleNumber: rn(4, 0)},
+				Proposal: &clustermetadatapb.ShardRule{RuleNumber: rn(5, 0)},
+			},
+			RewindReady: true,
 		}
-	}
-
-	t.Run("nil ConsensusStatus is allocated and folded into", func(t *testing.T) {
-		candidate := mkRP(5)
-		cs := FoldReplicationPrimary(nil, candidate)
-		require.NotNil(t, cs)
-		assert.Same(t, candidate, cs.GetReplicationPrimary())
+		decision := &clustermetadatapb.ReplicationPrimary{
+			Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{RuleNumber: rn(5, 0)}},
+			// RewindReady deliberately left unset, as a caller not restating it would.
+		}
+		result, changed := MergeReplicationPrimary(proposal, decision)
+		require.True(t, changed)
+		assert.True(t, result.GetRewindReady(), "rewind_ready must not regress across a same-term proposal->decision transition")
 	})
 
-	t.Run("higher candidate replaces", func(t *testing.T) {
-		cs := &clustermetadatapb.ConsensusStatus{ReplicationPrimary: mkRP(3)}
-		candidate := mkRP(5)
-		cs = FoldReplicationPrimary(cs, candidate)
-		assert.Same(t, candidate, cs.GetReplicationPrimary())
-	})
-
-	t.Run("lower candidate does not replace", func(t *testing.T) {
-		current := mkRP(5)
-		cs := &clustermetadatapb.ConsensusStatus{ReplicationPrimary: current}
-		cs = FoldReplicationPrimary(cs, mkRP(3))
-		assert.Same(t, current, cs.GetReplicationPrimary())
-	})
-
-	t.Run("reads through the phantom-0/0-safe accessor, not the raw field", func(t *testing.T) {
-		// A phantom 0/0 "current" must be treated as absent, so even a
-		// lower-looking real candidate (term 1) replaces it.
-		cs := &clustermetadatapb.ConsensusStatus{ReplicationPrimary: mkRP(0)}
-		candidate := mkRP(1)
-		cs = FoldReplicationPrimary(cs, candidate)
-		assert.Same(t, candidate, cs.GetReplicationPrimary())
+	t.Run("primary preserved when candidate doesn't supply one", func(t *testing.T) {
+		current := mkRPWithAddr(5, "host-a", 5432)
+		candidate := mkRP(6, false) // advances the rule, no Primary set
+		result, changed := MergeReplicationPrimary(current, candidate)
+		require.True(t, changed)
+		assert.True(t, proto.Equal(current.GetPrimary(), result.GetPrimary()))
 	})
 }
 

--- a/go/services/multiorch/recovery/leader_info_propagation.go
+++ b/go/services/multiorch/recovery/leader_info_propagation.go
@@ -26,6 +26,7 @@ import (
 	commontypes "github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
+	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
 	"github.com/multigres/multigres/go/services/multiorch/store"
 )
 
@@ -147,17 +148,26 @@ func (re *Engine) propagateLeaderInfoToPooler(
 		return
 	}
 
+	replicationPrimary := &clustermetadatapb.ReplicationPrimary{
+		Position:    highestKnownPosition,
+		Primary:     leaderAddress,
+		RewindReady: leaderRewindReady,
+	}
 	rpcCtx, cancel := context.WithTimeout(ctx, setPrimaryPropagationTimeout)
 	defer cancel()
 	_, err := re.rpcClient.SetPrimary(rpcCtx, health.GetMultipooler(), &consensusdatapb.SetPrimaryRequest{
-		ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
-			Position:    highestKnownPosition,
-			Primary:     leaderAddress,
-			RewindReady: leaderRewindReady,
-		},
+		ReplicationPrimary: replicationPrimary,
 	})
 	if err != nil {
 		re.logger.WarnContext(ctx, "leader-info propagation: SetPrimary failed, will retry next tick",
 			"pooler", health.GetMultipooler().GetId().GetName(), "error", err)
+		return
 	}
+
+	// Optimistically cache the just-applied primary so the next reconcile
+	// tick doesn't redundantly re-send it before the pooler's own streamed
+	// health update reports it back to us.
+	pooler.Mutate(func(h *multiorchdatapb.PoolerHealthState) {
+		h.ConsensusStatus = commonconsensus.FoldReplicationPrimary(h.ConsensusStatus, replicationPrimary)
+	})
 }

--- a/go/services/multiorch/recovery/leader_info_propagation.go
+++ b/go/services/multiorch/recovery/leader_info_propagation.go
@@ -168,6 +168,12 @@ func (re *Engine) propagateLeaderInfoToPooler(
 	// tick doesn't redundantly re-send it before the pooler's own streamed
 	// health update reports it back to us.
 	pooler.Mutate(func(h *multiorchdatapb.PoolerHealthState) {
-		h.ConsensusStatus = commonconsensus.FoldReplicationPrimary(h.ConsensusStatus, replicationPrimary)
+		if h.ConsensusStatus == nil {
+			h.ConsensusStatus = &clustermetadatapb.ConsensusStatus{}
+		}
+		current := commonconsensus.ReplicationPrimaryOrNil(h.ConsensusStatus)
+		if merged, changed := commonconsensus.MergeReplicationPrimary(current, replicationPrimary); changed {
+			h.ConsensusStatus.ReplicationPrimary = merged //nolint:gocritic // the linter is trying to protect against not using ReplicationPrimaryOrNil on read, but this is a write.
+		}
 	})
 }

--- a/go/services/multiorch/recovery/leader_info_propagation_test.go
+++ b/go/services/multiorch/recovery/leader_info_propagation_test.go
@@ -15,13 +15,19 @@
 package recovery
 
 import (
+	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/multigres/multigres/go/common/rpcclient"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
+	"github.com/multigres/multigres/go/services/multiorch/store"
 )
 
 func leaderInfoTestRule(term int64) *clustermetadatapb.ShardRule {
@@ -139,4 +145,59 @@ func TestShouldPropagateLeaderInfo(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestPropagateLeaderInfoToPooler_CachesSuccessfulSetPrimary verifies that a
+// successful SetPrimary call optimistically updates the pooler's cached
+// ReplicationPrimary, so a reconcile tick immediately after doesn't
+// needlessly re-send the same SetPrimary before the pooler's own streamed
+// health update reports it back (see shouldPropagateLeaderInfo).
+func TestPropagateLeaderInfoToPooler_CachesSuccessfulSetPrimary(t *testing.T) {
+	fake := rpcclient.NewFakeClient()
+	re := &Engine{rpcClient: fake, logger: slog.Default()}
+
+	poolerID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "p1"}
+	pooler := store.NewPooler(&multiorchdatapb.PoolerHealthState{
+		Multipooler: &clustermetadatapb.Multipooler{Id: poolerID},
+		LastSeen:    timestamppb.Now(),
+	}, nil)
+
+	leaderAddress := leaderInfoTestAddress("leader")
+	position := &clustermetadatapb.RulePosition{Decision: leaderInfoTestRule(5)}
+
+	re.propagateLeaderInfoToPooler(t.Context(), pooler, leaderAddress, true, position)
+
+	require.Equal(t, []string{"SetPrimary(multipooler-zone1-p1)"}, fake.GetCallLog(), "SetPrimary must actually have been called")
+	got := pooler.Health().GetConsensusStatus().GetReplicationPrimary()
+	require.NotNil(t, got)
+	assert.True(t, proto.Equal(leaderAddress, got.GetPrimary()))
+	assert.True(t, got.GetRewindReady())
+	assert.True(t, proto.Equal(position, got.GetPosition()))
+}
+
+// TestPropagateLeaderInfoToPooler_NeverRegressesCachedPrimary verifies the
+// optimistic cache update never overwrites a fresher view with a stale one —
+// e.g. a real streamed health update landed while an older SetPrimary call
+// (still in flight from an earlier tick) was completing.
+func TestPropagateLeaderInfoToPooler_NeverRegressesCachedPrimary(t *testing.T) {
+	fake := rpcclient.NewFakeClient()
+	re := &Engine{rpcClient: fake, logger: slog.Default()}
+
+	poolerID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "p1"}
+	newerPrimary := &clustermetadatapb.ReplicationPrimary{
+		Position: &clustermetadatapb.RulePosition{Decision: leaderInfoTestRule(10)},
+		Primary:  leaderInfoTestAddress("newer-leader"),
+	}
+	pooler := store.NewPooler(&multiorchdatapb.PoolerHealthState{
+		Multipooler:     &clustermetadatapb.Multipooler{Id: poolerID},
+		ConsensusStatus: &clustermetadatapb.ConsensusStatus{ReplicationPrimary: newerPrimary},
+		LastSeen:        timestamppb.Now(),
+	}, nil)
+
+	stalePosition := &clustermetadatapb.RulePosition{Decision: leaderInfoTestRule(3)}
+	re.propagateLeaderInfoToPooler(t.Context(), pooler, leaderInfoTestAddress("stale-leader"), false, stalePosition)
+
+	require.Equal(t, []string{"SetPrimary(multipooler-zone1-p1)"}, fake.GetCallLog(), "SetPrimary must actually have been called with the stale info")
+	got := pooler.Health().GetConsensusStatus().GetReplicationPrimary()
+	assert.True(t, proto.Equal(newerPrimary, got), "must not regress a fresher cached view with a stale optimistic update")
 }

--- a/go/services/multipooler/internal/manager/consensus/manager.go
+++ b/go/services/multipooler/internal/manager/consensus/manager.go
@@ -320,22 +320,10 @@ func (cm *ConsensusManager) LeadershipStatus() *clustermetadatapb.LeadershipStat
 	}
 }
 
-// RecordTermPrimary updates the highest-known (rule, primary, rewind_ready)
-// based on what this pooler has been told. A nil argument (or nil rule) is a
-// no-op. Bump semantics:
-//
-//   - rule: updated only when strictly greater than the current value
-//     (comparison by RuleNumber: coordinator_term then leader_subterm).
-//
-//   - primary: updated when the rule advances, OR when the supplied rule
-//     equals the current rule but the primary's contact info has changed.
-//     The same-rule-different-contact case covers a primary pooler being
-//     re-homed (host or port changes) without a new election.
-//
-//   - rewind_ready: recorded alongside, and a change to it is itself enough to
-//     record even at the same rule and contact — the leader completing its
-//     post-promotion checkpoint flips rewind_ready false->true without a new
-//     election, and a diverged follower gates its pg_rewind on that flip.
+// RecordTermPrimary folds a newly observed ReplicationPrimary into the
+// highest-known one via consensus.MergeReplicationPrimary — the same helper
+// orch's health-stream cache uses, so the two can't drift on what counts as
+// an advance. A nil argument (or nil rule) is a no-op.
 //
 // Safe to call on no-op SetPrimary paths so the recorded values reflect
 // everything the pooler has been told, regardless of whether postgres-side
@@ -344,46 +332,12 @@ func (cm *ConsensusManager) RecordTermPrimary(ctx context.Context, rp *clusterme
 	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
 		return err
 	}
-	position := rp.GetPosition()
-	if consensus.PossiblyUndecidedRule(position) == nil {
-		return nil
-	}
-	primary := rp.GetPrimary()
-	rewindReady := rp.GetRewindReady()
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 
-	// rewind_ready belongs to the term, not to proposal-vs-decision, so
-	// deciding an already-ready proposal must not clear it.
-	if consensus.PossiblyUndecidedRule(position).GetRuleNumber().GetCoordinatorTerm() ==
-		consensus.PossiblyUndecidedRule(cm.replicationPrimary.GetPosition()).GetRuleNumber().GetCoordinatorTerm() {
-		rewindReady = rewindReady || cm.replicationPrimary.GetRewindReady()
-	}
-
-	cmp := consensus.CompareRulePosition(position, cm.replicationPrimary.GetPosition())
-	if cmp < 0 {
+	next, changed := consensus.MergeReplicationPrimary(cm.replicationPrimary, rp)
+	if !changed {
 		return nil
-	}
-	if cmp == 0 &&
-		(primary == nil || proto.Equal(primary, cm.replicationPrimary.GetPrimary())) &&
-		rewindReady == cm.replicationPrimary.GetRewindReady() {
-		return nil
-	}
-	// Build the next value by starting from the existing fields (via getters,
-	// which are nil-safe) and overlaying the updates we want to apply.
-	next := &clustermetadatapb.ReplicationPrimary{
-		Position:    cm.replicationPrimary.GetPosition(),
-		Primary:     cm.replicationPrimary.GetPrimary(),
-		RewindReady: rewindReady,
-	}
-	if cmp > 0 {
-		next.Position = proto.Clone(position).(*clustermetadatapb.RulePosition)
-	}
-	// Update primary only when one is supplied; an RPC that advances the rule
-	// without re-stating the primary (or a future WAL-observation path) leaves
-	// the previously-recorded contact info in place.
-	if primary != nil {
-		next.Primary = proto.Clone(primary).(*clustermetadatapb.PoolerAddress)
 	}
 	// Stamp the time the leader identity changed, so a subsequent rewind toward
 	// this leader can report how long it waited for the leader to become


### PR DESCRIPTION
leader-info propagation was re-issuing SetPrimary to a follower on every recovery cycle even after it had already succeeded, because it had no memory of what it last successfully sent. Adds a comparison helper and caches the last successfully-propagated target so propagation only re-sends when something has actually changed.