### PR TITLE
feat(multiadmin): expose backup start/stop timestamps and job_id

### DIFF
--- a/go/pb/multiadmin/multiadminservice.pb.go
+++ b/go/pb/multiadmin/multiadminservice.pb.go
@@ -1539,6 +1539,9 @@ type BackupInfo struct {
 	// status of the backup
 	Status BackupStatus `protobuf:"varint,6,opt,name=status,proto3,enum=multiadmin.BackupStatus" json:"status,omitempty"`
 	// backup_time is when the backup was created
+	// Deprecated: use start_timestamp/stop_timestamp instead.
+	//
+	// Deprecated: Marked as deprecated in multiadminservice.proto.
 	BackupTime *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=backup_time,json=backupTime,proto3" json:"backup_time,omitempty"`
 	// backup_size_bytes is the size of the backup in bytes
 	BackupSizeBytes uint64 `protobuf:"varint,8,opt,name=backup_size_bytes,json=backupSizeBytes,proto3" json:"backup_size_bytes,omitempty"`
@@ -1552,7 +1555,16 @@ type BackupInfo struct {
 	// stop_lsn is the WAL stop LSN of the backup (pgbackrest backup[].lsn.stop)
 	StopLsn string `protobuf:"bytes,12,opt,name=stop_lsn,json=stopLsn,proto3" json:"stop_lsn,omitempty"`
 	// pg_version is the full PostgreSQL server_version the backup was taken from (e.g. "16.2")
-	PgVersion     string `protobuf:"bytes,13,opt,name=pg_version,json=pgVersion,proto3" json:"pg_version,omitempty"`
+	PgVersion string `protobuf:"bytes,13,opt,name=pg_version,json=pgVersion,proto3" json:"pg_version,omitempty"`
+	// start_timestamp is when the backup started, from pgbackrest info backup[].timestamp.start.
+	// Unset if unknown.
+	StartTimestamp *timestamppb.Timestamp `protobuf:"bytes,14,opt,name=start_timestamp,json=startTimestamp,proto3" json:"start_timestamp,omitempty"`
+	// stop_timestamp is when the backup completed, from pgbackrest info backup[].timestamp.stop.
+	// Unset if unknown.
+	StopTimestamp *timestamppb.Timestamp `protobuf:"bytes,15,opt,name=stop_timestamp,json=stopTimestamp,proto3" json:"stop_timestamp,omitempty"`
+	// job_id is the multiadmin backup job ID that produced this backup, if known
+	// (from the pgbackrest job_id annotation).
+	JobId         string `protobuf:"bytes,16,opt,name=job_id,json=jobId,proto3" json:"job_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1629,6 +1641,7 @@ func (x *BackupInfo) GetStatus() BackupStatus {
 	return BackupStatus_BACKUP_STATUS_UNKNOWN
 }
 
+// Deprecated: Marked as deprecated in multiadminservice.proto.
 func (x *BackupInfo) GetBackupTime() *timestamppb.Timestamp {
 	if x != nil {
 		return x.BackupTime
@@ -1674,6 +1687,27 @@ func (x *BackupInfo) GetStopLsn() string {
 func (x *BackupInfo) GetPgVersion() string {
 	if x != nil {
 		return x.PgVersion
+	}
+	return ""
+}
+
+func (x *BackupInfo) GetStartTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartTimestamp
+	}
+	return nil
+}
+
+func (x *BackupInfo) GetStopTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StopTimestamp
+	}
+	return nil
+}
+
+func (x *BackupInfo) GetJobId() string {
+	if x != nil {
+		return x.JobId
 	}
 	return ""
 }
@@ -2414,7 +2448,7 @@ const file_multiadminservice_proto_rawDesc = "" +
 	"\x15VerifyBackupsResponse\x125\n" +
 	"\bduration\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\bduration\x12\x1d\n" +
 	"\n" +
-	"raw_output\x18\x02 \x01(\tR\trawOutput\"\xf9\x03\n" +
+	"raw_output\x18\x02 \x01(\tR\trawOutput\"\x9c\x05\n" +
 	"\n" +
 	"BackupInfo\x12\x1b\n" +
 	"\tbackup_id\x18\x01 \x01(\tR\bbackupId\x12\x1a\n" +
@@ -2423,8 +2457,8 @@ const file_multiadminservice_proto_rawDesc = "" +
 	"tableGroup\x12\x14\n" +
 	"\x05shard\x18\x04 \x01(\tR\x05shard\x12\x12\n" +
 	"\x04type\x18\x05 \x01(\tR\x04type\x120\n" +
-	"\x06status\x18\x06 \x01(\x0e2\x18.multiadmin.BackupStatusR\x06status\x12;\n" +
-	"\vbackup_time\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"\x06status\x18\x06 \x01(\x0e2\x18.multiadmin.BackupStatusR\x06status\x12?\n" +
+	"\vbackup_time\x18\a \x01(\v2\x1a.google.protobuf.TimestampB\x02\x18\x01R\n" +
 	"backupTime\x12*\n" +
 	"\x11backup_size_bytes\x18\b \x01(\x04R\x0fbackupSizeBytes\x124\n" +
 	"\x16multipooler_service_id\x18\t \x01(\tR\x14multipoolerServiceId\x12?\n" +
@@ -2433,7 +2467,10 @@ const file_multiadminservice_proto_rawDesc = "" +
 	"\tstart_lsn\x18\v \x01(\tR\bstartLsn\x12\x19\n" +
 	"\bstop_lsn\x18\f \x01(\tR\astopLsn\x12\x1d\n" +
 	"\n" +
-	"pg_version\x18\r \x01(\tR\tpgVersion\"J\n" +
+	"pg_version\x18\r \x01(\tR\tpgVersion\x12C\n" +
+	"\x0fstart_timestamp\x18\x0e \x01(\v2\x1a.google.protobuf.TimestampR\x0estartTimestamp\x12A\n" +
+	"\x0estop_timestamp\x18\x0f \x01(\v2\x1a.google.protobuf.TimestampR\rstopTimestamp\x12\x15\n" +
+	"\x06job_id\x18\x10 \x01(\tR\x05jobId\"J\n" +
 	"\x16GetPoolerStatusRequest\x120\n" +
 	"\tpooler_id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\bpoolerId\"\x9e\x01\n" +
 	"\x17GetPoolerStatusResponse\x126\n" +
@@ -2589,59 +2626,61 @@ var file_multiadminservice_proto_depIdxs = []int32{
 	2,  // 10: multiadmin.BackupInfo.status:type_name -> multiadmin.BackupStatus
 	46, // 11: multiadmin.BackupInfo.backup_time:type_name -> google.protobuf.Timestamp
 	47, // 12: multiadmin.BackupInfo.routing_role:type_name -> clustermetadata.RoutingRole
-	48, // 13: multiadmin.GetPoolerStatusRequest.pooler_id:type_name -> clustermetadata.ID
-	49, // 14: multiadmin.GetPoolerStatusResponse.status:type_name -> multipoolermanagerdata.Status
-	50, // 15: multiadmin.GetPoolerStatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
-	48, // 16: multiadmin.SetPostgresRestartsEnabledRequest.pooler_id:type_name -> clustermetadata.ID
-	48, // 17: multiadmin.GetGatewayQueriesRequest.gateway_id:type_name -> clustermetadata.ID
-	51, // 18: multiadmin.GetGatewayQueriesResponse.snapshot:type_name -> multigatewaymanagerdata.QueryRegistrySnapshot
-	48, // 19: multiadmin.GetGatewayConsolidatorRequest.gateway_id:type_name -> clustermetadata.ID
-	52, // 20: multiadmin.GetGatewayConsolidatorResponse.stats:type_name -> multigatewaymanagerdata.ConsolidatorStats
-	53, // 21: multiadmin.ApplyCertifiedRuleChangeRequest.shard_key:type_name -> clustermetadata.ShardKey
-	54, // 22: multiadmin.ApplyCertifiedRuleChangeRequest.proposed_transition:type_name -> clustermetadata.RulePosition
-	55, // 23: multiadmin.ApplyCertifiedRuleChangeRequest.cert:type_name -> clustermetadata.ExternallyCertifiedRevocation
-	37, // 24: multiadmin.ApplyCertifiedRuleChangeRequest.unsafe_derive_cert:type_name -> multiadmin.UnsafeDeriveCertOptions
-	56, // 25: multiadmin.ApplyCertifiedRuleChangeResponse.installed_rule:type_name -> clustermetadata.ShardRule
-	55, // 26: multiadmin.ApplyCertifiedRuleChangeResponse.cert_used:type_name -> clustermetadata.ExternallyCertifiedRevocation
-	3,  // 27: multiadmin.MultiadminService.GetCell:input_type -> multiadmin.GetCellRequest
-	5,  // 28: multiadmin.MultiadminService.GetDatabase:input_type -> multiadmin.GetDatabaseRequest
-	7,  // 29: multiadmin.MultiadminService.GetCellNames:input_type -> multiadmin.GetCellNamesRequest
-	9,  // 30: multiadmin.MultiadminService.GetDatabaseNames:input_type -> multiadmin.GetDatabaseNamesRequest
-	11, // 31: multiadmin.MultiadminService.GetGateways:input_type -> multiadmin.GetGatewaysRequest
-	13, // 32: multiadmin.MultiadminService.GetPoolers:input_type -> multiadmin.GetPoolersRequest
-	15, // 33: multiadmin.MultiadminService.GetOrchs:input_type -> multiadmin.GetOrchsRequest
-	17, // 34: multiadmin.MultiadminService.Backup:input_type -> multiadmin.BackupRequest
-	19, // 35: multiadmin.MultiadminService.GetBackupJobStatus:input_type -> multiadmin.GetBackupJobStatusRequest
-	21, // 36: multiadmin.MultiadminService.GetBackups:input_type -> multiadmin.GetBackupsRequest
-	23, // 37: multiadmin.MultiadminService.ExpireBackups:input_type -> multiadmin.ExpireBackupsRequest
-	25, // 38: multiadmin.MultiadminService.VerifyBackups:input_type -> multiadmin.VerifyBackupsRequest
-	28, // 39: multiadmin.MultiadminService.GetPoolerStatus:input_type -> multiadmin.GetPoolerStatusRequest
-	30, // 40: multiadmin.MultiadminService.SetPostgresRestartsEnabled:input_type -> multiadmin.SetPostgresRestartsEnabledRequest
-	32, // 41: multiadmin.MultiadminService.GetGatewayQueries:input_type -> multiadmin.GetGatewayQueriesRequest
-	34, // 42: multiadmin.MultiadminService.GetGatewayConsolidator:input_type -> multiadmin.GetGatewayConsolidatorRequest
-	36, // 43: multiadmin.MultiadminService.ApplyCertifiedRuleChange:input_type -> multiadmin.ApplyCertifiedRuleChangeRequest
-	4,  // 44: multiadmin.MultiadminService.GetCell:output_type -> multiadmin.GetCellResponse
-	6,  // 45: multiadmin.MultiadminService.GetDatabase:output_type -> multiadmin.GetDatabaseResponse
-	8,  // 46: multiadmin.MultiadminService.GetCellNames:output_type -> multiadmin.GetCellNamesResponse
-	10, // 47: multiadmin.MultiadminService.GetDatabaseNames:output_type -> multiadmin.GetDatabaseNamesResponse
-	12, // 48: multiadmin.MultiadminService.GetGateways:output_type -> multiadmin.GetGatewaysResponse
-	14, // 49: multiadmin.MultiadminService.GetPoolers:output_type -> multiadmin.GetPoolersResponse
-	16, // 50: multiadmin.MultiadminService.GetOrchs:output_type -> multiadmin.GetOrchsResponse
-	18, // 51: multiadmin.MultiadminService.Backup:output_type -> multiadmin.BackupResponse
-	20, // 52: multiadmin.MultiadminService.GetBackupJobStatus:output_type -> multiadmin.GetBackupJobStatusResponse
-	22, // 53: multiadmin.MultiadminService.GetBackups:output_type -> multiadmin.GetBackupsResponse
-	24, // 54: multiadmin.MultiadminService.ExpireBackups:output_type -> multiadmin.ExpireBackupsResponse
-	26, // 55: multiadmin.MultiadminService.VerifyBackups:output_type -> multiadmin.VerifyBackupsResponse
-	29, // 56: multiadmin.MultiadminService.GetPoolerStatus:output_type -> multiadmin.GetPoolerStatusResponse
-	31, // 57: multiadmin.MultiadminService.SetPostgresRestartsEnabled:output_type -> multiadmin.SetPostgresRestartsEnabledResponse
-	33, // 58: multiadmin.MultiadminService.GetGatewayQueries:output_type -> multiadmin.GetGatewayQueriesResponse
-	35, // 59: multiadmin.MultiadminService.GetGatewayConsolidator:output_type -> multiadmin.GetGatewayConsolidatorResponse
-	38, // 60: multiadmin.MultiadminService.ApplyCertifiedRuleChange:output_type -> multiadmin.ApplyCertifiedRuleChangeResponse
-	44, // [44:61] is the sub-list for method output_type
-	27, // [27:44] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	46, // 13: multiadmin.BackupInfo.start_timestamp:type_name -> google.protobuf.Timestamp
+	46, // 14: multiadmin.BackupInfo.stop_timestamp:type_name -> google.protobuf.Timestamp
+	48, // 15: multiadmin.GetPoolerStatusRequest.pooler_id:type_name -> clustermetadata.ID
+	49, // 16: multiadmin.GetPoolerStatusResponse.status:type_name -> multipoolermanagerdata.Status
+	50, // 17: multiadmin.GetPoolerStatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	48, // 18: multiadmin.SetPostgresRestartsEnabledRequest.pooler_id:type_name -> clustermetadata.ID
+	48, // 19: multiadmin.GetGatewayQueriesRequest.gateway_id:type_name -> clustermetadata.ID
+	51, // 20: multiadmin.GetGatewayQueriesResponse.snapshot:type_name -> multigatewaymanagerdata.QueryRegistrySnapshot
+	48, // 21: multiadmin.GetGatewayConsolidatorRequest.gateway_id:type_name -> clustermetadata.ID
+	52, // 22: multiadmin.GetGatewayConsolidatorResponse.stats:type_name -> multigatewaymanagerdata.ConsolidatorStats
+	53, // 23: multiadmin.ApplyCertifiedRuleChangeRequest.shard_key:type_name -> clustermetadata.ShardKey
+	54, // 24: multiadmin.ApplyCertifiedRuleChangeRequest.proposed_transition:type_name -> clustermetadata.RulePosition
+	55, // 25: multiadmin.ApplyCertifiedRuleChangeRequest.cert:type_name -> clustermetadata.ExternallyCertifiedRevocation
+	37, // 26: multiadmin.ApplyCertifiedRuleChangeRequest.unsafe_derive_cert:type_name -> multiadmin.UnsafeDeriveCertOptions
+	56, // 27: multiadmin.ApplyCertifiedRuleChangeResponse.installed_rule:type_name -> clustermetadata.ShardRule
+	55, // 28: multiadmin.ApplyCertifiedRuleChangeResponse.cert_used:type_name -> clustermetadata.ExternallyCertifiedRevocation
+	3,  // 29: multiadmin.MultiadminService.GetCell:input_type -> multiadmin.GetCellRequest
+	5,  // 30: multiadmin.MultiadminService.GetDatabase:input_type -> multiadmin.GetDatabaseRequest
+	7,  // 31: multiadmin.MultiadminService.GetCellNames:input_type -> multiadmin.GetCellNamesRequest
+	9,  // 32: multiadmin.MultiadminService.GetDatabaseNames:input_type -> multiadmin.GetDatabaseNamesRequest
+	11, // 33: multiadmin.MultiadminService.GetGateways:input_type -> multiadmin.GetGatewaysRequest
+	13, // 34: multiadmin.MultiadminService.GetPoolers:input_type -> multiadmin.GetPoolersRequest
+	15, // 35: multiadmin.MultiadminService.GetOrchs:input_type -> multiadmin.GetOrchsRequest
+	17, // 36: multiadmin.MultiadminService.Backup:input_type -> multiadmin.BackupRequest
+	19, // 37: multiadmin.MultiadminService.GetBackupJobStatus:input_type -> multiadmin.GetBackupJobStatusRequest
+	21, // 38: multiadmin.MultiadminService.GetBackups:input_type -> multiadmin.GetBackupsRequest
+	23, // 39: multiadmin.MultiadminService.ExpireBackups:input_type -> multiadmin.ExpireBackupsRequest
+	25, // 40: multiadmin.MultiadminService.VerifyBackups:input_type -> multiadmin.VerifyBackupsRequest
+	28, // 41: multiadmin.MultiadminService.GetPoolerStatus:input_type -> multiadmin.GetPoolerStatusRequest
+	30, // 42: multiadmin.MultiadminService.SetPostgresRestartsEnabled:input_type -> multiadmin.SetPostgresRestartsEnabledRequest
+	32, // 43: multiadmin.MultiadminService.GetGatewayQueries:input_type -> multiadmin.GetGatewayQueriesRequest
+	34, // 44: multiadmin.MultiadminService.GetGatewayConsolidator:input_type -> multiadmin.GetGatewayConsolidatorRequest
+	36, // 45: multiadmin.MultiadminService.ApplyCertifiedRuleChange:input_type -> multiadmin.ApplyCertifiedRuleChangeRequest
+	4,  // 46: multiadmin.MultiadminService.GetCell:output_type -> multiadmin.GetCellResponse
+	6,  // 47: multiadmin.MultiadminService.GetDatabase:output_type -> multiadmin.GetDatabaseResponse
+	8,  // 48: multiadmin.MultiadminService.GetCellNames:output_type -> multiadmin.GetCellNamesResponse
+	10, // 49: multiadmin.MultiadminService.GetDatabaseNames:output_type -> multiadmin.GetDatabaseNamesResponse
+	12, // 50: multiadmin.MultiadminService.GetGateways:output_type -> multiadmin.GetGatewaysResponse
+	14, // 51: multiadmin.MultiadminService.GetPoolers:output_type -> multiadmin.GetPoolersResponse
+	16, // 52: multiadmin.MultiadminService.GetOrchs:output_type -> multiadmin.GetOrchsResponse
+	18, // 53: multiadmin.MultiadminService.Backup:output_type -> multiadmin.BackupResponse
+	20, // 54: multiadmin.MultiadminService.GetBackupJobStatus:output_type -> multiadmin.GetBackupJobStatusResponse
+	22, // 55: multiadmin.MultiadminService.GetBackups:output_type -> multiadmin.GetBackupsResponse
+	24, // 56: multiadmin.MultiadminService.ExpireBackups:output_type -> multiadmin.ExpireBackupsResponse
+	26, // 57: multiadmin.MultiadminService.VerifyBackups:output_type -> multiadmin.VerifyBackupsResponse
+	29, // 58: multiadmin.MultiadminService.GetPoolerStatus:output_type -> multiadmin.GetPoolerStatusResponse
+	31, // 59: multiadmin.MultiadminService.SetPostgresRestartsEnabled:output_type -> multiadmin.SetPostgresRestartsEnabledResponse
+	33, // 60: multiadmin.MultiadminService.GetGatewayQueries:output_type -> multiadmin.GetGatewayQueriesResponse
+	35, // 61: multiadmin.MultiadminService.GetGatewayConsolidator:output_type -> multiadmin.GetGatewayConsolidatorResponse
+	38, // 62: multiadmin.MultiadminService.ApplyCertifiedRuleChange:output_type -> multiadmin.ApplyCertifiedRuleChangeResponse
+	46, // [46:63] is the sub-list for method output_type
+	29, // [29:46] is the sub-list for method input_type
+	29, // [29:29] is the sub-list for extension type_name
+	29, // [29:29] is the sub-list for extension extendee
+	0,  // [0:29] is the sub-list for field type_name
 }
 
 func init() { file_multiadminservice_proto_init() }

--- a/go/services/multiadmin/backup.go
+++ b/go/services/multiadmin/backup.go
@@ -317,6 +317,9 @@ func (s *MultiadminServer) GetBackups(ctx context.Context, req *multiadminpb.Get
 			StartLsn:             b.StartLsn,
 			StopLsn:              b.StopLsn,
 			PgVersion:            b.PgVersion,
+			StartTimestamp:       b.StartTimestamp,
+			StopTimestamp:        b.StopTimestamp,
+			JobId:                b.JobId,
 		}
 	}
 

--- a/go/services/multiadmin/backup_test.go
+++ b/go/services/multiadmin/backup_test.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/multigres/multigres/go/common/rpcclient"
 	"github.com/multigres/multigres/go/common/topoclient"
@@ -251,18 +252,24 @@ func TestGetBackups_PropagatesLSNAndPgVersion(t *testing.T) {
 	}
 	require.NoError(t, ts.CreateMultipooler(ctx, replicaPooler))
 
+	startTimestamp := timestamppb.New(time.Date(2026, 1, 4, 10, 0, 0, 0, time.UTC))
+	stopTimestamp := timestamppb.New(time.Date(2026, 1, 4, 10, 5, 0, 0, time.UTC))
+
 	fakeClient := rpcclient.NewFakeClient()
 	poolerKey := topoclient.ComponentID("multipooler-cell1-replica-pooler")
 	fakeClient.GetBackupsResponses[poolerKey] = &multipoolermanagerdata.GetBackupsResponse{
 		Backups: []*multipoolermanagerdata.BackupMetadata{{
-			BackupId:   "20250104-100000F",
-			TableGroup: "default",
-			Shard:      "0",
-			Type:       "full",
-			Status:     multipoolermanagerdata.BackupMetadata_COMPLETE,
-			StartLsn:   "0/21000028",
-			StopLsn:    "0/21000100",
-			PgVersion:  "16.2",
+			BackupId:       "20250104-100000F",
+			TableGroup:     "default",
+			Shard:          "0",
+			Type:           "full",
+			Status:         multipoolermanagerdata.BackupMetadata_COMPLETE,
+			StartLsn:       "0/21000028",
+			StopLsn:        "0/21000100",
+			PgVersion:      "16.2",
+			StartTimestamp: startTimestamp,
+			StopTimestamp:  stopTimestamp,
+			JobId:          "20250104-100000.000000_replica-pooler",
 		}},
 	}
 	server.SetRPCClient(fakeClient)
@@ -275,6 +282,9 @@ func TestGetBackups_PropagatesLSNAndPgVersion(t *testing.T) {
 	require.Equal(t, "0/21000028", resp.Backups[0].StartLsn)
 	require.Equal(t, "0/21000100", resp.Backups[0].StopLsn)
 	require.Equal(t, "16.2", resp.Backups[0].PgVersion)
+	require.True(t, startTimestamp.AsTime().Equal(resp.Backups[0].StartTimestamp.AsTime()))
+	require.True(t, stopTimestamp.AsTime().Equal(resp.Backups[0].StopTimestamp.AsTime()))
+	require.Equal(t, "20250104-100000.000000_replica-pooler", resp.Backups[0].JobId)
 }
 
 func TestBackup_ForcePrimary(t *testing.T) {

--- a/proto/multiadminservice.proto
+++ b/proto/multiadminservice.proto
@@ -387,7 +387,8 @@ message BackupInfo {
   // status of the backup
   BackupStatus status = 6;
   // backup_time is when the backup was created
-  google.protobuf.Timestamp backup_time = 7;
+  // Deprecated: use start_timestamp/stop_timestamp instead.
+  google.protobuf.Timestamp backup_time = 7 [deprecated = true];
   // backup_size_bytes is the size of the backup in bytes
   uint64 backup_size_bytes = 8;
   // multipooler_service_id is the ID of the multipooler that reported the backup
@@ -401,6 +402,15 @@ message BackupInfo {
   string stop_lsn = 12;
   // pg_version is the full PostgreSQL server_version the backup was taken from (e.g. "16.2")
   string pg_version = 13;
+  // start_timestamp is when the backup started, from pgbackrest info backup[].timestamp.start.
+  // Unset if unknown.
+  google.protobuf.Timestamp start_timestamp = 14;
+  // stop_timestamp is when the backup completed, from pgbackrest info backup[].timestamp.stop.
+  // Unset if unknown.
+  google.protobuf.Timestamp stop_timestamp = 15;
+  // job_id is the multiadmin backup job ID that produced this backup, if known
+  // (from the pgbackrest job_id annotation).
+  string job_id = 16;
 }
 
 // BackupStatus indicates the state of a backup artifact

--- a/web/multiadmin/lib/api/generated/multiadminservice_pb.ts
+++ b/web/multiadmin/lib/api/generated/multiadminservice_pb.ts
@@ -1347,8 +1347,10 @@ export class BackupInfo extends Message<BackupInfo> {
 
   /**
    * backup_time is when the backup was created
+   * Deprecated: use start_timestamp/stop_timestamp instead.
    *
-   * @generated from field: google.protobuf.Timestamp backup_time = 7;
+   * @generated from field: google.protobuf.Timestamp backup_time = 7 [deprecated = true];
+   * @deprecated
    */
   backupTime?: Timestamp;
 
@@ -1395,6 +1397,30 @@ export class BackupInfo extends Message<BackupInfo> {
    */
   pgVersion = "";
 
+  /**
+   * start_timestamp is when the backup started, from pgbackrest info backup[].timestamp.start.
+   * Unset if unknown.
+   *
+   * @generated from field: google.protobuf.Timestamp start_timestamp = 14;
+   */
+  startTimestamp?: Timestamp;
+
+  /**
+   * stop_timestamp is when the backup completed, from pgbackrest info backup[].timestamp.stop.
+   * Unset if unknown.
+   *
+   * @generated from field: google.protobuf.Timestamp stop_timestamp = 15;
+   */
+  stopTimestamp?: Timestamp;
+
+  /**
+   * job_id is the multiadmin backup job ID that produced this backup, if known
+   * (from the pgbackrest job_id annotation).
+   *
+   * @generated from field: string job_id = 16;
+   */
+  jobId = "";
+
   constructor(data?: PartialMessage<BackupInfo>) {
     super();
     proto3.util.initPartial(data, this);
@@ -1416,6 +1442,9 @@ export class BackupInfo extends Message<BackupInfo> {
     { no: 11, name: "start_lsn", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 12, name: "stop_lsn", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 13, name: "pg_version", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 14, name: "start_timestamp", kind: "message", T: Timestamp },
+    { no: 15, name: "stop_timestamp", kind: "message", T: Timestamp },
+    { no: 16, name: "job_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): BackupInfo {


### PR DESCRIPTION
GetBackups dropped start_timestamp, stop_timestamp, and job_id when converting pooler BackupMetadata to BackupInfo, so backup_time was always zero over the wire.

Add start_timestamp/stop_timestamp as separate fields plus job_id, and deprecate backup_time in favor of the two explicit fields.