### PR TITLE
feat(multipooler): report NotReady when postgres is not accepting

### DIFF
--- a/demo/k8s/k8s-multipooler-statefulset.yaml
+++ b/demo/k8s/k8s-multipooler-statefulset.yaml
@@ -141,6 +141,18 @@ spec:
               port: 16000
             initialDelaySeconds: 10
             periodSeconds: 10
+          # Readiness reflects whether this pod's PostgreSQL is accepting
+          # connections. A dead or FATAL-looping postmaster makes /ready return
+          # 503 so the pod goes NotReady and a wedged/down node is visible to
+          # operators (MUL-1009). This only affects Service endpoint membership
+          # and rollout gating; query routing and failover run off the health
+          # stream + topology, not this probe.
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 16000
+            initialDelaySeconds: 5
+            periodSeconds: 5
           volumeMounts:
             # We use the subPathExpr to ensure that each pod
             # gets its own subdirectory.

--- a/go/services/multipooler/init.go
+++ b/go/services/multipooler/init.go
@@ -191,6 +191,7 @@ func NewMultipooler(telemetry *telemetry.Telemetry) *Multipooler {
 			Links: []Link{
 				{"Config", "Server configuration details", "/config"},
 				{"Live", "URL for liveness check", "/live"},
+				{"Ready", "URL for readiness check", "/ready"},
 			},
 		},
 	}
@@ -413,6 +414,25 @@ func (mp *Multipooler) Init(startCtx context.Context) error {
 	grpcpoolerservice.RegisterPoolerServices(mp.senv, mp.grpcServer)
 
 	mp.senv.HTTPHandleFunc("/", mp.handleIndex)
+
+	// Register the /ready probe: the pod is ready only while PostgreSQL is
+	// accepting connections. A dead or FATAL-looping postmaster (e.g. a
+	// genuinely diverged standby that fails safe by staying down) makes /ready
+	// return 503 so Kubernetes marks the pod NotReady and the wedged node is
+	// visible to operators (MUL-1009). This gates only k8s endpoint membership
+	// and rollout — query routing and failover are driven by the health stream
+	// and topology, not this probe — so a primary briefly flapping NotReady
+	// during a legitimate postgres restart never triggers failover or eviction.
+	// Replication health is intentionally excluded, mirroring pgctld's /ready.
+	readyPGSocketFile := mp.socketFilePath.Get()
+	readyPGHost := mp.senv.GetHostname()
+	readyPGPort := mp.pgPort.Get()
+	mp.senv.RegisterReadyCheck(func() error {
+		if !postgresAccepting(readyPGSocketFile, readyPGHost, readyPGPort) {
+			return errors.New("postgres not accepting connections")
+		}
+		return nil
+	})
 
 	// Kick off the pooler's topology lifecycle once the server starts.
 	// Initial registration (with retry + alarm), the eventually-consistent

--- a/go/services/multipooler/ready.go
+++ b/go/services/multipooler/ready.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multipooler
+
+import (
+	"net"
+	"strconv"
+
+	"github.com/multigres/multigres/go/common/timeouts"
+)
+
+// postgresAccepting reports whether PostgreSQL is currently accepting
+// connections on the multipooler's configured leg to postgres: the Unix socket
+// when socketFile is set, otherwise a TCP dial to host:port (matching how
+// init.go chooses the postgres address). A successful dial means the postmaster
+// handed off to a listener, distinguishing a live server from a dead or
+// FATAL-looping one that left a stale socket file behind (by a crash, for
+// example). Any dial error (ENOENT, ECONNREFUSED, timeout, ...) returns false.
+//
+// This mirrors pgctld's readiness dial (go/cmd/pgctld/command/ready.go); the
+// two are intentionally kept as small, self-contained probes rather than a
+// shared dependency.
+func postgresAccepting(socketFile, host string, port int) bool {
+	network, address := "unix", socketFile
+	if socketFile == "" {
+		// TCP fallback. A wildcard/empty host is dialed as "localhost" so the
+		// resolver picks a working loopback address on IPv4-only, IPv6-only, and
+		// dual-stack hosts.
+		if host == "" || host == "0.0.0.0" || host == "::" {
+			host = "localhost"
+		}
+		network = "tcp"
+		address = net.JoinHostPort(host, strconv.Itoa(port))
+	}
+	conn, err := net.DialTimeout(network, address, timeouts.ReadyDialTimeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}

--- a/go/services/multipooler/ready_test.go
+++ b/go/services/multipooler/ready_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multipooler
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// shortTempDir returns a tmp dir under /tmp rather than t.TempDir() to keep
+// Unix socket paths within sun_path's 104-byte limit on macOS.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "p")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// listenUnix starts a Unix socket listener at path and registers cleanup.
+func listenUnix(t *testing.T, path string) string {
+	t.Helper()
+	require.LessOrEqualf(t, len(path), 104, "unix socket path exceeds sun_path limit: %s", path)
+	l, err := net.Listen("unix", path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.Close() })
+	return path
+}
+
+// listenTCP starts a TCP listener on the given host:0 and returns the assigned
+// port. t.Skip()s if the host can't be bound (e.g. "::1" on an IPv4-only CI
+// runner) so these tests don't flake by environment.
+func listenTCP(t *testing.T, host string) int {
+	t.Helper()
+	l, err := net.Listen("tcp", net.JoinHostPort(host, "0"))
+	if err != nil {
+		t.Skipf("cannot listen on %s: %v", host, err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// closedTCPPort returns a port that was briefly bound and then closed, so
+// nothing is listening on it. Useful for "not accepting" assertions.
+func closedTCPPort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
+}
+
+func TestPostgresAccepting(t *testing.T) {
+	t.Run("live unix socket returns true", func(t *testing.T) {
+		dir := shortTempDir(t)
+		sock := listenUnix(t, filepath.Join(dir, "pg.sock"))
+		// host/port are ignored when a socket file is configured.
+		assert.True(t, postgresAccepting(sock, "", closedTCPPort(t)))
+	})
+
+	t.Run("missing unix socket returns false", func(t *testing.T) {
+		dir := shortTempDir(t)
+		assert.False(t, postgresAccepting(filepath.Join(dir, "missing.sock"), "", 0))
+	})
+
+	t.Run("stale socket file returns false", func(t *testing.T) {
+		dir := shortTempDir(t)
+		path := filepath.Join(dir, "stale.sock")
+		require.NoError(t, os.WriteFile(path, nil, 0o600))
+		assert.False(t, postgresAccepting(path, "", 0))
+	})
+
+	t.Run("tcp fallback when no socket", func(t *testing.T) {
+		port := listenTCP(t, "127.0.0.1")
+		assert.True(t, postgresAccepting("", "127.0.0.1", port))
+	})
+
+	t.Run("tcp wildcard host dials localhost", func(t *testing.T) {
+		port := listenTCP(t, "127.0.0.1")
+		assert.True(t, postgresAccepting("", "", port))
+		assert.True(t, postgresAccepting("", "0.0.0.0", port))
+	})
+
+	t.Run("tcp not listening returns false", func(t *testing.T) {
+		port := closedTCPPort(t)
+		assert.False(t, postgresAccepting("", "127.0.0.1", port))
+	})
+}

--- a/go/test/endtoend/multipooler/readiness_test.go
+++ b/go/test/endtoend/multipooler/readiness_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multipooler
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/utils"
+
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+)
+
+// readyStatusCode issues a GET against the multipooler's /ready endpoint and
+// returns the HTTP status code, or 0 if the request could not be made.
+func readyStatusCode(t *testing.T, httpPort int) int {
+	t.Helper()
+	url := fmt.Sprintf("http://localhost:%d/ready", httpPort)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Logf("GET %s failed: %v", url, err)
+		return 0
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// TestMultipoolerReadinessReflectsPostmaster verifies the MUL-1009 readiness
+// gap fix: when this pod's PostgreSQL postmaster is dead, the multipooler's
+// HTTP /ready endpoint returns 503 (so Kubernetes marks the pod NotReady)
+// instead of the previous always-200 behavior that hid a crashed/down node.
+// It then confirms /ready recovers to 200 once postgres is back.
+func TestMultipoolerReadinessReflectsPostmaster(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("skipping: PostgreSQL binaries not found")
+	}
+
+	setup := getSharedTestSetup(t)
+	setupPoolerTest(t, setup)
+
+	waitForManagerReady(t, setup, setup.PrimaryMultipooler)
+	httpPort := setup.PrimaryMultipooler.HttpPort
+	require.NotZero(t, httpPort, "primary multipooler HTTP port should be set")
+
+	primaryClient := setup.NewPrimaryClient(t)
+	defer primaryClient.Close()
+
+	// Baseline: a healthy pooler with postgres accepting connections is ready.
+	require.Eventually(t, func() bool {
+		return readyStatusCode(t, httpPort) == http.StatusOK
+	}, 30*time.Second, 500*time.Millisecond, "/ready should return 200 while postgres is healthy")
+
+	// Hold postgres down by disabling the monitor's auto-restart before killing
+	// it, so we can observe the NotReady window deterministically. The deferred
+	// re-enable is a best-effort safety net for the shared fixture in case an
+	// assertion below fails early; the happy path re-enables inline and then
+	// asserts recovery.
+	restartsReEnabled := false
+	reEnableRestarts := func() {
+		if restartsReEnabled {
+			return
+		}
+		ctx := utils.WithShortDeadline(t)
+		if _, err := primaryClient.Manager.SetPostgresRestartsEnabled(ctx,
+			&multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest{Enabled: true}); err != nil {
+			t.Logf("failed to re-enable postgres restarts: %v", err)
+			return
+		}
+		restartsReEnabled = true
+	}
+	defer reEnableRestarts()
+
+	disableCtx := utils.WithShortDeadline(t)
+	_, err := primaryClient.Manager.SetPostgresRestartsEnabled(disableCtx,
+		&multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest{Enabled: false})
+	require.NoError(t, err, "should disable postgres restarts")
+
+	t.Logf("Killing postgres on primary node %s", setup.PrimaryName)
+	setup.KillPostgres(t, setup.PrimaryName)
+
+	// With the postmaster dead, /ready must flip to 503.
+	require.Eventually(t, func() bool {
+		return readyStatusCode(t, httpPort) == http.StatusServiceUnavailable
+	}, 30*time.Second, 500*time.Millisecond, "/ready should return 503 once the postmaster is dead")
+
+	// Re-enable auto-restart; the monitor brings postgres back (crash recovery
+	// for the SIGKILLed primary) and /ready recovers to 200.
+	reEnableRestarts()
+	require.True(t, restartsReEnabled, "postgres restarts should have been re-enabled")
+
+	require.Eventually(t, func() bool {
+		return readyStatusCode(t, httpPort) == http.StatusOK
+	}, 60*time.Second, 500*time.Millisecond, "/ready should return 200 again after postgres recovers")
+
+	// Sanity: the manager also reports postgres as ready again.
+	require.Eventually(t, func() bool {
+		ctx := utils.WithShortDeadline(t)
+		status, err := primaryClient.Manager.Status(ctx, &multipoolermanagerdatapb.StatusRequest{})
+		if err != nil {
+			return false
+		}
+		return status.GetStatus().GetPostgresReady()
+	}, 30*time.Second, 500*time.Millisecond, "manager should report postgres ready after recovery")
+
+	assert.Equal(t, http.StatusOK, readyStatusCode(t, httpPort), "/ready should be 200 at test end")
+}

--- a/go/test/endtoend/multipooler/readiness_test.go
+++ b/go/test/endtoend/multipooler/readiness_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
 	"github.com/multigres/multigres/go/test/utils"
 
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
@@ -49,6 +49,10 @@ func readyStatusCode(t *testing.T, httpPort int) int {
 // HTTP /ready endpoint returns 503 (so Kubernetes marks the pod NotReady)
 // instead of the previous always-200 behavior that hid a crashed/down node.
 // It then confirms /ready recovers to 200 once postgres is back.
+//
+// Uses an isolated single-node shard rather than the shared fixture: killing a
+// postmaster is destructive, and a single node with no peer and no live
+// multiorch cannot trigger a failover, so the kill can't poison other tests.
 func TestMultipoolerReadinessReflectsPostmaster(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping end-to-end tests in short mode")
@@ -57,48 +61,44 @@ func TestMultipoolerReadinessReflectsPostmaster(t *testing.T) {
 		t.Skip("skipping: PostgreSQL binaries not found")
 	}
 
-	setup := getSharedTestSetup(t)
-	setupPoolerTest(t, setup)
+	// Single pooler, no multiorch. Deferred start so the pooler self-bootstraps
+	// into a serving primary via its monitor loop once we start it.
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(1),
+		shardsetup.WithDeferredMultipoolerStart(),
+	)
+	defer cleanup()
 
-	waitForManagerReady(t, setup, setup.PrimaryMultipooler)
-	httpPort := setup.PrimaryMultipooler.HttpPort
-	require.NotZero(t, httpPort, "primary multipooler HTTP port should be set")
+	require.Len(t, setup.Multipoolers, 1)
+	var inst *shardsetup.MultipoolerInstance
+	for _, v := range setup.Multipoolers {
+		inst = v
+	}
 
-	primaryClient := setup.NewPrimaryClient(t)
-	defer primaryClient.Close()
+	require.NoError(t, inst.Multipooler.Start(t.Context(), t))
+	shardsetup.WaitForManagerReady(t, inst.Multipooler)
 
-	// Baseline: a healthy pooler with postgres accepting connections is ready.
+	httpPort := inst.Multipooler.HttpPort
+	require.NotZero(t, httpPort, "multipooler HTTP port should be set")
+
+	client, err := shardsetup.NewMultipoolerClient(inst.Multipooler.GrpcPort)
+	require.NoError(t, err)
+	defer client.Close()
+
+	// Baseline: once postgres has self-bootstrapped and is accepting, /ready is 200.
 	require.Eventually(t, func() bool {
 		return readyStatusCode(t, httpPort) == http.StatusOK
-	}, 30*time.Second, 500*time.Millisecond, "/ready should return 200 while postgres is healthy")
+	}, 90*time.Second, 1*time.Second, "/ready should return 200 once postgres is up")
 
 	// Hold postgres down by disabling the monitor's auto-restart before killing
-	// it, so we can observe the NotReady window deterministically. The deferred
-	// re-enable is a best-effort safety net for the shared fixture in case an
-	// assertion below fails early; the happy path re-enables inline and then
-	// asserts recovery.
-	restartsReEnabled := false
-	reEnableRestarts := func() {
-		if restartsReEnabled {
-			return
-		}
-		ctx := utils.WithShortDeadline(t)
-		if _, err := primaryClient.Manager.SetPostgresRestartsEnabled(ctx,
-			&multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest{Enabled: true}); err != nil {
-			t.Logf("failed to re-enable postgres restarts: %v", err)
-			return
-		}
-		restartsReEnabled = true
-	}
-	defer reEnableRestarts()
-
+	// it, so the NotReady window is observable deterministically.
 	disableCtx := utils.WithShortDeadline(t)
-	_, err := primaryClient.Manager.SetPostgresRestartsEnabled(disableCtx,
+	_, err = client.Manager.SetPostgresRestartsEnabled(disableCtx,
 		&multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest{Enabled: false})
 	require.NoError(t, err, "should disable postgres restarts")
 
-	t.Logf("Killing postgres on primary node %s", setup.PrimaryName)
-	setup.KillPostgres(t, setup.PrimaryName)
+	t.Logf("Killing postgres on %s", inst.Name)
+	setup.KillPostgres(t, inst.Name)
 
 	// With the postmaster dead, /ready must flip to 503.
 	require.Eventually(t, func() bool {
@@ -106,23 +106,13 @@ func TestMultipoolerReadinessReflectsPostmaster(t *testing.T) {
 	}, 30*time.Second, 500*time.Millisecond, "/ready should return 503 once the postmaster is dead")
 
 	// Re-enable auto-restart; the monitor brings postgres back (crash recovery
-	// for the SIGKILLed primary) and /ready recovers to 200.
-	reEnableRestarts()
-	require.True(t, restartsReEnabled, "postgres restarts should have been re-enabled")
+	// for the SIGKILLed node) and /ready recovers to 200.
+	enableCtx := utils.WithShortDeadline(t)
+	_, err = client.Manager.SetPostgresRestartsEnabled(enableCtx,
+		&multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest{Enabled: true})
+	require.NoError(t, err, "should re-enable postgres restarts")
 
 	require.Eventually(t, func() bool {
 		return readyStatusCode(t, httpPort) == http.StatusOK
 	}, 60*time.Second, 500*time.Millisecond, "/ready should return 200 again after postgres recovers")
-
-	// Sanity: the manager also reports postgres as ready again.
-	require.Eventually(t, func() bool {
-		ctx := utils.WithShortDeadline(t)
-		status, err := primaryClient.Manager.Status(ctx, &multipoolermanagerdatapb.StatusRequest{})
-		if err != nil {
-			return false
-		}
-		return status.GetStatus().GetPostgresReady()
-	}, 30*time.Second, 500*time.Millisecond, "manager should report postgres ready after recovery")
-
-	assert.Equal(t, http.StatusOK, readyStatusCode(t, httpPort), "/ready should be 200 at test end")
 }


### PR DESCRIPTION
Part of MUL-1009.

## Problem

The multipooler registered **zero** readiness checks, so its HTTP `/ready` always returned 200. A pod whose PostgreSQL postmaster is dead — a crashed or FATAL-looping standby — still reported Ready, hiding the down node from Kubernetes and operators.

## Change

Register a readiness check in the multipooler that dials its configured postgres leg (the Unix socket, or a TCP fallback matching how `init.go` selects the postgres address) and returns 503 when nothing is accepting. This mirrors pgctld's postmaster-aware `/ready` (`go/cmd/pgctld/command/ready.go`). A successful dial distinguishes a live postmaster from a dead one that left a stale socket file behind.

Also wires a `readinessProbe` onto the multipooler container in the demo StatefulSet so the pod actually flips to NotReady.

## Why this is safe for the PRIMARY case

Readiness gates only Kubernetes endpoint membership and rollout. Query routing and failover are driven by the health stream and topology, **not** the HTTP `/ready` probe (verified: nothing internal consumes the pooler's `/ready`). So a primary briefly flapping NotReady during a legitimate postgres restart does not trigger failover or eviction.

## Testing

- Unit: `TestPostgresAccepting` — live/missing/stale Unix socket, TCP fallback, wildcard host, closed port.
- E2E: `TestMultipoolerReadinessReflectsPostmaster` — baseline `/ready` 200 → SIGKILL the primary's postgres → `/ready` returns 503 → re-enable restarts → recovers to 200.

## Scope / follow-ups

- This makes the in-repo multipooler `/ready` honest and wires the **demo** probe. Production/staging pod readiness is defined by the operator, **outside this repo**; those pods won't flip to NotReady until the operator's multipooler `readinessProbe` points at `/ready` instead of `/live` (`/live` is hardcoded-OK). That operator change is tracked as the follow-up **MUL-240** — which is why this PR is **Part of MUL-1009** (non-closing) rather than a fix. MUL-1009 closes once this PR and MUL-240 are both deployed.
- Companion recovery-half PR #1357 (a clean follower whose postmaster is SIGKILLed auto-recovers via standby-mode crash recovery) is now merged.
- Out of scope: auto-escalating a genuinely-diverged standby to `pg_rewind` so it self-heals instead of FATAL-looping (separate, larger follow-up).
- The postgres socket-dial helper is deliberately self-contained (a small mirror of pgctld's), rather than a shared dependency; consolidating both into `go/tools/netutil` is a noted follow-up.
