### PR TITLE
fix(pgctld): recover a crashed standby via standby-mode recovery

### DIFF
--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -622,31 +622,39 @@ func (s *PgCtldService) Start(ctx context.Context, req *pb.StartRequest) (*pb.St
 		}
 	}
 
-	// When the caller allows it, make sure a node that was not cleanly shut down
-	// is crash recovered before the start below. crashRecoveryRan reports whether
-	// recovery occurs (here, or via the postmaster on the normal start) so the
-	// caller can treat it as evidence the node was not cleanly shut down.
+	// When the caller allows it, force single-user crash recovery for a standby
+	// the caller flagged as possibly diverged, so it reaches the clean-shutdown
+	// state pg_rewind needs before the start below. crashRecoveryRan reports
+	// whether that single-user recovery ran (matching
+	// StartResponse.crash_recovery_ran); a clean follower, or an as_primary start,
+	// is instead crash-recovered by the postmaster on the normal start below and
+	// does not set it.
 	var crashRecoveryRan bool
 	if req.GetAllowCrashRecovery() {
 		needed, nErr := s.crashRecoveryNeeded(ctx)
 		if nErr != nil {
 			s.logger.WarnContext(ctx, "could not determine clean-shutdown state before start (continuing)", "error", nErr)
-		} else if needed {
-			// crash recovery happens either way, so report it. A node without a
-			// standby.signal is crash-recovered by the postmaster on the normal start
-			// below, so it needs no explicit step. A standby may not be: if an early
-			// pg_rewind stamped minRecoveryPoint onto the wrong timeline, standby
-			// startup FATAL-loops and never reaches a clean state. Force single-user
-			// recovery for it — runCrashRecovery removes standby.signal first, since
-			// postgres --single refuses to run with it (that incompatibility, not
-			// standby.signal blocking the postmaster's own recovery, is why the
-			// explicit step is gated on standby.signal).
+		} else if needed && s.hasStandbySignal() && req.GetSuspectedDivergence() {
+			// A not-cleanly-stopped standby that the caller suspects may have
+			// diverged (a former primary being demoted, or a node already flagged
+			// for rewind) is force-recovered in single-user mode. runCrashRecovery
+			// removes standby.signal first — postgres --single refuses to run with
+			// it — and recreates it afterwards; this reaches the clean-shutdown
+			// state pg_rewind needs (e.g. to unwedge a node whose earlier pg_rewind
+			// stamped minRecoveryPoint onto the wrong timeline).
+			//
+			// A clean follower is deliberately NOT sent here: single-user
+			// recovery runs in primary mode and does not follow timeline-history
+			// switches, so it would finalize the node on its old timeline past the
+			// leader's fork and wedge the standby start ("requested timeline N is not
+			// a child"). Its crash recovery — and that of a node without
+			// standby.signal — is handled by the postmaster on the normal start
+			// below, which in standby mode follows the timeline switch. crashRecoveryRan
+			// therefore reports specifically whether single-user recovery ran.
 			crashRecoveryRan = true
-			if s.hasStandbySignal() {
-				if rcErr := s.runCrashRecovery(ctx); rcErr != nil {
-					// Best effort: the start below may still surface a clearer error.
-					s.logger.WarnContext(ctx, "standby crash recovery before start failed (continuing)", "error", rcErr)
-				}
+			if rcErr := s.runCrashRecovery(ctx); rcErr != nil {
+				// Best effort: the start below may still surface a clearer error.
+				s.logger.WarnContext(ctx, "standby crash recovery before start failed (continuing)", "error", rcErr)
 			}
 		}
 	}

--- a/go/cmd/pgctld/command/server_test.go
+++ b/go/cmd/pgctld/command/server_test.go
@@ -187,16 +187,28 @@ func TestPgCtldServiceStart_AsPrimaryCrashRecoveryMatrix(t *testing.T) {
 		name                 string
 		asPrimary            bool
 		allowCrashRecovery   bool
+		suspectedDivergence  bool
 		wantStandbySignal    bool
 		wantCrashRecoveryRan bool
 	}{
 		{
 			name:      "standby, no crash recovery",
-			asPrimary: false, allowCrashRecovery: false, wantStandbySignal: true, wantCrashRecoveryRan: false,
+			asPrimary: false, allowCrashRecovery: false, suspectedDivergence: false, wantStandbySignal: true, wantCrashRecoveryRan: false,
 		},
-		{name: "standby, allow crash recovery", asPrimary: false, allowCrashRecovery: true, wantStandbySignal: true, wantCrashRecoveryRan: true},
-		{name: "primary, no crash recovery", asPrimary: true, allowCrashRecovery: false, wantStandbySignal: false, wantCrashRecoveryRan: false},
-		{name: "primary, allow crash recovery", asPrimary: true, allowCrashRecovery: true, wantStandbySignal: false, wantCrashRecoveryRan: true},
+		// Standby, crash recovery allowed but no suspected divergence: a clean
+		// follower is recovered by the postmaster in standby mode (which follows
+		// timeline switches), not by single-user recovery, so crash_recovery_ran
+		// stays false.
+		{name: "standby, allow crash recovery, not diverged", asPrimary: false, allowCrashRecovery: true, suspectedDivergence: false, wantStandbySignal: true, wantCrashRecoveryRan: false},
+		// Standby, crash recovery allowed and divergence suspected: single-user
+		// recovery runs (removing and recreating standby.signal) to reach the
+		// clean-shutdown state pg_rewind needs.
+		{name: "standby, allow crash recovery, suspected divergence", asPrimary: false, allowCrashRecovery: true, suspectedDivergence: true, wantStandbySignal: true, wantCrashRecoveryRan: true},
+		{name: "primary, no crash recovery", asPrimary: true, allowCrashRecovery: false, suspectedDivergence: false, wantStandbySignal: false, wantCrashRecoveryRan: false},
+		// Primary target: standby.signal is removed and single-user recovery never
+		// runs, even with suspected_divergence set (single-user is a standby-only
+		// concern); the postmaster crash-recovers on the normal start.
+		{name: "primary, allow crash recovery", asPrimary: true, allowCrashRecovery: true, suspectedDivergence: true, wantStandbySignal: false, wantCrashRecoveryRan: false},
 	}
 
 	for _, tc := range cases {
@@ -226,8 +238,9 @@ func TestPgCtldServiceStart_AsPrimaryCrashRecoveryMatrix(t *testing.T) {
 
 			ctx := context.Background()
 			resp, err := service.Start(ctx, &pb.StartRequest{
-				AsPrimary:          tc.asPrimary,
-				AllowCrashRecovery: tc.allowCrashRecovery,
+				AsPrimary:           tc.asPrimary,
+				AllowCrashRecovery:  tc.allowCrashRecovery,
+				SuspectedDivergence: tc.suspectedDivergence,
 			})
 			// Stop the mock postgres (pg_ctl start backgrounds a sleep) on cleanup.
 			defer func() { _, _ = service.Stop(ctx, &pb.StopRequest{Mode: "fast"}) }()

--- a/go/cmd/pgctld/command/server_test.go
+++ b/go/cmd/pgctld/command/server_test.go
@@ -184,12 +184,13 @@ func TestPgCtldServiceStart(t *testing.T) {
 //     before the start; the response reports it via CrashRecoveryRan.
 func TestPgCtldServiceStart_AsPrimaryCrashRecoveryMatrix(t *testing.T) {
 	cases := []struct {
-		name                 string
-		asPrimary            bool
-		allowCrashRecovery   bool
-		suspectedDivergence  bool
-		wantStandbySignal    bool
-		wantCrashRecoveryRan bool
+		name                    string
+		asPrimary               bool
+		allowCrashRecovery      bool
+		suspectedDivergence     bool
+		singleUserRecoveryFails bool
+		wantStandbySignal       bool
+		wantCrashRecoveryRan    bool
 	}{
 		{
 			name:      "standby, no crash recovery",
@@ -204,6 +205,11 @@ func TestPgCtldServiceStart_AsPrimaryCrashRecoveryMatrix(t *testing.T) {
 		// recovery runs (removing and recreating standby.signal) to reach the
 		// clean-shutdown state pg_rewind needs.
 		{name: "standby, allow crash recovery, suspected divergence", asPrimary: false, allowCrashRecovery: true, suspectedDivergence: true, wantStandbySignal: true, wantCrashRecoveryRan: true},
+		// Single-user recovery itself fails: Start logs the failure and proceeds
+		// best-effort (the normal start below can still bring postgres up), and the
+		// defer restores standby.signal. crashRecoveryRan is still reported true
+		// because the single-user step ran. Exercises the runCrashRecovery error branch.
+		{name: "standby, suspected divergence, single-user recovery fails", asPrimary: false, allowCrashRecovery: true, suspectedDivergence: true, singleUserRecoveryFails: true, wantStandbySignal: true, wantCrashRecoveryRan: true},
 		{name: "primary, no crash recovery", asPrimary: true, allowCrashRecovery: false, suspectedDivergence: false, wantStandbySignal: false, wantCrashRecoveryRan: false},
 		// Primary target: standby.signal is removed and single-user recovery never
 		// runs, even with suspected_divergence set (single-user is a standby-only
@@ -224,6 +230,13 @@ func TestPgCtldServiceStart_AsPrimaryCrashRecoveryMatrix(t *testing.T) {
 			// recovery (the default mock reports "shut down").
 			testutil.MockBinary(t, binDir, "pg_controldata",
 				`echo "Database cluster state:               in production"`)
+			// Optionally make single-user (`postgres --single`) crash recovery fail,
+			// to exercise Start's best-effort error path. pg_ctl start is a separate
+			// mock binary, so the normal start below still succeeds.
+			if tc.singleUserRecoveryFails {
+				testutil.MockBinary(t, binDir, "postgres",
+					`if [[ "$*" == *"--single"* ]]; then echo "mock single-user recovery failure" >&2; exit 1; fi; exit 0`)
+			}
 			t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 			// Initialized data dir, plus a pre-existing standby.signal so we can

--- a/go/pb/pgctldservice/pgctldservice.pb.go
+++ b/go/pb/pgctldservice/pgctldservice.pb.go
@@ -103,11 +103,12 @@ type StartRequest struct {
 	Port int32 `protobuf:"varint,1,opt,name=port,proto3" json:"port,omitempty"`
 	// Additional postgres command line arguments
 	ExtraArgs []string `protobuf:"bytes,2,rep,name=extra_args,json=extraArgs,proto3" json:"extra_args,omitempty"`
-	// When true and PostgreSQL is not cleanly shut down, run single-user crash
-	// recovery before starting. A standby.signal blocks single-user mode, so it is
-	// briefly removed for recovery and recreated afterwards. Callers that may be
-	// recovering a former primary (e.g. the postgres monitor) set this so the node
-	// reaches a clean state; the response reports whether recovery actually ran.
+	// When true and PostgreSQL is not cleanly shut down, allow crash recovery
+	// before starting. For a standby this forces single-user (`postgres --single`)
+	// recovery only when suspected_divergence is also set; otherwise the node is
+	// started normally and the postmaster performs standby-mode crash recovery
+	// (which follows timeline switches). The response reports whether single-user
+	// recovery actually ran.
 	AllowCrashRecovery bool `protobuf:"varint,3,opt,name=allow_crash_recovery,json=allowCrashRecovery,proto3" json:"allow_crash_recovery,omitempty"`
 	// Controls the start mode when the data directory already exists. Defaults to
 	// false, which writes standby.signal so PostgreSQL comes up in recovery
@@ -116,9 +117,18 @@ type StartRequest struct {
 	// pg_promote(). Set to true only for the rare case that intentionally needs a
 	// writable primary from the start (e.g. bootstrapping a brand-new shard),
 	// which removes standby.signal instead.
-	AsPrimary     bool `protobuf:"varint,4,opt,name=as_primary,json=asPrimary,proto3" json:"as_primary,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	AsPrimary bool `protobuf:"varint,4,opt,name=as_primary,json=asPrimary,proto3" json:"as_primary,omitempty"`
+	// When true, the caller suspects this node's WAL may have diverged from the
+	// current leader's timeline (e.g. a former primary being demoted, or a node
+	// already flagged for rewind). Combined with allow_crash_recovery, a
+	// not-cleanly-stopped standby is recovered via single-user mode to reach the
+	// clean-shutdown state pg_rewind requires. A clean follower must NOT set this:
+	// single-user recovery runs in primary mode and does not follow timeline
+	// history, so it would finalize the node on its old timeline past the leader's
+	// fork and wedge the standby start.
+	SuspectedDivergence bool `protobuf:"varint,5,opt,name=suspected_divergence,json=suspectedDivergence,proto3" json:"suspected_divergence,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *StartRequest) Reset() {
@@ -175,6 +185,13 @@ func (x *StartRequest) GetAllowCrashRecovery() bool {
 func (x *StartRequest) GetAsPrimary() bool {
 	if x != nil {
 		return x.AsPrimary
+	}
+	return false
+}
+
+func (x *StartRequest) GetSuspectedDivergence() bool {
+	if x != nil {
+		return x.SuspectedDivergence
 	}
 	return false
 }
@@ -1274,14 +1291,15 @@ var File_pgctldservice_proto protoreflect.FileDescriptor
 
 const file_pgctldservice_proto_rawDesc = "" +
 	"\n" +
-	"\x13pgctldservice.proto\x12\rpgctldservice\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x92\x01\n" +
+	"\x13pgctldservice.proto\x12\rpgctldservice\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc5\x01\n" +
 	"\fStartRequest\x12\x12\n" +
 	"\x04port\x18\x01 \x01(\x05R\x04port\x12\x1d\n" +
 	"\n" +
 	"extra_args\x18\x02 \x03(\tR\textraArgs\x120\n" +
 	"\x14allow_crash_recovery\x18\x03 \x01(\bR\x12allowCrashRecovery\x12\x1d\n" +
 	"\n" +
-	"as_primary\x18\x04 \x01(\bR\tasPrimary\"i\n" +
+	"as_primary\x18\x04 \x01(\bR\tasPrimary\x121\n" +
+	"\x14suspected_divergence\x18\x05 \x01(\bR\x13suspectedDivergence\"i\n" +
 	"\rStartResponse\x12\x10\n" +
 	"\x03pid\x18\x01 \x01(\x05R\x03pid\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12,\n" +

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -1203,11 +1203,18 @@ func (pm *MultipoolerManager) startPostgres(ctx context.Context) error {
 		}
 	}
 
-	// Allow crash recovery: a standby that was not cleanly shut down can't be
-	// started as a standby (postgres --single, which pgctld uses to crash-recover,
-	// refuses to run with a standby.signal present), so pgctld forces single-user
-	// crash recovery first when needed.
-	resp, err := pm.pgctldClient.Start(ctx, &pgctldpb.StartRequest{AllowCrashRecovery: true})
+	// Recover and start via pgctld. AllowCrashRecovery lets pgctld recover a node
+	// that was not cleanly shut down. SuspectedDivergence tells pgctld whether this
+	// node may have diverged from the leader's timeline: only then does it force
+	// single-user (postgres --single) recovery for a standby, to reach the clean
+	// state pg_rewind needs. A clean follower (SuspectedDivergence false) is left to
+	// the postmaster's own standby-mode crash recovery, which follows the timeline
+	// switch — forcing single-user recovery on it would finalize it on the old
+	// timeline and wedge the start on a timeline mismatch.
+	resp, err := pm.pgctldClient.Start(ctx, &pgctldpb.StartRequest{
+		AllowCrashRecovery:  true,
+		SuspectedDivergence: pm.consensusMgr.SuspectedDivergence(),
+	})
 	if err != nil {
 		return fmt.Errorf("MonitorPostgres: failed to start PostgreSQL: %w", err)
 	}

--- a/go/test/endtoend/multiorch/standby_crash_recovery_test.go
+++ b/go/test/endtoend/multiorch/standby_crash_recovery_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiorch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+	"github.com/multigres/multigres/go/tools/testtiming"
+
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+)
+
+// TestStandbyRecoversAfterPostmasterKill verifies that a crashed standby is
+// brought back automatically instead of getting wedged in a restart loop.
+//
+// A healthy, caught-up standby whose postmaster is SIGKILLed must be brought
+// back automatically by the pooler's postgres monitor. Before the fix it was
+// not: pgctld's crash-recovery path ran single-user (`postgres --single`)
+// recovery unconditionally for any not-cleanly-stopped standby. Single-user
+// recovery runs in primary mode and does not follow timeline-history switches,
+// so it finalized the standby on its old timeline past the leader's fork point;
+// the ensuing standby start then FATAL-looped "requested timeline N is not a
+// child of this server's history", and the monitor retried it forever while the
+// pod kept reporting Ready.
+//
+// The test establishes that the standby is genuinely non-diverged before the
+// kill (its replay has caught up to a fixed post-fork primary position on the
+// current timeline, and its walreceiver is streaming), so the only correct
+// outcome is that ordinary standby-mode crash recovery brings it back.
+//
+// The primary analog — SIGKILL the primary's postmaster and assert the monitor
+// auto-restarts it — is TestPostgresMonitorControl in
+// go/test/endtoend/multipooler/postgres_monitor_test.go.
+func TestStandbyRecoversAfterPostmasterKill(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping end-to-end test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("Skipping end-to-end test (short mode or no postgres binaries)")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2), // primary + 1 standby
+		shardsetup.WithMultiorchCount(1),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+	)
+	defer cleanup()
+
+	// A live multiorch watches the shard, as in production.
+	setup.StartMultiorchs(t.Context(), t)
+	setup.WaitForHealthStreamsEstablished(t, "multiorch", 60*time.Second)
+
+	primary := setup.GetPrimary(t)
+	standby := setup.GetStandbys()[0]
+	t.Logf("primary=%s standby=%s", primary.Name, standby.Name)
+
+	primaryClient, err := shardsetup.NewMultipoolerClient(primary.Multipooler.GrpcPort)
+	require.NoError(t, err, "connect to primary")
+	defer primaryClient.Close()
+	standbyClient, err := shardsetup.NewMultipoolerClient(standby.Multipooler.GrpcPort)
+	require.NoError(t, err, "connect to standby")
+	defer standbyClient.Close()
+
+	// Generate WAL on the primary, past the timeline fork.
+	generateCtx := utils.WithTimeout(t, 10*time.Second)
+	_, err = primaryClient.Pooler.ExecuteQuery(generateCtx, "CREATE TABLE IF NOT EXISTS crash_recovery_probe(id int)", 0)
+	require.NoError(t, err, "create probe table")
+	_, err = primaryClient.Pooler.ExecuteQuery(generateCtx, "INSERT INTO crash_recovery_probe SELECT generate_series(1,1000)", 0)
+	require.NoError(t, err, "insert probe rows")
+
+	// Pin the primary's current WAL position (from its Status, no raw SQL) and wait
+	// for the standby to replay up to it via the WaitForLSN RPC. Reaching a
+	// post-fork position on the current timeline is only possible if the standby
+	// followed the switch cleanly — i.e. it is not timeline-diverged.
+	primaryStatus, err := primaryClient.Manager.Status(utils.WithShortDeadline(t), &multipoolermanagerdatapb.StatusRequest{})
+	require.NoError(t, err, "primary Status")
+	targetLSN := primaryStatus.GetStatus().GetPrimaryStatus().GetLsn()
+	require.NotEmpty(t, targetLSN, "primary should report a current WAL LSN")
+	t.Logf("waiting for standby to replay up to primary LSN %s", targetLSN)
+
+	_, err = standbyClient.Manager.WaitForLSN(utils.WithTimeout(t, 60*time.Second), &multipoolermanagerdatapb.WaitForLSNRequest{
+		TargetLsn: targetLSN,
+		Timeout:   durationpb.New(45 * time.Second),
+	})
+	require.NoError(t, err, "standby should replay up to primary LSN %s (cleanly following the current timeline)", targetLSN)
+
+	// Confirm the walreceiver is streaming — with the caught-up replay position
+	// this establishes a non-diverged standby on the current timeline.
+	status, err := standbyClient.Manager.Status(utils.WithShortDeadline(t), &multipoolermanagerdatapb.StatusRequest{})
+	require.NoError(t, err, "standby Status before kill")
+	require.True(t, status.GetStatus().GetPostgresReady(), "standby postgres should be ready before kill")
+	require.Equal(t, "streaming", status.GetStatus().GetReplicationStatus().GetWalReceiverStatus(),
+		"standby walreceiver should be streaming (non-diverged) before kill")
+
+	// SIGKILL the standby's postmaster (a real crash, bypassing clean shutdown).
+	setup.KillPostgres(t, standby.Name)
+	killedAt := time.Now()
+
+	// The pooler monitor must auto-restart postgres via ordinary standby-mode
+	// crash recovery. Record how long that takes so it lands in the e2e timing
+	// summary alongside bootstrap/recovery/failover.
+	restartLimit := utils.ScaleTimeout(60 * time.Second)
+	require.Eventually(t, func() bool {
+		status, err := standbyClient.Manager.Status(utils.WithShortDeadline(t), &multipoolermanagerdatapb.StatusRequest{})
+		return err == nil && status.GetStatus().GetPostgresReady()
+	}, restartLimit, 2*time.Second,
+		"SIGKILLed standby postmaster should be auto-restarted by the pooler monitor")
+
+	restartDuration := time.Since(killedAt)
+	testtiming.Record(t, "standby postgres restart after kill", restartDuration, restartLimit)
+	t.Logf("standby postgres recovered %s after SIGKILL", restartDuration.Round(time.Second))
+}

--- a/proto/pgctldservice.proto
+++ b/proto/pgctldservice.proto
@@ -67,11 +67,12 @@ message StartRequest {
   // Additional postgres command line arguments
   repeated string extra_args = 2;
 
-  // When true and PostgreSQL is not cleanly shut down, run single-user crash
-  // recovery before starting. A standby.signal blocks single-user mode, so it is
-  // briefly removed for recovery and recreated afterwards. Callers that may be
-  // recovering a former primary (e.g. the postgres monitor) set this so the node
-  // reaches a clean state; the response reports whether recovery actually ran.
+  // When true and PostgreSQL is not cleanly shut down, allow crash recovery
+  // before starting. For a standby this forces single-user (`postgres --single`)
+  // recovery only when suspected_divergence is also set; otherwise the node is
+  // started normally and the postmaster performs standby-mode crash recovery
+  // (which follows timeline switches). The response reports whether single-user
+  // recovery actually ran.
   bool allow_crash_recovery = 3;
 
   // Controls the start mode when the data directory already exists. Defaults to
@@ -82,6 +83,16 @@ message StartRequest {
   // writable primary from the start (e.g. bootstrapping a brand-new shard),
   // which removes standby.signal instead.
   bool as_primary = 4;
+
+  // When true, the caller suspects this node's WAL may have diverged from the
+  // current leader's timeline (e.g. a former primary being demoted, or a node
+  // already flagged for rewind). Combined with allow_crash_recovery, a
+  // not-cleanly-stopped standby is recovered via single-user mode to reach the
+  // clean-shutdown state pg_rewind requires. A clean follower must NOT set this:
+  // single-user recovery runs in primary mode and does not follow timeline
+  // history, so it would finalize the node on its old timeline past the leader's
+  // fork and wedge the standby start.
+  bool suspected_divergence = 5;
 }
 
 message StartResponse {


### PR DESCRIPTION
## Summary

pgctld's crash-recovery path ran single-user (`postgres --single`) recovery for **any** not-cleanly-stopped standby. Single-user recovery runs in primary mode and does not follow timeline-history switches, so for a healthy standby that had followed a leader's timeline switch it advanced the checkpoint on the node's **old** timeline, past the point where the leader's timeline forked. The subsequent standby start then FATAL-looped `requested timeline N is not a child of this server's history`, and the pooler monitor retried it every few seconds forever while the pod kept reporting Ready.

This PR scopes the single-user step to nodes that may actually have diverged, and lets a clean follower recover through ordinary standby-mode crash recovery (which follows the timeline switch).

Part of [MUL-1009](https://linear.app/supabase/issue/MUL-1009) — linked intentionally *without* a closing keyword, because this PR does not fully resolve the issue on its own. It restores automatic recovery of a crashed standby, but closing MUL-1009 also needs the readiness gap fixed so a postmaster-dead pod is marked NotReady (see follow-ups). The issue should stay open until that lands.

## Problem (before)

**Why pgctld runs single-user recovery at all:** it is how a node reaches a *clean shutdown*, which is the state `pg_rewind` requires. It was introduced for the demote path (a SIGKILLed former primary that must be rewound onto the new leader's timeline) and later reused to rescue a standby wedged by an earlier `pg_rewind` that stamped `minRecoveryPoint` onto the wrong timeline. In both cases the node has genuinely diverged and needs a rewind, and single-user recovery is the prerequisite for it — a standby-only concern, so the step is gated on `standby.signal` (`postgres --single` refuses to run with it present, hence the remove/recreate).

**The bug** is that `Start(allow_crash_recovery)` applied that step to **every** not-cleanly-stopped standby. The crashed node here is a **clean follower**: its WAL is a clean descendant of the current leader's timeline, with nothing un-replicated. It needs nothing more than ordinary standby-mode crash recovery. Instead, pgctld force-runs single-user recovery, which strips `standby.signal`, recovers **in primary mode on the node's old timeline**, and recreates `standby.signal`. The node can then never start as a standby of the current timeline:

```mermaid
sequenceDiagram
    participant PG as postmaster
    participant Mon as pooler monitor
    participant Ctl as pgctld
    Note over PG: crash / SIGKILL of a healthy streaming standby
    Note over PG: local WAL is a clean descendant of the leader timeline (no real divergence)
    loop every few seconds, forever
        Mon->>Ctl: Start(allow_crash_recovery)
        Ctl->>Ctl: remove standby.signal
        Ctl->>PG: postgres --single (primary-mode recovery)
        PG-->>Ctl: clean shutdown on OLD timeline, checkpoint now past the fork
        Ctl->>Ctl: recreate standby.signal
        Ctl->>PG: start as standby
        PG-->>Ctl: FATAL requested timeline N is not a child
        Ctl-->>Mon: error, postgres still down
    end
    Note over Mon,Ctl: pod keeps reporting Ready, multiorch loops fix-replication
```

The pod stays `Ready` throughout (readiness does not cover the postmaster), and multiorch spins its fix-replication action about once per second because it can't reach the dead postgres to verify replication status.

### Where does the divergence come from?

It is generated by single-user recovery itself — nothing foreign is received. `postgres --single` (with `standby.signal` removed) does plain crash recovery on the node's **own** timeline and does not follow the timeline-history switch. It replays the old timeline to its end and then, on its clean exit, writes a brand-new `CHECKPOINT_SHUTDOWN` onto that old timeline — past the point where the leader's timeline forked. `pg_waldump` of a wedged node makes it concrete. Past the fork (`0/5000000`) the old timeline TL1 carries exactly two records, both written by the `--single` run:

```
0/05000028  CHECKPOINT_SHUTDOWN  tli 1      # the real end of TL1, at the fork
0/050000A0  SWITCH                          # written by --single
0/06000028  CHECKPOINT_SHUTDOWN  tli 1      # written by --single; pg_control now points here
```

while the timeline the standby should follow forks cleanly at the same LSN and continues with the real data:

```
0/05000028  END_OF_RECOVERY   tli 2; prev tli 1   # TL2 branches here
0/050000B8  CHECKPOINT_ONLINE tli 2 ...            # real WAL continues on TL2
```

So `pg_control`'s latest checkpoint ends up at `0/6000028` on TL1, beyond where TL2 forked (`0/5000000`). A later standby start asked to follow TL2 finds the node's own history already extends past the TL2 fork point, hence "requested timeline 2 is not a child of this server's history." Without the `--single` step, standby-mode recovery replays TL1 only up to `0/5000000`, reads the TL2 history, switches, and follows TL2 — the node never writes anything onto TL1, so there is no divergence.

### Why not just pg_rewind it?

Because **there is nothing to rewind** — the divergence is self-inflicted. Before the crash the standby held only WAL from the leader's timeline; standby-mode crash recovery would replay it, read the timeline-history file, follow the switch, and resume streaming in a couple of seconds. The `--single` step is what *creates* the divergence (primary-mode replay advances the checkpoint past the fork on the abandoned timeline), so "just rewind it" would only repair damage pgctld itself caused. The correct fix is to not cause it.

`pg_rewind` is the right tool for a node that genuinely diverged — a former primary with un-replicated WAL past the fork — and that path is preserved (see below); it is also strictly heavier (it needs the leader reachable and rewind-ready and adds downtime), so using it to undo self-inflicted damage on a clean follower is the wrong trade even where it would work.

## Fix (after)

`StartRequest` gains a `suspected_divergence` signal. pgctld runs single-user recovery for a standby only when the caller sets it — i.e. a node that may genuinely have diverged (a former primary being demoted, or one already flagged for rewind), for which single-user recovery is the correct way to reach the clean-shutdown state `pg_rewind` needs. A clean follower is left to the postmaster's own standby-mode crash recovery, which follows the timeline switch and resumes streaming — no rewind required. The postgres monitor passes `SuspectedDivergence` from consensus.

```mermaid
sequenceDiagram
    participant PG as postmaster
    participant Mon as pooler monitor
    participant Ctl as pgctld
    Note over PG: crash / SIGKILL of a healthy streaming standby
    Mon->>Ctl: Start(allow_crash_recovery, suspected_divergence=false)
    Note over Ctl: clean follower, skip single-user recovery
    Ctl->>PG: start as standby (standby.signal kept)
    PG->>PG: standby-mode crash recovery, follows the timeline switch
    PG-->>Ctl: reached consistency, streaming from leader (no rewind needed)
    Ctl-->>Mon: started
    Note over Mon: postgres Ready within seconds
```

A genuinely-diverged node (`suspected_divergence=true`, set by the demote/rewind paths) still takes the `--single` route to reach a clean shutdown and is then rewound against the leader — unchanged by this PR.

## Testing

- New end-to-end regression test `TestStandbyRecoversAfterPostmasterKill` (`go/test/endtoend/multiorch`): brings a standby to a provably non-diverged, caught-up, streaming state, SIGKILLs its postmaster, and asserts the monitor auto-restarts it. It fails on the pre-fix code (standby stays down for the full window) and passes after the fix (recovers in a few seconds). Restart latency is recorded in the e2e timing summary.
- Its primary analog, `TestPostgresMonitorControl`, already covers the primary case.
- `TestPgCtldServiceStart_AsPrimaryCrashRecoveryMatrix` is extended with a `suspected_divergence` dimension: a clean follower with `allow_crash_recovery` no longer runs single-user recovery, while a suspected-diverged standby still does.
- No regression: `TestDemoteStalePrimary_SIGKILL` / `_GracefulShutdown` confirm the single-user + `pg_rewind` path for a genuinely-diverged former primary still works; `TestPgRewind_AfterCrash*` and the manager/pgctld unit suites are green.

## Behavior on a genuinely-diverged (unflagged) standby

A SIGKILLed standby that is *not* a clean follower — it durably flushed WAL past the fork on the old timeline (e.g. a phantom transaction from a sync-replication ack the old primary later lost) and consensus did not flag it — is handled **fail-safe**, not silently. Standby-mode recovery replays the local WAL and then postgres's own timeline check refuses to attach to the leader's timeline (`requested timeline N is not a child`), so the node stays **down**: it never comes up serving divergent data, never promotes, never corrupts. It simply does not *auto-recover* in this PR (the monitor retries the start). This is not a regression — the old unconditional `--single` also wedged this case (it clean-shut the node past the fork, so the standby start still FATAL-looped). Auto-healing it is the follow-up below.

Note the recovery contract is unchanged for the common torn-tail case: a partial final WAL record from the crash is discarded by ordinary crash recovery (records are length- and CRC-checked), which is not divergence.

## Follow-ups (not in this PR)

- **Escalate genuine divergence to pg_rewind**: when a clean-follower standby start FATALs with a timeline `not a child` error, treat it as suspected divergence and route through `--single` + `pg_rewind` — so the rare unflagged-diverged case (above) self-heals instead of retrying. The standby-mode start is a reliable, non-destructive detector for this.
- **Readiness gap**: a postgres-dead pod still reports Ready. Wiring postmaster liveness into multipooler readiness so the pod goes NotReady is a separate change.
- **multiorch escalation**: the fix-replication action retries without escalating. With this fix the pooler self-heals in the common case, so the loop clears on its own, but bounding/escalating the retry deserves its own follow-up.
