### PR TITLE
feat(multipooler): quarantine pooler when postgres is unrecoverable

### DIFF
--- a/go/common/constants/manager.go
+++ b/go/common/constants/manager.go
@@ -26,4 +26,12 @@ const (
 	// be frequent enough to catch state changes (a new backup, an expiration,
 	// the repo going unreachable), not to keep ages fresh — hence minutes.
 	BackupHealthPollInterval = 5 * time.Minute
+
+	// defaultUnrecoverableMinAttempts is the floor of genuine failed recovery
+	// attempts required before a pooler may quarantine itself, regardless of
+	// elapsed time. It guards against quarantining on too few real attempts — e.g.
+	// a single attempt that hangs for the whole timeout, or sparse monitor ticks.
+	// Overridable via --postgres-unrecoverable-min-attempts; used when the manager's
+	// unrecoverableMinAttempts is unset (0), e.g. in tests.
+	DefaultUnrecoverableMinAttempts = 3
 )

--- a/go/services/multipooler/init.go
+++ b/go/services/multipooler/init.go
@@ -41,6 +41,36 @@ import (
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
 
+// defaultPostgresUnrecoverableTimeout defaults the unrecoverable-postgres
+// classifier to OFF (0). Quarantining a pooler disables its restarts and marks
+// it cohort-INELIGIBLE, so it is only safe to enable once an actor exists to
+// replace the node (the operator-side Layer 2 remediation). Until then the
+// operator's manifests opt in explicitly (a good value is ~5m of continuous
+// FATAL-looping — long enough that transient faults self-heal first).
+const defaultPostgresUnrecoverableTimeout time.Duration = 0
+
+// Bounds for --postgres-unrecoverable-min-attempts: must be at least 2 (a floor
+// of 1 would defeat its purpose) and less than 10 (the timeout is the real gate;
+// a large floor would just delay a genuine quarantine).
+const (
+	// defaultPostgresUnrecoverableMinAttempts is the flag default; it shares the
+	// single source of truth in the constants package with the manager-side
+	// fallback used when the flag is unset (e.g. in tests).
+	defaultPostgresUnrecoverableMinAttempts = constants.DefaultUnrecoverableMinAttempts
+	minPostgresUnrecoverableMinAttempts     = 2
+	maxPostgresUnrecoverableMinAttempts     = 10 // exclusive upper bound
+)
+
+// validateUnrecoverableMinAttempts enforces the [min, max) bounds on the
+// --postgres-unrecoverable-min-attempts flag.
+func validateUnrecoverableMinAttempts(n int) error {
+	if n < minPostgresUnrecoverableMinAttempts || n >= maxPostgresUnrecoverableMinAttempts {
+		return fmt.Errorf("--postgres-unrecoverable-min-attempts must be >= %d and < %d, got %d",
+			minPostgresUnrecoverableMinAttempts, maxPostgresUnrecoverableMinAttempts, n)
+	}
+	return nil
+}
+
 // Multipooler represents the main multipooler instance with all configuration and state
 type Multipooler struct {
 	pgctldAddr          viperutil.Value[string]
@@ -59,12 +89,14 @@ type Multipooler struct {
 	// tests detect a frozen pooler quickly instead of waiting the full window.
 	healthStreamStalenessTimeout viperutil.Value[time.Duration]
 	// pgBackRest TLS certificate paths for client authentication to primary's pgBackRest server
-	pgBackRestCertFile         viperutil.Value[string]
-	pgBackRestKeyFile          viperutil.Value[string]
-	pgBackRestCAFile           viperutil.Value[string]
-	pgBackRestPort             viperutil.Value[int]
-	pgBackRestCipherKeyFile    viperutil.Value[string]
-	backendVpidTrackingEnabled viperutil.Value[bool]
+	pgBackRestCertFile               viperutil.Value[string]
+	pgBackRestKeyFile                viperutil.Value[string]
+	pgBackRestCAFile                 viperutil.Value[string]
+	pgBackRestPort                   viperutil.Value[int]
+	pgBackRestCipherKeyFile          viperutil.Value[string]
+	backendVpidTrackingEnabled       viperutil.Value[bool]
+	postgresUnrecoverableTimeout     viperutil.Value[time.Duration]
+	postgresUnrecoverableMinAttempts viperutil.Value[int]
 	// flagSet is saved at RegisterFlags time so resolvers can distinguish an
 	// explicitly-set-but-empty flag from an unset one (pflag.Flag.Changed),
 	// which viperutil.Get cannot.
@@ -181,6 +213,16 @@ func NewMultipooler(telemetry *telemetry.Telemetry) *Multipooler {
 			FlagName: "backend-vpid-tracking-enabled",
 			Dynamic:  false,
 		}),
+		postgresUnrecoverableTimeout: viperutil.Configure(reg, "postgres-unrecoverable-timeout", viperutil.Options[time.Duration]{
+			Default:  defaultPostgresUnrecoverableTimeout,
+			FlagName: "postgres-unrecoverable-timeout",
+			Dynamic:  false,
+		}),
+		postgresUnrecoverableMinAttempts: viperutil.Configure(reg, "postgres-unrecoverable-min-attempts", viperutil.Options[int]{
+			Default:  defaultPostgresUnrecoverableMinAttempts,
+			FlagName: "postgres-unrecoverable-min-attempts",
+			Dynamic:  false,
+		}),
 		grpcServer:     servenv.NewGrpcServer(reg),
 		senv:           servenv.NewServEnvWithConfig(reg, servenv.NewLogger(reg, telemetry), viperutil.NewViperConfig(reg), telemetry),
 		telemetry:      telemetry,
@@ -220,8 +262,11 @@ func (mp *Multipooler) RegisterFlags(flags *pflag.FlagSet) {
 	flags.Int("pgbackrest-port", mp.pgBackRestPort.Default(), "pgBackRest TLS server port")
 	flags.String("pgbackrest-cipher-key-file", mp.pgBackRestCipherKeyFile.Default(), "Path to a JSON file mapping backup repository generation to cipher passphrase, e.g. {\"1\": \"<passphrase>\"} (env: "+backup.CipherKeyFileEnvVar+"). When set, the initial repository is encrypted at stanza creation.")
 	flags.Bool("backend-vpid-tracking-enabled", mp.backendVpidTrackingEnabled.Default(), "Track active gateway virtual pid to PostgreSQL backend pid mappings in multigres.backend_vpid")
+	flags.Duration("postgres-unrecoverable-timeout", mp.postgresUnrecoverableTimeout.Default(), "How long postgres may continuously fail to start/rewind/restore before the pooler quarantines itself for replacement (e.g. 5m). 0 (default) disables it; enable only where an actor replaces quarantined nodes.")
+	flags.Int("postgres-unrecoverable-min-attempts", mp.postgresUnrecoverableMinAttempts.Default(), "Minimum consecutive failed postgres start/rewind/restore attempts required alongside --postgres-unrecoverable-timeout before quarantining. Must be >= 2 and < 10.")
 
-	viperutil.BindFlags(flags,
+	viperutil.BindFlags(
+		flags,
 		mp.pgctldAddr,
 		mp.cell,
 		mp.database,
@@ -239,6 +284,8 @@ func (mp *Multipooler) RegisterFlags(flags *pflag.FlagSet) {
 		mp.pgBackRestPort,
 		mp.pgBackRestCipherKeyFile,
 		mp.backendVpidTrackingEnabled,
+		mp.postgresUnrecoverableTimeout,
+		mp.postgresUnrecoverableMinAttempts,
 	)
 	mp.flagSet = flags
 
@@ -320,7 +367,8 @@ func (mp *Multipooler) Init(startCtx context.Context) error {
 		return fmt.Errorf("topo open: %w", err)
 	}
 
-	logger.InfoContext(startCtx, "multipooler starting up",
+	logger.InfoContext(
+		startCtx, "multipooler starting up",
 		"pgctld_addr", mp.pgctldAddr.Get(),
 		"cell", mp.cell.Get(),
 		"database", mp.database.Get(),
@@ -384,6 +432,11 @@ func (mp *Multipooler) Init(startCtx context.Context) error {
 	multipooler.PoolerDir = mp.poolerDir.Get()
 	multipooler.PgDataDir = os.Getenv(constants.PgDataDirEnvVar)
 
+	minAttempts := mp.postgresUnrecoverableMinAttempts.Get()
+	if err := validateUnrecoverableMinAttempts(minAttempts); err != nil {
+		return err
+	}
+
 	logger.InfoContext(startCtx, "initializing MultipoolerManager")
 	poolerManager, err := manager.NewMultipoolerManager(logger, multipooler, &manager.Config{
 		SocketFilePath:               mp.socketFilePath.Get(),
@@ -399,6 +452,9 @@ func (mp *Multipooler) Init(startCtx context.Context) error {
 		PgBackRestKeyFile:  mp.pgBackRestKeyFile.Get(),
 		PgBackRestCAFile:   mp.pgBackRestCAFile.Get(),
 		BackupCipherKeys:   cipherKeys,
+
+		PostgresUnrecoverableTimeout:     mp.postgresUnrecoverableTimeout.Get(),
+		PostgresUnrecoverableMinAttempts: minAttempts,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create multipooler: %w", err)

--- a/go/services/multipooler/internal/manager/config.go
+++ b/go/services/multipooler/internal/manager/config.go
@@ -44,6 +44,19 @@ type Config struct {
 	// internal, programmatic override for tests; production uses the default.
 	StandbyStuckDivergenceThreshold time.Duration
 
+	// PostgresUnrecoverableTimeout is how long postgres may continuously fail to
+	// start/rewind/restore before the monitor gives up and quarantines the pooler
+	// (LIFECYCLE_QUARANTINED) so it is replaced rather than FATAL-looping forever.
+	// The timeout is the primary gate; a small minimum-attempts floor
+	// (unrecoverableMinAttempts) additionally guards against quarantining on too
+	// few real attempts (e.g. a single hung attempt). 0 disables the classifier
+	// (the monitor keeps retrying indefinitely, the pre-quarantine behaviour).
+	PostgresUnrecoverableTimeout time.Duration
+
+	// PostgresUnrecoverableMinAttempts is the minimum-attempts floor described
+	// above. <= 0 falls back to defaultUnrecoverableMinAttempts.
+	PostgresUnrecoverableMinAttempts int
+
 	// pgBackRest TLS certificate paths for connecting to primary's pgBackRest server
 	PgBackRestCertFile string // TLS client certificate file path
 	PgBackRestKeyFile  string // TLS client key file path

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -197,6 +197,30 @@ type MultipoolerManager struct {
 	// pgMonitorLastLoggedReason tracks the last logged reason in the monitor to avoid duplicate logs.
 	pgMonitorLastLoggedReason string
 
+	// Unrecoverable-postgres (FATAL-loop) classifier state. All fields are touched
+	// only from the single-goroutine monitor iteration (monitorPostgresIteration
+	// and its callees under the action lock), so they need no synchronisation.
+	// The durable verdict itself is published on the pooler record as
+	// LIFECYCLE_QUARANTINED — the record is the source of truth.
+	//
+	// unrecoverableTimeout is how long postgres may continuously fail to recover
+	// before the pooler quarantines itself. It is the primary gate. 0 disables it.
+	unrecoverableTimeout time.Duration
+	// unrecoverableMinAttempts is the floor of genuine failed recovery attempts
+	// required alongside the timeout. <= 0 falls back to
+	// defaultUnrecoverableMinAttempts (see trackRecoveryOutcome).
+	unrecoverableMinAttempts int
+	// unrecoverableFailedAttempts counts consecutive failed recovery attempts in
+	// the current streak (reset to 0 whenever postgres is observed running); it
+	// backs the minimum-attempts floor so we never quarantine on too few attempts.
+	unrecoverableFailedAttempts int
+	// unrecoverableFirstFailureAt anchors the timeout: elapsed since the first
+	// failure in the current streak is compared against unrecoverableTimeout.
+	unrecoverableFirstFailureAt time.Time
+	// nowFn returns the current time; overridable in tests so the timeout gate is
+	// deterministic. nil means time.Now (see now()).
+	nowFn func() time.Time
+
 	// stateManager coordinates serving state transitions across components
 	// (query service, heartbeat tracker) and updates the multipooler record.
 	stateManager *StateManager
@@ -348,11 +372,14 @@ func newMultipoolerManager(logger *slog.Logger, multipooler *clustermetadatapb.M
 		state:                  ManagerStateStarting,
 		loadTimeout:            loadTimeout,
 		pgMonitorRetryInterval: monitorRetryInterval,
-		pgctldClient:           pgctldClient,
-		connPoolMgr:            connPoolMgr,
-		readyChan:              make(chan struct{}),
-		pgMonitor:              monitorRunner,
-		healthStreamer:         newHealthStreamer(logger, multipooler.Id, multipooler.GetShardKey().GetTableGroup(), multipooler.GetShardKey().GetShard()),
+
+		unrecoverableTimeout:     config.PostgresUnrecoverableTimeout,
+		unrecoverableMinAttempts: config.PostgresUnrecoverableMinAttempts,
+		pgctldClient:             pgctldClient,
+		connPoolMgr:              connPoolMgr,
+		readyChan:                make(chan struct{}),
+		pgMonitor:                monitorRunner,
+		healthStreamer:           newHealthStreamer(logger, multipooler.Id, multipooler.GetShardKey().GetTableGroup(), multipooler.GetShardKey().GetShard()),
 		// We create a dummy context because some unit tests need them.
 		// These will be overwritten when Open gets called.
 		ctx:    ctx,

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -277,6 +277,10 @@ func (pm *MultipoolerManager) monitorPostgresIteration(ctx context.Context) (pos
 			if !pm.consensusMgr.SuspectedDivergence() {
 				pm.consensusMgr.ResetRewindBackoff()
 			}
+			// Postgres came up: the FATAL-loop streak (if any) is broken. This is
+			// the common healthy path, which returns before reaching
+			// trackRecoveryOutcome, so reset the classifier here too.
+			pm.resetUnrecoverableTracking()
 		}
 		return currentState, nil
 	}
@@ -305,7 +309,13 @@ func (pm *MultipoolerManager) monitorPostgresIteration(ctx context.Context) (pos
 	action = pm.determineRemedialAction(lockCtx, currentState)
 
 	// Take remedial action with lock held
-	pm.takeRemedialAction(lockCtx, action, currentState)
+	actionErr := pm.takeRemedialAction(lockCtx, action, currentState)
+
+	// Feed the unrecoverable-FATAL-loop classifier: a postgres that keeps
+	// failing to start (or rewind/restore) for long enough is quarantined so it
+	// gets replaced instead of spinning forever. Runs under the same action lock
+	// so the quarantine record write is serialised with the rest of the tick.
+	pm.trackRecoveryOutcome(lockCtx, action, currentState, actionErr)
 
 	return currentState, nil
 }
@@ -538,6 +548,108 @@ func (pm *MultipoolerManager) connInfoReconcileAllowed() (*clustermetadatapb.Poo
 		return nil, false
 	}
 	return target, true
+}
+
+// isRecoveryAction reports whether a remedial action is an attempt to bring
+// postgres back up. Only failures of these count toward the unrecoverable
+// (FATAL-loop) verdict — a benign reconcile or a rewind-ready broadcast failing
+// does not mean the node can't start.
+func isRecoveryAction(action remedialAction) bool {
+	switch action {
+	case remedialActionStartPostgres, remedialActionRewindToLeader, remedialActionRestoreFromBackup:
+		return true
+	default:
+		return false
+	}
+}
+
+// resetUnrecoverableTracking clears the consecutive-failure streak. Called
+// whenever postgres is observed running — the FATAL-loop, if there was one, is
+// over. Touches only monitor-goroutine-local fields.
+func (pm *MultipoolerManager) resetUnrecoverableTracking() {
+	pm.unrecoverableFailedAttempts = 0
+	pm.unrecoverableFirstFailureAt = time.Time{}
+}
+
+// trackRecoveryOutcome is the unrecoverable-FATAL-loop classifier. It runs once
+// per monitor tick, under the action lock, after takeRemedialAction. It observes
+// consecutive failed postgres recovery attempts (start/rewind/restore) and, once
+// postgres has been continuously failing for longer than unrecoverableTimeout
+// AND at least unrecoverableMinAttempts genuine attempts have failed, quarantines
+// the pooler so it is replaced rather than looping forever.
+//
+// The timeout is the primary gate (operator-facing, independent of the monitor
+// interval and of how long individual attempts take — a fast start-FATAL and a
+// slow restore-failure are judged on the same wall-clock budget). The attempts
+// floor guards the degenerate cases where few real attempts happened (a single
+// hung attempt, sparse ticks).
+//
+// It deliberately does NOT fire for a postgres that is merely down transiently:
+// a running postgres resets the streak, and only genuine failed recovery
+// attempts (an action that tried and errored) advance it — a skipped start
+// (restarts disabled), a benign reconcile, or a legitimately in-progress restore
+// do not. This is what distinguishes "postgres momentarily down" from
+// "unrecoverable".
+func (pm *MultipoolerManager) trackRecoveryOutcome(ctx context.Context, action remedialAction, state postgresState, actionErr error) {
+	// Classifier disabled (timeout 0): keep the pre-quarantine behaviour of
+	// retrying indefinitely.
+	if pm.unrecoverableTimeout <= 0 {
+		return
+	}
+
+	// The verdict is latched on the record and only cleared by pod replacement
+	// (a fresh manager). The classifier itself has nothing more to do once
+	// quarantined — but the quarantine side effects are applied across several
+	// steps (record write, cohort ineligibility, restart suppression) and any of
+	// them can fail on the tick we first quarantine. In particular, if the
+	// lifecycle status latched but SetCohortEligibility failed, the coordinator
+	// would keep trying to recruit this node and the orchestrator would never
+	// elect a new primary. Re-run the idempotent side effects each tick until
+	// they fully apply; once cohort eligibility is INELIGIBLE there is genuinely
+	// nothing left to do.
+	if lifecycle := pm.record.Snapshot().GetLifecycleStatus(); lifecycle.GetStatus() == clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_QUARANTINED {
+		if pm.consensusMgr.CohortEligibility() != clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE {
+			pm.markPoolerQuarantinedLocked(ctx, lifecycle.GetReason())
+		}
+		return
+	}
+
+	// Postgres is up: the streak (if any) is broken.
+	if state.postgresRunning {
+		pm.resetUnrecoverableTracking()
+		return
+	}
+
+	// Only a failed recovery attempt counts. Anything else (benign action,
+	// skipped start, or a success that nonetheless left postgres reported down
+	// this tick) is not evidence the node can't recover.
+	if !isRecoveryAction(action) || actionErr == nil {
+		return
+	}
+
+	now := pm.now()
+	if pm.unrecoverableFailedAttempts == 0 {
+		pm.unrecoverableFirstFailureAt = now
+	}
+	pm.unrecoverableFailedAttempts++
+
+	minAttempts := pm.unrecoverableMinAttempts
+	if minAttempts <= 0 {
+		minAttempts = constants.DefaultUnrecoverableMinAttempts
+	}
+	elapsed := now.Sub(pm.unrecoverableFirstFailureAt)
+	// Both gates must hold: enough real attempts AND long enough elapsed.
+	if pm.unrecoverableFailedAttempts < minAttempts || elapsed < pm.unrecoverableTimeout {
+		return
+	}
+
+	reason := fmt.Sprintf(
+		"postgres failed to recover for %s across %d attempts (last error: %v)",
+		elapsed.Round(time.Second),
+		pm.unrecoverableFailedAttempts,
+		actionErr,
+	)
+	pm.markPoolerQuarantinedLocked(ctx, reason)
 }
 
 // primaryConnInfoDiffersFromRecorded returns true when this pooler has been
@@ -975,11 +1087,16 @@ func (pm *MultipoolerManager) determinePostgresNotRunningAction(state postgresSt
 
 // takeRemedialAction executes the specified remedial action.
 // Caller must hold the action lock.
-func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action remedialAction, state postgresState) {
+// takeRemedialAction performs the chosen remediation. It returns the error from
+// a postgres recovery attempt (start / rewind / restore) so the caller's
+// unrecoverable-FATAL-loop classifier can count consecutive failures; it returns
+// nil for non-recovery actions, skipped actions, and successes. The returned
+// error is already logged here — the caller uses it only as a failure signal.
+func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action remedialAction, state postgresState) error {
 	// Assert that the action lock is held
 	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
 		pm.logger.ErrorContext(ctx, "takeRemedialAction called without action lock", "error", err)
-		return
+		return nil
 	}
 
 	const (
@@ -993,7 +1110,7 @@ func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action rem
 	switch action {
 	case remedialActionNone:
 		// No action to take
-		return
+		return nil
 
 	case remedialActionDemoteStalePrimary:
 		// Re-check under the action lock: the decision was made on a lock-free
@@ -1002,7 +1119,7 @@ func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action rem
 		// until the recorded leader has checkpointed onto its current timeline).
 		target := pm.staleStandbyDemoteTarget()
 		if target == nil {
-			return
+			return nil
 		}
 		pm.setMonitorReason(ctx, reasonPostgresRunning, "MonitorPostgres: PostgreSQL is running")
 		pm.logger.InfoContext(ctx, "MonitorPostgres: stale primary; consensus names another leader, restarting as standby", //nolint:sloglint // message intentionally starts with an operation name or proper noun
@@ -1018,7 +1135,7 @@ func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action rem
 		}
 		if _, err := pm.restartAsStandbyLocked(ctx, target.GetHost(), target.GetPostgresPort()); err != nil {
 			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to restart stale primary as standby", "error", err) //nolint:sloglint // message intentionally starts with an operation name or proper noun
-			return
+			return nil
 		}
 		// Sync the physical standby role and re-enable reads only after the rewind
 		// path has cleared suspected divergence.
@@ -1073,7 +1190,7 @@ func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action rem
 		// during controlled failovers.
 		if pm.postgresRestartsDisabled.Load() {
 			pm.logger.InfoContext(ctx, "MonitorPostgres: skipping start, postgres restarts disabled") //nolint:sloglint // message intentionally starts with an operation name or proper noun
-			return
+			return nil
 		}
 		pm.setMonitorReason(ctx, reasonStartingPostgres, "MonitorPostgres: PostgreSQL initialized but not running, starting PostgreSQL")
 		// Retract writability and serving before the blocking restart. Otherwise a
@@ -1091,17 +1208,18 @@ func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action rem
 		}
 		if err := pm.startPostgres(ctx); err != nil {
 			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to start Postgres, will retry", "error", err) //nolint:sloglint // message intentionally starts with an operation name or proper noun
+			return err
 		}
 
 	case remedialActionRewindToLeader:
 		// Honor the in-memory flag set by tests and demos to suppress auto-restart.
 		if pm.postgresRestartsDisabled.Load() {
 			pm.logger.InfoContext(ctx, "MonitorPostgres: skipping rewind, postgres restarts disabled") //nolint:sloglint // message intentionally starts with an operation name or proper noun
-			return
+			return nil
 		}
 		host, port, ok := pm.consensusMgr.RewindTarget()
 		if !ok {
-			return
+			return nil
 		}
 		// Stamp the backoff before attempting, so a failed rewind is rate-limited
 		// regardless of how it fails.
@@ -1114,7 +1232,7 @@ func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action rem
 			"target_host", host, "target_port", port)
 		if _, err := pm.restartAsStandbyLocked(ctx, host, port); err != nil {
 			pm.logger.ErrorContext(ctx, "MonitorPostgres: rewind to leader failed, will retry with backoff", "error", err) //nolint:sloglint // message intentionally starts with an operation name or proper noun
-			return
+			return err
 		}
 		// Success: postgres is back as a standby (suspectedDivergence cleared in
 		// restartAsStandbyLocked). The backoff is cleared on the next healthy
@@ -1130,7 +1248,7 @@ func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action rem
 		// orch's old RewindToSource RPC for a diverged-but-running standby.
 		if err := pm.markSuspectedDivergence(ctx); err != nil {
 			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to mark suspected divergence for stuck standby", "error", err) //nolint:sloglint // message intentionally starts with an operation name or proper noun
-			return
+			return nil
 		}
 		// Clear the debounce timer; the rewind path now owns the incident.
 		pm.standbyStuckSince.Store(0)
@@ -1142,6 +1260,7 @@ func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action rem
 		}
 		if err := pm.restoreAndStartPostgres(ctx); err != nil {
 			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to restore from backup, will retry", "error", err) //nolint:sloglint // message intentionally starts with an operation name or proper noun
+			return err
 		}
 
 	case remedialActionCreateFirstBackup:
@@ -1195,6 +1314,8 @@ func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action rem
 			pm.broadcastHealth()
 		}
 	}
+
+	return nil
 }
 
 // hasCompleteBackups checks if there are any complete backups available

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -917,7 +917,7 @@ func TestTakeRemedialAction_PgctldUnavailable(t *testing.T) {
 	defer pm.actionLock.Release(lockCtx)
 
 	// Should log error and take no action
-	pm.takeRemedialAction(lockCtx, remedialActionNone, postgresState{})
+	_ = pm.takeRemedialAction(lockCtx, remedialActionNone, postgresState{})
 
 	// Note: takeRemedialAction with remedialActionNone doesn't log
 	assert.Equal(t, "", pm.pgMonitorLastLoggedReason)
@@ -940,7 +940,7 @@ func TestTakeRemedialAction_PostgresReady(t *testing.T) {
 	defer pm.actionLock.Release(lockCtx)
 
 	// Should log info and take no action (no type mismatch)
-	pm.takeRemedialAction(lockCtx, remedialActionNone, postgresState{})
+	_ = pm.takeRemedialAction(lockCtx, remedialActionNone, postgresState{})
 
 	// Note: takeRemedialAction with remedialActionNone doesn't log
 	assert.Equal(t, "", pm.pgMonitorLastLoggedReason)
@@ -963,7 +963,7 @@ func TestTakeRemedialAction_StartPostgres(t *testing.T) {
 	defer pm.actionLock.Release(lockCtx)
 
 	// Should attempt to start postgres
-	pm.takeRemedialAction(lockCtx, remedialActionStartPostgres, postgresState{})
+	_ = pm.takeRemedialAction(lockCtx, remedialActionStartPostgres, postgresState{})
 
 	assert.Equal(t, "starting_postgres", pm.pgMonitorLastLoggedReason)
 	assert.True(t, mockPgctld.startCalled, "Should have called Start()")
@@ -987,10 +987,61 @@ func TestTakeRemedialAction_StartPostgresFails(t *testing.T) {
 	defer pm.actionLock.Release(lockCtx)
 
 	// Should handle error gracefully
-	pm.takeRemedialAction(lockCtx, remedialActionStartPostgres, postgresState{})
+	_ = pm.takeRemedialAction(lockCtx, remedialActionStartPostgres, postgresState{})
 
 	assert.True(t, mockPgctld.startCalled, "Should have attempted to call Start()")
 	// Reason stays the same since we're retrying
+}
+
+// TestTakeRemedialAction_RewindToLeaderFails verifies that a failed rewind
+// propagates its error out of takeRemedialAction (so the unrecoverable-FATAL-loop
+// classifier counts it). A recorded, rewind-ready foreign leader makes
+// RewindTarget return ok, so the action proceeds into restartAsStandbyLocked;
+// with no pgctld client wired, that fails FAILED_PRECONDITION.
+func TestTakeRemedialAction_RewindToLeaderFails(t *testing.T) {
+	selfID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "z", Name: "self"}
+	otherID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "z", Name: "other"}
+	otherAddr := &clustermetadatapb.PoolerAddress{Id: otherID, Host: "other-host", PostgresPort: 5432}
+	rule := &clustermetadatapb.ShardRule{
+		RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
+		LeaderId:   otherID,
+	}
+
+	pm := newTestManager(t,
+		withServiceID(selfID),
+		withReplicationPrimary(&clustermetadatapb.ReplicationPrimary{
+			Position:    &clustermetadatapb.RulePosition{Decision: rule},
+			Primary:     otherAddr,
+			RewindReady: true,
+		}),
+	)
+	pm.pgctldClient = nil // makes restartAsStandbyLocked fail early
+
+	lockCtx, err := pm.actionLock.Acquire(t.Context(), "test")
+	require.NoError(t, err)
+	defer pm.actionLock.Release(lockCtx)
+
+	got := pm.takeRemedialAction(lockCtx, remedialActionRewindToLeader, postgresState{})
+	require.Error(t, got, "a failed rewind must propagate its error so the classifier counts it")
+}
+
+// TestTakeRemedialAction_RestoreFromBackupFails verifies that a failed
+// restore-from-backup propagates its error out of takeRemedialAction. pgctld
+// reports NOT_INITIALIZED so restoreAndStartPostgres proceeds to list backups;
+// with no real pgBackRest repo there are no complete backups, so restore errors.
+func TestTakeRemedialAction_RestoreFromBackupFails(t *testing.T) {
+	pm := newTestManager(t)
+	pm.pgctldClient = &mockPgctldClient{
+		statusResponse: &pgctldpb.StatusResponse{Status: pgctldpb.ServerStatus_NOT_INITIALIZED},
+	}
+	pm.backup = backupengine.NewEngine(pm.logger, pm.runLongCommand, pm.record, backupengine.Settings{})
+
+	lockCtx, err := pm.actionLock.Acquire(t.Context(), "test")
+	require.NoError(t, err)
+	defer pm.actionLock.Release(lockCtx)
+
+	got := pm.takeRemedialAction(lockCtx, remedialActionRestoreFromBackup, postgresState{})
+	require.Error(t, got, "a failed restore must propagate its error so the classifier counts it")
 }
 
 func TestTakeRemedialAction_WaitingForBackup(t *testing.T) {
@@ -1007,7 +1058,7 @@ func TestTakeRemedialAction_WaitingForBackup(t *testing.T) {
 	defer pm.actionLock.Release(lockCtx)
 
 	// With no backups and uninitialized dir, action is None - doesn't do anything
-	pm.takeRemedialAction(lockCtx, remedialActionNone, postgresState{})
+	_ = pm.takeRemedialAction(lockCtx, remedialActionNone, postgresState{})
 
 	// takeRemedialAction with None action doesn't modify last logged reason
 	assert.Equal(t, "", pm.pgMonitorLastLoggedReason)
@@ -1029,17 +1080,17 @@ func TestTakeRemedialAction_LogDeduplication(t *testing.T) {
 	defer pm.actionLock.Release(lockCtx)
 
 	// Call multiple times with same action - reason should stay the same (log deduplication)
-	pm.takeRemedialAction(lockCtx, remedialActionStartPostgres, postgresState{})
+	_ = pm.takeRemedialAction(lockCtx, remedialActionStartPostgres, postgresState{})
 	assert.Equal(t, "starting_postgres", pm.pgMonitorLastLoggedReason)
 
-	pm.takeRemedialAction(lockCtx, remedialActionStartPostgres, postgresState{})
+	_ = pm.takeRemedialAction(lockCtx, remedialActionStartPostgres, postgresState{})
 	assert.Equal(t, "starting_postgres", pm.pgMonitorLastLoggedReason)
 
-	pm.takeRemedialAction(lockCtx, remedialActionStartPostgres, postgresState{})
+	_ = pm.takeRemedialAction(lockCtx, remedialActionStartPostgres, postgresState{})
 	assert.Equal(t, "starting_postgres", pm.pgMonitorLastLoggedReason)
 
 	// Change action type - reason should change
-	pm.takeRemedialAction(lockCtx, remedialActionRestoreFromBackup, postgresState{})
+	_ = pm.takeRemedialAction(lockCtx, remedialActionRestoreFromBackup, postgresState{})
 	assert.Equal(t, "restoring_from_backup", pm.pgMonitorLastLoggedReason)
 }
 
@@ -1150,7 +1201,7 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 				}))
 			}
 
-			pm.takeRemedialAction(lockCtx, tc.action, postgresState{})
+			_ = pm.takeRemedialAction(lockCtx, tc.action, postgresState{})
 
 			assert.Equal(t, tc.wantAvStatus, pm.buildAvailabilityStatus())
 		})
@@ -1173,7 +1224,7 @@ func TestTakeRemedialAction_ReconcileGUC(t *testing.T) {
 	require.NoError(t, err)
 	defer pm.actionLock.Release(lockCtx)
 
-	pm.takeRemedialAction(lockCtx, remedialActionReconcileGUC, postgresState{pgMode: pgmode.Primary})
+	_ = pm.takeRemedialAction(lockCtx, remedialActionReconcileGUC, postgresState{pgMode: pgmode.Primary})
 
 	assert.True(t, frs.reconcileGUCCalled, "ReconcileGUC should have been called")
 	assert.Equal(t, "postgres_running", pm.pgMonitorLastLoggedReason)
@@ -1309,7 +1360,7 @@ func TestTakeRemedialAction_DisableRestoreCommand(t *testing.T) {
 	require.NoError(t, err)
 	defer pm.actionLock.Release(lockCtx)
 
-	pm.takeRemedialAction(lockCtx, remedialActionDisableRestoreCommand, postgresState{pgMode: pgmode.InRecovery})
+	_ = pm.takeRemedialAction(lockCtx, remedialActionDisableRestoreCommand, postgresState{pgMode: pgmode.InRecovery})
 
 	assert.NoError(t, m.ExpectationsWereMet(), "resetRestoreCommand's queries should have run")
 	assert.Len(t, mockPgctld.StopRestoreCommandCalls, 1, "stopRestoreCommand should have called the pgctld RPC")
@@ -1336,7 +1387,7 @@ func TestTakeRemedialAction_ReconcileRole_AppliesRuleDerivedRole(t *testing.T) {
 	require.NoError(t, err)
 	defer pm.actionLock.Release(lockCtx)
 
-	pm.takeRemedialAction(lockCtx, remedialActionReconcileState,
+	_ = pm.takeRemedialAction(lockCtx, remedialActionReconcileState,
 		postgresState{pgctldAvailable: true, postgresRunning: true, pgMode: pgmode.Primary})
 
 	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, pm.record.Type())

--- a/go/services/multipooler/internal/manager/quarantine.go
+++ b/go/services/multipooler/internal/manager/quarantine.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+)
+
+// markPoolerQuarantinedLocked latches this pooler into LIFECYCLE_QUARANTINED.
+//
+// The pooler process is up but its postgres is unrecoverably failing to start
+// (the classic case is a diverged standby FATAL-looping), so it cannot
+// self-heal and must be replaced. Unlike the transient "postgres momentarily
+// down" state, quarantine is a durable verdict:
+//
+//   - It is published on the pooler's own topology record (lifecycle_status),
+//     the signal the operator watches to drive replacement (delete pod + wipe
+//     PVC + restore-from-backup) and the orchestrator observes to drop the node.
+//   - It flips cohort eligibility to INELIGIBLE so the coordinator stops trying
+//     to include the node in consensus.
+//   - It disables further local restart attempts so the node stops
+//     FATAL-looping; a replacement pod comes up clean and re-bootstraps.
+//
+// The verdict does not auto-clear within a process lifetime — recovery happens
+// by replacing the pod, which starts a fresh manager. The caller must hold the
+// action lock (record.Mutate asserts this); the monitor calls it from within
+// monitorPostgresIteration, which already holds the lock.
+func (pm *MultipoolerManager) markPoolerQuarantinedLocked(ctx context.Context, reason string) {
+	// We run both these steps idempotently so that if the first succeeds but
+	// the second fails, we can retry on the next monitor tick without
+	// re-logging the same warning or re-writing the same lifecycle status. It
+	// is critical that both steps succeed eventually, so the operator sees a
+	// quarantined server that is not a primary.
+	var stateChanged bool
+
+	// Idempotent: skip quarantining if already quarantined. This avoids
+	// repeatedly writing the same lifecycle status to the record and logging
+	// the same warning on every monitor tick. The operator/orchestrator only
+	// needs to see the first warning and the first lifecycle-status update;
+	// subsequent ticks are just noise.
+	if pm.record.Snapshot().GetLifecycleStatus().GetStatus() != clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_QUARANTINED {
+		setLifecycleStatus := func(s *MutablePoolerRecordState) {
+			s.LifecycleStatus = &clustermetadatapb.PoolerLifecycle{
+				Status:  clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_QUARANTINED,
+				Reason:  reason,
+				Updated: timestamppb.Now(),
+			}
+		}
+		if err := pm.record.Mutate(ctx, setLifecycleStatus); err != nil {
+			pm.logger.ErrorContext(ctx, "failed to mark pooler quarantined; will retry next tick", "error", err)
+			return
+		}
+		pm.logger.WarnContext(ctx, "pooler quarantined: postgres is unrecoverable, node needs replacement", "reason", reason)
+		stateChanged = true
+	}
+
+	// Idempotent: Stop participating in consensus so the coordinator drops us
+	// from the cohort rather than repeatedly trying (and failing) to recruit
+	// us. If we failed to set the cohort eligibility on a previous tick, we
+	// will retry here. It is critical to avoid the coordinator repeatedly
+	// trying to recruit a node that is known to be unrecoverable and also
+	// ensure that the orchestrator elects a new primary.
+	//
+	// If the node is quarantined but still eligible, the coordinator will keep
+	// trying to recruit it and the orchestrator will not elect a new primary.
+	if pm.consensusMgr.CohortEligibility() != clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE {
+		if err := pm.consensusMgr.SetCohortEligibility(ctx, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE); err != nil {
+			pm.logger.ErrorContext(ctx, "failed to mark cohort ineligible on quarantine", "error", err)
+		} else {
+			// Only count this as a change on success, so a failed set does not
+			// trigger a broadcast for state that did not actually change; the
+			// next tick retries (see trackRecoveryOutcome).
+			stateChanged = true
+		}
+	}
+
+	// Idempotent: Stop hammering doomed start attempts. The node is being
+	// replaced; a fresh pod restarts with this flag clear.
+	pm.postgresRestartsDisabled.Store(true)
+
+	// Publish the transition immediately rather than waiting for the next
+	// heartbeat so the orchestrator/operator see the durable verdict promptly.
+	// We only broadcast if the state changed, to avoid spamming the network
+	// with unnecessary broadcasts.
+	if stateChanged {
+		pm.broadcastHealth()
+	}
+}
+
+// now returns the current time via the injectable clock, defaulting to
+// time.Now when nowFn is unset. Used by the unrecoverable classifier so its
+// timeout gate is deterministic in tests.
+func (pm *MultipoolerManager) now() time.Time {
+	if pm.nowFn != nil {
+		return pm.nowFn()
+	}
+	return time.Now()
+}

--- a/go/services/multipooler/internal/manager/quarantine_test.go
+++ b/go/services/multipooler/internal/manager/quarantine_test.go
@@ -1,0 +1,311 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+)
+
+// fakeClock is a manually-advanced clock so the timeout gate is deterministic.
+type fakeClock struct{ t time.Time }
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+}
+func (c *fakeClock) now() time.Time          { return c.t }
+func (c *fakeClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+// newQuarantineTestManager builds a manager wired with the given timeout and a
+// controllable clock for the unrecoverable classifier.
+func newQuarantineTestManager(t *testing.T, timeout time.Duration) (*MultipoolerManager, *fakeClock) {
+	t.Helper()
+	pm := newTestManager(t)
+	pm.unrecoverableTimeout = timeout
+	clock := newFakeClock()
+	pm.nowFn = clock.now
+	return pm, clock
+}
+
+// withLock runs fn with the action lock held, matching how the monitor calls
+// trackRecoveryOutcome (which writes the quarantine record via record.Mutate).
+func withLock(t *testing.T, pm *MultipoolerManager, fn func(ctx context.Context)) {
+	t.Helper()
+	lockCtx, err := pm.actionLock.Acquire(t.Context(), "test")
+	require.NoError(t, err)
+	defer pm.actionLock.Release(lockCtx)
+	fn(lockCtx)
+}
+
+// failStart drives one failed start attempt through the classifier.
+func failStart(ctx context.Context, pm *MultipoolerManager) {
+	pm.trackRecoveryOutcome(ctx, remedialActionStartPostgres, postgresState{}, assert.AnError)
+}
+
+// quarantineState reads the quarantine verdict straight off the pooler record
+// (the source of truth): whether it is quarantined, plus the reason and the
+// time the verdict latched.
+func quarantineState(pm *MultipoolerManager) (quarantined bool, reason string, since time.Time) {
+	lc := pm.record.Snapshot().GetLifecycleStatus()
+	if lc.GetStatus() != clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_QUARANTINED {
+		return false, "", time.Time{}
+	}
+	return true, lc.GetReason(), lc.GetUpdated().AsTime()
+}
+
+func TestTrackRecoveryOutcome_QuarantinesAfterTimeoutAndAttempts(t *testing.T) {
+	pm, clock := newQuarantineTestManager(t, 30*time.Second)
+
+	withLock(t, pm, func(ctx context.Context) {
+		// Attempts accrue but neither gate is satisfied yet.
+		failStart(ctx, pm) // attempt 1, elapsed 0s
+		clock.advance(10 * time.Second)
+		failStart(ctx, pm) // attempt 2, elapsed 10s
+		clock.advance(10 * time.Second)
+		failStart(ctx, pm) // attempt 3 (floor met), elapsed 20s (< 30s timeout)
+		quarantined, _, _ := quarantineState(pm)
+		assert.False(t, quarantined, "must not quarantine before the timeout elapses")
+
+		// Cross the timeout.
+		clock.advance(15 * time.Second)
+		failStart(ctx, pm) // attempt 4, elapsed 35s (>= 30s)
+	})
+
+	quarantined, reason, since := quarantineState(pm)
+	assert.True(t, quarantined, "should quarantine once both timeout and attempt floor are met")
+	assert.NotEmpty(t, reason)
+	assert.False(t, since.IsZero(), "quarantine timestamp should be set")
+
+	// Side effects: cohort ineligible + restarts disabled so the node stops looping.
+	assert.Equal(t, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE,
+		pm.consensusMgr.CohortEligibility())
+	assert.True(t, pm.postgresRestartsDisabled.Load(), "restarts should be disabled after quarantine")
+}
+
+// TestTrackRecoveryOutcome_RetriesCohortIneligibilityAfterPartialApply covers a
+// node that latched the QUARANTINED lifecycle but is not yet cohort-INELIGIBLE —
+// the state left behind if SetCohortEligibility failed on the tick the node
+// first quarantined. A later monitor tick must re-apply the missing side effect;
+// otherwise the coordinator keeps trying to recruit the node and the
+// orchestrator never elects a new primary. (The lifecycle latch alone would make
+// trackRecoveryOutcome short-circuit, so the retry has to be driven explicitly.)
+func TestTrackRecoveryOutcome_RetriesCohortIneligibilityAfterPartialApply(t *testing.T) {
+	pm, clock := newQuarantineTestManager(t, 30*time.Second)
+
+	// Quarantine the node the normal way (both side effects applied).
+	withLock(t, pm, func(ctx context.Context) {
+		failStart(ctx, pm)
+		clock.advance(10 * time.Second)
+		failStart(ctx, pm)
+		clock.advance(10 * time.Second)
+		failStart(ctx, pm)
+		clock.advance(15 * time.Second)
+		failStart(ctx, pm) // crosses both gates -> quarantined
+	})
+	quarantined, _, _ := quarantineState(pm)
+	require.True(t, quarantined, "precondition: node should be quarantined")
+	require.Equal(t, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE,
+		pm.consensusMgr.CohortEligibility())
+
+	// Simulate a first-quarantine tick where the lifecycle latched but the cohort
+	// ineligibility write did not stick: force eligibility back to ELIGIBLE.
+	withLock(t, pm, func(ctx context.Context) {
+		require.NoError(t, pm.consensusMgr.SetCohortEligibility(ctx,
+			clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE))
+	})
+	require.Equal(t, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE,
+		pm.consensusMgr.CohortEligibility(), "precondition: quarantined but still recruitable")
+
+	// A later monitor tick must re-apply the missing side effect.
+	withLock(t, pm, func(ctx context.Context) {
+		failStart(ctx, pm)
+	})
+
+	stillQuarantined, _, _ := quarantineState(pm)
+	assert.True(t, stillQuarantined, "lifecycle verdict must remain latched")
+	assert.Equal(t, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE,
+		pm.consensusMgr.CohortEligibility(),
+		"cohort ineligibility should be retried and applied on a later tick")
+}
+
+func TestTrackRecoveryOutcome_TimeoutGateHolds(t *testing.T) {
+	// Many attempts but the timeout never elapses: must not quarantine.
+	pm, clock := newQuarantineTestManager(t, time.Hour)
+
+	withLock(t, pm, func(ctx context.Context) {
+		for range 20 {
+			failStart(ctx, pm)
+			clock.advance(5 * time.Second) // 20 * 5s = 100s << 1h
+		}
+	})
+
+	quarantined, _, _ := quarantineState(pm)
+	assert.False(t, quarantined, "should not quarantine before the timeout regardless of attempt count")
+}
+
+func TestTrackRecoveryOutcome_MinAttemptsFloorHolds(t *testing.T) {
+	// Timeout is tiny, so only the attempts floor should keep it from quarantining
+	// on too few real attempts.
+	pm, clock := newQuarantineTestManager(t, time.Second)
+
+	withLock(t, pm, func(ctx context.Context) {
+		failStart(ctx, pm) // attempt 1, elapsed 0
+		clock.advance(10 * time.Second)
+		failStart(ctx, pm) // attempt 2, elapsed 10s (>= timeout) but attempts < floor(3)
+		quarantined, _, _ := quarantineState(pm)
+		assert.False(t, quarantined, "must not quarantine before the min-attempts floor")
+
+		failStart(ctx, pm) // attempt 3, elapsed 10s -> both gates satisfied
+	})
+
+	quarantined, _, _ := quarantineState(pm)
+	assert.True(t, quarantined, "should quarantine once the attempt floor is also met")
+}
+
+func TestTrackRecoveryOutcome_ConfigurableMinAttemptsFloor(t *testing.T) {
+	// A custom floor of 2 (below the default 3) must be honored: quarantine on
+	// the second failed attempt once the timeout has elapsed, not the third.
+	pm, clock := newQuarantineTestManager(t, time.Second)
+	pm.unrecoverableMinAttempts = 2
+
+	withLock(t, pm, func(ctx context.Context) {
+		failStart(ctx, pm) // attempt 1, elapsed 0 (< timeout, and < floor)
+		quarantined, _, _ := quarantineState(pm)
+		assert.False(t, quarantined, "one attempt must not quarantine")
+
+		clock.advance(2 * time.Second)
+		failStart(ctx, pm) // attempt 2, elapsed 2s -> floor(2) met and timeout met
+	})
+
+	quarantined, _, _ := quarantineState(pm)
+	assert.True(t, quarantined, "custom floor of 2 should quarantine on the second attempt")
+}
+
+func TestTrackRecoveryOutcome_ResetOnPostgresRunning(t *testing.T) {
+	pm, clock := newQuarantineTestManager(t, 30*time.Second)
+
+	withLock(t, pm, func(ctx context.Context) {
+		failStart(ctx, pm)
+		clock.advance(25 * time.Second)
+		failStart(ctx, pm)
+
+		// Postgres comes up: the streak breaks (attempts and anchor reset).
+		pm.trackRecoveryOutcome(ctx, remedialActionNone, postgresState{postgresRunning: true}, nil)
+		assert.Equal(t, 0, pm.unrecoverableFailedAttempts, "streak should reset when postgres runs")
+
+		// A fresh streak: the timeout is now measured from here, so a short burst
+		// must not quarantine even though a lot of wall-clock has passed overall.
+		clock.advance(time.Hour)
+		failStart(ctx, pm)
+		failStart(ctx, pm)
+		failStart(ctx, pm)
+	})
+
+	quarantined, _, _ := quarantineState(pm)
+	assert.False(t, quarantined, "reset should re-anchor the timeout window")
+}
+
+func TestTrackRecoveryOutcome_DisabledWhenTimeoutZero(t *testing.T) {
+	pm, clock := newQuarantineTestManager(t, 0) // classifier disabled
+
+	withLock(t, pm, func(ctx context.Context) {
+		for range 100 {
+			failStart(ctx, pm)
+			clock.advance(time.Minute)
+		}
+	})
+
+	quarantined, _, _ := quarantineState(pm)
+	assert.False(t, quarantined, "timeout 0 must never quarantine")
+}
+
+func TestTrackRecoveryOutcome_OnlyFailedRecoveryActionsCount(t *testing.T) {
+	pm, clock := newQuarantineTestManager(t, 10*time.Second)
+
+	withLock(t, pm, func(ctx context.Context) {
+		// A successful start (nil error) does not count.
+		pm.trackRecoveryOutcome(ctx, remedialActionStartPostgres, postgresState{}, nil)
+		// A non-recovery action that errored does not count.
+		pm.trackRecoveryOutcome(ctx, remedialActionReconcileState, postgresState{}, assert.AnError)
+		assert.Equal(t, 0, pm.unrecoverableFailedAttempts)
+
+		// Genuine failed recovery attempts across the timeout window quarantine.
+		failStart(ctx, pm)
+		clock.advance(6 * time.Second)
+		pm.trackRecoveryOutcome(ctx, remedialActionRewindToLeader, postgresState{}, assert.AnError)
+		clock.advance(6 * time.Second)
+		pm.trackRecoveryOutcome(ctx, remedialActionRestoreFromBackup, postgresState{}, assert.AnError)
+	})
+
+	quarantined, _, _ := quarantineState(pm)
+	assert.True(t, quarantined, "mixed failed recovery actions should count toward quarantine")
+}
+
+func TestTrackRecoveryOutcome_IdempotentAfterQuarantine(t *testing.T) {
+	pm, clock := newQuarantineTestManager(t, 5*time.Second)
+
+	withLock(t, pm, func(ctx context.Context) {
+		failStart(ctx, pm)
+		clock.advance(3 * time.Second)
+		failStart(ctx, pm)
+		clock.advance(3 * time.Second)
+		failStart(ctx, pm) // attempt 3, elapsed 6s -> quarantine
+		quarantined, _, firstSince := quarantineState(pm)
+		require.True(t, quarantined)
+
+		// Further failing ticks must not re-publish or move the latch time.
+		clock.advance(time.Minute)
+		failStart(ctx, pm)
+		_, _, laterSince := quarantineState(pm)
+		assert.Equal(t, firstSince, laterSince, "quarantine latch time should be stable")
+	})
+}
+
+func TestMarkPoolerQuarantinedLocked_Idempotent(t *testing.T) {
+	pm := newTestManager(t)
+
+	withLock(t, pm, func(ctx context.Context) {
+		pm.markPoolerQuarantinedLocked(ctx, "first")
+		quarantined, reason, firstSince := quarantineState(pm)
+		require.True(t, quarantined)
+		require.Equal(t, "first", reason)
+
+		// A second call is a no-op: the idempotency guard short-circuits before
+		// re-publishing, so neither the reason nor the latch time changes.
+		pm.markPoolerQuarantinedLocked(ctx, "second")
+		quarantined, reason, laterSince := quarantineState(pm)
+		assert.True(t, quarantined)
+		assert.Equal(t, "first", reason, "reason must not change on a repeat call")
+		assert.Equal(t, firstSince, laterSince, "latch time must not change on a repeat call")
+	})
+}
+
+func TestManagerNow_FallsBackToWallClock(t *testing.T) {
+	pm := newTestManager(t)
+	pm.nowFn = nil // exercise the time.Now() fallback
+
+	before := time.Now()
+	got := pm.now()
+	after := time.Now()
+
+	assert.False(t, got.Before(before), "now() should not predate the call")
+	assert.False(t, got.After(after), "now() should not postdate the call")
+}

--- a/go/services/multipooler/quarantine_flag_test.go
+++ b/go/services/multipooler/quarantine_flag_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multipooler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateUnrecoverableMinAttempts(t *testing.T) {
+	tests := []struct {
+		n  int
+		ok bool
+	}{
+		{0, false},  // unset / below floor
+		{1, false},  // a floor of 1 defeats the purpose
+		{2, true},   // lower bound (inclusive)
+		{3, true},   // default
+		{9, true},   // upper bound (inclusive, since 10 is exclusive)
+		{10, false}, // upper bound is exclusive
+		{50, false},
+		{-1, false},
+	}
+	for _, tc := range tests {
+		err := validateUnrecoverableMinAttempts(tc.n)
+		if tc.ok {
+			require.NoError(t, err, "n=%d should be valid", tc.n)
+		} else {
+			assert.Error(t, err, "n=%d should be rejected", tc.n)
+		}
+	}
+
+	// The default must fall inside the valid range.
+	require.NoError(t, validateUnrecoverableMinAttempts(defaultPostgresUnrecoverableMinAttempts))
+}

--- a/go/test/endtoend/multiorch/pooler_quarantine_test.go
+++ b/go/test/endtoend/multiorch/pooler_quarantine_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiorch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestStandbyQuarantinesOnUnrecoverablePostgres verifies the Layer-1
+// unrecoverable-FATAL-loop detection end to end with real postgres: a standby
+// whose postgres can no longer start (the classic genuinely-diverged case,
+// simulated here by corrupting its control file) must quarantine itself rather
+// than retrying forever, flipping its topology record to LIFECYCLE_QUARANTINED.
+//
+// Uses NewIsolated because the fault (corrupting a data directory) is
+// destructive and must not poison the shared fixture.
+func TestStandbyQuarantinesOnUnrecoverablePostgres(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real-postgres e2e in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("real postgres binaries not available")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(
+		t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultiorchCount(1),
+		// Quarantine quickly: a 15s continuous-failure budget (plus the built-in
+		// min-attempts floor, reached in ~15s at the 5s monitor tick) versus the
+		// production default of OFF.
+		shardsetup.WithMultipoolerExtraArgs("--postgres-unrecoverable-timeout=15s"),
+	)
+	defer cleanup()
+
+	setup.StartMultiorchs(t.Context(), t)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioInitialSettle)
+	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
+
+	// Pick a standby — never the primary. Corrupting the primary would trigger a
+	// failover, which is a different scenario; we want to observe a standby
+	// self-quarantining.
+	setup.RefreshPrimary(t)
+	standbys := setup.GetStandbys()
+	require.NotEmpty(t, standbys, "expected at least one standby")
+	standby := standbys[0]
+	standbyName := standby.Name
+	t.Logf("Inducing unrecoverable postgres on standby %s (primary=%s)", standbyName, setup.PrimaryName)
+
+	// Make postgres persistently fail to start:
+	//  1. Stop it. StopPostgres disables the monitor's auto-restart first, so we
+	//     get a clean window to corrupt the data directory.
+	//  2. Truncate global/pg_control — postgres FATALs on every subsequent start
+	//     ("could not read control file"). We leave PG_VERSION intact so pgctld
+	//     still reports the directory as initialized and the monitor keeps
+	//     choosing StartPostgres (which fails) instead of restore-from-backup.
+	//  3. Re-enable restarts. From here every 5s monitor tick attempts a start,
+	//     fails, and increments the unrecoverable streak.
+	resume := setup.StopPostgres(t, standbyName, "immediate")
+	pgControl := filepath.Join(standby.Pgctld.PoolerDir, "pg_data", "global", "pg_control")
+	require.FileExists(t, pgControl, "pg_control should exist before corruption")
+	require.NoError(t, os.Truncate(pgControl, 0), "failed to truncate pg_control")
+	resume()
+
+	// The pooler quarantines itself in topology.
+	standbyID := setup.GetMultipoolerID(standbyName)
+	require.Eventually(t, func() bool {
+		mp, err := setup.TopoServer.GetMultipooler(t.Context(), standbyID)
+		if err != nil {
+			return false
+		}
+		return mp.GetLifecycleStatus().GetStatus() == clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_QUARANTINED
+	}, utils.ScaleTimeout(60*time.Second), 500*time.Millisecond,
+		"standby %s should quarantine itself once postgres is unrecoverable", standbyName)
+}


### PR DESCRIPTION
## What & why

A multipooler whose PostgreSQL is *unrecoverably* failing to start — the classic case being a genuinely diverged standby that keeps FATAL-looping — is invisible to Kubernetes today. postgres is a child of pgctld, so the pgctld and multipooler containers stay `Running` and the pod stays `Ready`; the monitor just logs "failed to start Postgres, will retry" every 5s forever with no terminal state and no backoff on the start path. Nothing ever flags the node for replacement.

This PR adds **Layer 1** of the fix: the pooler detects that its postgres is unrecoverable, marks itself not-usable, and exposes a durable signal that an external actor can act on. It is deliberately orthogonal to the readiness probe (#1363 intentionally keeps `/ready` on the gRPC control plane, not postgres); this is the separate "needs replacement" signal.

## What it does

The postgres monitor now classifies "postgres continuously failing to start/rewind/restore for longer than a configurable timeout, across at least a small floor of genuine attempts" as an unrecoverable FATAL loop, and quarantines the pooler:

- Writes `LIFECYCLE_QUARANTINED` to its own topology record — the durable signal an external replacer watches (a pre-existing, purpose-built lifecycle value; see the design note below).
- Flips cohort eligibility to `INELIGIBLE` so the coordinator drops it from consensus.
- Disables further restart attempts so the node stops FATAL-looping.

The verdict needs no new proto or health-stream surface. The topology `lifecycle_status` is the single signal: the operator (Layer 2) reads it, and multiorch already carries the topology `Multipooler` record — including `lifecycle_status` — in its pooler-watch cache, so it needs no new plumbing to observe it. multiorch's behavioural response (dropping the node from consensus) comes from the `INELIGIBLE` cohort-eligibility signal above, which it already acts on. (multiorch only acts on the `SHUTDOWN` lifecycle value today; it deliberately does not tear down a `QUARANTINED` pooler — the node is kept for replacement, not tombstoned.)

## Design notes

**Reuses a state the codebase was already designed for — this PR only supplies the missing producer.** `LIFECYCLE_QUARANTINED` is not new. It has existed in the proto with a detailed doc comment describing exactly this scenario — "it cannot automatically recover to a functioning state (e.g. it could not complete a pg_rewind, could not restore from backup to start postgres…) … Only the pooler sets this on itself … the operator/provisioner should treat a QUARANTINED pooler as absent … and provision a replacement" — and the operator **already** reads it (`isLifecycleQuarantined`, used to drop such poolers from the healthy set and from primary-candidate selection). Until now, though, *nothing ever set it*: the value was defined and consumed but had **no producer**. This PR is that producer. That the enum, its precise semantics, its pooler-owns-it rule, and its operator-side consumer were all put in place up front is a strong signal that a pooler-owned, lifecycle-based signal is the sanctioned shape of this fix — we are completing an intended design, not bolting on a new mechanism.

**Ownership — only the pooler writes its own topology record. Why not the orchestrator?** A fair question is whether the orchestrator should set `LIFECYCLE_QUARANTINED` instead. It can't, durably: the pooler continuously republishes its own topology record, so any lifecycle value another actor writes is overwritten on the next publish — the pooler is the sole writer by construction. This isn't specific to this PR; `fix_replication` already carries a TODO to "signal this durably via the pooler's lifecycle stage … Orch must not write the pooler's topology Type — the pooler owns its own record and would clobber an external write."

Beyond that hard constraint, the pooler is also the *right* owner on the merits: it has first-hand ground truth (the actual failed start/rewind/restore attempts) where the orchestrator can only infer liveness from a distance, and by ruleguard the orchestrator may not even read role/serving fields for identity. This matches the codebase's direction of travel — orchestrator-driven RPCs like `RewindToSource` and `DemoteStalePrimary` were removed in favor of pooler-autonomous self-heal.

The orchestrator does retain a role for the one case the pooler can't judge alone — "this node has fallen irrecoverably behind while its peers replicate fine" — but that is a future orchestrator-*initiated* request that asks the pooler to quarantine itself; the pooler stays the writer.

**Time-based gating with an attempts floor.** The gate is elapsed time since the first failure (`--postgres-unrecoverable-timeout`, e.g. `5m`) plus a minimum-attempts floor (`--postgres-unrecoverable-min-attempts`, default 3, validated to be in `[2, 10)`), rather than a raw attempt count. This is independent of the monitor interval and, importantly, robust to the fact that a fast start-FATAL (seconds) and a slow restore failure (minutes) would otherwise map to wildly different wall-clock budgets under a pure count. The timeout is the real gate; the floor just guards the degenerate cases (a single hung attempt, sparse ticks) — hence the small upper bound.

**Defaults to disabled.** Quarantining disables restarts and marks the node ineligible, so it is only safe once an actor exists to replace quarantined nodes. `--postgres-unrecoverable-timeout` defaults to `0` (disabled); the operator's manifests opt in when Layer 2 ships.

## Follow-up (Layer 2, separate PR)

The operator (multigres/multigres-operator) will watch `LIFECYCLE_QUARANTINED` and drive remediation — delete the pod, wipe its data PVC, and let the node re-bootstrap from backup — which is the only path that actually heals genuine on-disk divergence (a same-PVC restart would FATAL-loop identically). It lives in the operator repo, so it is a separate PR; it needs no proto change from this one — the operator already reads the `QUARANTINED` lifecycle value.

## Testing

- Unit: `quarantine_test.go` — 7 tests with an injectable clock covering both gates independently (timeout holds despite many attempts; attempts floor holds despite elapsed timeout; reset re-anchors the window on recovery; disabled; only genuine failed recovery actions count; idempotent latch).
- E2E (real postgres): `multiorch/pooler_quarantine_test.go` — brings up a 3-pooler shard with multiorch on an isolated fixture, corrupts a standby's `pg_control` so postgres persistently FATALs on start, and asserts the standby self-quarantines in topology.
- Full multipooler package suite green; `golangci-lint` clean. No proto or generated-file changes.

## Related PRs

- **Layer 2 (operator):** multigres/multigres-operator#568 — watches the `LIFECYCLE_QUARANTINED` signal produced here and drives remediation (delete pod + wipe data PVC + re-bootstrap from backup).

Fixes MUL-644. Part of MUL-1009.


