### PR TITLE
test(queryserving): add PostgREST spec suite through the multigateway

### DIFF
--- a/.github/workflows/test-postgrest.yml
+++ b/.github/workflows/test-postgrest.yml
@@ -1,0 +1,119 @@
+# Copyright 2026 Supabase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: PostgREST Spec Suite
+
+# Runs PostgREST's upstream hspec suite with PostgREST pointed at the
+# multigateway, classifying each failure as a gateway divergence (fails
+# proxied, passes on direct PostgreSQL) or an environment failure. The test
+# fails while any divergence remains, so this job is EXPECTED to be red until
+# the open divergences in DIVERGENCES.md are closed — the divergence count is
+# written to the job summary via report.go. Opt-in only: runs when a PR is
+# labeled "Run Extended Query Serving Tests" / "Run all Query Serving Tests",
+# or on manual dispatch. No cron (and thus no Slack) while divergences remain.
+on: # yamllint disable-line rule:truthy
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  test-postgrest:
+    name: Run PostgREST spec suite
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'Run Extended Query Serving Tests') ||
+      contains(github.event.pull_request.labels.*.name, 'Run all Query Serving Tests')
+    runs-on: ubuntu-24.04
+    environment:
+      name: ci
+      deployment: false
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Set up test environment
+        run: .github/scripts/setup-test-environment.sh
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          # build-essential/bison/flex/libreadline/zlib build the multigres
+          # binaries. postgresql-17-postgis-3 gives the system PG the PostGIS
+          # extension the fixtures need, so the test uses the package instead of
+          # building PostGIS from source (the pgcrypto/ltree/isn/file_fdw
+          # extensions already ship in postgresql-contrib-17 from the shared
+          # setup script above).
+          sudo apt-get install -y \
+            build-essential bison flex libreadline-dev zlib1g-dev \
+            postgresql-17-postgis-3
+
+      - name: Build
+        run: make build
+
+      - name: Start port pool server
+        run: |
+          ./bin/portpoolserver --socket /tmp/multigres-port-pool.sock &
+          echo "PORT_POOL_PID=$!" >> "$GITHUB_ENV"
+          echo "MULTIGRES_PORT_POOL_ADDR=/tmp/multigres-port-pool.sock" >> "$GITHUB_ENV"
+
+      - name: Run PostgREST spec suite
+        # The test fails on any gateway divergence; pipefail propagates that exit
+        # code through tparse so the job goes red (expected while divergences are
+        # open). The divergence count is written to the job summary regardless.
+        env:
+          RUN_EXTENDED_QUERY_SERVING_TESTS: "1"
+          TEST_PRINT_LOGS: "1"
+        run: |
+          set -o pipefail
+          go test -json -v -run 'TestPostgREST$' \
+            ./go/test/endtoend/queryserving/postgresttests/... \
+            -timeout 170m | tee postgrest-results.jsonl | go tool tparse -follow
+
+      - name: Stop port pool server
+        if: always()
+        run: kill "$PORT_POOL_PID" || true
+
+      - name: Upload PostgREST results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ !cancelled() }}
+        with:
+          name: postgrest-results
+          path: |
+            /tmp/multigres_postgrest_cache/results/**/*
+            postgrest-results.jsonl
+          if-no-files-found: warn
+
+      # On failure, surface the per-process cluster logs from the shardsetup
+      # tempdir (multipooler.log, pgctld.log, multigateway.log, multiorch.log).
+      - name: Upload cluster logs on failure
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ failure() }}
+        with:
+          name: postgrest-cluster-logs
+          path: /tmp/shardsetup_test_*/**/*.log
+          if-no-files-found: warn
+          retention-days: 7
+
+      # The Go test writes the pass/divergence summary (shields.io badge + the
+      # divergence and environment-failure lists) to GITHUB_STEP_SUMMARY via
+      # report.go; full per-spec output is in the uploaded artifact.

--- a/.github/workflows/test-postgrest.yml
+++ b/.github/workflows/test-postgrest.yml
@@ -15,13 +15,15 @@
 name: PostgREST Spec Suite
 
 # Runs PostgREST's upstream hspec suite with PostgREST pointed at the
-# multigateway, classifying each failure as a gateway divergence (fails
-# proxied, passes on direct PostgreSQL) or an environment failure. The test
-# fails while any divergence remains, so this job is EXPECTED to be red until
-# the open divergences in DIVERGENCES.md are closed — the divergence count is
-# written to the job summary via report.go. Opt-in only: runs when a PR is
-# labeled "Run Extended Query Serving Tests" / "Run all Query Serving Tests",
-# or on manual dispatch. No cron (and thus no Slack) while divergences remain.
+# multigateway. The direct-PostgreSQL baseline is an asserted invariant (every
+# non-skipped spec passes on plain postgres), so this job is gateway-only and
+# every gateway failure is a divergence; POSTGREST_FULL_BASELINE=1 re-verifies
+# the invariant locally (not run here). The test fails while any divergence
+# remains, so this job is EXPECTED to be red until the open divergences in
+# DIVERGENCES.md are closed — the divergence count is written to the job summary
+# via report.go. Opt-in only: runs when a PR is labeled "Run Extended Query
+# Serving Tests" / "Run all Query Serving Tests", or on manual dispatch. No cron
+# (and thus no Slack) while divergences remain.
 on: # yamllint disable-line rule:truthy
   pull_request:
     types: [labeled]

--- a/go/test/endtoend/queryserving/postgresttests/DIVERGENCES.md
+++ b/go/test/endtoend/queryserving/postgresttests/DIVERGENCES.md
@@ -15,9 +15,10 @@ RUN_POSTGREST=1 go test -v -run 'TestPostgREST$' ./go/test/endtoend/queryserving
 # DIVERGE: lines are gateway divergences; ENV: lines are environment failures.
 ```
 
-**Status (2026-08-11, full suite = 1303 examples):** 48 gateway divergences,
-1 environment failure. ~42 of the 48 are a single root cause (set_config
-position, below) — fixing that one closes the large majority.
+**Status (2026-08-11, full suite = 1303 examples):** 49 gateway divergences,
+0 environment failures — the direct-PostgreSQL baseline is fully green. ~42 of
+the divergences are a single root cause (set_config position, below) — fixing
+that one closes the large majority.
 
 ## Normalizations already applied (so these are NOT divergences)
 
@@ -31,6 +32,13 @@ as gateway bugs:
 max_parallel_workers_per_gather/max_parallel_workers` back to PostgreSQL defaults
   (pgctld tunes them, which changes EXPLAIN costs and EXPLAIN `(SETTINGS)` output).
   Fixed 5 PlanSpec cost/settings divergences.
+- **RangeSpec ANALYZE hook** → the suite ANALYZEs `test.items` / `test.child_entities`
+  before the RangeSpec group "to get accurate results from EXPLAIN"
+  (`SpecHelper.analyzeTable`), by shelling out to `psql -U postgres` inside the spec
+  container. That is the suite's only subprocess call, and it has no in-container psql
+  and no `postgres` superuser reachable through the proxy, so it failed on both paths.
+  `loadFixtures` now runs the ANALYZE itself as the loader's superuser, and the image
+  ships a no-op `psql` shim so the redundant hook exits 0. Fixed the 1 environment failure.
 
 ## Open gateway divergences
 

--- a/go/test/endtoend/queryserving/postgresttests/DIVERGENCES.md
+++ b/go/test/endtoend/queryserving/postgresttests/DIVERGENCES.md
@@ -1,0 +1,88 @@
+# PostgREST suite — known gateway divergences
+
+`TestPostgREST` runs PostgREST's upstream spec suite with PostgREST pointed at
+the multigateway and compares each failing spec against a direct-PostgreSQL
+baseline (see `postgrest_test.go`). A **gateway divergence** = a spec that fails
+through the gateway but passes on direct PostgreSQL — a real behavioural gap on
+the proxied path. The test **fails** while any divergence remains; this file is
+the checklist for closing them. **Environment failures** (fail on both paths)
+are not the gateway's fault and do not fail the test.
+
+Regenerate the list:
+
+```bash
+RUN_POSTGREST=1 go test -v -run 'TestPostgREST$' ./go/test/endtoend/queryserving/postgresttests/...
+# DIVERGE: lines are gateway divergences; ENV: lines are environment failures.
+```
+
+**Status (2026-08-11, full suite = 1303 examples):** 48 gateway divergences,
+1 environment failure. ~42 of the 48 are a single root cause (set_config
+position, below) — fixing that one closes the large majority.
+
+## Normalizations already applied (so these are NOT divergences)
+
+Handled in `loadFixtures` / the runner so environment differences don't masquerade
+as gateway bugs:
+
+- **Timezone** → `ALTER DATABASE … SET timezone = 'UTC'` (our built PG inherits the
+  host tz; upstream bakes UTC via `TZ=utc initdb`). Fixed the 11 data-representation
+  failures.
+- **Planner GUCs** → `ALTER DATABASE … SET work_mem/random_page_cost/effective_cache_size/
+max_parallel_workers_per_gather/max_parallel_workers` back to PostgreSQL defaults
+  (pgctld tunes them, which changes EXPLAIN costs and EXPLAIN `(SETTINGS)` output).
+  Fixed 5 PlanSpec cost/settings divergences.
+
+## Open gateway divergences
+
+### 1. `set_config()` rejected outside a top-level SELECT target — ~42 divergences ⬅ **fix this first**
+
+**Affected:** all mutation-path specs — `UpsertSpec` (29), `PlanSpec` upsert-plan
+tests (6), `PostGISSpec`/`MultipleSchemaSpec`/`RpcPreRequestGucsSpec` PUT tests (3),
+and the `Rollback{Allowed,Disallowed,Forced}Spec` POST tests.
+
+**Symptom:** HTTP 400/500; backend error `SQLSTATE 0A000: set_config is only
+supported as a top-level SELECT target list entry — use a SET statement, or
+set_config(..., true) for a transaction-scoped change`.
+
+**Root cause:** PostgREST's mutation SQL calls `set_config('pgrst.inserted', …, true)`
+inside the INSERT's `WHERE` clause (its row-count trick), wrapped in a CTE:
+
+```sql
+WITH pgrst_source AS (
+  INSERT INTO t (...) SELECT ... WHERE set_config('pgrst.inserted', …, true) <> '0'
+  ON CONFLICT (...) DO UPDATE SET ... WHERE set_config('pgrst.inserted', …, true) <> '-1'
+  RETURNING ...
+) SELECT ...
+```
+
+The gateway's unsafe-funccall analyzer only allows `set_config` as a top-level
+`SelectStmt` target — `go/services/multigateway/planner/unsafe_funccall.go:501-504`,
+and `collectTopLevelSetConfigs` deliberately does not recurse into CTEs / subqueries
+/ WHERE. So it rejects the call, even though it is `is_local=true` (transaction-scoped
+and harmless — the analyzer already leaves top-level `is_local` set_config untracked
+at `unsafe_funccall.go:548`). PostgreSQL accepts `set_config` anywhere, so the write
+works on a direct connection and fails only through the gateway.
+
+**Minimal repro (deterministic):**
+
+```sql
+SELECT 1 WHERE set_config('x','1',true) <> '0'   -- gateway: 0A000; postgres: ok
+SELECT set_config('x','1',true)                  -- gateway: ok (top-level, allowed)
+```
+
+**Fix direction:** allow `set_config(name, value, true)` (is_local) in non-top-level
+positions — it is transaction-scoped, so the pooler needn't track or intercept it
+(the same reasoning already applied to top-level is_local calls).
+
+### 2. `ServerTimingSpec` — 1 divergence
+
+**Symptom:** Server-Timing response header differs. Likely timing-value/format
+dependent; needs its own look. Status: open, unexamined.
+
+## Intentionally skipped specs
+
+Skipped via `specSkips()` in `spec_runner.go` (extend with `POSTGREST_SKIP`):
+
+- **`Feature.Query.PgSafeUpdateSpec`** — needs the `pg-safeupdate` extension
+  (github.com/eradman/pg-safeupdate), which we don't build. Not a gateway bug;
+  install the extension to cover these 4 tests.

--- a/go/test/endtoend/queryserving/postgresttests/DIVERGENCES.md
+++ b/go/test/endtoend/queryserving/postgresttests/DIVERGENCES.md
@@ -1,18 +1,28 @@
 # PostgREST suite — known gateway divergences
 
 `TestPostgREST` runs PostgREST's upstream spec suite with PostgREST pointed at
-the multigateway and compares each failing spec against a direct-PostgreSQL
-baseline (see `postgrest_test.go`). A **gateway divergence** = a spec that fails
-through the gateway but passes on direct PostgreSQL — a real behavioural gap on
-the proxied path. The test **fails** while any divergence remains; this file is
-the checklist for closing them. **Environment failures** (fail on both paths)
-are not the gateway's fault and do not fail the test.
+the multigateway (see `postgrest_test.go`). The direct-PostgreSQL baseline is an
+**asserted invariant**: every non-skipped spec passes on plain postgres, so the
+default run is **gateway-only** and any gateway failure is a **gateway
+divergence** — a real behavioural gap on the proxied path. The test **fails**
+while any divergence remains; this file is the checklist for closing them.
 
-Regenerate the list:
+Regenerate the list (gateway-only):
 
 ```bash
 RUN_POSTGREST=1 go test -v -run 'TestPostgREST$' ./go/test/endtoend/queryserving/postgresttests/...
-# DIVERGE: lines are gateway divergences; ENV: lines are environment failures.
+# DIVERGE: lines are gateway divergences.
+```
+
+Re-verify the baseline invariant after bumping the PostgREST tag or editing
+fixtures — this also runs a throwaway direct PostgreSQL and classifies each
+gateway failure as a divergence or an **environment failure** (fails on both
+paths, so the invariant is broken — fix the harness/fixtures, not the gateway):
+
+```bash
+RUN_POSTGREST=1 POSTGREST_FULL_BASELINE=1 \
+  go test -v -run 'TestPostgREST$' ./go/test/endtoend/queryserving/postgresttests/...
+# ENV: lines are environment failures; BASELINE FAIL lines break the invariant.
 ```
 
 **Status (2026-08-11, full suite = 1303 examples):** 49 gateway divergences,

--- a/go/test/endtoend/queryserving/postgresttests/fixtures.go
+++ b/go/test/endtoend/queryserving/postgresttests/fixtures.go
@@ -140,6 +140,19 @@ func loadFixtures(t *testing.T, ctx context.Context, conn pgConn, srcDir string)
 		return fmt.Errorf("load fixtures from %s: %w", loadSQL, err)
 	}
 
+	// Refresh planner statistics on the tables the suite ANALYZEs before the
+	// RangeSpec group ("to get accurate results from EXPLAIN" — Main.hs /
+	// SpecHelper.analyzeTable). Upstream does this by shelling out to
+	// `psql -U postgres` from inside the spec container, but our harness has no
+	// in-container superuser psql and no `postgres` role reachable through the
+	// proxy, so we run the ANALYZE here as the loader's superuser instead. The
+	// container's psql is a no-op shim so the (now redundant) hook still exits 0
+	// — see testdata/Dockerfile.spec.
+	analyze := fmt.Sprintf(`ANALYZE %[1]s."items"; ANALYZE %[1]s."child_entities";`, fixtureSchema)
+	if err := runPsql(ctx, conn, []string{"-v", "ON_ERROR_STOP=1", "-c", analyze}); err != nil {
+		return fmt.Errorf("analyze fixture tables: %w", err)
+	}
+
 	t.Logf("Loaded PostgREST fixtures into %s:%d (schema %q, authenticator %q)",
 		conn.Host, conn.Port, fixtureSchema, authenticatorRole)
 	return nil

--- a/go/test/endtoend/queryserving/postgresttests/fixtures.go
+++ b/go/test/endtoend/queryserving/postgresttests/fixtures.go
@@ -94,6 +94,28 @@ func loadFixtures(t *testing.T, ctx context.Context, conn pgConn, srcDir string)
 		return fmt.Errorf("set database timezone to UTC: %w", err)
 	}
 
+	// Reset the query-planner GUCs to PostgreSQL defaults for this database. The
+	// multigres cluster's pgctld tunes them (work_mem=1092kB, random_page_cost=1.1,
+	// effective_cache_size=192MB, max_parallel_workers_per_gather=1), which changes
+	// EXPLAIN cost estimates and makes PostgREST's PlanSpec (which asserts exact
+	// costs) diverge from the default-config direct baseline. Setting the defaults
+	// at the database level (PostgREST resets each request's session to it) makes
+	// the planner behave identically on both paths, so those become non-divergences.
+	for _, guc := range []string{
+		"work_mem TO '4MB'",
+		"random_page_cost TO 4",
+		"effective_cache_size TO '4GB'",
+		"max_parallel_workers_per_gather TO 2",
+		// max_parallel_workers is GUC_EXPLAIN, so a non-default value (the cluster
+		// sets 2) shows up in EXPLAIN (SETTINGS) output and breaks the PlanSpec
+		// "outputs the search path when using the settings option" test.
+		"max_parallel_workers TO 8",
+	} {
+		if err := runPsql(ctx, conn, []string{"-v", "ON_ERROR_STOP=1", "-c", "ALTER DATABASE postgres SET " + guc + ";"}); err != nil {
+			return fmt.Errorf("reset planner GUC (%s): %w", guc, err)
+		}
+	}
+
 	// Create the authenticator role first (idempotently), with a password so it
 	// can authenticate over TCP/scram. NOINHERIT + no elevated attributes match
 	// upstream; SET ROLE relies on the grants in roles.sql.

--- a/go/test/endtoend/queryserving/postgresttests/fixtures.go
+++ b/go/test/endtoend/queryserving/postgresttests/fixtures.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresttests
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/multigres/multigres/go/tools/executil"
+)
+
+const (
+	// authenticatorRole is the login role PostgREST connects as. Upstream's
+	// harness uses this exact mixed-case name deliberately, to exercise
+	// identifier quoting in the schema-cache queries; keep it verbatim. It is a
+	// minimally privileged role (no superuser, no inherit) that SET ROLEs into
+	// the per-request impersonated roles granted to it by roles.sql.
+	authenticatorRole = "Postgrest_Test_Authenticator"
+
+	// authenticatorPassword is the password PostgREST authenticates with. The
+	// cluster/standalone require password auth (scram/md5), unlike upstream's
+	// trust-over-socket setup, so the authenticator gets an explicit password.
+	authenticatorPassword = "postgrest_authenticator_pw"
+
+	// fixtureSchema is the schema PostgREST exposes (PGRST_DB_SCHEMAS).
+	fixtureSchema = "test"
+)
+
+// pgConn describes how to reach a PostgreSQL instance for host-side psql. Host
+// is either 127.0.0.1 (TCP standalone) or a unix-socket directory (the cluster
+// primary, which is socket-only); libpq treats an absolute path as a socket dir.
+type pgConn struct {
+	Host      string // 127.0.0.1 or a socket directory
+	Port      int
+	SuperUser string // bootstrap superuser (e.g. "postgres")
+	SuperPass string
+	Database  string
+	SSLMode   string // "disable" for TCP; "" leaves libpq default (socket)
+}
+
+// psqlEnv returns the libpq env for connecting to c as the superuser.
+func (c pgConn) psqlEnv() []string {
+	env := []string{
+		"PGHOST=" + c.Host,
+		"PGPORT=" + strconv.Itoa(c.Port),
+		"PGUSER=" + c.SuperUser,
+		"PGPASSWORD=" + c.SuperPass,
+		"PGDATABASE=" + c.Database,
+		"PGCONNECT_TIMEOUT=10",
+	}
+	if c.SSLMode != "" {
+		env = append(env, "PGSSLMODE="+c.SSLMode)
+	}
+	return env
+}
+
+// loadFixtures creates the authenticator role and loads PostgREST's fixture
+// schema into the database at conn, as the bootstrap superuser. srcDir is a
+// PostgREST checkout; fixtures live under test/spec/fixtures. This mirrors the
+// upstream withPg flow: createuser (non-superuser, non-inherit, login) then
+// `psql -v PGUSER=<authenticator> -f load.sql`. roles.sql creates a SUPERUSER
+// role and grants all test roles to the authenticator, so the loader must be a
+// real superuser.
+func loadFixtures(t *testing.T, ctx context.Context, conn pgConn, srcDir string) error {
+	t.Helper()
+
+	fixturesDir := filepath.Join(srcDir, "test", "spec", "fixtures")
+	loadSQL := filepath.Join(fixturesDir, "load.sql")
+
+	// Force the database default timezone to UTC. Upstream's withPg bakes UTC into
+	// the server via `TZ=utc initdb`; our built PostgreSQL inherits the host tz,
+	// which makes timestamptz→text (and PostgREST's data-representation casts)
+	// render in local time and diverge from the expected fixtures. PostgREST
+	// resets the session to the DB default per request, so a database-scoped
+	// default (not a session PGOPTIONS) is what takes effect. On the cluster PG
+	// this is already UTC, so it is a harmless no-op there.
+	if err := runPsql(ctx, conn, []string{"-v", "ON_ERROR_STOP=1", "-c", "ALTER DATABASE postgres SET timezone TO 'UTC';"}); err != nil {
+		return fmt.Errorf("set database timezone to UTC: %w", err)
+	}
+
+	// Create the authenticator role first (idempotently), with a password so it
+	// can authenticate over TCP/scram. NOINHERIT + no elevated attributes match
+	// upstream; SET ROLE relies on the grants in roles.sql.
+	createRole := fmt.Sprintf(
+		`DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='%s') THEN `+
+			`CREATE ROLE "%s" LOGIN NOINHERIT NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION PASSWORD '%s'; `+
+			`END IF; END $$;`,
+		authenticatorRole, authenticatorRole, authenticatorPassword,
+	)
+	if err := runPsql(ctx, conn, []string{"-v", "ON_ERROR_STOP=1", "-c", createRole}); err != nil {
+		return fmt.Errorf("create authenticator role: %w", err)
+	}
+
+	// Load the fixture schema. \ir includes in load.sql resolve relative to the
+	// file, so -f with the absolute path finds the sibling SQL files.
+	loadArgs := []string{
+		"-v", "ON_ERROR_STOP=1",
+		"-v", "PGUSER=" + authenticatorRole,
+		"-f", loadSQL,
+	}
+	if err := runPsql(ctx, conn, loadArgs); err != nil {
+		return fmt.Errorf("load fixtures from %s: %w", loadSQL, err)
+	}
+
+	t.Logf("Loaded PostgREST fixtures into %s:%d (schema %q, authenticator %q)",
+		conn.Host, conn.Port, fixtureSchema, authenticatorRole)
+	return nil
+}
+
+// runPsql runs the built psql (found on PATH) against conn with the given args.
+func runPsql(ctx context.Context, conn pgConn, args []string) error {
+	cmd := executil.Command(ctx, "psql", args...)
+	cmd.AddEnv(conn.psqlEnv()...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%w\n%s", err, tail(out.String(), 30))
+	}
+	return nil
+}

--- a/go/test/endtoend/queryserving/postgresttests/helpers.go
+++ b/go/test/endtoend/queryserving/postgresttests/helpers.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresttests
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// brewPrefix returns the homebrew prefix for keg if it is actually installed,
+// else "". `brew --prefix X` prints a path even for uninstalled formulae, so the
+// path is stat'd to confirm the keg exists on disk.
+func brewPrefix(keg string) string {
+	brew, err := exec.LookPath("brew")
+	if err != nil {
+		return ""
+	}
+	out, err := exec.Command(brew, "--prefix", keg).Output()
+	if err != nil {
+		return ""
+	}
+	p := strings.TrimSpace(string(out))
+	if p == "" {
+		return ""
+	}
+	if info, err := os.Stat(p); err != nil || !info.IsDir() {
+		return ""
+	}
+	return p
+}
+
+// lookPathOrEmpty returns the absolute path to a binary on PATH (e.g.
+// geos-config), or "" if not found.
+func lookPathOrEmpty(name string) string {
+	p, err := exec.LookPath(name)
+	if err != nil {
+		return ""
+	}
+	return p
+}

--- a/go/test/endtoend/queryserving/postgresttests/main_test.go
+++ b/go/test/endtoend/queryserving/postgresttests/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresttests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+)
+
+// TestMain sets up the shared test environment (notably PATH, so the cluster can
+// find etcd and run_in_test.sh). buildPostgres later prepends the built
+// PostgreSQL bin ahead of the repo bin, so pgctld uses the PostGIS-enabled build
+// while etcd/run_in_test.sh still resolve from the repo bin.
+func TestMain(m *testing.M) {
+	os.Exit(shardsetup.RunTestMain(m)) //nolint:forbidigo // TestMain may call os.Exit
+}

--- a/go/test/endtoend/queryserving/postgresttests/postgres.go
+++ b/go/test/endtoend/queryserving/postgresttests/postgres.go
@@ -1,0 +1,231 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresttests
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/multigres/multigres/go/test/endtoend/pgbuilder"
+	"github.com/multigres/multigres/go/tools/executil"
+)
+
+// postgisTag pins the PostGIS version built when the system PostgreSQL doesn't
+// already provide it (macOS local dev). On Linux CI postgis comes from the
+// distro package (postgresql-17-postgis-3), so this build is skipped.
+const postgisTag = "3.6.3"
+
+// requiredExtensions are the extensions PostgREST's fixtures load. All except
+// postgis ship with the server/contrib packages; postgis is handled separately.
+var requiredExtensions = []string{"pgcrypto", "ltree", "isn", "file_fdw"}
+
+// ensurePostgres locates a system PostgreSQL 17 install, makes sure PostGIS is
+// available in it, and prepends its bin directory to PATH so pgctld (via
+// shardsetup) and host-side psql use it. It returns the install prefix so the
+// direct-baseline arm can start a standalone off the same binaries.
+//
+// Unlike the pgregress suite, this does NOT build PostgreSQL from source — the
+// PostgREST suite only needs a working PG 17 with the fixture extensions, which
+// the packaged server + contrib already provide (matching how the repo's other
+// integration tests provision PostgreSQL via setup-test-environment.sh). Only
+// PostGIS may be missing locally; it is built into the system PG on demand.
+func ensurePostgres(t *testing.T, ctx context.Context) string {
+	t.Helper()
+
+	binDir := resolvePgBinDir(t)
+	prefix := filepath.Dir(binDir)
+
+	// Confirm it's PostgreSQL 17 (multigres requires major 17).
+	if ver, err := exec.Command(filepath.Join(binDir, "pg_config"), "--version").Output(); err != nil {
+		t.Skipf("pg_config not usable at %s: %v", binDir, err)
+	} else if !strings.Contains(string(ver), "PostgreSQL 17") {
+		t.Skipf("need PostgreSQL 17, found %q at %s", strings.TrimSpace(string(ver)), binDir)
+	}
+
+	// Prepend to PATH first so the postgis build and the cluster use this PG.
+	if err := os.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH")); err != nil {
+		t.Fatalf("set PATH: %v", err)
+	}
+
+	verifyExtensionsAvailable(t, binDir)
+	ensurePostGIS(t, ctx, binDir, prefix)
+
+	t.Logf("Using system PostgreSQL 17 at %s", prefix)
+	return prefix
+}
+
+// resolvePgBinDir returns the bin directory of the PostgreSQL 17 to use.
+// Order: POSTGREST_PG_BINDIR override, then platform defaults (homebrew
+// postgresql@17 on macOS, PGDG /usr/lib/postgresql/17/bin on Linux), then a
+// pg_config already on PATH.
+func resolvePgBinDir(t *testing.T) string {
+	t.Helper()
+
+	if d := os.Getenv("POSTGREST_PG_BINDIR"); d != "" {
+		if _, err := os.Stat(filepath.Join(d, "initdb")); err != nil {
+			t.Skipf("POSTGREST_PG_BINDIR=%s has no initdb: %v", d, err)
+		}
+		return d
+	}
+	if runtime.GOOS == "darwin" {
+		if p := brewPrefix("postgresql@17"); p != "" {
+			return filepath.Join(p, "bin")
+		}
+	} else {
+		if d := "/usr/lib/postgresql/17/bin"; fileExists(filepath.Join(d, "initdb")) {
+			return d
+		}
+	}
+	if pgc, err := exec.LookPath("pg_config"); err == nil {
+		if out, err := exec.Command(pgc, "--bindir").Output(); err == nil {
+			return strings.TrimSpace(string(out))
+		}
+	}
+	t.Skip("PostgreSQL 17 not found: set POSTGREST_PG_BINDIR, or install postgresql@17 (brew) / postgresql-17 (apt)")
+	return ""
+}
+
+// verifyExtensionsAvailable skips the test with an actionable message if a
+// required non-postgis extension's control file is missing from the PG install.
+func verifyExtensionsAvailable(t *testing.T, binDir string) {
+	t.Helper()
+	shareDir := pgShareDir(t, binDir)
+	for _, ext := range requiredExtensions {
+		if !fileExists(filepath.Join(shareDir, "extension", ext+".control")) {
+			t.Skipf("extension %q missing from %s/extension — install postgresql-contrib-17 (apt) or postgresql@17 (brew)", ext, shareDir)
+		}
+	}
+}
+
+// ensurePostGIS makes sure postgis is installed in the system PG. If its control
+// file is already present (Linux distro package, or a prior local build), nothing
+// happens. Otherwise it builds postgis from source against this PG's pg_config —
+// the fixtures require it and PG17 loads extensions only from the server's own
+// extension dir, so it must live there.
+func ensurePostGIS(t *testing.T, ctx context.Context, binDir, prefix string) {
+	t.Helper()
+	shareDir := pgShareDir(t, binDir)
+	if fileExists(filepath.Join(shareDir, "extension", "postgis.control")) {
+		return
+	}
+
+	t.Logf("PostGIS not found in %s/extension; building it into the system PostgreSQL (one-time)...", shareDir)
+	if err := pgbuilder.CheckBuildDependencies(t); err != nil {
+		t.Skipf("cannot build PostGIS (missing build tools): %v", err)
+	}
+	applyDarwinBuildEnv()
+
+	// Point a Builder at the system install so InstallExternalExtension's
+	// `make install` (driven by this PG's pg_config) lands postgis in the
+	// server's own lib/share dirs. Clean any partial clone from a prior aborted
+	// run so the shallow clone doesn't fail on a non-empty directory.
+	externalDir := filepath.Join(cacheRoot(), "external")
+	_ = os.RemoveAll(filepath.Join(externalDir, "postgis"))
+	b := &pgbuilder.Builder{
+		InstallDir:  prefix,
+		OutputDir:   t.TempDir(),
+		ExternalDir: externalDir,
+	}
+	if _, err := b.InstallExternalExtension(t, ctx, postgisSpec()); err != nil {
+		t.Fatalf("install PostGIS into system PostgreSQL: %v", err)
+	}
+}
+
+// postgisSpec pins the PostGIS source build (full build — disabling components
+// triggers a parallel-make race in 3.6's upgrade-SQL generation). On macOS the
+// keg-only geos-config/proj are pointed at explicitly; Linux finds them by default.
+func postgisSpec() pgbuilder.ExtensionBuildSpec {
+	var args []string
+	if runtime.GOOS == "darwin" {
+		if gc := lookPathOrEmpty("geos-config"); gc != "" {
+			args = append(args, "--with-geosconfig="+gc)
+		}
+		if proj := brewPrefix("proj"); proj != "" {
+			args = append(args, "--with-projdir="+proj)
+		}
+	}
+	args = append(args, strings.Fields(os.Getenv("POSTGREST_POSTGIS_CONFIGURE_ARGS"))...)
+	return pgbuilder.ExtensionBuildSpec{
+		Name:          "postgis",
+		Repo:          "https://github.com/postgis/postgis",
+		Tag:           postgisTag,
+		BuildSystem:   "postgis",
+		ConfigureArgs: args,
+	}
+}
+
+// applyDarwinBuildEnv extends PKG_CONFIG_PATH so the PostGIS configure step finds
+// homebrew's keg-only json-c/proj/protobuf-c/gdal .pc files. No-op off macOS.
+func applyDarwinBuildEnv() {
+	if runtime.GOOS != "darwin" {
+		return
+	}
+	var paths []string
+	for _, keg := range []string{"json-c", "proj", "geos", "protobuf-c", "gdal"} {
+		if p := brewPrefix(keg); p != "" {
+			paths = append(paths, filepath.Join(p, "lib", "pkgconfig"))
+		}
+	}
+	if existing := os.Getenv("PKG_CONFIG_PATH"); existing != "" {
+		paths = append(paths, existing)
+	}
+	if len(paths) > 0 {
+		_ = os.Setenv("PKG_CONFIG_PATH", strings.Join(paths, ":"))
+	}
+
+	// Homebrew's PostgreSQL is built with NLS, so its server c.h includes
+	// <libintl.h>; building an extension against it needs gettext's (keg-only)
+	// headers and lib on the compile/link path.
+	if gt := brewPrefix("gettext"); gt != "" {
+		appendEnv("CPPFLAGS", "-I"+filepath.Join(gt, "include"))
+		appendEnv("LDFLAGS", "-L"+filepath.Join(gt, "lib"))
+	}
+}
+
+// appendEnv appends val to a space-separated environment variable.
+func appendEnv(key, val string) {
+	if existing := os.Getenv(key); existing != "" {
+		val = existing + " " + val
+	}
+	_ = os.Setenv(key, val)
+}
+
+// pgShareDir returns `pg_config --sharedir` for the PG at binDir.
+func pgShareDir(t *testing.T, binDir string) string {
+	t.Helper()
+	out, err := executil.Command(context.Background(), filepath.Join(binDir, "pg_config"), "--sharedir").Output()
+	if err != nil {
+		t.Fatalf("pg_config --sharedir: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// cacheRoot is the shared on-disk cache dir for this suite's downloads/builds.
+func cacheRoot() string {
+	if d := os.Getenv("POSTGREST_CACHE_DIR"); d != "" {
+		return d
+	}
+	return defaultCacheRoot
+}

--- a/go/test/endtoend/queryserving/postgresttests/postgrest_source.go
+++ b/go/test/endtoend/queryserving/postgresttests/postgrest_source.go
@@ -1,0 +1,178 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package postgresttests runs PostgREST's own upstream hspec test suite with
+// PostgREST pointed at the multigateway, to find behavioural divergences on the
+// proxied path. PostgREST is a plain libpq client, so it is repointed at the
+// gateway with a connection-string change; the suite (test:spec) connects purely
+// via libpq env, so this harness provides the database (a multigres cluster),
+// loads PostgREST's fixtures itself, and runs the compiled suite from a pinned
+// Docker image. See README.md for the design.
+package postgresttests
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/multigres/multigres/go/tools/executil"
+)
+
+const (
+	// postgrestRepo is the upstream PostgREST source we clone to build the
+	// test-suite image and load fixtures from.
+	postgrestRepo = "https://github.com/PostgREST/postgrest"
+
+	// postgrestTag pins the PostgREST version. The suite, its fixtures, and the
+	// image are all built from this tag so pass-rate tracking is meaningful.
+	// Bump deliberately (re-baseline the divergence report when you do).
+	postgrestTag = "v14.16"
+
+	// specImage is the local tag of the compiled test-suite image. Includes the
+	// PostgREST tag so a version bump builds a fresh image rather than reusing a
+	// stale one.
+	specImage = "postgrest-spec:" + postgrestTag
+
+	defaultCacheRoot = "/tmp/multigres_postgrest_cache"
+)
+
+// resolvePostgrestSource returns a directory containing a PostgREST checkout at
+// postgrestTag. Default behaviour shallow-clones the pinned tag into the cache
+// (reused across runs). Override with POSTGREST_SRC_DIR to point at a local
+// checkout — useful for iterating on fixtures or the Dockerfile.
+func resolvePostgrestSource(t *testing.T, ctx context.Context) (string, error) {
+	t.Helper()
+
+	if override := os.Getenv("POSTGREST_SRC_DIR"); override != "" {
+		abs, err := filepath.Abs(override)
+		if err != nil {
+			return "", fmt.Errorf("resolve POSTGREST_SRC_DIR=%q: %w", override, err)
+		}
+		if info, err := os.Stat(abs); err != nil || !info.IsDir() {
+			return "", fmt.Errorf("POSTGREST_SRC_DIR=%q is not a directory", override)
+		}
+		t.Logf("Using POSTGREST_SRC_DIR override: %s", abs)
+		return abs, nil
+	}
+	return ensurePostgrestSource(t, ctx)
+}
+
+// ensurePostgrestSource clones the pinned tag if the cache is missing or points
+// at a different ref. Returns the absolute checkout directory.
+func ensurePostgrestSource(t *testing.T, ctx context.Context) (string, error) {
+	t.Helper()
+
+	cacheRoot := os.Getenv("POSTGREST_CACHE_DIR")
+	if cacheRoot == "" {
+		cacheRoot = defaultCacheRoot
+	}
+	dir := filepath.Join(cacheRoot, "source", "postgrest-"+postgrestTag)
+
+	if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+		// Confirm the checkout is at the pinned tag; the tag ref resolves to a
+		// commit, so compare against the tag's commit.
+		want, werr := executil.Command(ctx, "git", "-C", dir, "rev-list", "-n", "1", postgrestTag).Output()
+		head, herr := executil.Command(ctx, "git", "-C", dir, "rev-parse", "HEAD").Output()
+		if werr == nil && herr == nil && strings.TrimSpace(string(want)) == strings.TrimSpace(string(head)) {
+			t.Logf("Using cached PostgREST source at %s (%s)", dir, postgrestTag)
+			return dir, nil
+		}
+		t.Logf("Cached PostgREST source at %s does not match %s; re-cloning", dir, postgrestTag)
+		if err := os.RemoveAll(dir); err != nil {
+			return "", fmt.Errorf("remove stale source: %w", err)
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
+		return "", fmt.Errorf("mkdir source parent: %w", err)
+	}
+
+	t.Logf("Cloning PostgREST %s from %s ...", postgrestTag, postgrestRepo)
+	var cloneStderr bytes.Buffer
+	cloneCmd := executil.Command(ctx, "git", "clone",
+		"--depth", "1",
+		"--branch", postgrestTag,
+		postgrestRepo,
+		dir,
+	)
+	cloneCmd.Stderr = &cloneStderr
+	if err := cloneCmd.Run(); err != nil {
+		return "", fmt.Errorf("clone PostgREST: %w (stderr: %s)", err, cloneStderr.String())
+	}
+
+	t.Logf("PostgREST source ready at %s (%s)", dir, postgrestTag)
+	return dir, nil
+}
+
+// ensureSpecImage builds the compiled test-suite image from srcDir if it is not
+// already present locally. Building compiles GHC deps + PostgREST + test:spec
+// (~8 min cold, cached thereafter), so an existing image is reused. Set
+// POSTGREST_REBUILD_IMAGE=1 to force a rebuild.
+func ensureSpecImage(t *testing.T, ctx context.Context, srcDir string) error {
+	t.Helper()
+
+	if os.Getenv("POSTGREST_REBUILD_IMAGE") != "1" {
+		if imageExists(ctx, specImage) {
+			t.Logf("Using existing spec image %s", specImage)
+			return nil
+		}
+	}
+
+	dockerfile := dockerfilePath()
+	if _, err := os.Stat(dockerfile); err != nil {
+		return fmt.Errorf("spec Dockerfile not found at %s: %w", dockerfile, err)
+	}
+
+	t.Logf("Building spec image %s from %s (first build compiles PostgREST; ~8 min)...", specImage, srcDir)
+	var buildOut bytes.Buffer
+	build := executil.Command(ctx, "docker", "build",
+		"-f", dockerfile,
+		"-t", specImage,
+		srcDir,
+	)
+	build.Stdout = &buildOut
+	build.Stderr = &buildOut
+	if err := build.Run(); err != nil {
+		return fmt.Errorf("docker build spec image: %w\n%s", err, tail(buildOut.String(), 40))
+	}
+	t.Logf("Spec image %s built", specImage)
+	return nil
+}
+
+// imageExists reports whether a local docker image with the given tag exists.
+func imageExists(ctx context.Context, image string) bool {
+	out, err := executil.Command(ctx, "docker", "image", "inspect", image).Output()
+	return err == nil && len(out) > 0
+}
+
+// dockerfilePath returns the absolute path to the vendored spec Dockerfile,
+// resolved via runtime.Caller so it is correct regardless of the working dir.
+func dockerfilePath() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(file), "testdata", "Dockerfile.spec")
+}
+
+// tail returns the last n lines of s (for trimming long build logs in errors).
+func tail(s string, n int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) <= n {
+		return s
+	}
+	return strings.Join(lines[len(lines)-n:], "\n")
+}

--- a/go/test/endtoend/queryserving/postgresttests/postgrest_test.go
+++ b/go/test/endtoend/queryserving/postgresttests/postgrest_test.go
@@ -65,8 +65,15 @@ func TestPostgREST(t *testing.T) {
 	prefix := ensurePostgres(t, ctx)
 	match := specMatch()
 
+	// Write the run summary (badge + divergence count) to GITHUB_STEP_SUMMARY on
+	// every exit path, so CI surfaces the count even when the test fails on an
+	// open divergence. Populated as the arms run below.
+	rep := &postgrestReport{}
+	defer writeReport(t, rep)
+
 	// Gateway run (the primary path).
 	gw := runGateway(t, ctx, src, match)
+	rep.Gateway = gw
 	t.Logf("gateway: %d examples, %d passed, %d failed, %d pending",
 		gw.Total, gw.Passed(), gw.Failures, gw.Pending)
 
@@ -77,6 +84,7 @@ func TestPostgREST(t *testing.T) {
 
 	// Run the same match on a throwaway direct PostgreSQL — the classifier.
 	base := runDirectBaseline(t, ctx, src, prefix, match)
+	rep.Baseline = base
 	t.Logf("direct baseline: %d examples, %d passed, %d failed, %d pending",
 		base.Total, base.Passed(), base.Failures, base.Pending)
 
@@ -100,6 +108,8 @@ func TestPostgREST(t *testing.T) {
 			divergences = append(divergences, f)
 		}
 	}
+	rep.Divergences = divergences
+	rep.EnvFailures = envFailures
 
 	if len(envFailures) > 0 {
 		t.Logf("%d environment failure(s) (fail on direct PostgreSQL too — NOT gateway bugs):", len(envFailures))

--- a/go/test/endtoend/queryserving/postgresttests/postgrest_test.go
+++ b/go/test/endtoend/queryserving/postgresttests/postgrest_test.go
@@ -116,9 +116,13 @@ func TestPostgREST(t *testing.T) {
 		t.Logf("no gateway divergences: all %d gateway failure(s) also fail on direct PostgreSQL (environment, not gateway)", len(gw.Failing))
 	}
 
-	// Divergences are informational findings tracked over time (some are
-	// intermittent), so they are logged, not fatal — mirroring pgregress.
-	// Regression-gating against a recorded baseline is a later phase.
+	// A gateway divergence is a real behavioural gap on the proxied path, so it
+	// fails the test. Known gaps we are tracking are listed in DIVERGENCES.md;
+	// as they are closed the run goes green. Environment failures (fail on direct
+	// PostgreSQL too) do not fail the test — they are not the gateway's fault.
+	if len(divergences) > 0 {
+		t.Errorf("%d gateway divergence(s) — see DIVERGENCES.md", len(divergences))
+	}
 }
 
 // runGateway brings up a 2-pooler + multigateway cluster, loads PostgREST's

--- a/go/test/endtoend/queryserving/postgresttests/postgrest_test.go
+++ b/go/test/endtoend/queryserving/postgresttests/postgrest_test.go
@@ -205,13 +205,11 @@ func requireDocker(t *testing.T) {
 	}
 }
 
-// specMatch returns the hspec --match filter, defaulting to the Query specs (the
-// current milestone scope). Override with POSTGREST_MATCH.
+// specMatch returns the hspec --match filter. Empty (the default) runs the whole
+// PostgREST spec suite; set POSTGREST_MATCH to scope a run (e.g. to a single
+// Feature.Query.QuerySpec while iterating).
 func specMatch() string {
-	if m, ok := os.LookupEnv("POSTGREST_MATCH"); ok {
-		return m
-	}
-	return "Feature.Query.QuerySpec"
+	return os.Getenv("POSTGREST_MATCH")
 }
 
 func toSet(items []string) map[string]bool {

--- a/go/test/endtoend/queryserving/postgresttests/postgrest_test.go
+++ b/go/test/endtoend/queryserving/postgresttests/postgrest_test.go
@@ -1,0 +1,223 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresttests
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/multigres/multigres/go/test/endtoend/pgbuilder"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
+)
+
+// TestPostgREST runs PostgREST's upstream spec suite with PostgREST pointed at the
+// multigateway (client → multigateway → multipooler → postgres) — the behaviour
+// we actually want to validate.
+//
+// The suite is upstream's own, so it passes against a correctly-set-up
+// PostgreSQL; the interesting signal is which specs behave differently through
+// the gateway. To keep that signal trustworthy without paying for a full second
+// run every time, the direct-PostgreSQL "baseline" is used only as a CLASSIFIER:
+// it runs solely when the gateway has failures (or when POSTGREST_FULL_BASELINE=1
+// forces it), and only to decide, per failing spec, whether the failure is a
+//   - gateway divergence: fails through the gateway, passes on direct PostgreSQL
+//     (attributable to multigres), or
+//   - environment failure: fails on both (our fixtures / PG version / config,
+//     not the gateway).
+//
+// Gated off by default (builds/needs a PG + PostGIS and a Haskell test image).
+func TestPostgREST(t *testing.T) {
+	if !gateEnabled() {
+		t.Skipf("skipping: set RUN_POSTGREST=1 (or %s=1) to run", suiteutil.EnvRunExtendedQueryServingTests)
+	}
+	requireDocker(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Minute)
+	defer cancel()
+
+	src, err := resolvePostgrestSource(t, ctx)
+	if err != nil {
+		t.Fatalf("resolve PostgREST source: %v", err)
+	}
+	if err := ensureSpecImage(t, ctx, src); err != nil {
+		t.Fatalf("ensure spec image: %v", err)
+	}
+
+	// System PostgreSQL 17 (with PostGIS + fixture extensions) on PATH, before
+	// cluster bootstrap so pgctld starts it.
+	prefix := ensurePostgres(t, ctx)
+	match := specMatch()
+
+	// Gateway run (the primary path).
+	gw := runGateway(t, ctx, src, match)
+	t.Logf("gateway: %d examples, %d passed, %d failed, %d pending",
+		gw.Total, gw.Passed(), gw.Failures, gw.Pending)
+
+	fullBaseline := os.Getenv("POSTGREST_FULL_BASELINE") == "1"
+	if len(gw.Failing) == 0 && !fullBaseline {
+		return // gateway clean — no need to classify anything
+	}
+
+	// Run the same match on a throwaway direct PostgreSQL — the classifier.
+	base := runDirectBaseline(t, ctx, src, prefix, match)
+	t.Logf("direct baseline: %d examples, %d passed, %d failed, %d pending",
+		base.Total, base.Passed(), base.Failures, base.Pending)
+
+	if len(gw.Failing) == 0 {
+		// Only reachable with POSTGREST_FULL_BASELINE=1: the gateway was clean, so
+		// there is nothing to classify. base.Failing here would be environment
+		// issues in the harness itself, worth surfacing.
+		t.Logf("gateway clean: no failures to classify")
+		for _, f := range base.Failing {
+			t.Logf("  BASELINE-ONLY FAIL (harness/env, not gateway): %s", f)
+		}
+		return
+	}
+
+	baseFailed := toSet(base.Failing)
+	var divergences, envFailures []string
+	for _, f := range gw.Failing {
+		if baseFailed[f] {
+			envFailures = append(envFailures, f)
+		} else {
+			divergences = append(divergences, f)
+		}
+	}
+
+	if len(envFailures) > 0 {
+		t.Logf("%d environment failure(s) (fail on direct PostgreSQL too — NOT gateway bugs):", len(envFailures))
+		for _, f := range envFailures {
+			t.Logf("  ENV:  %s", f)
+		}
+	}
+	if len(divergences) > 0 {
+		t.Logf("%d GATEWAY DIVERGENCE(S) (fail through gateway, pass on direct PostgreSQL):", len(divergences))
+		for _, f := range divergences {
+			t.Logf("  DIVERGE: %s", f)
+		}
+	} else {
+		t.Logf("no gateway divergences: all %d gateway failure(s) also fail on direct PostgreSQL (environment, not gateway)", len(gw.Failing))
+	}
+
+	// Divergences are informational findings tracked over time (some are
+	// intermittent), so they are logged, not fatal — mirroring pgregress.
+	// Regression-gating against a recorded baseline is a later phase.
+}
+
+// runGateway brings up a 2-pooler + multigateway cluster, loads PostgREST's
+// fixtures on the primary (socket-only, so loaded directly, bypassing gateway
+// DDL handling), and runs the spec suite against the gateway's TCP port.
+func runGateway(t *testing.T, ctx context.Context, src, match string) *specResult {
+	t.Helper()
+
+	setup := shardsetup.New(t,
+		shardsetup.WithMultipoolerCount(2), // primary + standby
+		shardsetup.WithMultigateway(),
+		// Keep pooled capacity under the generated max_connections=60 ceiling.
+		shardsetup.WithMultipoolerExtraArgs("--connpool-global-capacity=50"),
+	)
+	setup.SetupTest(t)
+
+	primary := setup.GetPrimary(t)
+	conn := pgConn{
+		Host:      filepath.Join(primary.Pgctld.PoolerDir, "pg_sockets"),
+		Port:      primary.Pgctld.PgPort,
+		SuperUser: shardsetup.DefaultTestUser,
+		SuperPass: shardsetup.TestPostgresPassword,
+		Database:  "postgres",
+	}
+	if err := loadFixtures(t, ctx, conn, src); err != nil {
+		t.Fatalf("load fixtures on primary: %v", err)
+	}
+
+	res, err := runSpec(t, ctx, specTarget{Name: "gateway", Port: setup.MultigatewayPgPort}, match)
+	if err != nil {
+		t.Fatalf("run spec suite through gateway: %v", err)
+	}
+	return res
+}
+
+// runDirectBaseline starts a standalone PostgreSQL off the same system binaries,
+// loads the fixtures, and runs the spec suite against it — the classifier for
+// gateway failures. It is only called when the gateway has failures (or a full
+// baseline is forced).
+func runDirectBaseline(t *testing.T, ctx context.Context, src, prefix, match string) *specResult {
+	t.Helper()
+
+	b := &pgbuilder.Builder{InstallDir: prefix, OutputDir: t.TempDir()}
+	sa, err := pgbuilder.StartStandalone(t, ctx, b, "test_password_123")
+	if err != nil {
+		t.Fatalf("start standalone postgres: %v", err)
+	}
+	defer func() { _ = sa.Stop() }()
+
+	conn := pgConn{
+		Host:      "127.0.0.1",
+		Port:      sa.Port,
+		SuperUser: sa.User,
+		SuperPass: sa.Password,
+		Database:  sa.Database,
+		SSLMode:   "disable",
+	}
+	if err := loadFixtures(t, ctx, conn, src); err != nil {
+		t.Fatalf("load fixtures on standalone: %v", err)
+	}
+
+	res, err := runSpec(t, ctx, specTarget{Name: "direct", Port: sa.Port}, match)
+	if err != nil {
+		t.Fatalf("run spec suite on direct baseline: %v", err)
+	}
+	return res
+}
+
+// gateEnabled reports whether the PostgREST suite should run. Gated off by
+// default (heavy: needs a PostgreSQL + PostGIS and a Haskell test image).
+func gateEnabled() bool {
+	return os.Getenv("RUN_POSTGREST") == "1" ||
+		os.Getenv(suiteutil.EnvRunExtendedQueryServingTests) == "1"
+}
+
+// requireDocker skips the test unless a working docker daemon is reachable.
+func requireDocker(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not found on PATH")
+	}
+	if err := exec.Command("docker", "info").Run(); err != nil {
+		t.Skip("docker daemon not reachable")
+	}
+}
+
+// specMatch returns the hspec --match filter, defaulting to the Query specs (the
+// current milestone scope). Override with POSTGREST_MATCH.
+func specMatch() string {
+	if m, ok := os.LookupEnv("POSTGREST_MATCH"); ok {
+		return m
+	}
+	return "Feature.Query.QuerySpec"
+}
+
+func toSet(items []string) map[string]bool {
+	s := make(map[string]bool, len(items))
+	for _, it := range items {
+		s[it] = true
+	}
+	return s
+}

--- a/go/test/endtoend/queryserving/postgresttests/postgrest_test.go
+++ b/go/test/endtoend/queryserving/postgresttests/postgrest_test.go
@@ -71,32 +71,42 @@ func TestPostgREST(t *testing.T) {
 	rep := &postgrestReport{}
 	defer writeReport(t, rep)
 
-	// Gateway run (the primary path).
+	// Gateway run — the path we validate. The direct-PostgreSQL baseline is an
+	// asserted invariant: every non-skipped spec passes on plain postgres (see
+	// DIVERGENCES.md), so any gateway failure is by definition a divergence and
+	// the default run is gateway-only — no second postgres run. Known gaps are
+	// tracked in DIVERGENCES.md; as they are closed the run goes green.
 	gw := runGateway(t, ctx, src, match)
 	rep.Gateway = gw
 	t.Logf("gateway: %d examples, %d passed, %d failed, %d pending",
 		gw.Total, gw.Passed(), gw.Failures, gw.Pending)
 
-	fullBaseline := os.Getenv("POSTGREST_FULL_BASELINE") == "1"
-	if len(gw.Failing) == 0 && !fullBaseline {
-		return // gateway clean — no need to classify anything
+	if os.Getenv("POSTGREST_FULL_BASELINE") != "1" {
+		// Default: baseline assumed green, so every gateway failure is a divergence.
+		rep.Divergences = gw.Failing
+		for _, f := range gw.Failing {
+			t.Logf("  DIVERGE: %s", f)
+		}
+		if len(gw.Failing) > 0 {
+			t.Errorf("%d gateway divergence(s) — see DIVERGENCES.md", len(gw.Failing))
+		}
+		return
 	}
 
-	// Run the same match on a throwaway direct PostgreSQL — the classifier.
+	// POSTGREST_FULL_BASELINE=1 re-verifies the invariant: run the same match on
+	// a throwaway direct PostgreSQL and classify. A gateway failure that also
+	// fails on direct postgres is an environment failure — the invariant is
+	// broken (fix the harness/fixtures), not a gateway bug. Use this after
+	// bumping the PostgREST tag or editing fixtures.
 	base := runDirectBaseline(t, ctx, src, prefix, match)
 	rep.Baseline = base
 	t.Logf("direct baseline: %d examples, %d passed, %d failed, %d pending",
 		base.Total, base.Passed(), base.Failures, base.Pending)
 
-	if len(gw.Failing) == 0 {
-		// Only reachable with POSTGREST_FULL_BASELINE=1: the gateway was clean, so
-		// there is nothing to classify. base.Failing here would be environment
-		// issues in the harness itself, worth surfacing.
-		t.Logf("gateway clean: no failures to classify")
-		for _, f := range base.Failing {
-			t.Logf("  BASELINE-ONLY FAIL (harness/env, not gateway): %s", f)
-		}
-		return
+	// The invariant says base.Failing should be empty; if it is not, surface each
+	// one — those are the specs that broke the "postgres passes everything" rule.
+	for _, f := range base.Failing {
+		t.Logf("  BASELINE FAIL (invariant broken — harness/env, not gateway): %s", f)
 	}
 
 	baseFailed := toSet(base.Failing)
@@ -117,19 +127,10 @@ func TestPostgREST(t *testing.T) {
 			t.Logf("  ENV:  %s", f)
 		}
 	}
-	if len(divergences) > 0 {
-		t.Logf("%d GATEWAY DIVERGENCE(S) (fail through gateway, pass on direct PostgreSQL):", len(divergences))
-		for _, f := range divergences {
-			t.Logf("  DIVERGE: %s", f)
-		}
-	} else {
-		t.Logf("no gateway divergences: all %d gateway failure(s) also fail on direct PostgreSQL (environment, not gateway)", len(gw.Failing))
+	for _, f := range divergences {
+		t.Logf("  DIVERGE: %s", f)
 	}
 
-	// A gateway divergence is a real behavioural gap on the proxied path, so it
-	// fails the test. Known gaps we are tracking are listed in DIVERGENCES.md;
-	// as they are closed the run goes green. Environment failures (fail on direct
-	// PostgreSQL too) do not fail the test — they are not the gateway's fault.
 	if len(divergences) > 0 {
 		t.Errorf("%d gateway divergence(s) — see DIVERGENCES.md", len(divergences))
 	}

--- a/go/test/endtoend/queryserving/postgresttests/report.go
+++ b/go/test/endtoend/queryserving/postgresttests/report.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresttests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
+)
+
+// postgrestReport is the classified outcome of one TestPostgREST run, ready to
+// render as a markdown summary. Gateway is always set once the gateway arm has
+// run; Baseline is nil when the gateway was clean (the classifier is skipped).
+// Divergences and EnvFailures are populated only once both arms have run.
+type postgrestReport struct {
+	Gateway     *specResult // gateway arm; nil if the gateway arm never produced a result
+	Baseline    *specResult // direct-PostgreSQL classifier arm; nil if it was skipped
+	Divergences []string    // fail through gateway, pass on direct PostgreSQL (gateway bugs)
+	EnvFailures []string    // fail on both paths (harness/env, not gateway bugs)
+}
+
+// writeReport renders the run summary as markdown and writes it to the results
+// dir, mirroring it to GITHUB_STEP_SUMMARY when running in CI so the divergence
+// count is visible on the job page without downloading artifacts. It is a no-op
+// when the gateway arm never produced a result (e.g. an early t.Fatalf during
+// setup), since there is nothing to summarize.
+func writeReport(t *testing.T, r *postgrestReport) {
+	t.Helper()
+	if r.Gateway == nil {
+		return
+	}
+
+	summary := renderReport(r)
+	path, err := suiteutil.WriteMarkdown(resultsDir(), "compatibility-report.md", summary)
+	if err != nil {
+		t.Logf("write PostgREST summary: %v", err)
+		return
+	}
+	t.Logf("Markdown summary written to: %s", path)
+}
+
+// renderReport builds the markdown summary: a shields.io badge for the gateway
+// pass rate, a counts table, and the divergence / environment-failure lists.
+func renderReport(r *postgrestReport) string {
+	gw := r.Gateway
+
+	var sb strings.Builder
+	sb.WriteString("## PostgREST Spec Suite (through the multigateway)\n\n")
+
+	// The headline signal is gateway divergences (fail proxied, pass direct) —
+	// the only failures attributable to multigres. The badge tracks them: green
+	// only at zero. When the classifier did not run (gateway clean), there are
+	// no divergences by construction.
+	div := len(r.Divergences)
+	sb.WriteString(suiteutil.BadgeMarkdown("PostgREST_gateway_divergences", 0, div, 0, false))
+	sb.WriteString("\n\n")
+
+	sb.WriteString("| Metric | Count |\n|---|---|\n")
+	fmt.Fprintf(&sb, "| Examples run (gateway) | %d |\n", gw.Total)
+	fmt.Fprintf(&sb, "| Passed | %d |\n", gw.Passed())
+	fmt.Fprintf(&sb, "| Pending | %d |\n", gw.Pending)
+	fmt.Fprintf(&sb, "| Failed (gateway) | %d |\n", gw.Failures)
+	fmt.Fprintf(&sb, "| — Gateway divergences (fail proxied, pass direct) | %d |\n", div)
+	fmt.Fprintf(&sb, "| — Environment failures (fail on direct PostgreSQL too) | %d |\n", len(r.EnvFailures))
+	sb.WriteString("\n")
+
+	if r.Baseline == nil && gw.Failures == 0 {
+		sb.WriteString("Gateway clean — all examples passed; the direct-PostgreSQL classifier was skipped.\n\n")
+	}
+
+	if div > 0 {
+		fmt.Fprintf(&sb, "### %d gateway divergence(s) — see DIVERGENCES.md\n\n", div)
+		fmt.Fprintf(&sb, "Fail through the gateway but pass on direct PostgreSQL — real behavioural gaps on the proxied path.\n\n")
+		for _, f := range r.Divergences {
+			fmt.Fprintf(&sb, "- `%s`\n", f)
+		}
+		sb.WriteString("\n")
+	}
+
+	if len(r.EnvFailures) > 0 {
+		fmt.Fprintf(&sb, "### %d environment failure(s) — not gateway bugs\n\n", len(r.EnvFailures))
+		fmt.Fprintf(&sb, "Fail on direct PostgreSQL too (harness / PG version / config), so they do not fail the test.\n\n")
+		for _, f := range r.EnvFailures {
+			fmt.Fprintf(&sb, "- `%s`\n", f)
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+// resultsDir is where the markdown summary is written. Defaults to a results
+// subdir under the suite cache root; override with POSTGREST_RESULTS_DIR (CI
+// points its artifact upload at this dir).
+func resultsDir() string {
+	if d := os.Getenv("POSTGREST_RESULTS_DIR"); d != "" {
+		return d
+	}
+	return filepath.Join(cacheRoot(), "results")
+}

--- a/go/test/endtoend/queryserving/postgresttests/report.go
+++ b/go/test/endtoend/queryserving/postgresttests/report.go
@@ -65,8 +65,9 @@ func renderReport(r *postgrestReport) string {
 
 	// The headline signal is gateway divergences (fail proxied, pass direct) —
 	// the only failures attributable to multigres. The badge tracks them: green
-	// only at zero. When the classifier did not run (gateway clean), there are
-	// no divergences by construction.
+	// only at zero. On the default gateway-only run these are simply every
+	// gateway failure; POSTGREST_FULL_BASELINE=1 additionally splits out
+	// environment failures (see postgrest_test.go).
 	div := len(r.Divergences)
 	sb.WriteString(suiteutil.BadgeMarkdown("PostgREST_gateway_divergences", 0, div, 0, false))
 	sb.WriteString("\n\n")
@@ -75,18 +76,26 @@ func renderReport(r *postgrestReport) string {
 	fmt.Fprintf(&sb, "| Examples run (gateway) | %d |\n", gw.Total)
 	fmt.Fprintf(&sb, "| Passed | %d |\n", gw.Passed())
 	fmt.Fprintf(&sb, "| Pending | %d |\n", gw.Pending)
-	fmt.Fprintf(&sb, "| Failed (gateway) | %d |\n", gw.Failures)
-	fmt.Fprintf(&sb, "| — Gateway divergences (fail proxied, pass direct) | %d |\n", div)
-	fmt.Fprintf(&sb, "| — Environment failures (fail on direct PostgreSQL too) | %d |\n", len(r.EnvFailures))
+	if r.Baseline == nil {
+		// Default gateway-only run: the baseline is asserted green, so every
+		// gateway failure is a divergence — no environment split to report.
+		fmt.Fprintf(&sb, "| Failed — gateway divergences (baseline asserted green) | %d |\n", div)
+	} else {
+		// POSTGREST_FULL_BASELINE=1: classified against a live direct-PostgreSQL run.
+		fmt.Fprintf(&sb, "| Failed (gateway) | %d |\n", gw.Failures)
+		fmt.Fprintf(&sb, "| — Gateway divergences (fail proxied, pass direct) | %d |\n", div)
+		fmt.Fprintf(&sb, "| — Environment failures (fail on direct PostgreSQL too) | %d |\n", len(r.EnvFailures))
+		fmt.Fprintf(&sb, "| Direct-baseline failures (invariant broken if > 0) | %d |\n", r.Baseline.Failures)
+	}
 	sb.WriteString("\n")
 
-	if r.Baseline == nil && gw.Failures == 0 {
-		sb.WriteString("Gateway clean — all examples passed; the direct-PostgreSQL classifier was skipped.\n\n")
+	if div == 0 && gw.Failures == 0 {
+		sb.WriteString("Gateway clean — all examples passed.\n\n")
 	}
 
 	if div > 0 {
 		fmt.Fprintf(&sb, "### %d gateway divergence(s) — see DIVERGENCES.md\n\n", div)
-		fmt.Fprintf(&sb, "Fail through the gateway but pass on direct PostgreSQL — real behavioural gaps on the proxied path.\n\n")
+		fmt.Fprintf(&sb, "Fail through the gateway — behavioural gaps on the proxied path (the direct-PostgreSQL baseline is asserted green).\n\n")
 		for _, f := range r.Divergences {
 			fmt.Fprintf(&sb, "- `%s`\n", f)
 		}

--- a/go/test/endtoend/queryserving/postgresttests/results.go
+++ b/go/test/endtoend/queryserving/postgresttests/results.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresttests
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// specResult holds the parsed outcome of one spec-suite run against one target.
+type specResult struct {
+	Target   string // "direct" or "gateway"
+	Total    int    // examples run
+	Failures int    // failing examples
+	Pending  int    // pending/skipped examples
+	// Failing holds the full hspec description path of each failing example, as
+	// printed by --format=failed-examples (e.g.
+	// "Feature.Query.QuerySpec, ...requesting no representation, ...").
+	Failing []string
+}
+
+// Passed returns the number of passing examples.
+func (r *specResult) Passed() int { return r.Total - r.Failures - r.Pending }
+
+var (
+	// hspec summary line, e.g. "212 examples, 0 failures" or
+	// "1264 examples, 7 failures, 3 pending".
+	summaryRE = regexp.MustCompile(`(\d+)\s+examples?,\s+(\d+)\s+failures?(?:,\s+(\d+)\s+pending)?`)
+	// failed-examples numbers each failure like "  1) Feature.Query...".
+	failingRE = regexp.MustCompile(`^\s*\d+\)\s+(.*\S)\s*$`)
+)
+
+// parseHspecOutput extracts counts and failing example descriptions from the
+// stdout of an hspec run using --format=failed-examples. That format prints a
+// numbered list of failures followed by the summary line, so the parser reads
+// both. It is tolerant of ANSI color and surrounding log lines.
+func parseHspecOutput(out string) *specResult {
+	res := &specResult{}
+	out = stripANSI(out)
+
+	if m := summaryRE.FindStringSubmatch(out); m != nil {
+		res.Total, _ = strconv.Atoi(m[1])
+		res.Failures, _ = strconv.Atoi(m[2])
+		if m[3] != "" {
+			res.Pending, _ = strconv.Atoi(m[3])
+		}
+	}
+
+	for line := range strings.SplitSeq(out, "\n") {
+		if m := failingRE.FindStringSubmatch(line); m != nil {
+			// Skip the "N) Failures:" style headers, which have no path.
+			desc := strings.TrimSpace(m[1])
+			if desc != "" {
+				res.Failing = append(res.Failing, desc)
+			}
+		}
+	}
+	return res
+}
+
+var ansiRE = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string { return ansiRE.ReplaceAllString(s, "") }

--- a/go/test/endtoend/queryserving/postgresttests/spec_runner.go
+++ b/go/test/endtoend/queryserving/postgresttests/spec_runner.go
@@ -29,9 +29,8 @@ import (
 )
 
 // specTarget is a database endpoint (as seen from the host) that the PostgREST
-// spec suite should connect to. The spec runs inside a container, so the runner
-// rewrites Host to host.docker.internal (which resolves to the host loopback on
-// both OrbStack and Linux Docker via --add-host) and keeps the same Port.
+// spec suite should connect to. The spec runs inside a container with host
+// networking, so it connects on 127.0.0.1 at the same Port (see runSpec).
 type specTarget struct {
 	Name string // "direct" or "gateway", for logging/reporting
 	Port int    // host TCP port (standalone PG port, or multigateway pg-port)
@@ -46,10 +45,13 @@ func runSpec(t *testing.T, ctx context.Context, target specTarget, match string)
 
 	args := []string{
 		"run", "--rm",
-		// Resolve host.docker.internal to the host on Linux Docker too; on
-		// OrbStack/macOS it already maps to the host loopback.
-		"--add-host=host.docker.internal:host-gateway",
-		"-e", "PGHOST=host.docker.internal",
+		// Run with host networking and connect on 127.0.0.1 so the container
+		// reaches the gateway and the standalone baseline postgres, which both
+		// bind to 127.0.0.1 (see shardsetup / pgbuilder.StartStandalone) — the
+		// standalone's 127.0.0.1/32 pg_hba rule already allows it, so no 0.0.0.0
+		// exposure is needed.
+		"--network=host",
+		"-e", "PGHOST=127.0.0.1",
 		"-e", "PGPORT=" + strconv.Itoa(target.Port),
 		"-e", "PGUSER=" + authenticatorRole,
 		"-e", "PGPASSWORD=" + authenticatorPassword,
@@ -75,7 +77,7 @@ func runSpec(t *testing.T, ctx context.Context, target specTarget, match string)
 		args = append(args, "--skip", skip)
 	}
 
-	t.Logf("Running spec suite against %s (host.docker.internal:%d, match=%q)...", target.Name, target.Port, match)
+	t.Logf("Running spec suite against %s (127.0.0.1:%d, match=%q)...", target.Name, target.Port, match)
 	var outBuf bytes.Buffer
 	cmd := executil.Command(ctx, "docker", args...)
 	// Stream to the test log and capture for parsing.

--- a/go/test/endtoend/queryserving/postgresttests/spec_runner.go
+++ b/go/test/endtoend/queryserving/postgresttests/spec_runner.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresttests
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/multigres/multigres/go/tools/executil"
+)
+
+// specTarget is a database endpoint (as seen from the host) that the PostgREST
+// spec suite should connect to. The spec runs inside a container, so the runner
+// rewrites Host to host.docker.internal (which resolves to the host loopback on
+// both OrbStack and Linux Docker via --add-host) and keeps the same Port.
+type specTarget struct {
+	Name string // "direct" or "gateway", for logging/reporting
+	Port int    // host TCP port (standalone PG port, or multigateway pg-port)
+}
+
+// runSpec runs the PostgREST spec suite (from specImage) against target and
+// returns the parsed result. match/skip scope the run via hspec's -m/--skip
+// (empty match runs everything). The suite connects as the authenticator over
+// TCP; fixtures must already be loaded into the target database.
+func runSpec(t *testing.T, ctx context.Context, target specTarget, match string) (*specResult, error) {
+	t.Helper()
+
+	args := []string{
+		"run", "--rm",
+		// Resolve host.docker.internal to the host on Linux Docker too; on
+		// OrbStack/macOS it already maps to the host loopback.
+		"--add-host=host.docker.internal:host-gateway",
+		"-e", "PGHOST=host.docker.internal",
+		"-e", "PGPORT=" + strconv.Itoa(target.Port),
+		"-e", "PGUSER=" + authenticatorRole,
+		"-e", "PGPASSWORD=" + authenticatorPassword,
+		"-e", "PGDATABASE=postgres",
+		"-e", "PGSSLMODE=disable",
+		"-e", "PGRST_DB_SCHEMAS=" + fixtureSchema,
+		"-e", "PGTZ=utc",
+		// search_path for the test harness's own setup queries (queryPgVersion /
+		// schema-cache load) that run outside PostgREST's per-request transaction.
+		// The server timezone is fixed to UTC at the database level in loadFixtures
+		// (PostgREST resets the session to the DB default per request, so a session
+		// PGOPTIONS timezone would not stick).
+		"-e", "PGOPTIONS=-c search_path=public," + fixtureSchema,
+		specImage,
+		// failed-examples prints each failure's full description path plus the
+		// summary line, which is all the divergence report needs.
+		"--format=failed-examples",
+	}
+	if match != "" {
+		args = append(args, "--match", match)
+	}
+
+	t.Logf("Running spec suite against %s (host.docker.internal:%d, match=%q)...", target.Name, target.Port, match)
+	var outBuf bytes.Buffer
+	cmd := executil.Command(ctx, "docker", args...)
+	// Stream to the test log and capture for parsing.
+	cmd.Stdout = io.MultiWriter(os.Stdout, &outBuf)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &outBuf)
+	cmd.SetWaitDelay(10 * time.Second)
+
+	runErr := cmd.Run()
+
+	res := parseHspecOutput(outBuf.String())
+	res.Target = target.Name
+	// A non-zero exit is expected when specs fail; only treat it as a harness
+	// error when we could not parse any examples (e.g. the suite crashed at
+	// startup — a connection/introspection failure through the gateway).
+	if res.Total == 0 {
+		return res, fmt.Errorf("spec suite produced no results against %s: %w", target.Name, runErr)
+	}
+	return res, nil
+}

--- a/go/test/endtoend/queryserving/postgresttests/spec_runner.go
+++ b/go/test/endtoend/queryserving/postgresttests/spec_runner.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -70,6 +71,9 @@ func runSpec(t *testing.T, ctx context.Context, target specTarget, match string)
 	if match != "" {
 		args = append(args, "--match", match)
 	}
+	for _, skip := range specSkips() {
+		args = append(args, "--skip", skip)
+	}
 
 	t.Logf("Running spec suite against %s (host.docker.internal:%d, match=%q)...", target.Name, target.Port, match)
 	var outBuf bytes.Buffer
@@ -90,4 +94,21 @@ func runSpec(t *testing.T, ctx context.Context, target specTarget, match string)
 		return res, fmt.Errorf("spec suite produced no results against %s: %w", target.Name, runErr)
 	}
 	return res, nil
+}
+
+// specSkips returns hspec --skip patterns for specs that require capabilities we
+// intentionally don't provide (not gateway bugs), so they don't show up as
+// environment failures. Extend via POSTGREST_SKIP (comma-separated). Currently:
+//   - PgSafeUpdateSpec needs the pg-safeupdate extension (github.com/eradman/
+//     pg-safeupdate), which we don't build; documented in DIVERGENCES.md.
+func specSkips() []string {
+	skips := []string{"Feature.Query.PgSafeUpdateSpec"}
+	if extra := os.Getenv("POSTGREST_SKIP"); extra != "" {
+		for s := range strings.SplitSeq(extra, ",") {
+			if s = strings.TrimSpace(s); s != "" {
+				skips = append(skips, s)
+			}
+		}
+	}
+	return skips
 }

--- a/go/test/endtoend/queryserving/postgresttests/testdata/Dockerfile.spec
+++ b/go/test/endtoend/queryserving/postgresttests/testdata/Dockerfile.spec
@@ -42,6 +42,15 @@ RUN cabal build test:spec \
 RUN printf '#!/bin/sh\nexec "$(cat /usr/local/bin/spec-binpath)" "$@"\n' > /usr/local/bin/run-spec \
     && chmod +x /usr/local/bin/run-spec
 
+# The suite's only subprocess call is SpecHelper.analyzeTable, which runs
+# `psql -U postgres -c 'ANALYZE test."<t>"'` before the RangeSpec group to
+# refresh planner stats. There is no psql client in this image and no `postgres`
+# superuser reachable through our proxy, so that ANALYZE is instead run by the Go
+# loader (loadFixtures) against the target DB. Provide a psql that exits 0 so the
+# now-redundant hook still succeeds; psql is used nowhere else in the suite.
+RUN printf '#!/bin/sh\n# ANALYZE is run by the multigres Go loader; see fixtures.go.\nexit 0\n' > /usr/local/bin/psql \
+    && chmod +x /usr/local/bin/psql
+
 # Run the suite as a non-root user. The build artifacts and fixtures under /src
 # are world-readable and the suite only reads them (it drives PostgREST over
 # HTTP, which talks to the external DB), so no ownership change is needed.

--- a/go/test/endtoend/queryserving/postgresttests/testdata/Dockerfile.spec
+++ b/go/test/endtoend/queryserving/postgresttests/testdata/Dockerfile.spec
@@ -9,25 +9,42 @@
 # build is reproducible for a given PostgREST tag.
 FROM haskell:9.4.8
 
+# One-shot build/test image: it compiles the spec suite and runs it to
+# completion against an external database, then exits. It is not a long-running
+# service, so it deliberately declares no healthcheck.
+HEALTHCHECK NONE
+
 # haskell:9.4.8 ships Debian 10 (buster), now EOL — its apt mirrors moved to
 # archive.debian.org, so repoint sources before installing build libs. (The libs
 # are already present in the base image today; kept explicit so the build does
-# not silently depend on that.)
+# not silently depend on that.) apt-get update + install stay in a single layer
+# (cache-correct); `cabal update` joins them so the Hackage index is refreshed
+# in the same one-time setup layer.
 RUN sed -i 's|deb.debian.org|archive.debian.org|g; s|security.debian.org|archive.debian.org|g; /buster-updates/d' /etc/apt/sources.list \
     && apt-get -o Acquire::Check-Valid-Until=false update \
     && apt-get install -y --no-install-recommends \
        libpq-dev zlib1g-dev libicu-dev pkg-config \
+    && cabal update \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src
 COPY . /src
 
-# Compile the test suite at build time so runtime is just "connect + run".
-RUN cabal update && cabal build test:spec
+# Compile the test suite at build time and record its binary path, so runtime is
+# just "connect + run" with no cabal invocation — which lets the container run
+# cleanly as a non-root user (cabal would otherwise want a writable HOME).
+RUN cabal build test:spec \
+    && cabal list-bin test:spec > /usr/local/bin/spec-binpath
 
 # Exec the prebuilt binary from the repo root (runtime fixtures such as
 # openapi.json / images resolve relative to test/spec/fixtures), passing through
 # hspec args. The DB connection comes entirely from libpq env.
-RUN printf '#!/bin/sh\nexec "$(cabal list-bin test:spec)" "$@"\n' > /usr/local/bin/run-spec \
+RUN printf '#!/bin/sh\nexec "$(cat /usr/local/bin/spec-binpath)" "$@"\n' > /usr/local/bin/run-spec \
     && chmod +x /usr/local/bin/run-spec
+
+# Run the suite as a non-root user. The build artifacts and fixtures under /src
+# are world-readable and the suite only reads them (it drives PostgREST over
+# HTTP, which talks to the external DB), so no ownership change is needed.
+RUN useradd --create-home spec
+USER spec
 ENTRYPOINT ["/usr/local/bin/run-spec"]

--- a/go/test/endtoend/queryserving/postgresttests/testdata/Dockerfile.spec
+++ b/go/test/endtoend/queryserving/postgresttests/testdata/Dockerfile.spec
@@ -1,0 +1,33 @@
+# Compiles PostgREST's `test:spec` hspec suite so it can run against an EXTERNAL
+# database (the multigateway, or a direct-postgres baseline) instead of the temp
+# DB the upstream `withPg` harness provisions. The suite connects purely via
+# libpq env (SpecHelper's configDbUri = "postgresql://"), so the harness injects
+# PGHOST/PGPORT/PGUSER/... at run time and loads fixtures itself.
+#
+# Base GHC matches PostgREST's nix pin (ghc948). Dependencies are solved against
+# the Hackage index-state pinned in the checkout's cabal.project.freeze, so the
+# build is reproducible for a given PostgREST tag.
+FROM haskell:9.4.8
+
+# haskell:9.4.8 ships Debian 10 (buster), now EOL — its apt mirrors moved to
+# archive.debian.org, so repoint sources before installing build libs. (The libs
+# are already present in the base image today; kept explicit so the build does
+# not silently depend on that.)
+RUN sed -i 's|deb.debian.org|archive.debian.org|g; s|security.debian.org|archive.debian.org|g; /buster-updates/d' /etc/apt/sources.list \
+    && apt-get -o Acquire::Check-Valid-Until=false update \
+    && apt-get install -y --no-install-recommends \
+       libpq-dev zlib1g-dev libicu-dev pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . /src
+
+# Compile the test suite at build time so runtime is just "connect + run".
+RUN cabal update && cabal build test:spec
+
+# Exec the prebuilt binary from the repo root (runtime fixtures such as
+# openapi.json / images resolve relative to test/spec/fixtures), passing through
+# hspec args. The DB connection comes entirely from libpq env.
+RUN printf '#!/bin/sh\nexec "$(cabal list-bin test:spec)" "$@"\n' > /usr/local/bin/run-spec \
+    && chmod +x /usr/local/bin/run-spec
+ENTRYPOINT ["/usr/local/bin/run-spec"]


### PR DESCRIPTION
## Summary

- Adds an end-to-end suite (`go/test/endtoend/queryserving/postgresttests`) that runs PostgREST's upstream hspec suite (1303 examples) with PostgREST pointed at the multigateway — client → multigateway → multipooler → postgres — using a real libpq client from a pinned Docker image.
- The direct-PostgreSQL baseline is an asserted invariant (every non-skipped spec passes on plain postgres), so the default run is **gateway-only** and any gateway failure is a divergence. `POSTGREST_FULL_BASELINE=1` re-runs the baseline and classifies, to re-verify the invariant after bumping the PostgREST tag or editing fixtures.
- Runs in CI behind the `Run Extended Query Serving Tests` / `Run all Query Serving Tests` labels; the divergence count lands in the job summary via `report.go`. Expected red until the tracked divergences in `DIVERGENCES.md` are closed.

## Status

49 gateway divergences, 0 environment failures (baseline fully green). ~42 of the divergences share one root cause: PostgREST's mutation SQL calls `set_config('pgrst.inserted', …, true)` inside an INSERT `WHERE` (wrapped in a CTE), and the gateway's unsafe-funccall analyzer only allows `set_config` as a top-level `SELECT` target — so it rejects the transaction-scoped (`is_local=true`) call postgres accepts anywhere. Closing that one closes the majority; repro in `DIVERGENCES.md`.

## Harness notes

- Provides the DB (a multigres cluster), loads PostgREST's fixtures directly, and normalizes environment differences that would otherwise masquerade as gateway bugs: timezone + planner GUCs via `ALTER DATABASE`, and the RangeSpec `ANALYZE` hook run in the loader instead of the container. Skips specs needing extensions we don't build (`pg-safeupdate`).
- The hspec container reaches the host gateway/postgres via `--network=host` + `127.0.0.1` (Linux CI and OrbStack). The spec image (`testdata/Dockerfile.spec`) is a non-root one-shot build/test image that passes Checkov's Docker policies.