### PR TITLE
test(e2e): cover gateway eviction of a stranded stale primary

### DIFF
--- a/go/services/multipooler/init.go
+++ b/go/services/multipooler/init.go
@@ -53,6 +53,11 @@ type Multipooler struct {
 	poolerDir           viperutil.Value[string]
 	pgPort              viperutil.Value[int]
 	heartbeatIntervalMs viperutil.Value[int]
+	// healthStreamStalenessTimeout overrides the staleness window this pooler
+	// advertises to the gateway in its health stream (RecommendedStalenessTimeout).
+	// Zero keeps the built-in default (see health_provider.go). Lower values let
+	// tests detect a frozen pooler quickly instead of waiting the full window.
+	healthStreamStalenessTimeout viperutil.Value[time.Duration]
 	// pgBackRest TLS certificate paths for client authentication to primary's pgBackRest server
 	pgBackRestCertFile         viperutil.Value[string]
 	pgBackRestKeyFile          viperutil.Value[string]
@@ -140,6 +145,11 @@ func NewMultipooler(telemetry *telemetry.Telemetry) *Multipooler {
 			FlagName: "heartbeat-interval-milliseconds",
 			Dynamic:  false,
 		}),
+		healthStreamStalenessTimeout: viperutil.Configure(reg, "health-stream-staleness-timeout", viperutil.Options[time.Duration]{
+			Default:  0,
+			FlagName: "health-stream-staleness-timeout",
+			Dynamic:  false,
+		}),
 		pgBackRestCertFile: viperutil.Configure(reg, "pgbackrest-cert-file", viperutil.Options[string]{
 			Default:  "/certs/pgbackrest.crt",
 			FlagName: "pgbackrest-cert-file",
@@ -202,6 +212,7 @@ func (mp *Multipooler) RegisterFlags(flags *pflag.FlagSet) {
 	flags.String("pooler-dir", mp.poolerDir.Default(), "pooler directory path (if empty, socket-file path will be used as-is)")
 	flags.Int("pg-port", mp.pgPort.Default(), "PostgreSQL port number")
 	flags.Int("heartbeat-interval-milliseconds", mp.heartbeatIntervalMs.Default(), "interval in milliseconds between heartbeat writes")
+	flags.Duration("health-stream-staleness-timeout", mp.healthStreamStalenessTimeout.Default(), "staleness window advertised to the gateway health stream; 0 keeps the built-in default")
 	flags.String("pgbackrest-cert-file", mp.pgBackRestCertFile.Default(), "TLS client certificate for connecting to primary's pgBackRest server")
 	flags.String("pgbackrest-key-file", mp.pgBackRestKeyFile.Default(), "TLS client key for connecting to primary's pgBackRest server")
 	flags.String("pgbackrest-ca-file", mp.pgBackRestCAFile.Default(), "TLS CA certificate for validating primary's pgBackRest server")
@@ -220,6 +231,7 @@ func (mp *Multipooler) RegisterFlags(flags *pflag.FlagSet) {
 		mp.poolerDir,
 		mp.pgPort,
 		mp.heartbeatIntervalMs,
+		mp.healthStreamStalenessTimeout,
 		mp.pgBackRestCertFile,
 		mp.pgBackRestKeyFile,
 		mp.pgBackRestCAFile,
@@ -373,13 +385,14 @@ func (mp *Multipooler) Init(startCtx context.Context) error {
 
 	logger.InfoContext(startCtx, "initializing MultipoolerManager")
 	poolerManager, err := manager.NewMultipoolerManager(logger, multipooler, &manager.Config{
-		SocketFilePath:             mp.socketFilePath.Get(),
-		TopoClient:                 mp.ts,
-		HeartbeatIntervalMs:        mp.heartbeatIntervalMs.Get(),
-		PgctldAddr:                 mp.pgctldAddr.Get(),
-		ConsensusEnabled:           mp.grpcServer.CheckServiceMap("consensus", mp.senv),
-		ConnPoolConfig:             mp.connPoolConfig,
-		BackendVpidTrackingEnabled: mp.backendVpidTrackingEnabled.Get(),
+		SocketFilePath:               mp.socketFilePath.Get(),
+		TopoClient:                   mp.ts,
+		HeartbeatIntervalMs:          mp.heartbeatIntervalMs.Get(),
+		HealthStreamStalenessTimeout: mp.healthStreamStalenessTimeout.Get(),
+		PgctldAddr:                   mp.pgctldAddr.Get(),
+		ConsensusEnabled:             mp.grpcServer.CheckServiceMap("consensus", mp.senv),
+		ConnPoolConfig:               mp.connPoolConfig,
+		BackendVpidTrackingEnabled:   mp.backendVpidTrackingEnabled.Get(),
 		// pgBackRest TLS certificate paths for connecting to primary's pgBackRest server
 		PgBackRestCertFile: mp.pgBackRestCertFile.Get(),
 		PgBackRestKeyFile:  mp.pgBackRestKeyFile.Get(),

--- a/go/services/multipooler/internal/manager/config.go
+++ b/go/services/multipooler/internal/manager/config.go
@@ -25,13 +25,17 @@ import (
 
 // Config holds configuration for the MultipoolerManager
 type Config struct {
-	SocketFilePath             string
-	TopoClient                 topoclient.Store
-	HeartbeatIntervalMs        int
-	PgctldAddr                 string                  // Address of pgctld gRPC service
-	ConsensusEnabled           bool                    // Whether consensus gRPC service is enabled
-	ConnPoolConfig             *connpoolmanager.Config // Connection pool config (manager created in MultipoolerManager)
-	BackendVpidTrackingEnabled bool                    // Whether to write active gateway-vpid/backend-pid mappings
+	SocketFilePath      string
+	TopoClient          topoclient.Store
+	HeartbeatIntervalMs int
+	// HealthStreamStalenessTimeout overrides the staleness window this pooler
+	// advertises to the gateway (RecommendedStalenessTimeout). Zero keeps the
+	// built-in default (defaultRecommendedStalenessTimeout).
+	HealthStreamStalenessTimeout time.Duration
+	PgctldAddr                   string                  // Address of pgctld gRPC service
+	ConsensusEnabled             bool                    // Whether consensus gRPC service is enabled
+	ConnPoolConfig               *connpoolmanager.Config // Connection pool config (manager created in MultipoolerManager)
+	BackendVpidTrackingEnabled   bool                    // Whether to write active gateway-vpid/backend-pid mappings
 
 	// StandbyStuckDivergenceThreshold is how long a standby must stay unable to
 	// stream from its correctly-recorded leader before the monitor concludes its

--- a/go/services/multipooler/internal/manager/health_provider.go
+++ b/go/services/multipooler/internal/manager/health_provider.go
@@ -102,6 +102,21 @@ func (hs *healthStreamer) SetQueryServer(qs poolerserver.PoolerController) {
 	hs.queryServer = qs
 }
 
+// SetRecommendedStalenessTimeout overrides the staleness window advertised to
+// clients (RecommendedStalenessTimeout). A non-positive value resets it to the
+// built-in defaultRecommendedStalenessTimeout, so the method is idempotent and a
+// later Set(0) undoes an earlier override rather than leaving it stuck. Must be
+// called before the pooler starts serving; the value is read under the same lock
+// as broadcasts.
+func (hs *healthStreamer) SetRecommendedStalenessTimeout(d time.Duration) {
+	if d <= 0 {
+		d = defaultRecommendedStalenessTimeout
+	}
+	hs.mu.Lock()
+	defer hs.mu.Unlock()
+	hs.recommendedStalenessTimeout = d
+}
+
 // OnStateChange updates the health stream's poolerType, leader observation, and
 // servingStatus atomically with a single broadcast. This implements the
 // StateAware interface so the healthStreamer can be registered with StateManager.

--- a/go/services/multipooler/internal/manager/health_provider_test.go
+++ b/go/services/multipooler/internal/manager/health_provider_test.go
@@ -389,3 +389,26 @@ func TestHealthStreamer_AdvertisesLeaderWhenWritable(t *testing.T) {
 		"writable primary must advertise itself")
 	assert.Equal(t, int64(42), st.RoutingState.GetRule().GetCoordinatorTerm())
 }
+
+func TestHealthStreamer_SetRecommendedStalenessTimeout(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	hs := newHealthStreamer(logger, nil, "tg1", "0")
+
+	// Starts at the built-in default.
+	assert.Equal(t, defaultRecommendedStalenessTimeout, hs.buildStateLocked().RecommendedStalenessTimeout)
+
+	// A positive value overrides it.
+	hs.SetRecommendedStalenessTimeout(50 * time.Millisecond)
+	assert.Equal(t, 50*time.Millisecond, hs.buildStateLocked().RecommendedStalenessTimeout)
+
+	// A non-positive value resets to the default (undoing a prior override),
+	// rather than leaving the earlier override stuck.
+	hs.SetRecommendedStalenessTimeout(0)
+	assert.Equal(t, defaultRecommendedStalenessTimeout, hs.buildStateLocked().RecommendedStalenessTimeout,
+		"Set(0) must reset to the default, not keep the previous override")
+
+	// Negative behaves the same as zero.
+	hs.SetRecommendedStalenessTimeout(50 * time.Millisecond)
+	hs.SetRecommendedStalenessTimeout(-1)
+	assert.Equal(t, defaultRecommendedStalenessTimeout, hs.buildStateLocked().RecommendedStalenessTimeout)
+}

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -353,6 +353,11 @@ func newMultipoolerManager(logger *slog.Logger, multipooler *clustermetadatapb.M
 		cancel: cancel,
 	}
 
+	// Apply the configured health-stream staleness override (zero is ignored,
+	// keeping the built-in default). Set before serving so the very first
+	// broadcast already advertises the override.
+	pm.healthStreamer.SetRecommendedStalenessTimeout(config.HealthStreamStalenessTimeout)
+
 	// shutdownCtx is independent of ctx: ctx is recreated on every Open(),
 	// while shutdownCtx exists for the lifetime of the manager and is
 	// cancelled exactly once, by GracefulShutdown. Background root is

--- a/go/test/endtoend/queryserving/stale_primary_eviction_test.go
+++ b/go/test/endtoend/queryserving/stale_primary_eviction_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq" // PostgreSQL driver
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestGateway_EvictsStrandedPrimaryOnStaleHealthStream reproduces the
+// stranded-gateway stale-primary bug and asserts the fix: when a primary
+// pooler's health stream to the gateway goes stale, the gateway must
+// retract that pooler's PRIMARY routing claim instead of keeping it forever and
+// routing writes (and CONSISTENT reads) to a superseded primary.
+//
+// Scenario:
+//  1. 3-node cluster with a gateway. Poolers advertise a short health-stream
+//     staleness window (2s) so the gateway marks a frozen pooler stale quickly
+//     instead of waiting the ~90s default; this keeps the test fast and is why
+//     it is gated behind testing.Short().
+//  2. A baseline write and read through the gateway confirm traffic routes to
+//     the primary (A). On the main gateway port every query is leader-routed
+//     (WRITABLE), so a plain SELECT is a leader read, not a replica read.
+//  3. Freeze A's multipooler with SIGSTOP. A's postgres keeps running, so A is a
+//     write-capable "stranded" primary whose gateway health stream now stalls.
+//     Crucially there is no voluntary demotion (a frozen A cannot report role
+//     != PRIMARY) and no topology OnGone — the exact state that used to leave
+//     the gateway routing to a superseded primary. setHealthError preserves A's
+//     cached PRIMARY RoutingState while recording LastError.
+//  4. Assert the gateway logged "routing primary retracted" for A because its
+//     stream went stale. This line is emitted only by the fixed
+//     onPoolerHealthUpdate (the else branch is reached only when LastError != nil,
+//     since A's cached role stays PRIMARY). Pre-fix the claim was re-affirmed and
+//     the line never appeared — a genuine fixed-vs-broken signal.
+//  5. Assert both a write and a leader-routed read now fail fast with "no
+//     writable primary" instead of hanging on — or reading stale from — the
+//     stranded primary. This covers both halves of the bug ("stale reads and hung
+//     writes"). Pre-fix the gateway keeps A's claim and routes the query to the
+//     frozen A, which blocks until the client deadline.
+//
+// This deliberately does NOT run a live multiorch failover. A normal failover
+// demotes the old primary (it reports role REPLICA and the gateway clears the
+// claim through the ordinary path — no bug), and freezing the live primary to
+// keep its stale PRIMARY claim also blocks multiorch's own (~90s) frozen-node
+// detection, so an in-window election is not reliably reproducible. The fix under
+// test is entirely gateway-side: it retracts a stranded primary's claim purely
+// because the stream went stale, independent of whether a replacement is elected.
+// Stranding the primary reproduces exactly that path. The pure
+// asymmetric-partition variant (gateway still reaches the old primary, its stream
+// never stalls) is out of scope here — it needs a pooler-side self-demoting lease
+// and a transport-level partition primitive the harness does not have.
+func TestGateway_EvictsStrandedPrimaryOnStaleHealthStream(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping stranded-primary eviction test in short mode (uses real postgres and a timed staleness window)")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping stranded-primary eviction test")
+	}
+
+	// No persistent multiorch: NewIsolated bootstraps the initial primary with a
+	// throwaway temp-multiorch that is torn down before the test body runs, so the
+	// stranded primary has nothing racing to replace it. Buffering is left at its
+	// default (off) so the "no writable primary" error surfaces to the client.
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultigateway(),
+		// Shrink the staleness window the poolers advertise to the gateway so a
+		// frozen pooler is detected in ~2s instead of the ~90s default.
+		shardsetup.WithMultipoolerExtraArgs("--health-stream-staleness-timeout=2s"),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+	)
+	defer cleanup()
+
+	setup.WaitForMultigatewayQueryServing(t)
+
+	primary := setup.GetPrimary(t)
+	require.NotNil(t, primary, "primary should exist after bootstrap")
+	primaryName := setup.PrimaryName
+	t.Logf("Primary: %s", primaryName)
+
+	gatewayDB := openGatewayDB(t, setup)
+	defer gatewayDB.Close()
+
+	// Baseline schema + write + read. On the main gateway port every query is
+	// leader-routed (WRITABLE) — including SELECTs — so both succeeding here
+	// confirms the gateway routes reads and writes to the current primary.
+	baseCtx, baseCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer baseCancel()
+	_, err := gatewayDB.ExecContext(baseCtx, "CREATE TABLE IF NOT EXISTS stranded_test (id INT PRIMARY KEY, val TEXT)")
+	require.NoError(t, err, "baseline CREATE TABLE through gateway should succeed")
+	_, err = gatewayDB.ExecContext(baseCtx, "INSERT INTO stranded_test (id, val) VALUES (1, 'before-freeze')")
+	require.NoError(t, err, "baseline INSERT through gateway should route to the primary")
+	var baselineCount int
+	require.NoError(t, gatewayDB.QueryRowContext(baseCtx, "SELECT COUNT(*) FROM stranded_test").Scan(&baselineCount),
+		"baseline SELECT through gateway should route to the primary")
+	require.Equal(t, 1, baselineCount, "baseline read should see the row just written")
+
+	// Freeze the primary's multipooler. Its postgres stays up (stranded,
+	// write-capable primary) while its gateway health stream stalls.
+	resume := setup.FreezeMultipooler(t, primaryName)
+	defer resume()
+
+	// Fix assertion: the gateway retracts the frozen primary's routing claim
+	// because its health stream went stale. The pooler id embeds the node name,
+	// so matching both substrings pins the eviction to the frozen node.
+	line := shardsetup.WaitForLogLine(t, setup.Multigateway.LogFile, 15*time.Second,
+		"routing primary retracted", primaryName)
+	require.Contains(t, line, "stale_stream", "retraction should be attributed to a stale stream")
+	t.Logf("Gateway evicted stranded primary %s: %s", primaryName, line)
+
+	// Behavioral assertion: with the stranded primary evicted and no replacement,
+	// WRITABLE traffic fails fast with "no writable primary" rather than hanging on
+	// the frozen primary. Bounded per-attempt context; Eventually rides out the
+	// brief window before the claim is fully retracted.
+	require.Eventually(t, func() bool {
+		ctx, c := context.WithTimeout(context.Background(), 5*time.Second)
+		defer c()
+		_, err := gatewayDB.ExecContext(ctx, "INSERT INTO stranded_test (id, val) VALUES (2, 'after-freeze')")
+		if err == nil {
+			t.Log("write unexpectedly succeeded against a stranded primary")
+			return false
+		}
+		if !strings.Contains(err.Error(), "no writable primary") {
+			t.Logf("write failed but not yet with the eviction error: %v", err)
+			return false
+		}
+		return true
+	}, utils.ScaleTimeout(30*time.Second), 500*time.Millisecond,
+		"WRITABLE writes should be rejected with 'no writable primary' after eviction, not hang on the stranded primary")
+
+	// Same for reads: a leader-routed SELECT must also fail fast with "no writable
+	// primary" rather than hang on — or serve a stale read from — the stranded
+	// primary. This is the read half of the bug ("stale reads and hung writes").
+	// By now the claim is retracted, so a single bounded attempt is deterministic.
+	readCtx, readCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer readCancel()
+	var count int
+	err = gatewayDB.QueryRowContext(readCtx, "SELECT COUNT(*) FROM stranded_test").Scan(&count)
+	require.Error(t, err, "a leader-routed read must not hang on or read stale from the stranded primary")
+	require.Contains(t, err.Error(), "no writable primary",
+		"leader-routed reads should be rejected with 'no writable primary' after eviction")
+
+	// Thaw the primary before teardown so cleanup can stop it gracefully.
+	resume()
+}

--- a/go/test/endtoend/shardsetup/events.go
+++ b/go/test/endtoend/shardsetup/events.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -66,6 +67,48 @@ func FindEvents(events []map[string]any, eventType, outcome string) []map[string
 		}
 	}
 	return matches
+}
+
+// WaitForLogLine polls logFile until a single raw line contains ALL of substrs,
+// or the timeout expires (failing the test fatally). Unlike WaitForEvent it
+// matches any log line, not just structured eventlog JSON (records carrying an
+// "event_type" attribute), so it works for plain slog output such as the
+// gateway's "routing primary retracted" debug line. Passing several substrs pins
+// the match to one specific line (e.g. a message plus the pooler id it concerns).
+// Returns the matching line.
+func WaitForLogLine(t *testing.T, logFile string, timeout time.Duration, substrs ...string) string {
+	t.Helper()
+	require.NotEmpty(t, substrs, "WaitForLogLine requires at least one substring")
+	timeout = utils.ScaleTimeout(timeout)
+	var match string
+	require.Eventually(t, func() bool {
+		data, err := os.ReadFile(logFile)
+		if err != nil {
+			return false
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(data))
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if lineContainsAll(line, substrs) {
+				match = line
+				return true
+			}
+		}
+		return false
+	}, timeout, 200*time.Millisecond,
+		"timed out waiting for log line containing all of %q in %s", substrs, logFile)
+	return match
+}
+
+// lineContainsAll reports whether line contains every substring in substrs.
+func lineContainsAll(line string, substrs []string) bool {
+	for _, s := range substrs {
+		if !strings.Contains(line, s) {
+			return false
+		}
+	}
+	return true
 }
 
 // WaitForEvent polls logFile until the given event_type+outcome appears or timeout expires.

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -2273,6 +2273,39 @@ func (s *ShardSetup) ShutdownPostgres(t *testing.T, name string) (resume func())
 	return s.StopPostgres(t, name, "fast")
 }
 
+// FreezeMultipooler sends SIGSTOP to the named multipooler process, freezing it
+// without terminating it. The frozen pooler stops serving RPCs and stops feeding
+// its health stream to the gateway and multiorch, so both observe it as a stalled
+// (stale) connection — simulating a pooler that is hung or unreachable while its
+// postgres keeps running. pgctld and postgres are left running, so a frozen
+// primary remains a write-capable "stranded" primary.
+//
+// It returns an idempotent resume function (SIGCONT) that the caller should defer
+// to guarantee the process is thawed before teardown even if the test fails.
+func (s *ShardSetup) FreezeMultipooler(t *testing.T, name string) (resume func()) {
+	t.Helper()
+
+	inst := s.GetMultipoolerInstance(name)
+	require.NotNil(t, inst, "node %s not found", name)
+	require.NotNil(t, inst.Multipooler.Process, "multipooler %s has no process handle", name)
+
+	require.NoError(t, inst.Multipooler.Process.Suspend(), "failed to SIGSTOP multipooler %s", name)
+	t.Logf("Froze multipooler %s (pid %d) with SIGSTOP", name, inst.Multipooler.Process.Process.Pid)
+
+	resumed := false
+	return func() {
+		if resumed {
+			return
+		}
+		resumed = true
+		if err := inst.Multipooler.Process.Resume(); err != nil {
+			t.Logf("FreezeMultipooler resume: failed to SIGCONT multipooler %s: %v", name, err)
+			return
+		}
+		t.Logf("Resumed multipooler %s with SIGCONT", name)
+	}
+}
+
 // baselineGucNames returns the GUC names to save/restore for baseline state.
 var baselineGucNames = []string{
 	"synchronous_standby_names",

--- a/go/tools/executil/command.go
+++ b/go/tools/executil/command.go
@@ -395,6 +395,37 @@ func (c *Cmd) Kill(ctx context.Context) (error, bool) {
 	}
 }
 
+// Suspend sends SIGSTOP to the process, freezing it without terminating it.
+// A stopped process stays alive but runs no code and reads no sockets, so any
+// stream it feeds (e.g. a health broadcast) stalls until Resume is called.
+// Used by tests to simulate a hung/partitioned process.
+//
+// Unlike Terminate/Kill this does not Wait: a stopped process never exits.
+// Honors the process group like Terminate/Kill so the whole group freezes when
+// the Cmd was created WithProcessGroup(). No-op if the process hasn't started.
+func (c *Cmd) Suspend() error {
+	if c.Process == nil {
+		return nil
+	}
+	if c.processGroup {
+		return syscall.Kill(-c.Process.Pid, syscall.SIGSTOP)
+	}
+	return c.Process.Signal(syscall.SIGSTOP)
+}
+
+// Resume sends SIGCONT to a process previously frozen by Suspend, letting it
+// run again. Safe to call on a process that was never suspended (SIGCONT is a
+// no-op then). No-op if the process hasn't started.
+func (c *Cmd) Resume() error {
+	if c.Process == nil {
+		return nil
+	}
+	if c.processGroup {
+		return syscall.Kill(-c.Process.Pid, syscall.SIGCONT)
+	}
+	return c.Process.Signal(syscall.SIGCONT)
+}
+
 // Stop gracefully stops the process: SIGTERM first, then SIGKILL if needed.
 //
 // The context controls how long to wait for graceful shutdown (SIGTERM phase).


### PR DESCRIPTION
## What & why

Adds end-to-end coverage for the stranded-gateway stale-primary scenario. When a primary pooler's health stream to the gateway goes stale, the gateway must retract that pooler's PRIMARY routing claim instead of keeping it forever and routing writes / CONSISTENT reads to a superseded primary (stale reads, hung writes).

The e2e harness under `go/test/endtoend/` previously had no way to freeze a pooler's health stream — it could only Kill/Stop/Recruit nodes. This PR adds that primitive and a test that reproduces the bug.

## Validates

The gateway-side fix `fix(multigateway): evict stale primary claim on stale/errored health stream` (07224cd7, MUL-1254), now on `main`. The test asserts the fixed behavior: `onPoolerHealthUpdate` gates the PRIMARY claim on `health.LastError == nil`, so a stranded pooler whose stream stalled is evicted rather than kept. It is green against current `main`; reverting that fix turns it red at the retraction assertion (verified locally), so it is a genuine guard, not a vacuous test.

## Changes

- **feat(multipooler):** `--health-stream-staleness-timeout` (default `0` = keep the built-in 90s). Sets the `RecommendedStalenessTimeout` the pooler advertises, which the gateway adopts as its health-stream staleness window. Lets the test shrink detection from ~90s to ~2s. No behavior change at the default; a non-positive value resets to the default.
- **executil:** `Cmd.Suspend()` / `Cmd.Resume()` (SIGSTOP/SIGCONT, process-group aware) — freeze a process without terminating it.
- **shardsetup:** `ShardSetup.FreezeMultipooler(t, name)` returning an idempotent resume func, and `WaitForLogLine` (matches plain slog lines, not just structured eventlog JSON).
- **e2e:** `TestGateway_EvictsStrandedPrimaryOnStaleHealthStream` in `go/test/endtoend/queryserving/`.

## How the test works

3-node cluster + gateway, no live multiorch. Poolers advertise a 2s staleness window. A baseline write and read confirm the primary is routable (on the main gateway port every query is leader-routed, so a `SELECT` is a leader read), then its multipooler is frozen with SIGSTOP (postgres stays up → a write-capable "stranded" primary whose gateway stream stalls). The test asserts two independent, distinguishing signals:

1. the gateway logs `routing primary retracted … "stale_stream":true` for the frozen pooler, and
2. leader-routed reads and writes then fail fast with `no writable primary is currently available` instead of hanging on — or reading stale from — the frozen primary (both halves of the bug: stale reads and hung writes).

**Why no live failover:** a normal failover demotes the old primary (it reports role REPLICA and the gateway clears the claim through the ordinary path — no bug), and freezing the live primary to keep its stale PRIMARY claim also blocks multiorch's own ~90s frozen-node detection, so an in-window election isn't reliably reproducible. The fix under test is entirely gateway-side — it retracts a stranded primary's claim purely because the stream went stale — so stranding the primary exercises exactly that path.

## Out of scope

The pure asymmetric-partition variant (gateway still *reaches* the old primary, its stream never stalls) is not covered — it needs a pooler-side self-demoting lease and a transport-level partition primitive the harness doesn't have. Worth adding once that lease lands.

## Validation

- e2e `TestGateway_EvictsStrandedPrimaryOnStaleHealthStream` → PASS on current `main`; FAILs with the fix reverted (confirms it's not vacuous).
- buffer suite (`TestBufferPlannedFailover`, `…TransactionsAndPreparedStatements`, `…MultipleFailovers`) → PASS (no regression to the zero-error planned-failover path).
- unit tests for `executil` and `multipooler/internal/manager` → PASS.
- full `go build ./go/...` and golangci-lint on touched packages → clean.
