### PR TITLE
build(docker): embed VCS metadata in release binaries

### DIFF
--- a/.github/workflows/docker-build-cluster.yml
+++ b/.github/workflows/docker-build-cluster.yml
@@ -87,6 +87,10 @@ jobs:
         id: goversion
         uses: ./.github/actions/go-version
 
+      - name: Read commit date
+        id: commitdate
+        run: echo "date=$(git show -s --format=%cI HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push cluster Docker image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
@@ -94,6 +98,8 @@ jobs:
           file: ./Dockerfile.cluster
           build-args: |
             GO_VERSION=${{ steps.goversion.outputs.version }}
+            GIT_COMMIT=${{ github.sha }}
+            COMMIT_DATE=${{ steps.commitdate.outputs.date }}
             ${{ matrix.extra_build_args }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-build-pgctld.yml
+++ b/.github/workflows/docker-build-pgctld.yml
@@ -66,6 +66,10 @@ jobs:
         id: goversion
         uses: ./.github/actions/go-version
 
+      - name: Read commit date
+        id: commitdate
+        run: echo "date=$(git show -s --format=%cI HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push pgctld Docker image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
@@ -73,6 +77,8 @@ jobs:
           file: ./Dockerfile.pgctld
           build-args: |
             GO_VERSION=${{ steps.goversion.outputs.version }}
+            GIT_COMMIT=${{ github.sha }}
+            COMMIT_DATE=${{ steps.commitdate.outputs.date }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -64,6 +64,10 @@ jobs:
         id: goversion
         uses: ./.github/actions/go-version
 
+      - name: Read commit date
+        id: commitdate
+        run: echo "date=$(git show -s --format=%cI HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
@@ -71,6 +75,8 @@ jobs:
           file: ./Dockerfile
           build-args: |
             GO_VERSION=${{ steps.goversion.outputs.version }}
+            GIT_COMMIT=${{ github.sha }}
+            COMMIT_DATE=${{ steps.commitdate.outputs.date }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -120,6 +120,7 @@ jobs:
           {
             echo "sha=$(git rev-parse --short HEAD)"
             echo "full_sha=$(git rev-parse HEAD)"
+            echo "commit_date=$(git show -s --format=%cI HEAD)"
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
@@ -208,10 +209,12 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
-          # GO_VERSION is unused by the Node-based multiadmin-web image (a
-          # harmless build-arg warning); the Go images pin their base to it.
+          # Build metadata args are unused by the Node-based multiadmin-web
+          # image (harmless warnings); the Go images embed them.
           build-args: |
             GO_VERSION=${{ steps.goversion.outputs.version }}
+            GIT_COMMIT=${{ steps.determine-sha.outputs.full_sha }}
+            COMMIT_DATE=${{ steps.determine-sha.outputs.commit_date }}
             ${{ matrix.extra_build_args }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,16 +159,22 @@ jobs:
         id: goversion
         uses: ./.github/actions/go-version
 
+      - name: Read commit date
+        id: commitdate
+        run: echo "date=$(git show -s --format=%cI HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Build release image
         id: build-release-image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
-          # GO_VERSION is unused by the Node-based multiadmin-web image (a
-          # harmless build-arg warning); the Go images pin their base to it.
+          # Build metadata args are unused by the Node-based multiadmin-web
+          # image (harmless warnings); the Go images embed them.
           build-args: |
             GO_VERSION=${{ steps.goversion.outputs.version }}
+            GIT_COMMIT=${{ github.sha }}
+            COMMIT_DATE=${{ steps.commitdate.outputs.date }}
           push: ${{ env.PUSH_IMAGE }}
           tags: ${{ env.IMAGE_REF }}:${{ env.RELEASE_TAG }}
           provenance: mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@
 ARG GO_VERSION=1.26
 FROM golang:${GO_VERSION}-alpine AS builder
 
+ARG GIT_COMMIT=unknown
+ARG COMMIT_DATE=unknown
+
 WORKDIR /src
 
 # Install build dependencies like git and make.
@@ -24,7 +27,7 @@ RUN go mod download
 
 # Copy source and build static binaries using Makefile
 COPY . .
-RUN make build-release
+RUN GIT_COMMIT="${GIT_COMMIT}" COMMIT_DATE="${COMMIT_DATE}" make build-release
 
 # =========================================================================
 # Stage 2: The Final Production Stage

--- a/Dockerfile.cluster
+++ b/Dockerfile.cluster
@@ -33,6 +33,9 @@ ARG POSTGRES_IMAGE=postgres:17.7
 ARG GO_VERSION=1.26
 FROM golang:${GO_VERSION}-alpine AS builder
 
+ARG GIT_COMMIT=unknown
+ARG COMMIT_DATE=unknown
+
 WORKDIR /src
 
 # Intentionally unpinned: the builder base (golang:1.25-alpine) is a rolling
@@ -46,7 +49,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN make build-release
+RUN GIT_COMMIT="${GIT_COMMIT}" COMMIT_DATE="${COMMIT_DATE}" make build-release
 
 # =========================================================================
 # Stage 2: Download and verify the etcd binaries

--- a/Dockerfile.pgctld
+++ b/Dockerfile.pgctld
@@ -8,6 +8,9 @@
 ARG GO_VERSION=1.26
 FROM golang:${GO_VERSION}-alpine AS builder
 
+ARG GIT_COMMIT=unknown
+ARG COMMIT_DATE=unknown
+
 WORKDIR /src
 
 # Intentionally unpinned: the builder base (golang:1.25-alpine) is a rolling
@@ -21,7 +24,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN make build-release
+RUN GIT_COMMIT="${GIT_COMMIT}" COMMIT_DATE="${COMMIT_DATE}" make build-release
 
 # =========================================================================
 # Stage 2: Final PostgreSQL + pgctld

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,13 @@ export PGPROTO_VER
 CMDS = multigateway multipooler pgctld multiorch multigres multiadmin portpoolserver
 BIN_DIR = bin
 
+GIT_COMMIT ?= unknown
+COMMIT_DATE ?= unknown
+SERVENV_PACKAGE = github.com/multigres/multigres/go/common/servenv
+RELEASE_LDFLAGS = -w -s \
+	-X $(SERVENV_PACKAGE).gitCommit=$(GIT_COMMIT) \
+	-X $(SERVENV_PACKAGE).commitDate=$(COMMIT_DATE)
+
 .PHONY: all build build-all clean images install test test-coverage pgregress pgregress-update-patches pgregress-update-patches-docker pgexternal pgexternal-update-patches pgproto pgproto-update-patches proto proto-ts tools parser metrics generate help
 
 ##@ General
@@ -141,7 +148,7 @@ build-release: ## Build Go binaries (release, static, stripped).
 	mkdir -p $(BIN_DIR)
 	@for cmd in $(CMDS); do \
 		echo "Building $$cmd (release)"; \
-		CGO_ENABLED=0 go build -ldflags="-w -s" -o $(BIN_DIR)/$$cmd ./go/cmd/$$cmd; \
+		CGO_ENABLED=0 go build -ldflags="$(RELEASE_LDFLAGS)" -o $(BIN_DIR)/$$cmd ./go/cmd/$$cmd; \
 	done
 
 # Build everything (proto + parser + binaries)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,14 @@ services:
         # which only works on the Debian base.
         POSTGRES_IMAGE: "${MULTIGRES_POSTGRES_IMAGE:-postgres:17.7}"
         PROVISION_PG_PACKAGES: "${MULTIGRES_PROVISION_PG_PACKAGES:-true}"
+        # VCS identity reported by `SELECT multigres.version()`. Compose can't
+        # run git itself, so export these to stamp a local build:
+        #   GIT_COMMIT=$(git rev-parse HEAD) \
+        #   COMMIT_DATE=$(git show -s --format=%cI HEAD) \
+        #   docker compose up --build
+        # Left unset, the image reports "(unknown revision)".
+        GIT_COMMIT: "${GIT_COMMIT:-unknown}"
+        COMMIT_DATE: "${COMMIT_DATE:-unknown}"
     image: multigres-cluster:local
     # Run a real init (tini) as PID 1 to reap the cluster's orphaned child
     # processes and forward signals to the entrypoint.

--- a/docs/query_serving/multigres_version.md
+++ b/docs/query_serving/multigres_version.md
@@ -94,12 +94,17 @@ a stable property of the commit.
 
 The **full** string (`servenv.AppVersion()`) prefixes that release version with
 the binary's VCS identity — revision, a `modified` marker for a dirty tree,
-commit date, and Go toolchain — read from `runtime/debug.BuildInfo`. This is the
-same build snapshot already used by the `/version` HTTP endpoint and the
-OpenTelemetry `service.version` attribute. Go does not embed VCS settings when
-building inside a linked git worktree, so worktree dev builds omit the VCS fields
-(`Multigres 0.1.0-SNAPSHOT (unknown revision) built with <go>`); normal checkouts
-and CI stamp them.
+commit date, and Go toolchain. This is the same build snapshot already used by
+the `/version` HTTP endpoint and the OpenTelemetry `service.version` attribute.
+The identity is read from `runtime/debug.BuildInfo` when Go could stamp it, with
+a linker-injected fallback for builds where it can't: Docker build contexts
+exclude `.git` (see `.dockerignore`), so the image workflows pass `GIT_COMMIT`
+and `COMMIT_DATE` build args that `make build-release` injects via `-ldflags`;
+native VCS settings take precedence when both are present. Builds with neither —
+a linked git worktree (where Go does not embed VCS settings), or a local
+`make images` / `docker compose` build without the args exported — omit the VCS
+fields (`Multigres 0.1.0-SNAPSHOT (unknown revision) built with <go>`); normal
+checkouts stamp them natively.
 
 ## Code organization
 

--- a/go/common/servenv/buildinfo.go
+++ b/go/common/servenv/buildinfo.go
@@ -23,8 +23,7 @@ import (
 )
 
 // buildSnapshot is the parsed, cached view of the binary's build identity,
-// derived from runtime/debug.BuildInfo. All fields may be empty if
-// -buildvcs was disabled at build time.
+// derived from runtime/debug.BuildInfo and linker-injected fallbacks.
 type buildSnapshot struct {
 	// revision is the VCS commit SHA (typically a 40-char git SHA).
 	revision string
@@ -46,6 +45,11 @@ type buildSnapshot struct {
 }
 
 var (
+	// Set by release builds through -ldflags. Go's native VCS settings take
+	// precedence when present.
+	gitCommit  string
+	commitDate string
+
 	buildSnapshotOnce sync.Once
 	buildSnapshotData buildSnapshot
 )
@@ -58,22 +62,32 @@ func readBuildSnapshot() buildSnapshot {
 }
 
 func loadBuildSnapshot() {
-	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		return
-	}
-	buildSnapshotData.goVersion = info.GoVersion
-	buildSnapshotData.mainPath = info.Main.Path
-	for _, s := range info.Settings {
-		switch s.Key {
-		case "vcs.revision":
-			buildSnapshotData.revision = s.Value
-		case "vcs.modified":
-			buildSnapshotData.modified = s.Value == "true"
-		case "vcs.time":
-			if t, err := time.Parse(time.RFC3339, s.Value); err == nil {
-				buildSnapshotData.commitTime = t
+	if info, ok := debug.ReadBuildInfo(); ok {
+		buildSnapshotData.goVersion = info.GoVersion
+		buildSnapshotData.mainPath = info.Main.Path
+		for _, s := range info.Settings {
+			switch s.Key {
+			case "vcs.revision":
+				buildSnapshotData.revision = s.Value
+			case "vcs.modified":
+				buildSnapshotData.modified = s.Value == "true"
+			case "vcs.time":
+				if t, err := time.Parse(time.RFC3339, s.Value); err == nil {
+					buildSnapshotData.commitTime = t
+				}
 			}
+		}
+	}
+	applyBuildFallbacks(&buildSnapshotData, gitCommit, commitDate)
+}
+
+func applyBuildFallbacks(snap *buildSnapshot, revision, date string) {
+	if snap.revision == "" && revision != "" && revision != "unknown" {
+		snap.revision = revision
+	}
+	if snap.commitTime.IsZero() {
+		if t, err := time.Parse(time.RFC3339, date); err == nil {
+			snap.commitTime = t
 		}
 	}
 }
@@ -90,9 +104,9 @@ func Version() string {
 // AppVersion returns a one-line, human-readable description of the running
 // binary's Multigres version, suitable for display to operators (e.g. via
 // `SHOW multigres.server_version` or a future --version flag) and for pasting into bug
-// reports. It is the release version plus the VCS identity the Go toolchain
-// embeds; VCS fields are omitted so it degrades gracefully on builds without VCS
-// stamping (e.g. inside a linked git worktree).
+// reports. It is the release version plus the VCS identity embedded at build
+// time; VCS fields are omitted so it degrades gracefully on builds without VCS
+// metadata (e.g. inside a linked git worktree without injected build args).
 func AppVersion() string {
 	return formatAppVersion(versionName, readBuildSnapshot())
 }

--- a/go/common/servenv/buildinfo_test.go
+++ b/go/common/servenv/buildinfo_test.go
@@ -38,6 +38,38 @@ func TestReadBuildSnapshot(t *testing.T) {
 	}
 }
 
+// TestApplyBuildFallbacks checks linker-injected metadata is used only when
+// Go's native VCS settings are absent.
+func TestApplyBuildFallbacks(t *testing.T) {
+	fallbackTime := time.Date(2026, 8, 5, 6, 8, 55, 0, time.UTC)
+	nativeTime := fallbackTime.Add(-time.Hour)
+
+	tests := []struct {
+		name string
+		snap buildSnapshot
+		want buildSnapshot
+	}{
+		{
+			name: "missing native VCS settings",
+			want: buildSnapshot{revision: "e481b99bde12b9600ee1e3134f108cb79826bc78", commitTime: fallbackTime},
+		},
+		{
+			name: "native VCS settings take precedence",
+			snap: buildSnapshot{revision: "native", commitTime: nativeTime},
+			want: buildSnapshot{revision: "native", commitTime: nativeTime},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applyBuildFallbacks(&tt.snap, "e481b99bde12b9600ee1e3134f108cb79826bc78", "2026-08-05T08:08:55+02:00")
+			if tt.snap.revision != tt.want.revision || !tt.snap.commitTime.Equal(tt.want.commitTime) {
+				t.Errorf("applyBuildFallbacks() = %+v, want revision %q and commit time %s", tt.snap, tt.want.revision, tt.want.commitTime)
+			}
+		})
+	}
+}
+
 // TestFormatAppVersion pins the string layout of the version reported by
 // `SHOW multigres.server_version` across the combinations of build fields that may be
 // present or absent.


### PR DESCRIPTION
## Summary

- Embed the commit SHA and commit date in Docker-built Go binaries without adding `.git` to the build context.
- Thread the metadata through the Makefile, all Go-building Dockerfiles, docker-compose, and the main, nightly, and release image workflows.
- Preserve Go's native VCS metadata when available and use linker-injected values only as fallbacks.

## Problem

Docker build contexts exclude `.git`, so Go cannot populate `vcs.revision` and `vcs.time`. Binaries in published images therefore report `(unknown revision)` from `SELECT multigres.version()`.

## Solution

Image workflows pass `GIT_COMMIT=${{ github.sha }}` (which always matches the checkout) and `COMMIT_DATE` (a one-line `git show -s --format=%cI HEAD` step) as build arguments. `make build-release` injects them with `-ldflags` into `servenv`, which uses them only when native Go VCS settings are absent.

The release version is deliberately **not** injected: `versionName` is a committed constant in the compiled source, so build-time injection could only ever duplicate it (`version.go` documents why the version is a property of the source tree, not the build).

`docker-compose.yml` gains `${GIT_COMMIT:-unknown}`-style passthrough args so local compose builds can be stamped by exporting the variables; unset, they degrade to `(unknown revision)` like other local builds. `docs/query_serving/multigres_version.md` is updated to describe the fallback mechanism.

GoReleaser artifacts are intentionally untouched: they build from a full checkout with `.git` present, so native VCS stamping already covers them (and carries the `modified` flag, which ldflags can't).

## Testing

- `go test ./go/common/servenv/` (includes new fallback-precedence coverage)
- `make build-release CMDS=multigateway GIT_COMMIT=<sentinel> COMMIT_DATE=<sentinel>` and verified both sentinel values are embedded in the binary — this catches a mistyped `-X` symbol, which would otherwise fail silently.