### PR TITLE
chore(pgbackrest): default tls-server-address to ipv6

### DIFF
--- a/config/pgbackrest/pgbackrest_server_template.conf
+++ b/config/pgbackrest/pgbackrest_server_template.conf
@@ -4,7 +4,7 @@ lock-path={{.LockPath}}
 tls-server-cert-file={{.ServerCertFile}}
 tls-server-key-file={{.ServerKeyFile}}
 tls-server-ca-file={{.ServerCAFile}}
-tls-server-address=0.0.0.0
+tls-server-address=::
 tls-server-port={{.ServerPort}}
 tls-server-auth=pgbackrest=*
 

--- a/go/common/backup/serverconfig_test.go
+++ b/go/common/backup/serverconfig_test.go
@@ -51,7 +51,7 @@ func TestWriteServerConfig(t *testing.T) {
 	assert.Equal(t, "/certs/pgbackrest.crt", global.Key("tls-server-cert-file").String())
 	assert.Equal(t, "/certs/pgbackrest.key", global.Key("tls-server-key-file").String())
 	assert.Equal(t, "/certs/ca.crt", global.Key("tls-server-ca-file").String())
-	assert.Equal(t, "0.0.0.0", global.Key("tls-server-address").String())
+	assert.Equal(t, "::", global.Key("tls-server-address").String())
 	assert.Equal(t, "8443", global.Key("tls-server-port").String())
 	assert.Equal(t, "pgbackrest=*", global.Key("tls-server-auth").String())
 


### PR DESCRIPTION
## Summary
- pgbackrest server's `tls-server-address` defaulted to `0.0.0.0` (IPv4-only), but pods can be IPv6-only, TLS connections to the pgbackrest server (e.g. for pg2 standby backups) failed to bind/reach it.
- Default to `::` instead, which binds dual-stack on Linux.

## Test plan
- [x] `go test ./go/common/backup/...` passes with updated assertion
- [x] Live-verified on an EKS cluster: pods running with `::` accepted v6 connections.