### PR TITLE
feat(multipooler,pgctld): base /ready on gRPC serving, not postgres

### DIFF
--- a/demo/k8s/k8s-multipooler-statefulset.yaml
+++ b/demo/k8s/k8s-multipooler-statefulset.yaml
@@ -141,6 +141,18 @@ spec:
               port: 16000
             initialDelaySeconds: 10
             periodSeconds: 10
+          # Readiness reflects only whether the multipooler's own gRPC control
+          # plane is serving — NOT postgres. A pooler whose postgres is down
+          # stays Ready so it keeps its Service endpoint/DNS and remains
+          # reachable for control RPCs and its health stream while its monitor
+          # brings postgres back. postgres liveness is signalled via the health
+          # stream, not this probe.
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 16000
+            initialDelaySeconds: 5
+            periodSeconds: 5
           volumeMounts:
             # We use the subPathExpr to ensure that each pod
             # gets its own subdirectory.

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -163,19 +163,12 @@ func (s *PgCtldServerCmd) runServer(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Register /ready probe: postgres socket accepting + gRPC accepting.
-	// Replication health is intentionally excluded (see pgctldReadyHandler).
-	pgSocketPath := filepath.Join(
-		pgctld.PostgresSocketDir(poolerDir),
-		fmt.Sprintf(".s.PGSQL.%d", s.pgCtlCmd.pgPort.Get()),
-	)
-	s.senv.RegisterReadyCheck(func() error {
-		if !unixSocketAccepting(pgSocketPath) {
-			return errors.New("postgres socket not accepting")
-		}
-		return nil
-	})
-
+	// Register /ready probe: ready iff the gRPC control plane is accepting
+	// connections. Postgres/replication health is intentionally excluded — a
+	// pod whose postgres is down must stay reachable and must NOT be pulled
+	// from Service endpoints / DNS, so operators and the control plane can
+	// still observe and drive it back to health. Postgres liveness is signalled
+	// out-of-band (health stream), not via this probe.
 	grpcSocketPath := s.grpcServer.SocketFile()
 	grpcBindAddress := s.grpcServer.BindAddress()
 	grpcPort := s.grpcServer.Port()
@@ -188,7 +181,8 @@ func (s *PgCtldServerCmd) runServer(cmd *cobra.Command, args []string) error {
 	})
 
 	s.senv.OnRun(func() {
-		logger.Info("pgctld server starting up",
+		logger.Info(
+			"pgctld server starting up",
 			"grpc_port", s.grpcServer.Port(),
 			"http_port", s.senv.GetHTTPPort(),
 		)

--- a/go/services/multipooler/init.go
+++ b/go/services/multipooler/init.go
@@ -191,6 +191,7 @@ func NewMultipooler(telemetry *telemetry.Telemetry) *Multipooler {
 			Links: []Link{
 				{"Config", "Server configuration details", "/config"},
 				{"Live", "URL for liveness check", "/live"},
+				{"Ready", "URL for readiness check", "/ready"},
 			},
 		},
 	}
@@ -413,6 +414,22 @@ func (mp *Multipooler) Init(startCtx context.Context) error {
 	grpcpoolerservice.RegisterPoolerServices(mp.senv, mp.grpcServer)
 
 	mp.senv.HTTPHandleFunc("/", mp.handleIndex)
+
+	// Register /ready probe: ready iff this pooler's own gRPC control plane is
+	// accepting connections. Postgres health is intentionally excluded — a
+	// pooler whose postgres is down must stay reachable (control RPCs, health
+	// stream) and must NOT be pulled from Service endpoints / DNS, so readiness
+	// reflects only whether the gRPC server is serving. Postgres liveness is
+	// signalled out-of-band via the health stream, not this probe.
+	grpcSocketPath := mp.grpcServer.SocketFile()
+	grpcBindAddress := mp.grpcServer.BindAddress()
+	grpcPort := mp.grpcServer.Port()
+	mp.senv.RegisterReadyCheck(func() error {
+		if !grpcAccepting(grpcSocketPath, grpcBindAddress, grpcPort) {
+			return errors.New("grpc not accepting")
+		}
+		return nil
+	})
 
 	// Kick off the pooler's topology lifecycle once the server starts.
 	// Initial registration (with retry + alarm), the eventually-consistent

--- a/go/services/multipooler/ready.go
+++ b/go/services/multipooler/ready.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multipooler
+
+import (
+	"net"
+	"strconv"
+
+	"github.com/multigres/multigres/go/common/timeouts"
+)
+
+// grpcAccepting verifies the gRPC server is accepting connections. Prefers the
+// Unix socket, and falls back to a TCP dial on the configured bind address when
+// only the port is configured. When neither is configured, gRPC is not in use
+// and the check is skipped.
+//
+// This mirrors pgctld's readiness dial (go/cmd/pgctld/command/ready.go); the
+// two are intentionally kept as small, self-contained probes rather than a
+// shared dependency (consolidating both into go/tools/netutil is a follow-up).
+func grpcAccepting(socketPath, bindAddress string, port int) bool {
+	if socketPath != "" {
+		return unixSocketAccepting(socketPath)
+	}
+	if port != 0 {
+		return tcpAccepting(bindAddress, port)
+	}
+	return true
+}
+
+// unixSocketAccepting returns true if a process is currently accepting
+// connections on the given Unix socket path. A successful Dial means the kernel
+// handed off to a listener, distinguishing a live listener from a stale socket
+// file left behind (by a crash, for example). Any dial error (e.g. ENOENT,
+// ECONNREFUSED, EACCES, timeout) returns false.
+func unixSocketAccepting(path string) bool {
+	conn, err := net.DialTimeout("unix", path, timeouts.ReadyDialTimeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// tcpAccepting returns true if a TCP listener is accepting on the given bind
+// address and port. A wildcard bind address ("", "0.0.0.0", or "::") is dialed
+// as "localhost" so the probe works on IPv4-only, IPv6-only, and dual-stack
+// hosts; a specific address is dialed directly.
+func tcpAccepting(bindAddress string, port int) bool {
+	host := bindAddress
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "localhost"
+	}
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, strconv.Itoa(port)), timeouts.ReadyDialTimeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}

--- a/go/services/multipooler/ready_test.go
+++ b/go/services/multipooler/ready_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multipooler
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// shortTempDir returns a tmp dir under /tmp rather than t.TempDir() to keep
+// Unix socket paths within sun_path's 104-byte limit on macOS.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "p")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// listenUnix starts a Unix socket listener at path and registers cleanup.
+func listenUnix(t *testing.T, path string) string {
+	t.Helper()
+	require.LessOrEqualf(t, len(path), 104, "unix socket path exceeds sun_path limit: %s", path)
+	l, err := net.Listen("unix", path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.Close() })
+	return path
+}
+
+// listenTCP starts a TCP listener on host:0 and returns the assigned port.
+// t.Skip()s if the host can't be bound (e.g. "::1" on an IPv4-only CI runner)
+// so these tests don't flake by environment.
+func listenTCP(t *testing.T, host string) int {
+	t.Helper()
+	l, err := net.Listen("tcp", net.JoinHostPort(host, "0"))
+	if err != nil {
+		t.Skipf("cannot listen on %s: %v", host, err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// closedTCPPort returns a port that was briefly bound and then closed, so
+// nothing is listening on it. Useful for "not accepting" assertions.
+func closedTCPPort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
+}
+
+func TestGrpcAccepting(t *testing.T) {
+	t.Run("unix socket preferred over tcp", func(t *testing.T) {
+		dir := shortTempDir(t)
+		sock := listenUnix(t, filepath.Join(dir, "grpc.sock"))
+		port := closedTCPPort(t) // would fail if consulted
+		assert.True(t, grpcAccepting(sock, "", port))
+	})
+
+	t.Run("falls back to tcp when no socket", func(t *testing.T) {
+		port := listenTCP(t, "127.0.0.1")
+		assert.True(t, grpcAccepting("", "", port))
+	})
+
+	t.Run("neither configured skips check", func(t *testing.T) {
+		assert.True(t, grpcAccepting("", "", 0))
+	})
+
+	t.Run("configured but not accepting", func(t *testing.T) {
+		assert.False(t, grpcAccepting("", "127.0.0.1", closedTCPPort(t)))
+	})
+}
+
+func TestTCPAccepting(t *testing.T) {
+	t.Run("wildcard bind dials localhost", func(t *testing.T) {
+		port := listenTCP(t, "127.0.0.1")
+		assert.True(t, tcpAccepting("", port))
+		assert.True(t, tcpAccepting("0.0.0.0", port))
+	})
+
+	t.Run("specific address dialled directly", func(t *testing.T) {
+		port := listenTCP(t, "127.0.0.1")
+		assert.True(t, tcpAccepting("127.0.0.1", port))
+	})
+
+	t.Run("not listening returns false", func(t *testing.T) {
+		assert.False(t, tcpAccepting("", closedTCPPort(t)))
+	})
+}
+
+func TestUnixSocketAccepting(t *testing.T) {
+	t.Run("live listener returns true", func(t *testing.T) {
+		dir := shortTempDir(t)
+		path := listenUnix(t, filepath.Join(dir, "sock"))
+		assert.True(t, unixSocketAccepting(path))
+	})
+
+	t.Run("missing path returns false", func(t *testing.T) {
+		dir := shortTempDir(t)
+		assert.False(t, unixSocketAccepting(filepath.Join(dir, "missing.sock")))
+	})
+
+	t.Run("stale regular file returns false", func(t *testing.T) {
+		dir := shortTempDir(t)
+		path := filepath.Join(dir, "stale.sock")
+		require.NoError(t, os.WriteFile(path, nil, 0o600))
+		assert.False(t, unixSocketAccepting(path))
+	})
+}

--- a/go/test/endtoend/multipooler/readiness_test.go
+++ b/go/test/endtoend/multipooler/readiness_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multipooler
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+)
+
+// readyStatusCode issues a GET against the multipooler's /ready endpoint and
+// returns the HTTP status code, or 0 if the request could not be made.
+func readyStatusCode(t *testing.T, httpPort int) int {
+	t.Helper()
+	url := fmt.Sprintf("http://localhost:%d/ready", httpPort)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Logf("GET %s failed: %v", url, err)
+		return 0
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// TestMultipoolerReadinessReflectsGRPCNotPostgres verifies that the pooler's
+// /ready endpoint reflects only whether its gRPC control plane is serving — and
+// is deliberately decoupled from postgres. A pooler whose postgres is dead must
+// stay Ready (200) so Kubernetes keeps its Service endpoint/DNS and the pod
+// remains reachable for control RPCs and its health stream. This is the
+// property that avoids coupling pod reachability to postgres availability.
+//
+// Uses an isolated single-node shard: killing a postmaster is destructive, and
+// a single node with no peer and no live multiorch cannot trigger a failover,
+// so the kill can't poison other tests.
+func TestMultipoolerReadinessReflectsGRPCNotPostgres(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("skipping: PostgreSQL binaries not found")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(1),
+		shardsetup.WithDeferredMultipoolerStart(),
+	)
+	defer cleanup()
+
+	require.Len(t, setup.Multipoolers, 1)
+	var inst *shardsetup.MultipoolerInstance
+	for _, v := range setup.Multipoolers {
+		inst = v
+	}
+
+	require.NoError(t, inst.Multipooler.Start(t.Context(), t))
+	shardsetup.WaitForManagerReady(t, inst.Multipooler)
+
+	httpPort := inst.Multipooler.HttpPort
+	require.NotZero(t, httpPort, "multipooler HTTP port should be set")
+
+	client, err := shardsetup.NewMultipoolerClient(inst.Multipooler.GrpcPort)
+	require.NoError(t, err)
+	defer client.Close()
+
+	// The gRPC server is up, so /ready is 200.
+	require.Eventually(t, func() bool {
+		return readyStatusCode(t, httpPort) == http.StatusOK
+	}, 60*time.Second, 500*time.Millisecond, "/ready should return 200 while the gRPC server is up")
+
+	// Kill postgres and hold it down (disable the monitor's auto-restart).
+	disableCtx := utils.WithShortDeadline(t)
+	_, err = client.Manager.SetPostgresRestartsEnabled(disableCtx,
+		&multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest{Enabled: false})
+	require.NoError(t, err, "should disable postgres restarts")
+
+	t.Logf("Killing postgres on %s (readiness must stay 200)", inst.Name)
+	setup.KillPostgres(t, inst.Name)
+
+	// The decoupling property: with postgres dead but the gRPC server still
+	// serving, /ready must remain 200 the whole time. If readiness were coupled
+	// to postgres it would flip to 503 here.
+	require.Never(t, func() bool {
+		return readyStatusCode(t, httpPort) != http.StatusOK
+	}, 15*time.Second, 1*time.Second, "/ready must stay 200 while postgres is down (readiness reflects gRPC, not postgres)")
+
+	// Re-enable restarts so the node returns to a healthy steady state before teardown.
+	enableCtx := utils.WithShortDeadline(t)
+	_, err = client.Manager.SetPostgresRestartsEnabled(enableCtx,
+		&multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest{Enabled: true})
+	require.NoError(t, err, "should re-enable postgres restarts")
+}


### PR DESCRIPTION
Part of MUL-1009. Supersedes #1358.

## What

Make the multipooler and pgctld `/ready` endpoints report ready based **only on whether their own gRPC control plane is accepting connections** — deliberately decoupled from postgres.

- **multipooler** (`init.go` + new `ready.go`): registered no ready checks before, so `/ready` was always 200. Adds a gRPC-accepting readiness check (and a `/ready` status-page link).
- **pgctld** (`server.go`): already gated `/ready` on the postgres socket **and** gRPC. Narrows it — drops the postgres-socket check so `/ready` reflects gRPC only. No new check is added; the postgres coupling is removed.
- **demo** (`k8s-multipooler-statefulset.yaml`): wires the multipooler container's `readinessProbe` to `/ready`.

Liveness probes and the pgctld gRPC-accepting check are unchanged.

## Why not gate readiness on postgres (the change from #1358)

#1358 made the pooler's `/ready` return 503 when postgres was down. Gating pod readiness on postgres couples **pod reachability** to **postgres availability**: a NotReady pod is dropped from Service endpoints and — unless the headless Service sets `publishNotReadyAddresses: true` — loses its DNS record. Since multigres components reach the pooler by its topology-registered `Hostname:grpcPort` (resolved via that headless DNS), a routine "stop postgres" could make the pod unreachable for the very control RPCs and health stream used to observe and recover it. That's a latent, worst-timed coupling whose correctness depends on a separate Service flag staying set.

Gating on gRPC serving removes the coupling entirely:

- A pooler whose postgres is down stays **Ready** and reachable; its monitor restarts postgres.
- postgres liveness is already signalled **out-of-band via the health stream**, which is what drives routing/failover. `multiorch` has no Kubernetes client and never reads pod readiness, so readiness was never an input to failover — its only role is external k8s visibility + rollout gating, which "is the control plane serving?" expresses correctly.
- Correctness no longer depends on `publishNotReadyAddresses` (a NotReady pod now only ever means "gRPC isn't serving", i.e. it genuinely shouldn't take traffic).

Liveness remains the tool for "restart a wedged process"; readiness here answers "is my gRPC control plane up?".

## Testing

- Unit (`go/services/multipooler/ready_test.go`): `TestGrpcAccepting` / `TestTCPAccepting` / `TestUnixSocketAccepting`. pgctld's own ready-probe tests are unchanged.
- E2E (`go/test/endtoend/multipooler/readiness_test.go`): `TestMultipoolerReadinessReflectsGRPCNotPostgres` — isolated single-node shard; `/ready` is 200 while up and **stays 200 after postgres is SIGKILLed** (auto-restart disabled), proving readiness is decoupled from postgres.

## Follow-ups

- Operator (**MUL-240**): point the multipooler/pgctld `readinessProbe`s at `/ready`. With `/ready` now postgres-independent, that wiring no longer needs `publishNotReadyAddresses: true` for correctness of this probe.
- The pooler's gRPC-accepting helper is a deliberate small mirror of pgctld's; consolidating both into `go/tools/netutil` is a noted follow-up.
