### PR TITLE
test(consensus): Fix time format parsing for created_at columns

### DIFF
--- a/go/services/multipooler/internal/executor/result.go
+++ b/go/services/multipooler/internal/executor/result.go
@@ -122,6 +122,7 @@ func scanValue(val []byte, dest any) error {
 		}
 		s := string(val)
 		for _, format := range []string{
+			"2006-01-02 15:04:05.999999-07:00",
 			"2006-01-02 15:04:05.999999-07",
 			"2006-01-02 15:04:05.999999",
 			"2006-01-02 15:04:05",
@@ -186,6 +187,7 @@ func scanValue(val []byte, dest any) error {
 		// https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-DATETIME-OUTPUT
 		// We support the ISO 8601 style formats commonly returned by PostgreSQL.
 		for _, format := range []string{
+			"2006-01-02 15:04:05.999999-07:00",
 			"2006-01-02 15:04:05.999999-07",
 			"2006-01-02 15:04:05.999999",
 			"2006-01-02 15:04:05",


### PR DESCRIPTION
## Summary

Tests in the consensus package failing due to insufficient time parsing format. Added the correct time format 
```
2006-01-02 15:04:05.999999-07:00
```


```bash
➜  multigres git:(main) ✗ MULTIGRES_PORT_POOL_ADDR=/tmp/abc.sock go test  -v ./go/services/multipooler/internal/manager/consensus | grep FAIL
--- FAIL: TestRuleStorePG_ObservePosition_FreshState (0.45s)
--- FAIL: TestRuleStorePG_ObservePosition_InitialPolicyCarriedThroughUpdate (0.01s)
--- FAIL: TestRuleStorePG_ObservePosition_SurfacesStuckProposal (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_RejectsWhenProposalStuck (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_SkipOutgoingQuorumSupersedesStuckProposal (0.00s)
--- FAIL: TestRuleStorePG_UpdateRule_PropagatesViaFinalizeThenPromote (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_FirstWrite (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_SameTermIncrementsSubterm (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_NewTermResetsSubterm (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_StaleTermRejected (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_ObserveAfterWrite (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_HistoryFields (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_CASSuccess (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_CASConflict (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_HistoryRecorded (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_Concurrent (0.12s)
--- FAIL: TestRuleStorePG_UpdateRule_DurabilityPolicyRoundTrip (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_DurabilityPolicyPreservedOnUpdate (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_DurabilityPolicyInHistory (0.00s)
--- FAIL: TestRuleStorePG_UpdateRule_DurabilityPolicyAchievabilityRejected (0.01s)
--- FAIL: TestRuleStorePG_GUCReconciliation (0.01s)
--- FAIL: TestRuleStorePG_GUCDriftDetectedAndHealed (0.01s)
--- FAIL: TestRuleStorePG_ReconcileGUC_FailsWhenRuleIsLocked (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_PreWriteGUCFails (0.00s)
--- FAIL: TestRuleStorePG_UpdateRule_PrePromoteGUCFails (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_PromotionHookFails (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_PostWriteGUCFails (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_RejectsLeaderChangeOutsidePromotion (0.01s)
--- FAIL: TestRuleStorePG_UpdateRule_InvalidLeaderID (0.00s)
--- FAIL: TestRuleStorePG_UpdateRule_InvalidCohortID (0.01s)
--- FAIL: TestRuleStorePG_ReconcileGUC_InvalidPolicy (0.00s)
--- FAIL: TestRuleStorePG_ReadCurrentRule_ParseFailureFromBogusQuorumType (0.01s)
FAIL
FAIL    github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus       1.255s
FAIL
```

## Testing

- `go test  -v ./go/services/multipooler/internal/manager/consensus`: passed.
- `go test -race  -v ./go/services/multipooler/internal/manager/consensus`: passed.