### PR TITLE
refactor(multipooler): single source of truth for primary_conninfo

### DIFF
--- a/go/services/multipooler/internal/manager/pg_config.go
+++ b/go/services/multipooler/internal/manager/pg_config.go
@@ -123,6 +123,26 @@ func parseSynchronousStandbyNames(value string) (*SyncStandbyConfig, error) {
 	}, nil
 }
 
+// buildPrimaryConnInfo renders a PrimaryConnInfo into a PostgreSQL
+// primary_conninfo connection string. This is the ONE place the string is
+// constructed: setPrimaryConnInfoLocked writes it via ALTER SYSTEM, and
+// expectedPrimaryConnInfo assembles the value the drift check compares against,
+// so a field added here is emitted on the write path and (via connInfoDrifted)
+// forced through the comparison — the two can no longer silently diverge.
+//
+// It is the inverse of parseAndRedactPrimaryConnInfo: fields it emits are the
+// fields that function parses back. The passfile clause is omitted when empty,
+// mirroring "no passfile written yet" (pgpassPath unknown); the password itself
+// is never embedded — it lives in the pgpass file the passfile= path points at.
+func buildPrimaryConnInfo(ci *multipoolermanagerdata.PrimaryConnInfo) string {
+	connInfo := fmt.Sprintf("host=%s port=%d user=%s application_name=%s",
+		ci.GetHost(), ci.GetPort(), ci.GetUser(), ci.GetApplicationName())
+	if ci.GetPassfile() != "" {
+		connInfo += " passfile=" + ci.GetPassfile()
+	}
+	return connInfo
+}
+
 // parseAndRedactPrimaryConnInfo parses a PostgreSQL primary_conninfo connection string into structured fields
 // Example input: "host=localhost port=5432 user=postgres application_name=cell_name"
 // Returns a PrimaryConnInfo message with parsed fields, or an error if parsing fails

--- a/go/services/multipooler/internal/manager/pg_config_test.go
+++ b/go/services/multipooler/internal/manager/pg_config_test.go
@@ -619,3 +619,68 @@ func TestParseAndRedactPrimaryConnInfo(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildPrimaryConnInfo covers the single conninfo-string builder: field
+// rendering and the passfile-omitted-when-empty rule.
+func TestBuildPrimaryConnInfo(t *testing.T) {
+	tests := []struct {
+		name string
+		ci   *multipoolermanagerdata.PrimaryConnInfo
+		want string
+	}{
+		{
+			name: "AllFields",
+			ci: &multipoolermanagerdata.PrimaryConnInfo{
+				Host:            "primary.example.com",
+				Port:            5432,
+				User:            "postgres",
+				ApplicationName: "zone1_standby1",
+				Passfile:        "/var/lib/pgpass",
+			},
+			want: "host=primary.example.com port=5432 user=postgres application_name=zone1_standby1 passfile=/var/lib/pgpass",
+		},
+		{
+			name: "PassfileOmittedWhenEmpty",
+			ci: &multipoolermanagerdata.PrimaryConnInfo{
+				Host:            "primary.example.com",
+				Port:            5432,
+				User:            "postgres",
+				ApplicationName: "zone1_standby1",
+			},
+			want: "host=primary.example.com port=5432 user=postgres application_name=zone1_standby1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, buildPrimaryConnInfo(tt.ci))
+		})
+	}
+}
+
+// TestPrimaryConnInfoRoundTrip asserts the builder and parser are inverses over
+// the managed fields: what buildPrimaryConnInfo emits, parseAndRedactPrimaryConnInfo
+// parses back unchanged. This locks the two sides of the single source of truth
+// together — a field added to one must be handled by the other or this fails.
+func TestPrimaryConnInfoRoundTrip(t *testing.T) {
+	original := &multipoolermanagerdata.PrimaryConnInfo{
+		Host:            "primary.example.com",
+		Port:            5432,
+		User:            "postgres",
+		ApplicationName: "zone1_standby1",
+		Passfile:        "/var/lib/pgpass",
+	}
+
+	rendered := buildPrimaryConnInfo(original)
+	parsed, err := parseAndRedactPrimaryConnInfo(rendered)
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+
+	assert.Equal(t, original.Host, parsed.Host)
+	assert.Equal(t, original.Port, parsed.Port)
+	assert.Equal(t, original.User, parsed.User)
+	assert.Equal(t, original.ApplicationName, parsed.ApplicationName)
+	assert.Equal(t, original.Passfile, parsed.Passfile)
+
+	// A field-drift comparison must see the round-tripped value as non-drifting.
+	assert.False(t, connInfoDrifted(parsed, original))
+}

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	commonconsensus "github.com/multigres/multigres/go/common/consensus"
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pgmode"
 	"github.com/multigres/multigres/go/tools/telemetry"
@@ -422,47 +423,129 @@ func (pm *MultipoolerManager) setMonitorReason(ctx context.Context, reason, mess
 	}
 }
 
-// matchesRecorded reports whether ci's contact info matches target: host,
-// port, AND the passfile clause. A conninfo that points at the right primary
-// but lacks a usable passfile= (e.g. it was written before pgpassPath was
-// known) leaves the walreceiver unable to authenticate, so passfile is part
-// of the match too — this lets the reconcile paths self-heal that case
-// instead of freezing a passwordless conninfo in place forever.
-//
-// The passfile comparison is asymmetric: pgpassFilePath() returns "" until
-// pgpassPath is known, and setPrimaryConnInfoLocked cannot append a passfile
-// in that state. Treating "" as "expect no passfile" would flag drift we
-// can't fix and reconcile in a loop that keeps producing the same
-// passwordless conninfo, so an unknown expected path is treated as a match
-// (nothing to reconcile toward yet) regardless of what ci carries.
-//
-// ci may be nil (absent/unparsable conninfo), which never matches.
-func (pm *MultipoolerManager) matchesRecorded(target *clustermetadatapb.PoolerAddress, ci *multipoolermanagerdatapb.PrimaryConnInfo) bool {
-	if ci == nil {
-		return false
+// expectedPrimaryConnInfo assembles the primary_conninfo this pooler should
+// have when following the recorded primary at `target`, from the single set of
+// authoritative inputs. It is the value the drift check compares the live
+// conninfo against.
+func (pm *MultipoolerManager) expectedPrimaryConnInfo(target *clustermetadatapb.PoolerAddress) *multipoolermanagerdatapb.PrimaryConnInfo {
+	return pm.expectedPrimaryConnInfoAt(target.GetHost(), target.GetPostgresPort())
+}
+
+// expectedPrimaryConnInfoAt assembles the PrimaryConnInfo this pooler should use
+// to follow the primary at (host, port) from the authoritative inputs: the
+// replication user (connPoolMgr.PgUser(), falling back to the default superuser
+// before the pool manager exists), this pooler's application_name
+// (servicePoolerID), and the pgpass path (pgpassFilePath(), the ONLY read of
+// pgpassPath). Both the write path (setPrimaryConnInfoLocked) and the drift
+// check assemble their value here, so there is one source of truth for what the
+// conninfo should contain.
+func (pm *MultipoolerManager) expectedPrimaryConnInfoAt(host string, port int32) *multipoolermanagerdatapb.PrimaryConnInfo {
+	user := constants.DefaultPostgresUser
+	if pm.connPoolMgr != nil {
+		user = pm.connPoolMgr.PgUser()
 	}
-	if ci.GetHost() != target.GetHost() || ci.GetPort() != target.GetPostgresPort() {
-		return false
+	return &multipoolermanagerdatapb.PrimaryConnInfo{
+		Host:            host,
+		Port:            port,
+		User:            user,
+		ApplicationName: pm.servicePoolerID.AppName(),
+		Passfile:        pm.pgpassFilePath(),
 	}
-	expectedPassfile := pm.pgpassFilePath()
-	return expectedPassfile == "" || ci.GetPassfile() == expectedPassfile
+}
+
+// connInfoPointsAt reports whether actual's host/port target (host, port).
+// actual may be nil (absent/unparsable conninfo), which never matches. Shared by
+// the drift comparison and standbyStuckDiverged so the host/port equality lives
+// in one place.
+func connInfoPointsAt(actual *multipoolermanagerdatapb.PrimaryConnInfo, host string, port int32) bool {
+	return actual != nil && actual.GetHost() == host && actual.GetPort() == port
+}
+
+// connInfoDrifted reports whether the live primary_conninfo (actual) differs
+// from what this pooler should have (expected) in ANY managed field: host, port,
+// user, application_name, and passfile. This is the single comparison site — a
+// field added to the builder (buildPrimaryConnInfo) and to expectedPrimaryConnInfo
+// must be compared here too or the round-trip test fails.
+//
+// actual may be nil (absent/unparsable conninfo), which is always drift when
+// there is an expected value to reconcile toward.
+//
+// The passfile comparison is asymmetric: expected.Passfile is "" until
+// pgpassPath is known, and setPrimaryConnInfoLocked cannot write a passfile in
+// that state. Treating "" as "expect no passfile" would flag drift we can't fix
+// and reconcile in a loop that keeps producing the same passwordless conninfo,
+// so an unknown expected passfile is treated as a match (nothing to reconcile
+// toward yet) regardless of what actual carries. This is the "only flag drift we
+// can fix" guard.
+func connInfoDrifted(actual, expected *multipoolermanagerdatapb.PrimaryConnInfo) bool {
+	if actual == nil {
+		return true
+	}
+	if !connInfoPointsAt(actual, expected.GetHost(), expected.GetPort()) {
+		return true
+	}
+	if actual.GetUser() != expected.GetUser() {
+		return true
+	}
+	if actual.GetApplicationName() != expected.GetApplicationName() {
+		return true
+	}
+	if expected.GetPassfile() != "" && actual.GetPassfile() != expected.GetPassfile() {
+		return true
+	}
+	return false
+}
+
+// connInfoReconcileAllowed reports whether this pooler may reconcile
+// primary_conninfo at all this tick, and if so returns the recorded primary
+// address to reconcile toward. It is the "may we touch it?" predicate — every
+// early-return gate, no comparison (that is connInfoDrifted):
+//
+//   - manual-stop: StopReplication set the flag, so setPrimaryConnInfoLocked
+//     would refuse every rewrite until StartReplication clears it. Reconciling
+//     anyway would fire the action on every tick and log a noisy
+//     FAILED_PRECONDITION each time.
+//   - no recorded primary: nothing to compare against (SetPrimary/Promote have
+//     not run, or recorded no contact info).
+//   - self-is-leader: the recorded rule names this pooler — primary-side case,
+//     out of scope for replica-conninfo reconciliation.
+//   - revoked rule: a Recruit that already advanced revoked_below_term has
+//     deliberately cleared primary_conninfo; the cached primary is stale until
+//     the next SetPrimary/Promote. Restoring conninfo to it would race the
+//     in-flight Recruit/Promote and make Promote refuse with
+//     "primary_conninfo is set".
+//   - empty target: recorded primary has no host/port to point at.
+func (pm *MultipoolerManager) connInfoReconcileAllowed() (*clustermetadatapb.PoolerAddress, bool) {
+	if pm.walReceiverManuallyStopped.Load() {
+		return nil, false
+	}
+	rp := pm.consensusMgr.GetReplicationPrimary()
+	if rp == nil {
+		return nil, false
+	}
+	target := rp.GetPrimary()
+	if target == nil {
+		return nil, false
+	}
+	if leader := commonconsensus.PossiblyUndecidedRule(rp.GetPosition()).GetLeaderId(); leader != nil &&
+		leader.GetCell() == pm.serviceID.GetCell() && leader.GetName() == pm.serviceID.GetName() {
+		return nil, false
+	}
+	if commonconsensus.IsRuleRevoked(rp.GetPosition(), pm.consensusMgr.Promises().GetInconsistentRevocation()) {
+		return nil, false
+	}
+	if target.GetHost() == "" || target.GetPostgresPort() == 0 {
+		return nil, false
+	}
+	return target, true
 }
 
 // primaryConnInfoDiffersFromRecorded returns true when this pooler has been
-// informed about a primary (via SetPrimary or Promote) and the live primary_conninfo
-// in postgres doesn't match the recorded primary's contact info. Returns false
-// when there's nothing to compare against, when we couldn't read the GUC, or
-// when the recorded primary names this pooler itself.
-//
-// "Contact info" is host, port, and the passfile clause — see matchesRecorded.
-//
-// Returns false when the recorded primary's rule is revoked by our recorded
-// revocation: a Recruit that's already advanced revoked_below_term has
-// deliberately cleared primary_conninfo, and the cached "recorded primary" is
-// stale until the next SetPrimary/Promote updates it. Without this gate, the
-// monitor would race the Recruit/Promote flow by restoring conninfo to the
-// just-revoked primary, which then causes Promote to refuse with
-// "primary_conninfo is set".
+// informed about a primary (via SetPrimary or Promote) and the live
+// primary_conninfo in postgres has drifted from the value this pooler should
+// have. It composes the two separated concerns: connInfoReconcileAllowed (may we
+// reconcile at all?) and connInfoDrifted (did the value drift?). Returns false
+// when reconciliation isn't allowed or when we couldn't read the GUC.
 //
 // Used by the postgres monitor to decide whether to trigger
 // remedialActionFixPrimaryConnInfo on each tick.
@@ -472,35 +555,8 @@ func (pm *MultipoolerManager) matchesRecorded(target *clustermetadatapb.PoolerAd
 // a fresh state snapshot (e.g. the SetPrimary RPC path) pass nil, in which case
 // the GUC is read here as before.
 func (pm *MultipoolerManager) primaryConnInfoDiffersFromRecorded(ctx context.Context, connInfo *multipoolermanagerdatapb.PrimaryConnInfo) bool {
-	// Don't detect drift we can't fix: when StopReplication has set the
-	// manual-stop flag, setPrimaryConnInfoLocked refuses every conninfo
-	// rewrite until StartReplication clears it. Detecting drift anyway would
-	// fire the reconciliation action on every tick and log a noisy
-	// FAILED_PRECONDITION error each time.
-	if pm.walReceiverManuallyStopped.Load() {
-		return false
-	}
-	rp := pm.consensusMgr.GetReplicationPrimary()
-	if rp == nil {
-		return false
-	}
-	target := rp.GetPrimary()
-	if target == nil {
-		return false
-	}
-	// Skip if the recorded rule names this pooler as the leader — that's the
-	// primary-side case, out of scope for replica-conninfo reconciliation.
-	if leader := commonconsensus.PossiblyUndecidedRule(rp.GetPosition()).GetLeaderId(); leader != nil &&
-		leader.GetCell() == pm.serviceID.GetCell() && leader.GetName() == pm.serviceID.GetName() {
-		return false
-	}
-	// Skip if the recorded rule is revoked. The cached primary is from before
-	// the current revocation took effect; restoring conninfo to it would race
-	// the Recruit/Promote flow that's mid-flight (see function doc).
-	if commonconsensus.IsRuleRevoked(rp.GetPosition(), pm.consensusMgr.Promises().GetInconsistentRevocation()) {
-		return false
-	}
-	if target.GetHost() == "" || target.GetPostgresPort() == 0 {
+	target, ok := pm.connInfoReconcileAllowed()
+	if !ok {
 		return false
 	}
 
@@ -514,17 +570,15 @@ func (pm *MultipoolerManager) primaryConnInfoDiffersFromRecorded(ctx context.Con
 			// Conservative: don't trigger reconciliation we can't verify.
 			return false
 		}
-		if connInfoStr == "" {
-			return true
-		}
 		parsed, err := parseAndRedactPrimaryConnInfo(connInfoStr)
 		if err != nil || parsed == nil {
-			// Unparsable conninfo is itself drift worth fixing.
+			// Unparsable conninfo is itself drift worth fixing. (An empty GUC
+			// parses to an all-empty PrimaryConnInfo, which drifts below.)
 			return true
 		}
 		connInfo = parsed
 	}
-	return !pm.matchesRecorded(target, connInfo)
+	return connInfoDrifted(connInfo, pm.expectedPrimaryConnInfo(target))
 }
 
 // reconcilePrimaryConnInfoToRecorded re-applies primary_conninfo so it points
@@ -777,7 +831,7 @@ func (pm *MultipoolerManager) standbyStuckDiverged(ctx context.Context, state po
 	if state.connInfo == nil {
 		return false
 	}
-	if state.connInfo.GetHost() != host || state.connInfo.GetPort() != port {
+	if !connInfoPointsAt(state.connInfo, host, port) {
 		pm.standbyStuckSince.Store(0)
 		return false
 	}

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/multigres/multigres/go/common/servenv"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor/mock"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
@@ -509,7 +510,8 @@ func TestDetermineRemedialAction(t *testing.T) {
 				// observation that names itself.
 				seed.RoutingState = &clustermetadatapb.RoutingState{Role: clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY}
 			}
-			pm := newTestManager(t,
+			pm := newTestManager(
+				t,
 				withServiceID(selfID),
 				withRecord(newRecordFromProto(seed)),
 				withReplicationPrimary(tt.seedPrimary),
@@ -610,7 +612,8 @@ func TestDetermineRemedialAction_StalePrimaryDemote(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pm := newTestManager(t,
+			pm := newTestManager(
+				t,
 				withServiceID(selfID),
 				withRecord(newRecordFromProto(&clustermetadatapb.Multipooler{
 					Id:           selfID,
@@ -815,7 +818,8 @@ func TestStaleStandbyDemoteTarget(t *testing.T) {
 		cs := consensus.NewConsensusPromises(dir, selfID)
 		_, err := cs.Load()
 		require.NoError(t, err)
-		pm := newTestManager(t,
+		pm := newTestManager(
+			t,
 			withServiceID(selfID),
 			withPromises(cs),
 			withReplicationPrimary(&clustermetadatapb.ReplicationPrimary{Position: &clustermetadatapb.RulePosition{Decision: rule(5, otherID)}, Primary: otherAddr, RewindReady: true}),
@@ -836,7 +840,8 @@ func TestStaleStandbyDemoteTarget(t *testing.T) {
 		// Same as the returns-target case, but the recorded leader has not advertised
 		// rewind-readiness, so we defer rather than restart into a rewind that would
 		// FATAL against a not-yet-checkpointed source.
-		pm := newTestManager(t,
+		pm := newTestManager(
+			t,
 			withServiceID(selfID),
 			withReplicationPrimary(&clustermetadatapb.ReplicationPrimary{Position: &clustermetadatapb.RulePosition{Decision: rule(5, otherID)}, Primary: otherAddr, RewindReady: false}),
 			withRuleStore(&fakeRuleStore{pos: &clustermetadatapb.PoolerPosition{Position: &clustermetadatapb.RulePosition{Decision: rule(4, selfID)}}}),
@@ -851,7 +856,8 @@ func TestShouldMarkRewindReady(t *testing.T) {
 	// shouldMarkRewindReady reads beyond (rewindSourceReady, role): the resigned
 	// term and the recorded ReplicationPrimary's rewind-ready flag.
 	newMgr := func(resignedTerm int64, rp *clustermetadatapb.ReplicationPrimary) *MultipoolerManager {
-		return newTestManager(t,
+		return newTestManager(
+			t,
 			withServiceID(selfID),
 			withResignedLeaderAtTerm(resignedTerm),
 			withReplicationPrimary(rp),
@@ -1106,7 +1112,8 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 			_, err := cs.Load()
 			require.NoError(t, err)
 
-			pm := newRemedialActionTestManager(t, multipooler,
+			pm := newRemedialActionTestManager(
+				t, multipooler,
 				withRuleStore(&fakeRuleStore{pos: tc.cachedPos}),
 				withPromises(cs),
 			)
@@ -1189,7 +1196,8 @@ func setupManagerWithMockDBAndPgctld(t *testing.T, mockQueryService *mock.QueryS
 		TopoClient: ts,
 		PgctldAddr: pgctldAddr,
 	}
-	pm, err := NewMultipoolerManagerForTesting(t, logger, multipooler, config,
+	pm, err := NewMultipoolerManagerForTesting(
+		t, logger, multipooler, config,
 		withMockController(&mockPoolerController{queryService: mockQueryService}),
 		withFakeRules(rules),
 	)
@@ -1567,6 +1575,13 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 	const (
 		recordedHost = "primary.example.com"
 		recordedPort = int32(5432)
+		// expectedUser and expectedApp are the identity fields
+		// expectedPrimaryConnInfo derives from this test manager: PgUser() falls
+		// back to the default superuser (connPoolMgr is nil in this setup) and
+		// application_name is servicePoolerID ("{cell}_{name}"). A runtime guard
+		// below asserts these match so the string literals below stay honest.
+		expectedUser = constants.DefaultPostgresUser
+		expectedApp  = "zone1_test-pooler"
 	)
 	recordedID := &clustermetadatapb.ID{
 		Component: clustermetadatapb.ID_MULTIPOOLER,
@@ -1714,7 +1729,7 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 				Primary:  mkAddress(recordedHost, recordedPort),
 			},
 			expectQuery:   true,
-			mockConnInfo:  "host=primary.example.com port=5432 user=replicator",
+			mockConnInfo:  "host=primary.example.com port=5432 user=" + expectedUser + " application_name=" + expectedApp,
 			matchPassfile: true,
 			want:          false,
 		},
@@ -1729,7 +1744,7 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 				Primary:  mkAddress(recordedHost, recordedPort),
 			},
 			expectQuery:  true,
-			mockConnInfo: "host=primary.example.com port=5432 user=replicator",
+			mockConnInfo: "host=primary.example.com port=5432 user=" + expectedUser + " application_name=" + expectedApp,
 			want:         true,
 		},
 		{
@@ -1741,7 +1756,7 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 				Primary:  mkAddress(recordedHost, recordedPort),
 			},
 			expectQuery:  true,
-			mockConnInfo: "host=primary.example.com port=5432 user=replicator passfile=/stale/path/pgpass",
+			mockConnInfo: "host=primary.example.com port=5432 user=" + expectedUser + " application_name=" + expectedApp + " passfile=/stale/path/pgpass",
 			want:         true,
 		},
 		{
@@ -1750,9 +1765,10 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 				Position: &clustermetadatapb.RulePosition{Decision: mkRule(5, recordedID)},
 				Primary:  mkAddress(recordedHost, recordedPort),
 			},
-			expectQuery:  true,
-			mockConnInfo: "host=other.example.com port=5432 user=replicator",
-			want:         true,
+			expectQuery:   true,
+			mockConnInfo:  "host=other.example.com port=5432 user=" + expectedUser + " application_name=" + expectedApp,
+			matchPassfile: true,
+			want:          true,
 		},
 		{
 			name: "LiveConnInfoPortMismatch",
@@ -1760,9 +1776,36 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 				Position: &clustermetadatapb.RulePosition{Decision: mkRule(5, recordedID)},
 				Primary:  mkAddress(recordedHost, recordedPort),
 			},
-			expectQuery:  true,
-			mockConnInfo: "host=primary.example.com port=9999 user=replicator",
-			want:         true,
+			expectQuery:   true,
+			mockConnInfo:  "host=primary.example.com port=9999 user=" + expectedUser + " application_name=" + expectedApp,
+			matchPassfile: true,
+			want:          true,
+		},
+		{
+			// Host/port/passfile all match, but the replication user drifted from
+			// what expectedPrimaryConnInfo derives (connPoolMgr.PgUser()).
+			name: "LiveConnInfoUserMismatch",
+			seedRP: &clustermetadatapb.ReplicationPrimary{
+				Position: &clustermetadatapb.RulePosition{Decision: mkRule(5, recordedID)},
+				Primary:  mkAddress(recordedHost, recordedPort),
+			},
+			expectQuery:   true,
+			mockConnInfo:  "host=primary.example.com port=5432 user=someoneelse application_name=" + expectedApp,
+			matchPassfile: true,
+			want:          true,
+		},
+		{
+			// Host/port/passfile all match, but application_name drifted from this
+			// pooler's servicePoolerID.
+			name: "LiveConnInfoAppNameMismatch",
+			seedRP: &clustermetadatapb.ReplicationPrimary{
+				Position: &clustermetadatapb.RulePosition{Decision: mkRule(5, recordedID)},
+				Primary:  mkAddress(recordedHost, recordedPort),
+			},
+			expectQuery:   true,
+			mockConnInfo:  "host=primary.example.com port=5432 user=" + expectedUser + " application_name=zone1_other-pooler",
+			matchPassfile: true,
+			want:          true,
 		},
 	}
 
@@ -1771,6 +1814,14 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 			mockQueryService := mock.NewQueryService()
 			pm, tmpDir := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(0)})
 
+			// Guard the identity constants baked into mockConnInfo against setup
+			// drift: expectedPrimaryConnInfo derives user/application_name from the
+			// manager, and the "matches" cases only hold if those equal what the
+			// literals above assume.
+			expected := pm.expectedPrimaryConnInfoAt(recordedHost, recordedPort)
+			require.Equal(t, expectedUser, expected.GetUser())
+			require.Equal(t, expectedApp, expected.GetApplicationName())
+
 			// Register the primary_conninfo mock after setup so matchPassfile can
 			// append the passfile path the manager actually resolved at startup.
 			// Setup's startup does not read primary_conninfo, so the once-pattern
@@ -1778,7 +1829,8 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 			if tt.expectQuery {
 				if tt.mockReadError {
 					mockQueryService.AddQueryPatternOnceWithError(
-						"current_setting.*primary_conninfo", assert.AnError)
+						"current_setting.*primary_conninfo", assert.AnError,
+					)
 				} else {
 					connInfo := tt.mockConnInfo
 					if tt.matchPassfile {
@@ -1792,7 +1844,8 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 					}
 					mockQueryService.AddQueryPatternOnce(
 						"current_setting.*primary_conninfo",
-						mock.MakeQueryResult([]string{"current_setting"}, row))
+						mock.MakeQueryResult([]string{"current_setting"}, row),
+					)
 				}
 			}
 
@@ -1816,6 +1869,134 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 			assert.NoError(t, mockQueryService.ExpectationsWereMet())
 		})
 	}
+}
+
+// TestConnInfoDrifted is the single-comparison-site guard: it asserts drift is
+// detected for a mismatch in EVERY field the builder emits (host, port, user,
+// application_name, passfile) and NOT detected when every field matches. If a
+// future field is added to buildPrimaryConnInfo / expectedPrimaryConnInfo but
+// not to connInfoDrifted, the "all match" round-trip stays green while the new
+// per-field case must be added here — forcing the field through the comparison.
+//
+// The mutators are derived from a base "expected" value so this test tracks the
+// builder's field set by construction rather than by a hand-copied literal.
+func TestConnInfoDrifted(t *testing.T) {
+	expected := &multipoolermanagerdatapb.PrimaryConnInfo{
+		Host:            "primary.example.com",
+		Port:            5432,
+		User:            "postgres",
+		ApplicationName: "zone1_test-pooler",
+		Passfile:        "/var/lib/pgpass",
+	}
+
+	// clone returns a fresh copy of expected so each mutator starts from a
+	// fully-matching value and changes exactly one field.
+	clone := func() *multipoolermanagerdatapb.PrimaryConnInfo {
+		return &multipoolermanagerdatapb.PrimaryConnInfo{
+			Host:            expected.Host,
+			Port:            expected.Port,
+			User:            expected.User,
+			ApplicationName: expected.ApplicationName,
+			Passfile:        expected.Passfile,
+		}
+	}
+
+	tests := []struct {
+		name   string
+		actual *multipoolermanagerdatapb.PrimaryConnInfo
+		want   bool
+	}{
+		{
+			name:   "AllFieldsMatch",
+			actual: clone(),
+			want:   false,
+		},
+		{
+			name:   "NilActual",
+			actual: nil,
+			want:   true,
+		},
+		{
+			name: "HostDiffers",
+			actual: func() *multipoolermanagerdatapb.PrimaryConnInfo {
+				a := clone()
+				a.Host = "other.example.com"
+				return a
+			}(),
+			want: true,
+		},
+		{
+			name: "PortDiffers",
+			actual: func() *multipoolermanagerdatapb.PrimaryConnInfo {
+				a := clone()
+				a.Port = 9999
+				return a
+			}(),
+			want: true,
+		},
+		{
+			name: "UserDiffers",
+			actual: func() *multipoolermanagerdatapb.PrimaryConnInfo {
+				a := clone()
+				a.User = "replicator"
+				return a
+			}(),
+			want: true,
+		},
+		{
+			name: "ApplicationNameDiffers",
+			actual: func() *multipoolermanagerdatapb.PrimaryConnInfo {
+				a := clone()
+				a.ApplicationName = "zone1_other-pooler"
+				return a
+			}(),
+			want: true,
+		},
+		{
+			name: "PassfileDiffers",
+			actual: func() *multipoolermanagerdatapb.PrimaryConnInfo {
+				a := clone()
+				a.Passfile = "/stale/pgpass"
+				return a
+			}(),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, connInfoDrifted(tt.actual, expected))
+		})
+	}
+
+	// Field-count guard: every non-Raw field of expected is exercised by a
+	// per-field mismatch case above. This is a soft tripwire — if a new field is
+	// added to PrimaryConnInfo and the builder starts emitting it, add a case.
+	// (Raw is not builder-emitted; it is the parser's redacted round-trip copy.)
+	const managedFieldCases = 5 // host, port, user, application_name, passfile
+	mismatchCases := 0
+	for _, tt := range tests {
+		if tt.want && tt.actual != nil {
+			mismatchCases++
+		}
+	}
+	assert.Equal(t, managedFieldCases, mismatchCases,
+		"expected one per-field mismatch case for each builder-emitted field")
+
+	// The passfile comparison is asymmetric ("only flag drift we can fix"):
+	// when expected has no passfile (pgpassPath not known yet), any actual
+	// passfile is tolerated so the monitor doesn't loop trying to write a
+	// passfile it cannot produce.
+	t.Run("UnknownExpectedPassfileToleratesAny", func(t *testing.T) {
+		exp := clone()
+		exp.Passfile = ""
+		withPassfile := clone()
+		withPassfile.Passfile = "/whatever/pgpass"
+		assert.False(t, connInfoDrifted(withPassfile, exp))
+		noPassfile := clone()
+		noPassfile.Passfile = ""
+		assert.False(t, connInfoDrifted(noPassfile, exp))
+	})
 }
 
 // TestStandbyStuckDiverged covers the monitor's self-detection of a diverged
@@ -1952,7 +2133,8 @@ func TestStandbyStuckDiverged(t *testing.T) {
 			if tt.expectStatusQuery {
 				mockQueryService.AddQueryPatternOnce(
 					"pg_last_wal_replay_lsn",
-					mock.MakeQueryResult(replStatusCols, replStatusRow(tt.walReceiverStatus)))
+					mock.MakeQueryResult(replStatusCols, replStatusRow(tt.walReceiverStatus)),
+				)
 			}
 
 			pm, _ := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(0)})

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -26,7 +26,6 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	commonconsensus "github.com/multigres/multigres/go/common/consensus"
-	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
@@ -128,8 +127,6 @@ func (pm *MultipoolerManager) setPrimaryConnInfoLocked(ctx context.Context, host
 			fmt.Sprintf("operation not allowed: the PostgreSQL instance is not in standby mode (service_id: %s)", pm.serviceID.String()))
 	}
 
-	appName := pm.servicePoolerID
-
 	// Optionally stop replication before making changes
 	if stopReplicationBefore {
 		_, err := pm.pauseReplication(ctx, multipoolermanagerdatapb.ReplicationPauseMode_REPLICATION_PAUSE_MODE_REPLAY_ONLY, false)
@@ -138,30 +135,23 @@ func (pm *MultipoolerManager) setPrimaryConnInfoLocked(ctx context.Context, host
 		}
 	}
 
-	// Build primary_conninfo connection string
-	// Format: host=<host> port=<port> user=<user> application_name=<name> [passfile=<path>]
-	// The heartbeat_interval is converted to keepalives_interval/keepalives_idle.
-	// passfile points libpq at the pgpass file written at manager startup so the
-	// standby can authenticate to the primary via SCRAM without embedding the
-	// password in postgresql.auto.conf. It is omitted when pgpassPath is unset
-	// (early startup or unit tests that bypass loadShardConfigFromGlobalTopo).
-	user := constants.DefaultPostgresUser
-	if pm.connPoolMgr != nil {
-		user = pm.connPoolMgr.PgUser()
-	}
-	connInfo := fmt.Sprintf("host=%s port=%d user=%s application_name=%s",
-		host, port, user, appName.AppName())
-	if pgpass := pm.pgpassFilePath(); pgpass != "" {
-		connInfo += " passfile=" + pgpass
-	} else {
+	// Assemble the expected primary_conninfo from the single authoritative
+	// representation and render it via the one builder. Writing the SAME value
+	// the drift check (connInfoDrifted) compares against is what keeps the write
+	// path and the comparator from diverging. passfile points libpq at the pgpass
+	// file so the standby authenticates via SCRAM without embedding the password
+	// in postgresql.auto.conf; it is empty until pgpassPath is known (early
+	// startup or unit tests that bypass loadShardConfigFromGlobalTopo).
+	expected := pm.expectedPrimaryConnInfoAt(host, port)
+	if expected.GetPassfile() == "" {
 		// Writing a conninfo with no passfile: the walreceiver will fail SCRAM
 		// with "fe_sendauth: no password supplied" until pgpassPath is known and
-		// the drift check (primaryConnInfoDiffersFromRecorded) self-heals it.
-		// Surface it so a stuck standby is diagnosable from the pooler log rather
-		// than only the postgres log.
+		// the drift check self-heals it. Surface it so a stuck standby is
+		// diagnosable from the pooler log rather than only the postgres log.
 		pm.logger.WarnContext(ctx, "writing primary_conninfo without passfile (pgpassPath not set yet); standby cannot authenticate to primary until reconciled",
 			"host", host, "port", port)
 	}
+	connInfo := buildPrimaryConnInfo(expected)
 
 	// Set primary_conninfo using ALTER SYSTEM
 	if err = pm.setPrimaryConnInfo(ctx, connInfo); err != nil {
@@ -489,13 +479,15 @@ func (pm *MultipoolerManager) UpdateConsensusRule(ctx context.Context, operation
 		coordID,
 		"replication_config",
 		"UpdateConsensusRule: "+operationName,
-		time.Now()).
+		time.Now(),
+	).
 		WithLeader(leaderID.ID()).
 		WithCohort(updatedStandbyIDs).
 		WithOperation(operationName).
 		WithPreviousRule(
 			expectedOutgoingRule.GetCoordinatorTerm(),
-			expectedOutgoingRule.GetLeaderSubterm())
+			expectedOutgoingRule.GetLeaderSubterm(),
+		)
 	if _, err := pm.DoUpdateRule(ctx, standbyUpdate); err != nil {
 		return mterrors.Wrap(err, "failed to record replication config history")
 	}

--- a/go/test/endtoend/multipooler/postgres_monitor_test.go
+++ b/go/test/endtoend/multipooler/postgres_monitor_test.go
@@ -305,7 +305,7 @@ func TestPostgresMonitor_FixesPrimaryConnInfoDrift(t *testing.T) {
 //  2. Externally clobber primary_conninfo to the same host/port but with the
 //     passfile= clause stripped out.
 //  3. Wait for the monitor (5s tick) to detect the passfile drift via
-//     primaryConnInfoDiffersFromRecorded/matchesRecorded and rewrite
+//     primaryConnInfoDiffersFromRecorded/connInfoDrifted and rewrite
 //     primary_conninfo to restore it.
 func TestPostgresMonitor_FixesMissingPassfileDrift(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
## What

Collapse the two hand-maintained definitions of `primary_conninfo` — an inline builder in `setPrimaryConnInfoLocked` and a field-picking comparator (`matchesRecorded`) — into a single source of truth.

## Why

The recently-merged passfile-drift fix (`fix(multipooler): detect missing passfile in primary_conninfo drift check`) patched the immediate symptom: it folded `passfile=` into the drift comparison so a passwordless conninfo (`fe_sendauth: no password supplied`) self-heals. But it left the underlying hazard in place — the value is still *written* in one place and *compared* in another, and the two can silently diverge. `matchesRecorded` still compares only host, port, and passfile; a conninfo that drifted in `user` or `application_name` reads as "no drift" and is silently accepted — the same blind-spot pattern one field over.

This change removes the bug class rather than another symptom.

## How

- Reuse the `PrimaryConnInfo` proto as the single in-memory representation.
- `buildPrimaryConnInfo(ci)` — the ONE place the conninfo string is rendered (inverse of `parseAndRedactPrimaryConnInfo`). `setPrimaryConnInfoLocked` writes via it.
- `expectedPrimaryConnInfo(target)` / `expectedPrimaryConnInfoAt(host, port)` — assemble the expected value from the authoritative inputs (recorded leader host/port, `connPoolMgr.PgUser()`, `servicePoolerID` app name, `pgpassFilePath()`). Both the write path and the drift check assemble here, so they cannot diverge.
- `connInfoDrifted(actual, expected)` — the single comparison site, across ALL managed fields (host, port, user, application_name, passfile), keeping the "only flag drift we can fix" guard for an unknown passfile. Removes the `passfileDrift` special-case and the duplicated host/port-only checks.
- Split the two concerns `primaryConnInfoDiffersFromRecorded` mixed: `connInfoReconcileAllowed()` (may we reconcile at all? — the gates) vs `connInfoDrifted()` (did the value drift? — pure, testable).
- DRY the host/port equality via `connInfoPointsAt(actual, host, port)`, shared with `standbyStuckDiverged`.

## Behavioral delta

The drift check now also detects and self-heals a conninfo that drifted in `user` or `application_name`, which today is silently accepted. No change to what gets written on the happy path.

## Tests

- `TestConnInfoDrifted` — per-field table that forces every builder-emitted field through the comparison; if a field is added to the builder but not the comparator, the round-trip case fails.
- `TestBuildPrimaryConnInfo` / `TestPrimaryConnInfoRoundTrip` — builder ↔ parser inverse.
- Updated `TestPrimaryConnInfoDiffersFromRecorded` for the full-field comparison (added `user` and `application_name` mismatch cases, plus a runtime guard tying the literal identity strings to what the manager derives).

Verified locally: `go build ./go/...`, full `manager` package with `-race`, golangci-lint (0 issues), and the conninfo-focused multipooler e2e tests + multiorch `TestFixReplication` / `TestSpuriousFailoverRecovery` against PostgreSQL 17.
