### PR TITLE
fix(multigateway): evict stale primary claim on stale/errored health stream

### DIFF
--- a/go/services/multigateway/poolergateway/load_balancer.go
+++ b/go/services/multigateway/poolergateway/load_balancer.go
@@ -611,14 +611,36 @@ func (lb *loadBalancer) onPoolerHealthUpdate(conn *poolerConnection) {
 	poolerID := topoclient.ComponentIDString(conn.PoolerInfo().GetId())
 	summary := lb.summaryForPooler(conn.PoolerInfo().Multipooler)
 
-	// A pooler is a routing primary iff its broadcast advertises role PRIMARY.
+	// A pooler is a routing primary iff a LIVE broadcast advertises role PRIMARY.
 	// That implies writability: a pooler only advertises PRIMARY once it is the
 	// writable routing primary (out of recovery and the active committed leader),
 	// so the gateway needs no separate writability check. Anything else — a
 	// replica (role REPLICA / UNKNOWN) or no routing state — retracts any prior
 	// claim (demotion / no-longer-primary).
+	//
+	// The observation must be live: a stale or errored health stream is NOT a
+	// primary claim, even though the last role reads PRIMARY. setHealthError
+	// preserves the previous RoutingState (role stays PRIMARY) via simpleCopy
+	// while flipping ServingStatus to DISABLED and recording LastError, so a
+	// stranded pooler whose stream stalled would otherwise keep its claim
+	// forever — there is no demote report (it never learns it was superseded)
+	// and no OnGone (it stays in the topology). Honoring that stale claim is the
+	// stranded-gateway bug: a gateway partitioned so it still reaches the old
+	// primary but not the newly promoted one keeps routing writes (and
+	// CONSISTENT reads) to a superseded primary, yielding stale reads and hung
+	// writes. Retract on a stale/errored stream so WRITABLE/CONSISTENT routing
+	// buffers instead of targeting an unobservable primary.
+	//
+	// The freshness gate keys on LastError, NOT on ServingStatus: a live report
+	// with a non-SERVING status (DRAINING during a planned failover) has
+	// LastError == nil and MUST keep its claim, so the query still reaches the
+	// draining primary, bounces with MTF01, and the failover buffer engages —
+	// the intended zero-error handoff. Gating on ServingStatus instead would
+	// evict a draining primary and turn that smooth handoff into UNAVAILABLE
+	// errors (UNAVAILABLE is actionFail, not buffered).
 	rs := health.RoutingState
-	if rs.GetRole() == clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY {
+	live := health.LastError == nil
+	if live && rs.GetRole() == clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY {
 		if summary.setPrimary(poolerID, rs) {
 			lb.logger.Debug("routing primary recorded",
 				"tablegroup", summary.shardKey.GetTableGroup(),
@@ -626,8 +648,13 @@ func (lb *loadBalancer) onPoolerHealthUpdate(conn *poolerConnection) {
 				"leader_id", poolerID,
 				"rule", commonconsensus.FormatRuleNumber(rs.GetRule()))
 		}
-	} else {
-		summary.clearPrimary(poolerID)
+	} else if summary.clearPrimary(poolerID) {
+		lb.logger.Debug("routing primary retracted",
+			"tablegroup", summary.shardKey.GetTableGroup(),
+			"shard", summary.shardKey.GetShard(),
+			"pooler_id", poolerID,
+			"stale_stream", !live,
+			"last_error", health.LastError)
 	}
 
 	// Re-check the SERVING-leader notification: if the elected routing primary is

--- a/go/services/multigateway/poolergateway/load_balancer_test.go
+++ b/go/services/multigateway/poolergateway/load_balancer_test.go
@@ -943,3 +943,92 @@ func TestLoadBalancer_OnLeaderServingRequiresSelfNamedLeader(t *testing.T) {
 	assert.Equal(t, constants.DefaultTableGroup, calls[0].GetTableGroup())
 	assert.Equal(t, "0", calls[0].GetShard())
 }
+
+// TestLoadBalancer_StalePrimaryStreamErrorEvicted is the regression for the
+// stranded-gateway stale-read/hung-write bug. A pooler that self-reports
+// ROUTING_ROLE_PRIMARY becomes the shard's routing primary. If its health
+// stream then goes stale or errors — WITHOUT an explicit demote report (a live
+// health update naming a different leader) and WITHOUT a topology OnGone — the
+// gateway must stop treating it as a routable primary. Otherwise a gateway
+// partitioned so it can still reach the old primary but not the newly promoted
+// one keeps routing writes (and CONSISTENT reads) to a superseded primary,
+// producing stale reads and hung writes.
+//
+// setHealthError models exactly that stall/error: it preserves the last
+// RoutingState (role still PRIMARY) via simpleCopy while flipping ServingStatus
+// to DISABLED and recording LastError. Before the fix the gateway kept the
+// primary claim (RoutingState.Role preserved) and WRITABLE routing still
+// resolved to the stranded pooler; after the fix the claim is retracted and
+// WRITABLE routing buffers (no leader observed) instead.
+func TestLoadBalancer_StalePrimaryStreamErrorEvicted(t *testing.T) {
+	lb := newTestLB(t, "zone1")
+
+	primary := createTestMultipooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+	addPoolerForTest(t, lb, primary)
+
+	conn := connForTest(t, lb, primary)
+	simulateHealthUpdate(conn, clustermetadatapb.PoolerServingStatus_SERVING,
+		primary.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
+
+	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
+	got, err := lb.getConnection(target)
+	require.NoError(t, err)
+	assert.Equal(t, poolerID(primary), got.ID(), "primary is routable while its stream is healthy")
+
+	// The health stream stalls/errors (staleness timeout or transport error).
+	// No demote report arrives (the pooler is stranded and never learns it was
+	// superseded), and the pooler stays in the topology so no OnGone fires.
+	conn.setHealthError(errors.New("health stream timed out"))
+
+	// The stranded primary must no longer be a routable writable leader.
+	_, err = lb.getConnection(target)
+	require.Error(t, err, "a stale-stream primary must not remain a routable writable leader")
+	assert.Equal(t, mtrpcpb.Code_UNAVAILABLE, mterrors.Code(err))
+	assert.Contains(t, err.Error(), "no leader observed yet",
+		"retracting the stale primary must leave the shard with no writable leader")
+
+	// It must also be gone from the LB's routing-primary set entirely (not just
+	// from leader election) — leadershipFor no longer reports it as leader.
+	assert.NotEqual(t, leadershipLeader, lb.leadershipFor(conn),
+		"a stale-stream primary must not be reported as the shard leader")
+}
+
+// TestLoadBalancer_DrainingPrimaryStaysRoutable is the guard against
+// over-eviction: a primary that cleanly reports a non-SERVING status (DRAINING
+// during a planned failover) is NOT a stale/errored stream — it is a live
+// observation with LastError == nil. Its routing-primary claim MUST be kept so
+// WRITABLE routing still resolves to it; the query then reaches the draining
+// pooler, bounces with MTF01, and the failover buffer engages (the intended
+// zero-error handoff). Evicting it here would return UNAVAILABLE, which is
+// actionFail (not buffered), turning a smooth failover into client-visible
+// errors. This pins the fix to the LastError signal, not ServingStatus alone.
+func TestLoadBalancer_DrainingPrimaryStaysRoutable(t *testing.T) {
+	lb := newTestLB(t, "zone1")
+
+	primary := createTestMultipooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+	addPoolerForTest(t, lb, primary)
+
+	conn := connForTest(t, lb, primary)
+	simulateHealthUpdate(conn, clustermetadatapb.PoolerServingStatus_SERVING,
+		primary.Id, &clustermetadatapb.RuleNumber{CoordinatorTerm: 1})
+
+	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
+	_, err := lb.getConnection(target)
+	require.NoError(t, err)
+
+	// Planned-failover drain: a clean health update (LastError == nil) reporting
+	// DRAINING while the pooler is still the writable primary (role PRIMARY).
+	conn.processHealthResponse(&multipoolerservice.StreamPoolerHealthResponse{
+		PoolerId:      primary.Id,
+		ServingStatus: clustermetadatapb.PoolerServingStatus_DRAINING,
+		RoutingState: &clustermetadatapb.RoutingState{
+			Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY,
+			Rule: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
+		},
+	})
+
+	got, err := lb.getConnection(target)
+	require.NoError(t, err,
+		"a cleanly-draining primary must stay routable so MTF01 buffering can engage")
+	assert.Equal(t, poolerID(primary), got.ID())
+}


### PR DESCRIPTION
## Summary

During a failover, a multigateway that is network-partitioned so it can still reach the OLD primary but not the newly promoted one keeps routing client traffic to the old primary. Under a synchronous durability policy this produces **stale reads** (the old primary serves data older than writes already acknowledged on the new primary — a read-your-writes / monotonic-read violation) and **hung writes** (each COMMIT blocks on `synchronous_commit` because the old primary's sync standbys have moved to the new leader).

This is **not** acked-write loss — durability is preserved. It is a read-consistency + liveness bug.

## Root cause

The gateway load balancer records a pooler as the shard's routing primary purely from its self-attested health stream (`onPoolerHealthUpdate` in `load_balancer.go`). When a pooler's health stream stalls or errors, `setHealthError` (`pooler_connection.go`) does a `simpleCopy()` that **preserves `RoutingState.Role = PRIMARY`** while flipping `ServingStatus` to `DISABLED` and recording `LastError`. `onPoolerHealthUpdate` then re-recorded the pooler as the routing primary, so the claim stuck forever:

- no demote report — a stranded/superseded primary never learns it was replaced (demotion only happens on an inbound `SetPrimary`/`Promote` RPC, which a partitioned node never receives), and
- no topology `OnGone` — the pooler stays in the topology.

`getConnection` for a `WRITABLE`/`CONSISTENT` target then resolves the highest-rule claimant and only requires it be known and connected — so it kept returning the stranded primary.

## How the situation happens

```mermaid
sequenceDiagram
    participant C as Client (on G's side)
    participant G as Gateway G (stranded)
    participant A as Old primary A
    participant O as multiorch
    participant B as New primary B

    Note over C,A: steady state — G routes to A
    C->>G: write / read
    G->>A: route to A (primary)
    A-->>G: health push - serving, primary (rule N)

    Note over C,B: network partition — {C, G, A} cut off from {O, B}
    O->>B: recruit {B,C}, promote B (rule N+1)
    O--xA: SetPrimary / Promote (blocked by partition)
    Note over A: never receives it → never demotes, stays primary (rule N)
    A-->>G: health still serving, primary (rule N)
    Note over G: never sees B → A is G's only primary claimant

    C->>G: read
    G->>A: routed to stranded A
    A-->>C: STALE data
    C->>G: write
    G->>A: routed to stranded A
    A-->>C: HANGS (no sync ack)
```

## What this PR changes

The fix targets the variant where the stranded primary's health stream to the gateway goes **stale or errored** (staleness timeout, transport error, or a partition that also severs the gateway↔old-primary link): the gateway now retracts the pooler's routing-primary claim instead of preserving `RoutingState.Role`. `WRITABLE`/`CONSISTENT` routing then buffers / fails fast rather than serving stale reads or hanging writes.

```mermaid
sequenceDiagram
    participant C as Client
    participant G as Gateway G
    participant A as Old primary A

    Note over C,A: A is the routing primary
    A-->>G: health - serving, primary (rule N)

    Note over A,G: stream stalls / errors (staleness timeout or transport)
    A--xG: setHealthError → DISABLED, LastError set (role PRIMARY preserved)
    Note over G: LastError != nil → retract A's primary claim

    C->>G: write / CONSISTENT read
    G-->>C: no writable primary → buffered / fail-fast (no stale read)
```

The freshness gate keys on `LastError`, **not** on `ServingStatus`. That distinction matters: a cleanly-draining primary during a planned failover reports `DRAINING` + role `PRIMARY` with `LastError == nil` (a live update via `processHealthResponse`) and **must keep** its claim, so the query still reaches it, bounces with `MTF01`, and the failover buffer engages — the intended zero-error handoff. Gating on `ServingStatus` instead would evict a draining primary and return `UNAVAILABLE`, which is `actionFail` (not buffered), turning a smooth failover into client-visible errors.

## Also triggered by stalling I/O, not just partitions

The same stranded-primary routing can arise from **stuck I/O on the primary** (a wedged data directory), and it reaches the gateway through exactly the path this fix keys on. The pooler's health push is event-driven — `StreamPoolerHealth` broadcasts on a state change plus an initial snapshot, with no periodic heartbeat. Those state changes come from the monitor's `discoverPostgresState`, which reads postgres; when I/O wedges, those reads either block (D-state) or error on a deadline, so the monitor computes no transition and **broadcasts nothing new**. The gateway keeps holding the last `SERVING` + `PRIMARY` snapshot (`LastError == nil`) and keeps routing there — writes hang on the un-`fsync`-able WAL, cached reads return stale data — until the gateway's own staleness timer (`DefaultHealthCheckTimeout` ≈ 60s; the pooler recommends 90s) fires `setHealthError`. That is precisely the trigger this fix retracts on, so the claim self-clears after the staleness window instead of sticking forever.

This **bounds but does not eliminate** the exposure: there is a ~60–90s window before the staleness timeout during which the gateway still routes to the wedged primary. Shrinking `DefaultHealthCheckTimeout` tightens the window, at the cost of spurious evictions on transient blips.

| | Stuck I/O on primary | Clean network partition (primary healthy, isolated) |
|---|---|---|
| Primary's health stream to gateway | stalls (monitor can't observe postgres) | stays healthy (keeps pushing `SERVING` + `PRIMARY`) |
| `setHealthError` fires? | yes, at the staleness timeout | no |
| This fix retracts the claim? | **yes** (after the staleness window) | no — residual gap (see below) |
| Dominant symptom | hung writes; reads hang or serve cached | silent stale reads + hung writes |

## Scope / residual gap

This is a gateway-only fix and intentionally contains the blast radius. The pure-partition variant where the gateway's link to the old primary stays fully intact (its health stream never stalls, so the old primary keeps reporting `SERVING` + `PRIMARY`) is **not** closed here — the gateway has no signal that the primary is stale relative to the cluster. Closing that needs a pooler-side self-demoting lease (drop the writable/serving signal on lost orchestrator contact within a TTL), which touches the consensus role model and is tracked as a follow-up. The e2e harness also lacks an asymmetric-partition primitive to reproduce that variant end-to-end (also a follow-up).

## Tests

- `TestLoadBalancer_StalePrimaryStreamErrorEvicted` — reproduces the bug: a self-reported `PRIMARY` whose stream then errors (no demote, no `OnGone`) must stop being a routable writable leader. Fails before the fix, passes after.
- `TestLoadBalancer_DrainingPrimaryStaysRoutable` — regression guard: a cleanly-`DRAINING` primary keeps its claim so `MTF01` buffering still engages. Pins the fix to the `LastError` signal, not `ServingStatus`.

Existing `go/test/endtoend/queryserving/buffer_test.go` planned-failover buffer tests remain the e2e regression net for the path this fix touches. `golangci-lint` and the full `./go/services/multigateway/...` suite (with `-race`) pass.

Closes MUL-1254.
