### PR TITLE
fix(topo): expire gateway/orch registrations via etcd leases and retry deregistration

### DIFF
--- a/go/common/servenv/servenv.go
+++ b/go/common/servenv/servenv.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/multigres/multigres/go/common/mterrors"
@@ -247,6 +248,25 @@ func (se *ServEnv) RegisterReadyCheck(f func() error) {
 	se.readyMu.Lock()
 	defer se.readyMu.Unlock()
 	se.readyChecks = append(se.readyChecks, f)
+}
+
+// InitiateShutdown triggers the same graceful shutdown sequence as SIGTERM:
+// lameduck, OnTerm/OnTermSync hooks, then OnClose hooks, then process exit.
+//
+// It exists for components that detect a fatal condition only a process
+// restart can repair — for example a gateway whose PID prefix claim has
+// passed to another gateway. Exiting from inside the process makes the
+// restart independent of deployment configuration: Kubernetes restartPolicy,
+// systemd, and docker-compose all restart an exited process, whether or not
+// any probe is wired up.
+//
+// Safe to call at any time and from any goroutine; repeat calls while a
+// shutdown is already pending are no-ops.
+func (se *ServEnv) InitiateShutdown() {
+	select {
+	case se.exitChan <- syscall.SIGTERM:
+	default: // A shutdown signal is already pending.
+	}
 }
 
 // GetHTTPPort returns the HTTP port value

--- a/go/common/servenv/servenv_test.go
+++ b/go/common/servenv/servenv_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -99,5 +100,33 @@ func TestRegisterReadyCheck(t *testing.T) {
 		w := httptest.NewRecorder()
 		se.mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/ready", nil))
 		require.Equal(t, http.StatusOK, w.Code)
+	})
+}
+
+func TestInitiateShutdown(t *testing.T) {
+	t.Run("delivers a termination signal", func(t *testing.T) {
+		se := NewServEnv(viperutil.NewRegistry())
+		se.InitiateShutdown()
+		select {
+		case sig := <-se.exitChan:
+			require.Equal(t, syscall.SIGTERM, sig)
+		default:
+			t.Fatal("InitiateShutdown should have queued a termination signal")
+		}
+	})
+
+	t.Run("never blocks on repeat calls", func(t *testing.T) {
+		// The channel holds one pending signal; further calls must be
+		// no-ops rather than blocking the caller (a re-assert goroutine).
+		se := NewServEnv(viperutil.NewRegistry())
+		se.InitiateShutdown()
+		se.InitiateShutdown()
+		se.InitiateShutdown()
+		require.Equal(t, syscall.SIGTERM, <-se.exitChan)
+		select {
+		case sig := <-se.exitChan:
+			t.Fatalf("expected exactly one queued signal, got a second: %v", sig)
+		default:
+		}
 	})
 }

--- a/go/common/servenv/toporeg/reassert_topo_test.go
+++ b/go/common/servenv/toporeg/reassert_topo_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toporeg
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/topoclient"
+	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
+)
+
+// TestReassert_RestoresRegistrationThroughStore drives the real registration
+// path — toporeg over a topoclient.Store — and removes the record behind the
+// component's back, the way a lease expiry, a replaced connection, or a cell
+// reconfiguration does. The record must come back on its own.
+//
+// This is the end-to-end form of the guarantee the ephemeral registrations
+// depend on: the topology layer is free to drop an entry whenever its
+// liveness binding ends, because the owner puts it back.
+func TestReassert_RestoresRegistrationThroughStore(t *testing.T) {
+	shortenReassert(t)
+
+	ctx := context.Background()
+	const cell = "zone-1"
+	ts := memorytopo.NewServer(ctx, cell)
+	defer ts.Close()
+
+	gateway := topoclient.NewMultigateway("gw-1", cell, "gw-1.example.com")
+
+	tr := Register(
+		func(ctx context.Context) error { return ts.RegisterMultigateway(ctx, gateway, true) },
+		func(ctx context.Context) error { return ts.UnregisterMultigateway(ctx, gateway.Id) },
+		func(string) {},
+		WithReassert(),
+	)
+	require.NotNil(t, tr)
+
+	_, err := ts.GetMultigateway(ctx, gateway.Id)
+	require.NoError(t, err, "component should be registered after Register returns")
+
+	// Something removed the entry without telling the component.
+	require.NoError(t, ts.UnregisterMultigateway(ctx, gateway.Id))
+	_, err = ts.GetMultigateway(ctx, gateway.Id)
+	require.Error(t, err, "precondition: the entry is gone")
+
+	assert.Eventually(t, func() bool {
+		_, err := ts.GetMultigateway(ctx, gateway.Id)
+		return err == nil
+	}, 2*time.Second, 10*time.Millisecond,
+		"re-assertion should restore a registration removed behind the component's back")
+
+	// And a real deregistration still wins: nothing puts it back afterwards.
+	tr.Unregister()
+	assert.Never(t, func() bool {
+		_, err := ts.GetMultigateway(ctx, gateway.Id)
+		return err == nil
+	}, 300*time.Millisecond, 10*time.Millisecond,
+		"deregistration must be final; re-assertion must not resurrect the entry")
+}

--- a/go/common/servenv/toporeg/toporeg.go
+++ b/go/common/servenv/toporeg/toporeg.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/multigres/multigres/go/common/servenv"
+	"github.com/multigres/multigres/go/common/topoclient"
 	"github.com/multigres/multigres/go/tools/retry"
 )
 
@@ -39,17 +40,50 @@ type TopoReg struct {
 	logger *slog.Logger
 
 	unregister func(ctx context.Context) error
+	reassert   bool
+}
+
+// reassertInterval is how often a WithReassert registration rewrites its
+// record. It bounds how long a component stays missing from the topology
+// after its entry is lost, so it should stay well under the topology
+// backend's liveness TTL (--topo-etcd-lease-ttl, 30s by default).
+// It is a var only so tests can shorten it.
+var reassertInterval = 10 * time.Second
+
+// Option configures a registration.
+type Option func(*TopoReg)
+
+// WithReassert makes a registration self-healing: the component rewrites its
+// record periodically, so the entry reappears on its own if anything removes
+// it while the process is alive.
+//
+// Use it for ephemeral (liveness-bound) registrations, whose entry can vanish
+// under the component in ways it never learns about: the backend expiring a
+// lease after a topology outage, a reconnection replacing the underlying
+// connection, or a cell reconfiguration replacing it wholesale. Without
+// re-assertion the component would stay silently absent from the topology
+// until it restarts.
+//
+// Do NOT use it for components that already maintain their own record on a
+// schedule — multipooler publishes its lifecycle state continuously, and a
+// second writer would both duplicate that and churn every watcher of those
+// keys.
+func WithReassert() Option {
+	return func(tp *TopoReg) { tp.reassert = true }
 }
 
 // Register registers the component using the register function. If the register function
 // returns an error, it will be retried with exponential backoff until successful.
 // The alarm will be invoked with the latest error message during retries. If the
 // registration succeeds, the alarm will be invoked with an empty string.
-func Register(register func(ctx context.Context) error, unregister func(ctx context.Context) error, alarm func(string)) *TopoReg {
+func Register(register func(ctx context.Context) error, unregister func(ctx context.Context) error, alarm func(string), opts ...Option) *TopoReg {
 	tp := &TopoReg{}
 	tp.ctx, tp.cancel = context.WithCancel(context.TODO())
 	tp.logger = servenv.GetLogger()
 	tp.unregister = unregister
+	for _, opt := range opts {
+		opt(tp)
+	}
 
 	// Use tp's ctx to abort retries if Unregister gets called.
 	ctx, cancel := context.WithTimeout(tp.ctx, time.Second)
@@ -57,6 +91,7 @@ func Register(register func(ctx context.Context) error, unregister func(ctx cont
 
 	if err := register(ctx); err == nil {
 		tp.logger.Info("successfully registered component with topology")
+		tp.startReassert(register)
 		return tp
 	} else {
 		alarm(fmt.Sprintf("Failed to register component with topology: %v", err))
@@ -76,6 +111,7 @@ func Register(register func(ctx context.Context) error, unregister func(ctx cont
 				tp.logger.Info("successfully registered component with topology")
 				alarm("")
 				cancel()
+				tp.startReassert(register)
 				return
 			} else {
 				// Just call alarm. No need to spam logs.
@@ -87,6 +123,35 @@ func Register(register func(ctx context.Context) error, unregister func(ctx cont
 	return tp
 }
 
+// startReassert runs the re-assertion loop for WithReassert registrations.
+// It is a no-op otherwise. The loop lives on tp.wg and stops on tp.ctx, so
+// Unregister's cancel-then-wait halts it before the deregistration runs —
+// re-assertion can never resurrect a record the component just removed.
+func (tp *TopoReg) startReassert(register func(ctx context.Context) error) {
+	if !tp.reassert {
+		return
+	}
+	tp.wg.Go(func() {
+		ticker := time.NewTicker(reassertInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-tp.ctx.Done():
+				return
+			case <-ticker.C:
+				ctx, cancel := context.WithTimeout(tp.ctx, time.Second)
+				err := register(ctx)
+				cancel()
+				if err != nil {
+					// The next tick tries again; a component missing from
+					// topology is visible in its own logs either way.
+					tp.logger.Warn("failed to re-assert topology registration", "error", err)
+				}
+			}
+		}
+	})
+}
+
 // RegisterSynchronous registers the component synchronously, retrying with
 // exponential backoff and jitter until successful or the context expires.
 // Unlike Register, it blocks until registration succeeds and returns an error
@@ -94,11 +159,14 @@ func Register(register func(ctx context.Context) error, unregister func(ctx cont
 //
 // Use this when the caller must know registration succeeded before proceeding
 // (e.g., claiming a PID prefix that other components depend on).
-func RegisterSynchronous(ctx context.Context, register func(ctx context.Context) error, unregister func(ctx context.Context) error) (*TopoReg, error) {
+func RegisterSynchronous(ctx context.Context, register func(ctx context.Context) error, unregister func(ctx context.Context) error, opts ...Option) (*TopoReg, error) {
 	tp := &TopoReg{}
 	tp.ctx, tp.cancel = context.WithCancel(context.TODO())
 	tp.logger = servenv.GetLogger()
 	tp.unregister = unregister
+	for _, opt := range opts {
+		opt(tp)
+	}
 
 	r := retry.New(50*time.Millisecond, 1*time.Second)
 	for _, err := range r.Attempts(ctx) {
@@ -111,6 +179,7 @@ func RegisterSynchronous(ctx context.Context, register func(ctx context.Context)
 		cancel()
 		if err == nil {
 			tp.logger.InfoContext(ctx, "successfully registered component with topology")
+			tp.startReassert(register)
 			return tp, nil
 		}
 	}
@@ -118,7 +187,20 @@ func RegisterSynchronous(ctx context.Context, register func(ctx context.Context)
 	return nil, errors.New("registration failed")
 }
 
-// Unregister unregisters the component from topology.
+// unregisterBudget bounds the total time Unregister spends retrying the
+// deregistration. It is deliberately smaller than servenv's OnClose window
+// (default 10s) so the caller's remaining shutdown steps still get a share
+// of that window. A longer budget would buy nothing anyway: if
+// deregistration is still failing after several seconds, the topology is
+// unreachable, and lease expiry cleans up the registration instead.
+// It is a var only so tests can shorten it.
+var unregisterBudget = 5 * time.Second
+
+// Unregister unregisters the component from topology, retrying with backoff
+// until it succeeds or the budget expires. Registration retries until it
+// succeeds; a deregistration that gives up after one attempt would leave the
+// component visible until its lease expires, so it deserves the same
+// persistence.
 // It will terminate any retry goroutines that are still running.
 // It is safe to call Unregister with a nil TopoReg.
 func (tp *TopoReg) Unregister() {
@@ -131,12 +213,26 @@ func (tp *TopoReg) Unregister() {
 	tp.wg.Wait()
 
 	// Use standalone ctx because tp.ctx is already canceled.
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	ctx, cancel := context.WithTimeout(context.TODO(), unregisterBudget)
 	defer cancel()
 
-	if err := tp.unregister(ctx); err != nil {
-		tp.logger.Error("failed to deregister component from topology", "error", err)
-	} else {
-		tp.logger.Info("successfully deregistered component from topology")
+	r := retry.New(100*time.Millisecond, 2*time.Second)
+	var lastErr error
+	for _, err := range r.Attempts(ctx) {
+		if err != nil {
+			tp.logger.Error("failed to deregister component from topology",
+				"error", lastErr, "budget", unregisterBudget)
+			return
+		}
+
+		attemptCtx, attemptCancel := context.WithTimeout(ctx, time.Second)
+		lastErr = tp.unregister(attemptCtx)
+		attemptCancel()
+		if lastErr == nil || errors.Is(lastErr, &topoclient.TopoError{Code: topoclient.NoNode}) {
+			// NoNode counts as success: a previous attempt's delete may
+			// have been applied even though its response timed out.
+			tp.logger.Info("successfully deregistered component from topology")
+			return
+		}
 	}
 }

--- a/go/common/servenv/toporeg/toporeg_test.go
+++ b/go/common/servenv/toporeg/toporeg_test.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/topoclient"
 )
 
 func TestRegister_SuccessOnFirstTry(t *testing.T) {
@@ -152,28 +154,177 @@ func TestUnregister_WithNilPointer(t *testing.T) {
 	}, "Unregister should handle nil pointer gracefully")
 }
 
-func TestUnregister_WithError(t *testing.T) {
-	var unregisterCalled bool
-	var unregisterError error
+// shortenReassert makes the re-assertion loop tick fast enough for tests.
+func shortenReassert(t *testing.T) {
+	t.Helper()
+	old := reassertInterval
+	reassertInterval = 10 * time.Millisecond
+	t.Cleanup(func() { reassertInterval = old })
+}
+
+func TestReassert_RewritesRegistrationPeriodically(t *testing.T) {
+	shortenReassert(t)
+
+	var registerCallCount atomic.Int32
+	register := func(ctx context.Context) error {
+		registerCallCount.Add(1)
+		return nil
+	}
+
+	tr := Register(register, func(context.Context) error { return nil }, func(string) {}, WithReassert())
+	require.NotNil(t, tr)
+	defer tr.Unregister()
+
+	// The initial registration counts as one; re-assertion keeps going.
+	assert.Eventually(t, func() bool {
+		return registerCallCount.Load() >= 4
+	}, time.Second, 5*time.Millisecond, "registration should be re-asserted repeatedly")
+}
+
+func TestReassert_DisabledByDefault(t *testing.T) {
+	shortenReassert(t)
+
+	var registerCallCount atomic.Int32
+	register := func(ctx context.Context) error {
+		registerCallCount.Add(1)
+		return nil
+	}
+
+	// Without WithReassert (e.g. multipooler, which maintains its own
+	// record) the registration is written exactly once.
+	tr := Register(register, func(context.Context) error { return nil }, func(string) {})
+	require.NotNil(t, tr)
+	defer tr.Unregister()
+
+	assert.Never(t, func() bool {
+		return registerCallCount.Load() > 1
+	}, 200*time.Millisecond, 10*time.Millisecond, "registration must not be rewritten without WithReassert")
+}
+
+func TestReassert_StopsBeforeUnregisterDeletes(t *testing.T) {
+	shortenReassert(t)
+
+	// Ordering guard: if re-assertion outlived the deregistration, it would
+	// rewrite the record the component just removed — re-introducing the
+	// stranded entry this whole mechanism exists to prevent.
+	var registerCallCount atomic.Int32
+	var unregistered atomic.Bool
+	var reassertedAfterUnregister atomic.Bool
+
+	register := func(ctx context.Context) error {
+		registerCallCount.Add(1)
+		if unregistered.Load() {
+			reassertedAfterUnregister.Store(true)
+		}
+		return nil
+	}
+	unregister := func(ctx context.Context) error {
+		unregistered.Store(true)
+		return nil
+	}
+
+	tr := Register(register, unregister, func(string) {}, WithReassert())
+	require.NotNil(t, tr)
+
+	// Let the loop run a few times, then shut down.
+	require.Eventually(t, func() bool {
+		return registerCallCount.Load() >= 3
+	}, time.Second, 5*time.Millisecond)
+	tr.Unregister()
+
+	assert.Never(t, func() bool {
+		return reassertedAfterUnregister.Load()
+	}, 200*time.Millisecond, 10*time.Millisecond, "re-assertion must stop before the record is deleted")
+}
+
+func TestReassert_SurvivesTransientFailures(t *testing.T) {
+	shortenReassert(t)
+
+	var registerCallCount atomic.Int32
+	register := func(ctx context.Context) error {
+		// Fail every other attempt; the loop must keep going regardless.
+		if registerCallCount.Add(1)%2 == 0 {
+			return errors.New("topology unavailable")
+		}
+		return nil
+	}
+
+	tr := Register(register, func(context.Context) error { return nil }, func(string) {}, WithReassert())
+	require.NotNil(t, tr)
+	defer tr.Unregister()
+
+	assert.Eventually(t, func() bool {
+		return registerCallCount.Load() >= 6
+	}, time.Second, 5*time.Millisecond, "a failed re-assertion must not stop the loop")
+}
+
+func TestUnregister_RetriesUntilSuccess(t *testing.T) {
+	var unregisterCallCount atomic.Int32
 
 	register := func(ctx context.Context) error {
 		return nil
 	}
 
 	unregister := func(ctx context.Context) error {
-		unregisterCalled = true
-		return errors.New("unregister failed")
+		if unregisterCallCount.Add(1) < 3 {
+			return errors.New("unregister failed")
+		}
+		return nil
 	}
 
-	alarm := func(msg string) {}
-
-	tr := Register(register, unregister, alarm)
+	tr := Register(register, unregister, func(msg string) {})
 	require.NotNil(t, tr)
 
 	tr.Unregister()
 
-	assert.True(t, unregisterCalled, "unregister should be called")
-	assert.Nil(t, unregisterError, "unregister error should be logged but not returned")
+	assert.Equal(t, int32(3), unregisterCallCount.Load(), "unregister should be retried until it succeeds")
+}
+
+func TestUnregister_GivesUpAfterBudget(t *testing.T) {
+	oldBudget := unregisterBudget
+	unregisterBudget = 300 * time.Millisecond
+	defer func() { unregisterBudget = oldBudget }()
+
+	var unregisterCallCount atomic.Int32
+
+	register := func(ctx context.Context) error {
+		return nil
+	}
+
+	unregister := func(ctx context.Context) error {
+		unregisterCallCount.Add(1)
+		return errors.New("unregister always fails")
+	}
+
+	tr := Register(register, unregister, func(msg string) {})
+	require.NotNil(t, tr)
+
+	// Must return (error is only logged), and must have retried within the budget.
+	tr.Unregister()
+
+	assert.Greater(t, unregisterCallCount.Load(), int32(1), "unregister should be retried before giving up")
+}
+
+func TestUnregister_NoNodeIsSuccess(t *testing.T) {
+	var unregisterCallCount atomic.Int32
+
+	register := func(ctx context.Context) error {
+		return nil
+	}
+
+	// NoNode means the registration is already gone (e.g. a previous
+	// attempt's delete was applied but its response was lost).
+	unregister := func(ctx context.Context) error {
+		unregisterCallCount.Add(1)
+		return topoclient.NewError(topoclient.NoNode, "gateways/foo")
+	}
+
+	tr := Register(register, unregister, func(msg string) {})
+	require.NotNil(t, tr)
+
+	tr.Unregister()
+
+	assert.Equal(t, int32(1), unregisterCallCount.Load(), "NoNode should count as success, not be retried")
 }
 
 func TestRegister_AlarmBehavior(t *testing.T) {

--- a/go/common/topoclient/conn.go
+++ b/go/common/topoclient/conn.go
@@ -96,6 +96,24 @@ type ConnFile interface {
 	// Returns ErrNodeExists if the file doesn't exist.
 	// Returns ErrBadVersion if the provided version is not current.
 	Delete(ctx context.Context, filePath string, version Version) error
+
+	// PutEphemeral creates or updates the file, binding its lifetime to
+	// this connection's process. Backends with liveness support (etcd
+	// leases) delete the file automatically when the process dies without
+	// deleting it first. Backends without liveness support treat this as
+	// an unconditional update.
+	//
+	// The binding can also end while the process is alive — a backend
+	// expiring it after an outage, or a reconnection replacing the
+	// connection underneath. Nothing at this layer re-creates the file:
+	// only its owner knows it should exist, so owners keep it alive by
+	// writing it again periodically (see servenv/toporeg's WithReassert).
+	//
+	// Ephemeral files must only be written through PutEphemeral: a plain
+	// Update on the same path would sever the liveness binding, making
+	// the file permanent.
+	// filePath is a path relative to the root directory of the cell.
+	PutEphemeral(ctx context.Context, filePath string, contents []byte) error
 }
 
 type ConnLock interface {
@@ -300,8 +318,9 @@ type DirEntry struct {
 	Type DirEntryType
 
 	// Ephemeral is set if the directory / file only contains
-	// data that was not set by the file API, like lock files
-	// or primary-election related files.
+	// data whose lifetime is bound to a process: lock files,
+	// primary-election related files, or liveness-bound files
+	// written via PutEphemeral.
 	// Only filled in if full is true.
 	Ephemeral bool
 }

--- a/go/common/topoclient/conn.go
+++ b/go/common/topoclient/conn.go
@@ -114,6 +114,23 @@ type ConnFile interface {
 	// the file permanent.
 	// filePath is a path relative to the root directory of the cell.
 	PutEphemeral(ctx context.Context, filePath string, contents []byte) error
+
+	// ClaimEphemeral atomically claims an ephemeral file on behalf of the
+	// owner identified by contents. It succeeds when the file is absent
+	// (creating it) or already holds exactly contents (refreshing its
+	// liveness binding); it returns NodeExists when another owner holds
+	// the file. Use it for exclusive claims from a shared pool — e.g. a
+	// gateway claiming a PID prefix — where create-if-absent must be
+	// atomic and a re-asserting owner must never overwrite a competitor.
+	//
+	// Like PutEphemeral, the file's lifetime is bound to this connection's
+	// process; a dead claimant's file expires on its own, freeing the
+	// claim. Owners re-assert periodically (toporeg.WithReassert); a
+	// NodeExists on re-assert means the claim was lost to another owner
+	// after an expiry, which the owner must treat as fatal for the
+	// claimed resource rather than retry past.
+	// filePath is a path relative to the root directory of the cell.
+	ClaimEphemeral(ctx context.Context, filePath string, contents []byte) error
 }
 
 type ConnLock interface {

--- a/go/common/topoclient/etcdtopo/directory.go
+++ b/go/common/topoclient/etcdtopo/directory.go
@@ -71,7 +71,8 @@ func (s *etcdtopo) ListDir(ctx context.Context, dirPath string, full bool) ([]to
 			if full {
 				e.Type = t
 				if ev.Lease != 0 {
-					// Only locks have a lease associated with them.
+					// Lease-backed keys are ephemeral: lock files,
+					// election files, and PutEphemeral registrations.
 					e.Ephemeral = true
 				}
 			}

--- a/go/common/topoclient/etcdtopo/ephemeral.go
+++ b/go/common/topoclient/etcdtopo/ephemeral.go
@@ -23,6 +23,7 @@ import (
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
 
+	"github.com/multigres/multigres/go/common/topoclient"
 	"github.com/multigres/multigres/go/tools/ctxutil"
 )
 
@@ -60,6 +61,51 @@ func (s *etcdtopo) PutEphemeral(ctx context.Context, filePath string, contents [
 			s.clearEphemeralLease(leaseID)
 		}
 		return convertError(err, nodePath)
+	}
+	return nil
+}
+
+// ClaimEphemeral is part of the topoclient.Conn interface.
+func (s *etcdtopo) ClaimEphemeral(ctx context.Context, filePath string, contents []byte) error {
+	nodePath := path.Join(s.root, filePath)
+
+	leaseID, err := s.ephemeralLease(ctx)
+	if err != nil {
+		return convertError(err, nodePath)
+	}
+
+	// Refresh-if-mine first: in steady state the claimant re-asserts a
+	// claim it already holds, and the value comparison also rebinds the
+	// file to the current lease after a lease change.
+	txnresp, err := s.cli.Txn(ctx).
+		If(clientv3.Compare(clientv3.Value(nodePath), "=", string(contents))).
+		Then(clientv3.OpPut(nodePath, string(contents), clientv3.WithLease(leaseID))).
+		Commit()
+	if err != nil {
+		if errors.Is(err, rpctypes.ErrLeaseNotFound) {
+			s.clearEphemeralLease(leaseID)
+		}
+		return convertError(err, nodePath)
+	}
+	if txnresp.Succeeded {
+		return nil
+	}
+
+	// Not ours (or absent): claim only if absent. A file appearing between
+	// the two transactions simply fails this one — no window where a
+	// competitor's claim can be overwritten.
+	txnresp, err = s.cli.Txn(ctx).
+		If(clientv3.Compare(clientv3.Version(nodePath), "=", 0)).
+		Then(clientv3.OpPut(nodePath, string(contents), clientv3.WithLease(leaseID))).
+		Commit()
+	if err != nil {
+		if errors.Is(err, rpctypes.ErrLeaseNotFound) {
+			s.clearEphemeralLease(leaseID)
+		}
+		return convertError(err, nodePath)
+	}
+	if !txnresp.Succeeded {
+		return topoclient.NewError(topoclient.NodeExists, nodePath)
 	}
 	return nil
 }

--- a/go/common/topoclient/etcdtopo/ephemeral.go
+++ b/go/common/topoclient/etcdtopo/ephemeral.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdtopo
+
+import (
+	"context"
+	"errors"
+	"path"
+	"sync"
+
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"github.com/multigres/multigres/go/tools/ctxutil"
+)
+
+// Ephemeral files are bound to a lease shared by every ephemeral file on this
+// connection and renewed for the connection's lifetime. When the process dies,
+// renewals stop and etcd deletes the files within one TTL
+// (--topo-etcd-lease-ttl) — that is what keeps a killed component from leaving
+// a permanent registration behind.
+//
+// This layer deliberately does not remember which files it wrote. If the lease
+// ends while the process is alive (etcd unreachable for longer than the TTL),
+// the files are gone and only their owner knows they should exist; re-creating
+// them is the owner's job, via toporeg's re-assertion loop. All this layer
+// does is forget the dead lease so the next write grants a fresh one.
+
+// ephemeralState holds the lease shared by this connection's ephemeral files.
+type ephemeralState struct {
+	mu      sync.Mutex
+	leaseID clientv3.LeaseID
+}
+
+// PutEphemeral is part of the topoclient.Conn interface.
+func (s *etcdtopo) PutEphemeral(ctx context.Context, filePath string, contents []byte) error {
+	nodePath := path.Join(s.root, filePath)
+
+	leaseID, err := s.ephemeralLease(ctx)
+	if err != nil {
+		return convertError(err, nodePath)
+	}
+
+	if _, err := s.cli.Put(ctx, nodePath, string(contents), clientv3.WithLease(leaseID)); err != nil {
+		if errors.Is(err, rpctypes.ErrLeaseNotFound) {
+			// The lease expired between the lookup and the write. Drop it
+			// so the caller's next attempt grants a fresh one.
+			s.clearEphemeralLease(leaseID)
+		}
+		return convertError(err, nodePath)
+	}
+	return nil
+}
+
+// ephemeralLease returns the connection's lease, granting and starting
+// keepalive for it on first use.
+func (s *etcdtopo) ephemeralLease(ctx context.Context) (clientv3.LeaseID, error) {
+	s.eph.mu.Lock()
+	defer s.eph.mu.Unlock()
+
+	if s.eph.leaseID != 0 {
+		return s.eph.leaseID, nil
+	}
+
+	lease, err := s.cli.Grant(ctx, int64(leaseTTL))
+	if err != nil {
+		return 0, err
+	}
+	// Renewals must outlive the caller's context: they run for the
+	// connection's lifetime. Conn.Close tears them down via cli.Close.
+	ka, err := s.cli.KeepAlive(ctxutil.Detach(ctx), lease.ID)
+	if err != nil {
+		return 0, err
+	}
+	s.eph.leaseID = lease.ID
+	go s.watchEphemeralLease(lease.ID, ka)
+	return lease.ID, nil
+}
+
+// watchEphemeralLease drains keepalive responses — the etcd client stops
+// renewing if the channel fills up — and clears the lease once it ends, so
+// the next write grants a fresh one.
+func (s *etcdtopo) watchEphemeralLease(id clientv3.LeaseID, ka <-chan *clientv3.LeaseKeepAliveResponse) {
+	for range ka {
+	}
+	s.clearEphemeralLease(id)
+}
+
+// clearEphemeralLease forgets the lease if it is still the current one.
+func (s *etcdtopo) clearEphemeralLease(id clientv3.LeaseID) {
+	s.eph.mu.Lock()
+	defer s.eph.mu.Unlock()
+	if s.eph.leaseID == id {
+		s.eph.leaseID = 0
+	}
+}

--- a/go/common/topoclient/etcdtopo/lock.go
+++ b/go/common/topoclient/etcdtopo/lock.go
@@ -42,7 +42,7 @@ func init() {
 }
 
 func registerEtcd2TopoLockFlags(fs *pflag.FlagSet) {
-	fs.IntVar(&leaseTTL, "topo-etcd-lease-ttl", leaseTTL, "Lease TTL for locks and leader election. The client will use KeepAlive to keep the lease going.")
+	fs.IntVar(&leaseTTL, "topo-etcd-lease-ttl", leaseTTL, "Lease TTL for locks, leader election, and ephemeral component registrations. The client will use KeepAlive to keep the lease going; registrations of a dead process expire within this TTL.")
 }
 
 // newUniqueEphemeralKV creates a new file in the provided directory.

--- a/go/common/topoclient/etcdtopo/store.go
+++ b/go/common/topoclient/etcdtopo/store.go
@@ -83,6 +83,9 @@ type etcdtopo struct {
 	root string
 
 	running chan struct{}
+
+	// eph tracks lease-backed ephemeral files; see ephemeral.go.
+	eph ephemeralState
 }
 
 func init() {

--- a/go/common/topoclient/etcdtopo/test_helpers.go
+++ b/go/common/topoclient/etcdtopo/test_helpers.go
@@ -33,6 +33,16 @@ import (
 	"github.com/multigres/multigres/go/tools/retry"
 )
 
+// SetLeaseTTLForTest overrides the lease TTL normally configured via
+// --topo-etcd-lease-ttl and returns a function restoring the previous value.
+// Test-only: lets lease-expiry tests run in seconds instead of the
+// production default.
+func SetLeaseTTLForTest(ttl int) (restore func()) {
+	old := leaseTTL
+	leaseTTL = ttl
+	return func() { leaseTTL = old }
+}
+
 // checkPortAvailable checks if a port is available for binding
 func checkPortAvailable(port int) error {
 	ln, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))

--- a/go/common/topoclient/memorytopo/file.go
+++ b/go/common/topoclient/memorytopo/file.go
@@ -15,7 +15,9 @@
 package memorytopo
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -164,6 +166,25 @@ func (c *conn) Update(ctx context.Context, filePath string, contents []byte, ver
 // no process-liveness concept, so this is a plain unconditional update.
 func (c *conn) PutEphemeral(ctx context.Context, filePath string, contents []byte) error {
 	_, err := c.Update(ctx, filePath, contents, nil)
+	return err
+}
+
+// ClaimEphemeral is part of the topoclient.Conn interface. The memory topo
+// has no process-liveness concept, so the claim never expires on its own; the
+// atomic claim-or-refresh semantics are preserved.
+func (c *conn) ClaimEphemeral(ctx context.Context, filePath string, contents []byte) error {
+	existing, _, err := c.Get(ctx, filePath)
+	switch {
+	case err == nil:
+		if !bytes.Equal(existing, contents) {
+			return topoclient.NewError(topoclient.NodeExists, filePath)
+		}
+	case errors.Is(err, &topoclient.TopoError{Code: topoclient.NoNode}):
+		// Absent: claimable.
+	default:
+		return err
+	}
+	_, err = c.Update(ctx, filePath, contents, nil)
 	return err
 }
 

--- a/go/common/topoclient/memorytopo/file.go
+++ b/go/common/topoclient/memorytopo/file.go
@@ -160,6 +160,13 @@ func (c *conn) Update(ctx context.Context, filePath string, contents []byte, ver
 	return NodeVersion(n.version), nil
 }
 
+// PutEphemeral is part of the topoclient.Conn interface. The memory topo has
+// no process-liveness concept, so this is a plain unconditional update.
+func (c *conn) PutEphemeral(ctx context.Context, filePath string, contents []byte) error {
+	_, err := c.Update(ctx, filePath, contents, nil)
+	return err
+}
+
 // Get is part of topoclient.Conn interface.
 func (c *conn) Get(ctx context.Context, filePath string) ([]byte, topoclient.Version, error) {
 	// c.factory.callstats.Add([]string{"Get"}, 1)

--- a/go/common/topoclient/mock_test.go
+++ b/go/common/topoclient/mock_test.go
@@ -15,6 +15,7 @@
 package topoclient
 
 import (
+	"bytes"
 	"context"
 	"sync"
 	"sync/atomic"
@@ -88,6 +89,19 @@ func (m *mockConn) Update(ctx context.Context, filePath string, contents []byte,
 func (m *mockConn) PutEphemeral(ctx context.Context, filePath string, contents []byte) error {
 	_, err := m.Update(ctx, filePath, contents, nil)
 	return err
+}
+
+func (m *mockConn) ClaimEphemeral(ctx context.Context, filePath string, contents []byte) error {
+	if err := m.checkError(); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if existing, ok := m.data[filePath]; ok && !bytes.Equal(existing, contents) {
+		return &TopoError{Code: NodeExists}
+	}
+	m.data[filePath] = contents
+	return nil
 }
 
 func (m *mockConn) Get(ctx context.Context, filePath string) ([]byte, Version, error) {

--- a/go/common/topoclient/mock_test.go
+++ b/go/common/topoclient/mock_test.go
@@ -85,6 +85,11 @@ func (m *mockConn) Update(ctx context.Context, filePath string, contents []byte,
 	return &mockVersion{version: "2"}, nil
 }
 
+func (m *mockConn) PutEphemeral(ctx context.Context, filePath string, contents []byte) error {
+	_, err := m.Update(ctx, filePath, contents, nil)
+	return err
+}
+
 func (m *mockConn) Get(ctx context.Context, filePath string) ([]byte, Version, error) {
 	if err := m.checkError(); err != nil {
 		return nil, nil, err

--- a/go/common/topoclient/multigateway.go
+++ b/go/common/topoclient/multigateway.go
@@ -239,8 +239,13 @@ func gatewayPrefixPath(prefix uint32) string {
 // gateway holds the prefix.
 //
 // The claim is ephemeral and lives in the global topology (prefixes route
-// query-cancels across cells, so the namespace is cluster-wide). A dead
-// claimant's file expires with its connection's lease, freeing the prefix.
+// query-cancels across cells, so the namespace is cluster-wide). Claims are
+// never explicitly released: lease expiry is the only release path, so a
+// claimant can never delete a claim that has passed to another gateway, and
+// a stopped gateway's prefix frees itself within one lease TTL. Slot reuse
+// has no urgency — the pool holds 2047 prefixes and each process claims
+// exactly one.
+//
 // The claiming gateway re-asserts periodically; NodeExists on a re-assert
 // means the claim was lost to another gateway after an expiry — the caller
 // must stop treating the prefix as its own rather than retry past it.
@@ -250,22 +255,6 @@ func (ts *store) ClaimGatewayPrefix(ctx context.Context, prefix uint32, id *clus
 		return err
 	}
 	return conn.ClaimEphemeral(ctx, gatewayPrefixPath(prefix), []byte(ComponentIDString(id)))
-}
-
-// ReleaseGatewayPrefix deletes the claim file for the given PID prefix. Used
-// on graceful shutdown for prompt release; lease expiry is the backstop.
-// The delete is unconditional: a gateway releases only a prefix it believes
-// it holds, and in the rare case the claim was already stolen, the thief's
-// next re-assert simply re-creates it.
-func (ts *store) ReleaseGatewayPrefix(ctx context.Context, prefix uint32) error {
-	conn, err := ts.ConnForCell(ctx, GlobalCell)
-	if err != nil {
-		return err
-	}
-	if err := conn.Delete(ctx, gatewayPrefixPath(prefix), nil); err != nil && !errors.Is(err, &TopoError{Code: NoNode}) {
-		return err
-	}
-	return nil
 }
 
 // UnregisterMultigateway deletes the specified multigateway.

--- a/go/common/topoclient/multigateway.go
+++ b/go/common/topoclient/multigateway.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"strconv"
 
 	"github.com/multigres/multigres/go/common/mterrors"
 
@@ -225,6 +226,45 @@ func (ts *store) CreateMultigateway(ctx context.Context, mtgateway *clustermetad
 		return err
 	}
 
+	return nil
+}
+
+// gatewayPrefixPath returns the claim file path for a PID prefix.
+func gatewayPrefixPath(prefix uint32) string {
+	return path.Join(GatewayPrefixesPath, strconv.FormatUint(uint64(prefix), 10))
+}
+
+// ClaimGatewayPrefix atomically claims the PID prefix for the given gateway,
+// or refreshes a claim it already holds. It returns NodeExists when another
+// gateway holds the prefix.
+//
+// The claim is ephemeral and lives in the global topology (prefixes route
+// query-cancels across cells, so the namespace is cluster-wide). A dead
+// claimant's file expires with its connection's lease, freeing the prefix.
+// The claiming gateway re-asserts periodically; NodeExists on a re-assert
+// means the claim was lost to another gateway after an expiry — the caller
+// must stop treating the prefix as its own rather than retry past it.
+func (ts *store) ClaimGatewayPrefix(ctx context.Context, prefix uint32, id *clustermetadatapb.ID) error {
+	conn, err := ts.ConnForCell(ctx, GlobalCell)
+	if err != nil {
+		return err
+	}
+	return conn.ClaimEphemeral(ctx, gatewayPrefixPath(prefix), []byte(ComponentIDString(id)))
+}
+
+// ReleaseGatewayPrefix deletes the claim file for the given PID prefix. Used
+// on graceful shutdown for prompt release; lease expiry is the backstop.
+// The delete is unconditional: a gateway releases only a prefix it believes
+// it holds, and in the rare case the claim was already stolen, the thief's
+// next re-assert simply re-creates it.
+func (ts *store) ReleaseGatewayPrefix(ctx context.Context, prefix uint32) error {
+	conn, err := ts.ConnForCell(ctx, GlobalCell)
+	if err != nil {
+		return err
+	}
+	if err := conn.Delete(ctx, gatewayPrefixPath(prefix), nil); err != nil && !errors.Is(err, &TopoError{Code: NoNode}) {
+		return err
+	}
 	return nil
 }
 

--- a/go/common/topoclient/multigateway.go
+++ b/go/common/topoclient/multigateway.go
@@ -206,6 +206,10 @@ func (ts *store) UpdateMultigatewayFields(ctx context.Context, id *clustermetada
 }
 
 // CreateMultigateway creates a new multigateway and all associated paths.
+//
+// The record is permanent — it carries no liveness binding and will outlive
+// the process that wrote it. Component self-registration must go through
+// RegisterMultigateway, which creates an ephemeral record instead.
 func (ts *store) CreateMultigateway(ctx context.Context, mtgateway *clustermetadatapb.Multigateway) error {
 	conn, err := ts.ConnForCell(ctx, mtgateway.Id.Cell)
 	if err != nil {
@@ -239,22 +243,37 @@ func (ts *store) UnregisterMultigateway(ctx context.Context, id *clustermetadata
 	return nil
 }
 
-// RegisterMultigateway creates or updates a multigateway. If allowUpdate is true,
-// and a multigateway with the same ID exists, just update it.
+// RegisterMultigateway creates or updates a multigateway. If allowUpdate is
+// false and a multigateway with the same ID already exists, it returns
+// NodeExists.
+//
+// The registration is ephemeral: backends with liveness support (etcd
+// leases) bind it to this process, so a gateway that dies without
+// unregistering — SIGKILL, OOM, node loss — disappears from the topology on
+// its own instead of leaking a permanent entry.
 func (ts *store) RegisterMultigateway(ctx context.Context, mtgateway *clustermetadatapb.Multigateway, allowUpdate bool) error {
-	err := ts.CreateMultigateway(ctx, mtgateway)
-	if errors.Is(err, &TopoError{Code: NodeExists}) && allowUpdate {
-		// Try to update then
-		oldMtGateway, err := ts.GetMultigateway(ctx, mtgateway.Id)
-		if err != nil {
+	conn, err := ts.ConnForCell(ctx, mtgateway.Id.Cell)
+	if err != nil {
+		return err
+	}
+
+	gatewayPath := path.Join(GatewaysPath, string(ComponentIDString(mtgateway.Id)), GatewayFile)
+	if !allowUpdate {
+		// Existence check to preserve NodeExists semantics. Not atomic
+		// with the put below, but IDs are unique per process instance, so
+		// concurrent registration of the same ID doesn't happen in
+		// practice.
+		switch _, _, err := conn.Get(ctx, gatewayPath); {
+		case err == nil:
+			return NewError(NodeExists, gatewayPath)
+		case !errors.Is(err, &TopoError{Code: NoNode}):
 			return fmt.Errorf("failed reading existing mtgateway %v: %w", ComponentIDString(mtgateway.Id), err)
 		}
-
-		oldMtGateway.Multigateway = proto.Clone(mtgateway).(*clustermetadatapb.Multigateway)
-		if err := ts.UpdateMultigateway(ctx, oldMtGateway); err != nil {
-			return fmt.Errorf("failed updating mtgateway %v: %w", ComponentIDString(mtgateway.Id), err)
-		}
-		return nil
 	}
-	return err
+
+	data, err := proto.Marshal(mtgateway)
+	if err != nil {
+		return err
+	}
+	return conn.PutEphemeral(ctx, gatewayPath, data)
 }

--- a/go/common/topoclient/multiorch.go
+++ b/go/common/topoclient/multiorch.go
@@ -206,6 +206,10 @@ func (ts *store) UpdateMultiorchFields(ctx context.Context, id *clustermetadatap
 }
 
 // CreateMultiorch creates a new multiorch and all associated paths.
+//
+// The record is permanent — it carries no liveness binding and will outlive
+// the process that wrote it. Component self-registration must go through
+// RegisterMultiorch, which creates an ephemeral record instead.
 func (ts *store) CreateMultiorch(ctx context.Context, mtorch *clustermetadatapb.Multiorch) error {
 	conn, err := ts.ConnForCell(ctx, mtorch.Id.Cell)
 	if err != nil {
@@ -239,22 +243,36 @@ func (ts *store) UnregisterMultiorch(ctx context.Context, id *clustermetadatapb.
 	return nil
 }
 
-// RegisterMultiorch creates or updates a multiorch. If allowUpdate is true,
-// and a multiorch with the same ID exists, just update it.
+// RegisterMultiorch creates or updates a multiorch. If allowUpdate is false
+// and a multiorch with the same ID already exists, it returns NodeExists.
+//
+// The registration is ephemeral: backends with liveness support (etcd
+// leases) bind it to this process, so a multiorch that dies without
+// unregistering — SIGKILL, OOM, node loss — disappears from the topology on
+// its own instead of leaking a permanent entry.
 func (ts *store) RegisterMultiorch(ctx context.Context, mtorch *clustermetadatapb.Multiorch, allowUpdate bool) error {
-	err := ts.CreateMultiorch(ctx, mtorch)
-	if errors.Is(err, &TopoError{Code: NodeExists}) && allowUpdate {
-		// Try to update then
-		oldMtOrch, err := ts.GetMultiorch(ctx, mtorch.Id)
-		if err != nil {
+	conn, err := ts.ConnForCell(ctx, mtorch.Id.Cell)
+	if err != nil {
+		return err
+	}
+
+	orchPath := path.Join(OrchsPath, string(ComponentIDString(mtorch.Id)), OrchFile)
+	if !allowUpdate {
+		// Existence check to preserve NodeExists semantics. Not atomic
+		// with the put below, but IDs are unique per process instance, so
+		// concurrent registration of the same ID doesn't happen in
+		// practice.
+		switch _, _, err := conn.Get(ctx, orchPath); {
+		case err == nil:
+			return NewError(NodeExists, orchPath)
+		case !errors.Is(err, &TopoError{Code: NoNode}):
 			return fmt.Errorf("failed reading existing mtorch %v: %w", ComponentIDString(mtorch.Id), err)
 		}
-
-		oldMtOrch.Multiorch = proto.Clone(mtorch).(*clustermetadatapb.Multiorch)
-		if err := ts.UpdateMultiorch(ctx, oldMtOrch); err != nil {
-			return fmt.Errorf("failed updating mtorch %v: %w", ComponentIDString(mtorch.Id), err)
-		}
-		return nil
 	}
-	return err
+
+	data, err := proto.Marshal(mtorch)
+	if err != nil {
+		return err
+	}
+	return conn.PutEphemeral(ctx, orchPath, data)
 }

--- a/go/common/topoclient/store.go
+++ b/go/common/topoclient/store.go
@@ -185,7 +185,6 @@ type CellStore interface {
 	UnregisterMultigateway(ctx context.Context, id *clustermetadatapb.ID) error
 	RegisterMultigateway(ctx context.Context, multigateway *clustermetadatapb.Multigateway, allowUpdate bool) error
 	ClaimGatewayPrefix(ctx context.Context, prefix uint32, id *clustermetadatapb.ID) error
-	ReleaseGatewayPrefix(ctx context.Context, prefix uint32) error
 
 	// Multiorch CRUD operations
 	GetMultiorch(ctx context.Context, id *clustermetadatapb.ID) (*MultiorchInfo, error)

--- a/go/common/topoclient/store.go
+++ b/go/common/topoclient/store.go
@@ -106,6 +106,10 @@ const (
 	GatewaysPath  = "gateways"
 	PoolersPath   = "poolers"
 	OrchsPath     = "orchs"
+	// GatewayPrefixesPath holds one claim file per PID prefix, in the
+	// global topology: prefixes route query-cancels across cells, so the
+	// namespace must be unique cluster-wide.
+	GatewayPrefixesPath = "gateway_prefixes"
 )
 
 // Factory is a factory interface to create Conn objects.
@@ -180,6 +184,8 @@ type CellStore interface {
 	UpdateMultigatewayFields(ctx context.Context, id *clustermetadatapb.ID, update func(*clustermetadatapb.Multigateway) error) (*clustermetadatapb.Multigateway, error)
 	UnregisterMultigateway(ctx context.Context, id *clustermetadatapb.ID) error
 	RegisterMultigateway(ctx context.Context, multigateway *clustermetadatapb.Multigateway, allowUpdate bool) error
+	ClaimGatewayPrefix(ctx context.Context, prefix uint32, id *clustermetadatapb.ID) error
+	ReleaseGatewayPrefix(ctx context.Context, prefix uint32) error
 
 	// Multiorch CRUD operations
 	GetMultiorch(ctx context.Context, id *clustermetadatapb.ID) (*MultiorchInfo, error)

--- a/go/common/topoclient/test/ephemeral.go
+++ b/go/common/topoclient/test/ephemeral.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/multigres/multigres/go/common/topoclient"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// checkPutEphemeral tests the backend-agnostic semantics of PutEphemeral:
+// create, overwrite, delete, and re-create. Liveness behavior (expiry after
+// process death, re-creation after lease loss) is backend-specific and
+// covered by the etcd end-to-end tests.
+func checkPutEphemeral(t *testing.T, ctx context.Context, ts topoclient.Store) {
+	conn, err := ts.ConnForCell(ctx, topoclient.GlobalCell)
+	require.NoError(t, err, "ConnForCell(global) failed")
+
+	filePath := "ephemeral/test/File"
+
+	// Put creates the file.
+	err = conn.PutEphemeral(ctx, filePath, []byte("v1"))
+	require.NoError(t, err, "PutEphemeral(create) failed")
+	contents, _, err := conn.Get(ctx, filePath)
+	require.NoError(t, err, "Get after PutEphemeral failed")
+	assert.Equal(t, []byte("v1"), contents)
+
+	// Put overwrites unconditionally.
+	err = conn.PutEphemeral(ctx, filePath, []byte("v2"))
+	require.NoError(t, err, "PutEphemeral(overwrite) failed")
+	contents, _, err = conn.Get(ctx, filePath)
+	require.NoError(t, err, "Get after overwrite failed")
+	assert.Equal(t, []byte("v2"), contents)
+
+	// Delete removes it.
+	err = conn.Delete(ctx, filePath, nil)
+	require.NoError(t, err, "Delete of ephemeral file failed")
+	_, _, err = conn.Get(ctx, filePath)
+	assert.True(t, errors.Is(err, &topoclient.TopoError{Code: topoclient.NoNode}),
+		"Get after Delete should return NoNode, got: %v", err)
+
+	// Re-create after delete works.
+	err = conn.PutEphemeral(ctx, filePath, []byte("v3"))
+	require.NoError(t, err, "PutEphemeral(re-create) failed")
+	contents, _, err = conn.Get(ctx, filePath)
+	require.NoError(t, err, "Get after re-create failed")
+	assert.Equal(t, []byte("v3"), contents)
+}

--- a/go/common/topoclient/test/ephemeral.go
+++ b/go/common/topoclient/test/ephemeral.go
@@ -63,3 +63,34 @@ func checkPutEphemeral(t *testing.T, ctx context.Context, ts topoclient.Store) {
 	require.NoError(t, err, "Get after re-create failed")
 	assert.Equal(t, []byte("v3"), contents)
 }
+
+// checkClaimEphemeral tests the backend-agnostic semantics of
+// ClaimEphemeral: atomic claim when absent, refresh when held by the same
+// owner, NodeExists when held by another, and claimable again after delete.
+func checkClaimEphemeral(t *testing.T, ctx context.Context, ts topoclient.Store) {
+	conn, err := ts.ConnForCell(ctx, topoclient.GlobalCell)
+	require.NoError(t, err, "ConnForCell(global) failed")
+
+	filePath := "ephemeral/claims/7"
+
+	// Absent: first claimant wins.
+	err = conn.ClaimEphemeral(ctx, filePath, []byte("owner-a"))
+	require.NoError(t, err, "ClaimEphemeral(absent) failed")
+
+	// Held by another: rejected, and the holder's contents are untouched.
+	err = conn.ClaimEphemeral(ctx, filePath, []byte("owner-b"))
+	assert.True(t, errors.Is(err, &topoclient.TopoError{Code: topoclient.NodeExists}),
+		"ClaimEphemeral(held by another) should return NodeExists, got: %v", err)
+	contents, _, err := conn.Get(ctx, filePath)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("owner-a"), contents, "a losing claim must not overwrite the holder")
+
+	// Held by the same owner: refresh succeeds.
+	err = conn.ClaimEphemeral(ctx, filePath, []byte("owner-a"))
+	require.NoError(t, err, "ClaimEphemeral(refresh own claim) failed")
+
+	// Released: claimable by the next owner.
+	require.NoError(t, conn.Delete(ctx, filePath, nil))
+	err = conn.ClaimEphemeral(ctx, filePath, []byte("owner-b"))
+	require.NoError(t, err, "ClaimEphemeral after release failed")
+}

--- a/go/common/topoclient/test/topo_test_suite.go
+++ b/go/common/topoclient/test/topo_test_suite.go
@@ -95,6 +95,11 @@ func TopoServerTestSuite(t *testing.T, ctx context.Context, factory func() topoc
 	checkPutEphemeral(t, ctx, ts)
 	_ = ts.Close()
 
+	t.Log("=== (File) checkClaimEphemeral")
+	ts = factory()
+	checkClaimEphemeral(t, ctx, ts)
+	_ = ts.Close()
+
 	// ShardInitClaim is part of the shard initialization API.
 	t.Log("=== (ShardInitClaim) checkShardInitClaim")
 	ts = factory()

--- a/go/common/topoclient/test/topo_test_suite.go
+++ b/go/common/topoclient/test/topo_test_suite.go
@@ -90,6 +90,11 @@ func TopoServerTestSuite(t *testing.T, ctx context.Context, factory func() topoc
 	checkList(t, ctx, ts)
 	_ = ts.Close()
 
+	t.Log("=== (File) checkPutEphemeral")
+	ts = factory()
+	checkPutEphemeral(t, ctx, ts)
+	_ = ts.Close()
+
 	// ShardInitClaim is part of the shard initialization API.
 	t.Log("=== (ShardInitClaim) checkShardInitClaim")
 	ts = factory()

--- a/go/common/topoclient/wrapperconn.go
+++ b/go/common/topoclient/wrapperconn.go
@@ -274,6 +274,19 @@ func (c *WrapperConn) PutEphemeral(ctx context.Context, filePath string, content
 	return err
 }
 
+// ClaimEphemeral atomically claims or refreshes a process-liveness-bound
+// file; see Conn.ClaimEphemeral. Like PutEphemeral, the wrapper keeps no
+// record — the owner re-asserts the claim (toporeg.WithReassert).
+func (c *WrapperConn) ClaimEphemeral(ctx context.Context, filePath string, contents []byte) error {
+	conn, err := c.getConnection()
+	if err != nil {
+		return err
+	}
+	err = conn.ClaimEphemeral(ctx, filePath, contents)
+	c.handleConnectionError(conn, err)
+	return err
+}
+
 // Lock acquires a distributed lock on the specified directory path.
 func (c *WrapperConn) Lock(ctx context.Context, dirPath, contents string) (LockDescriptor, error) {
 	conn, err := c.getConnection()

--- a/go/common/topoclient/wrapperconn.go
+++ b/go/common/topoclient/wrapperconn.go
@@ -258,6 +258,22 @@ func (c *WrapperConn) Delete(ctx context.Context, filePath string, version Versi
 	return err
 }
 
+// PutEphemeral creates or updates a process-liveness-bound file.
+//
+// A reconnection replaces the underlying Conn, and the replacement carries
+// its own liveness binding — anything written through the old one expires.
+// This wrapper does not track or re-create those files; the component that
+// owns the registration re-asserts it (see servenv/toporeg).
+func (c *WrapperConn) PutEphemeral(ctx context.Context, filePath string, contents []byte) error {
+	conn, err := c.getConnection()
+	if err != nil {
+		return err
+	}
+	err = conn.PutEphemeral(ctx, filePath, contents)
+	c.handleConnectionError(conn, err)
+	return err
+}
+
 // Lock acquires a distributed lock on the specified directory path.
 func (c *WrapperConn) Lock(ctx context.Context, dirPath, contents string) (LockDescriptor, error) {
 	conn, err := c.getConnection()

--- a/go/common/topoclient/wrapperconn_test.go
+++ b/go/common/topoclient/wrapperconn_test.go
@@ -127,6 +127,45 @@ func TestHandleConnectionError_RetriesOnSpecificErrors(t *testing.T) {
 	}
 }
 
+func TestPutEphemeral_ForwardsToConnection(t *testing.T) {
+	factory := newMockFactory()
+	wrapper := NewWrapperConn(factory.newConn, nil)
+
+	ctx := context.Background()
+	require.NoError(t, wrapper.PutEphemeral(ctx, "gateways/gw-1/Gateway", []byte("reg")))
+
+	data, _, err := wrapper.Get(ctx, "gateways/gw-1/Gateway")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("reg"), data)
+}
+
+func TestPutEphemeral_NotRestoredByWrapperAfterReconnection(t *testing.T) {
+	// The wrapper deliberately keeps no record of ephemeral files. A
+	// replacement connection brings its own liveness binding, so anything
+	// written through the old one is gone until the owner re-asserts it
+	// (toporeg.WithReassert). This test pins that layering: if the wrapper
+	// ever starts restoring again, the owner-side loop is no longer the
+	// single source of recovery.
+	factory := newMockFactory()
+	wrapper := NewWrapperConn(factory.newConn, nil)
+
+	ctx := context.Background()
+	require.NoError(t, wrapper.PutEphemeral(ctx, "gateways/gw-1/Gateway", []byte("reg")))
+
+	conn, err := wrapper.getConnection()
+	require.NoError(t, err, "Expected initial connection")
+	initialCount := factory.getCreateCount()
+
+	wrapper.handleConnectionError(conn, mterrors.Errorf(mtrpc.Code_UNAVAILABLE, "test error"))
+	factory.waitForNewConn(initialCount)
+
+	assert.Never(t, func() bool {
+		_, _, err := wrapper.Get(ctx, "gateways/gw-1/Gateway")
+		return err == nil
+	}, 200*time.Millisecond, 20*time.Millisecond,
+		"wrapper must not re-create ephemeral files; the owner re-asserts them")
+}
+
 func TestHandleConnectionError_DoesNotRetryOnOtherErrors(t *testing.T) {
 	factory := newMockFactory()
 	wrapper := NewWrapperConn(factory.newConn, nil)

--- a/go/services/multigateway/init.go
+++ b/go/services/multigateway/init.go
@@ -134,10 +134,15 @@ type Multigateway struct {
 	serverStatus Status
 	// prefixLost is set when a re-assertion finds this gateway's PID
 	// prefix claim held by another gateway (possible only after the claim
-	// expired during a topology outage). It fails the readiness check so
-	// the environment restarts the gateway into a fresh claim; a live
-	// gateway cannot safely renumber.
+	// expired during a topology outage). A live gateway cannot safely
+	// renumber, so the loss is fatal: it fails the readiness check (to
+	// drain new connections) and triggers shutdownOnPrefixLoss.
 	prefixLost atomic.Bool
+	// shutdownOnPrefixLoss initiates the gateway's graceful shutdown when
+	// its PID prefix claim is lost; the supervisor then restarts the
+	// process, which claims a fresh prefix. A field so tests can observe
+	// the trigger instead of terminating the test process.
+	shutdownOnPrefixLoss func()
 	// shutdownCtx is cancelled during Shutdown to propagate cancellation
 	// to all long-running goroutines (health streams, discovery, etc.)
 	shutdownCtx    context.Context
@@ -269,6 +274,7 @@ func NewMultigateway() *Multigateway {
 			},
 		},
 	}
+	mg.shutdownOnPrefixLoss = func() { mg.senv.InitiateShutdown() }
 
 	return mg
 }
@@ -453,22 +459,8 @@ func (mg *Multigateway) Init(ctx context.Context) error {
 					return err
 				}
 				multigateway.PidPrefix = prefix
-			} else {
-				// Re-assertion (or a retry after a successful claim):
-				// refresh the claim. NodeExists means it expired during an
-				// outage and another gateway took the prefix. A live
-				// gateway cannot renumber — clients hold PIDs stamped with
-				// this prefix — so surface the loss through readiness and
-				// let the environment restart us into a fresh claim.
-				err := mg.ts.ClaimGatewayPrefix(ctx, multigateway.PidPrefix, multigateway.Id)
-				if errors.Is(err, &topoclient.TopoError{Code: topoclient.NodeExists}) {
-					mg.prefixLost.Store(true)
-					return fmt.Errorf("PID prefix %d claim lost to another gateway", multigateway.PidPrefix)
-				}
-				if err != nil {
-					return err // Transient; the next re-assertion retries.
-				}
-				mg.prefixLost.Store(false)
+			} else if err := mg.refreshPrefixClaim(ctx, multigateway.PidPrefix, multigateway.Id); err != nil {
+				return err
 			}
 			return mg.ts.RegisterMultigateway(ctx, multigateway, true)
 		},
@@ -651,9 +643,9 @@ func (mg *Multigateway) Init(ctx context.Context) error {
 	// The gateway is ready only when all conditions are met:
 	// 1. No init errors (topology registration succeeded)
 	// 2. At least one pooler has been discovered (can actually serve queries)
-	// 3. It still holds its PID prefix claim — a lost claim means another
-	//    gateway owns this prefix, and only a restart (fresh claim) can
-	//    make cancel routing correct again.
+	// 3. It still holds its PID prefix claim. A lost claim also initiates
+	//    the gateway's own graceful shutdown (see refreshPrefixClaim);
+	//    failing readiness here drains new connections during that window.
 	mg.senv.RegisterReadyCheck(func() error {
 		mg.serverStatus.mu.Lock()
 		defer mg.serverStatus.mu.Unlock()
@@ -798,6 +790,31 @@ func (mg *Multigateway) claimUnusedPrefix(ctx context.Context, id *clustermetada
 		}
 	}
 	return 0, fmt.Errorf("no available PID prefix (all %d prefixes in use)", pid.MaxPrefix)
+}
+
+// refreshPrefixClaim re-asserts ownership of the gateway's claimed PID
+// prefix. NodeExists means the claim expired during a topology outage and
+// another gateway took the prefix — that loss is fatal: a live gateway
+// cannot renumber (its prefix is baked into the listeners and cancel
+// manager, and clients hold PIDs stamped with it), so the only repair is a
+// fresh process claiming a fresh prefix. On first detection the gateway
+// fails its readiness check (draining new connections) and initiates its
+// own graceful shutdown; the supervisor — Kubernetes restartPolicy,
+// systemd, docker-compose — restarts the process regardless of probe
+// configuration. Any other error is transient and left to the next
+// re-assertion.
+func (mg *Multigateway) refreshPrefixClaim(ctx context.Context, prefix uint32, id *clustermetadatapb.ID) error {
+	err := mg.ts.ClaimGatewayPrefix(ctx, prefix, id)
+	if errors.Is(err, &topoclient.TopoError{Code: topoclient.NodeExists}) {
+		if mg.prefixLost.CompareAndSwap(false, true) {
+			servenv.GetLogger().ErrorContext(ctx,
+				"PID prefix claim lost to another gateway; shutting down so a fresh process claims a fresh prefix",
+				"pid_prefix", prefix)
+			mg.shutdownOnPrefixLoss()
+		}
+		return fmt.Errorf("PID prefix %d claim lost to another gateway", prefix)
+	}
+	return err
 }
 
 // buildPGTLSConfig validates TLS flag combinations and loads the certificate.

--- a/go/services/multigateway/init.go
+++ b/go/services/multigateway/init.go
@@ -446,13 +446,19 @@ func (mg *Multigateway) Init(ctx context.Context) error {
 	mg.tr, err = toporeg.RegisterSynchronous(
 		regCtx,
 		func(ctx context.Context) error {
-			if multigateway.PidPrefix == 0 {
-				prefix, err := mg.findUnusedPrefix(ctx)
-				if err != nil {
-					return fmt.Errorf("finding unused prefix: %w", err)
-				}
-				multigateway.PidPrefix = prefix
+			if multigateway.PidPrefix != 0 {
+				// The prefix is already claimed and clients hold PIDs
+				// stamped with it, so re-assertions only refresh the
+				// record. Re-running the collision check here would let a
+				// live gateway renumber itself and strand the cancel
+				// routing for every connection it has already served.
+				return mg.ts.RegisterMultigateway(ctx, multigateway, true)
 			}
+			prefix, err := mg.findUnusedPrefix(ctx)
+			if err != nil {
+				return fmt.Errorf("finding unused prefix: %w", err)
+			}
+			multigateway.PidPrefix = prefix
 			if err := mg.ts.RegisterMultigateway(ctx, multigateway, true); err != nil {
 				return err
 			}
@@ -463,6 +469,7 @@ func (mg *Multigateway) Init(ctx context.Context) error {
 			return nil
 		},
 		func(ctx context.Context) error { return mg.ts.UnregisterMultigateway(ctx, multigateway.Id) },
+		toporeg.WithReassert(),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to register gateway: %w", err)

--- a/go/services/multigateway/init.go
+++ b/go/services/multigateway/init.go
@@ -24,11 +24,11 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"sync/atomic"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/pgprotocol/pid"
@@ -132,6 +132,12 @@ type Multigateway struct {
 	ts           topoclient.Store
 	tr           *toporeg.TopoReg
 	serverStatus Status
+	// prefixLost is set when a re-assertion finds this gateway's PID
+	// prefix claim held by another gateway (possible only after the claim
+	// expired during a topology outage). It fails the readiness check so
+	// the environment restarts the gateway into a fresh claim; a live
+	// gateway cannot safely renumber.
+	prefixLost atomic.Bool
 	// shutdownCtx is cancelled during Shutdown to propagate cancellation
 	// to all long-running goroutines (health streams, discovery, etc.)
 	shutdownCtx    context.Context
@@ -431,44 +437,51 @@ func (mg *Multigateway) Init(ctx context.Context) error {
 		multigateway.PortMap["postgres_replica"] = int32(replicaPort)
 	}
 
-	// Reuse existing PID prefix on re-registration.
-	existingGW, err := mg.ts.GetMultigateway(context.TODO(), multigateway.Id)
-	if err == nil && existingGW != nil && existingGW.GetPidPrefix() > 0 {
-		multigateway.PidPrefix = existingGW.GetPidPrefix()
-	}
-
 	// Register gateway in topo with a unique PID prefix for cross-gateway
-	// cancel routing. The register function assigns the prefix, registers the
-	// full record, and verifies no collision. On collision, RegisterSynchronous
-	// retries with jitter until two racing gateways converge on different prefixes.
+	// cancel routing. The prefix is claimed atomically before the record is
+	// written; the claim file, not the record, is what makes the prefix
+	// exclusively ours. Each process claims fresh — a restarted gateway has
+	// no live connections whose cancel routing could be worth preserving.
 	regCtx, regCancel := context.WithTimeout(context.TODO(), 10*time.Second)
 	defer regCancel()
 	mg.tr, err = toporeg.RegisterSynchronous(
 		regCtx,
 		func(ctx context.Context) error {
-			if multigateway.PidPrefix != 0 {
-				// The prefix is already claimed and clients hold PIDs
-				// stamped with it, so re-assertions only refresh the
-				// record. Re-running the collision check here would let a
-				// live gateway renumber itself and strand the cancel
-				// routing for every connection it has already served.
-				return mg.ts.RegisterMultigateway(ctx, multigateway, true)
+			if multigateway.PidPrefix == 0 {
+				prefix, err := mg.claimUnusedPrefix(ctx, multigateway.Id)
+				if err != nil {
+					return err
+				}
+				multigateway.PidPrefix = prefix
+			} else {
+				// Re-assertion (or a retry after a successful claim):
+				// refresh the claim. NodeExists means it expired during an
+				// outage and another gateway took the prefix. A live
+				// gateway cannot renumber — clients hold PIDs stamped with
+				// this prefix — so surface the loss through readiness and
+				// let the environment restart us into a fresh claim.
+				err := mg.ts.ClaimGatewayPrefix(ctx, multigateway.PidPrefix, multigateway.Id)
+				if errors.Is(err, &topoclient.TopoError{Code: topoclient.NodeExists}) {
+					mg.prefixLost.Store(true)
+					return fmt.Errorf("PID prefix %d claim lost to another gateway", multigateway.PidPrefix)
+				}
+				if err != nil {
+					return err // Transient; the next re-assertion retries.
+				}
+				mg.prefixLost.Store(false)
 			}
-			prefix, err := mg.findUnusedPrefix(ctx)
-			if err != nil {
-				return fmt.Errorf("finding unused prefix: %w", err)
-			}
-			multigateway.PidPrefix = prefix
-			if err := mg.ts.RegisterMultigateway(ctx, multigateway, true); err != nil {
+			return mg.ts.RegisterMultigateway(ctx, multigateway, true)
+		},
+		func(ctx context.Context) error {
+			// Release the prefix before deleting the record: the release
+			// tolerates NoNode, so a retry after a partial failure still
+			// reaches it, whereas the record delete's NoNode ends the
+			// caller's retry loop as success.
+			if err := mg.ts.ReleaseGatewayPrefix(ctx, multigateway.PidPrefix); err != nil {
 				return err
 			}
-			if mg.hasPrefixCollision(ctx, multigateway.PidPrefix, multigateway.Id) {
-				multigateway.PidPrefix = 0 // Reset for next retry.
-				return errors.New("PID prefix collision detected")
-			}
-			return nil
+			return mg.ts.UnregisterMultigateway(ctx, multigateway.Id)
 		},
-		func(ctx context.Context) error { return mg.ts.UnregisterMultigateway(ctx, multigateway.Id) },
 		toporeg.WithReassert(),
 	)
 	if err != nil {
@@ -639,9 +652,12 @@ func (mg *Multigateway) Init(ctx context.Context) error {
 
 	mg.senv.HTTPHandleFunc("/", mg.handleIndex)
 
-	// The gateway is ready only when both conditions are met:
+	// The gateway is ready only when all conditions are met:
 	// 1. No init errors (topology registration succeeded)
 	// 2. At least one pooler has been discovered (can actually serve queries)
+	// 3. It still holds its PID prefix claim — a lost claim means another
+	//    gateway owns this prefix, and only a restart (fresh claim) can
+	//    make cancel routing correct again.
 	mg.senv.RegisterReadyCheck(func() error {
 		mg.serverStatus.mu.Lock()
 		defer mg.serverStatus.mu.Unlock()
@@ -650,6 +666,9 @@ func (mg *Multigateway) Init(ctx context.Context) error {
 		}
 		if mg.poolerGateway.PoolerCount() == 0 {
 			return errors.New("no poolers discovered")
+		}
+		if mg.prefixLost.Load() {
+			return errors.New("PID prefix claim lost to another gateway; restart required to claim a fresh prefix")
 		}
 		return nil
 	})
@@ -729,10 +748,17 @@ func (mg *Multigateway) Shutdown() {
 	mg.ts.Close()
 }
 
-// findUnusedPrefix scans all cells for used PID prefixes and returns a random
-// unused one. Randomization reduces the chance of two gateways starting
-// simultaneously and picking the same prefix.
-func (mg *Multigateway) findUnusedPrefix(ctx context.Context) (uint32, error) {
+// claimUnusedPrefix atomically claims a PID prefix for this gateway and
+// returns it. Ownership is decided by ClaimGatewayPrefix's atomic create —
+// two gateways racing for the same candidate cannot both win, so there is no
+// post-registration collision check.
+//
+// The scan of gateway records is a mixed-version courtesy: gateways from
+// before prefix claims advertise a prefix without holding a claim file, so
+// their prefixes are avoided by reading their records. Once the whole fleet
+// writes claim files the scan narrows nothing — a claimed prefix fails the
+// atomic claim regardless.
+func (mg *Multigateway) claimUnusedPrefix(ctx context.Context, id *clustermetadatapb.ID) (uint32, error) {
 	usedPrefixes := make(map[uint32]bool)
 	cells, err := mg.ts.GetCellNames(ctx)
 	if err != nil {
@@ -751,38 +777,31 @@ func (mg *Multigateway) findUnusedPrefix(ctx context.Context) (uint32, error) {
 		}
 	}
 
-	// Collect all unused prefixes and pick one at random.
 	unused := make([]uint32, 0, pid.MaxPrefix-len(usedPrefixes))
 	for prefix := uint32(1); prefix <= pid.MaxPrefix; prefix++ {
 		if !usedPrefixes[prefix] {
 			unused = append(unused, prefix)
 		}
 	}
-	if len(unused) == 0 {
-		return 0, fmt.Errorf("no available PID prefix (all %d prefixes in use)", pid.MaxPrefix)
-	}
-	return unused[rand.IntN(len(unused))], nil
-}
 
-// hasPrefixCollision checks if any other gateway in topo has the same PID prefix.
-func (mg *Multigateway) hasPrefixCollision(ctx context.Context, prefix uint32, ownID *clustermetadatapb.ID) bool {
-	cells, err := mg.ts.GetCellNames(ctx)
-	if err != nil {
-		return false
-	}
+	// Claim random candidates until one wins. Losing a claim race
+	// (NodeExists) just means another gateway got there first — remove the
+	// candidate and try another.
+	for len(unused) > 0 {
+		i := rand.IntN(len(unused))
+		candidate := unused[i]
+		unused[i] = unused[len(unused)-1]
+		unused = unused[:len(unused)-1]
 
-	for _, c := range cells {
-		gateways, err := mg.ts.GetMultigatewaysByCell(ctx, c)
-		if err != nil {
-			continue
+		err := mg.ts.ClaimGatewayPrefix(ctx, candidate, id)
+		if err == nil {
+			return candidate, nil
 		}
-		for _, gw := range gateways {
-			if gw.GetPidPrefix() == prefix && !proto.Equal(gw.GetId(), ownID) {
-				return true
-			}
+		if !errors.Is(err, &topoclient.TopoError{Code: topoclient.NodeExists}) {
+			return 0, fmt.Errorf("claiming PID prefix %d: %w", candidate, err)
 		}
 	}
-	return false
+	return 0, fmt.Errorf("no available PID prefix (all %d prefixes in use)", pid.MaxPrefix)
 }
 
 // buildPGTLSConfig validates TLS flag combinations and loads the certificate.

--- a/go/services/multigateway/init.go
+++ b/go/services/multigateway/init.go
@@ -472,16 +472,12 @@ func (mg *Multigateway) Init(ctx context.Context) error {
 			}
 			return mg.ts.RegisterMultigateway(ctx, multigateway, true)
 		},
-		func(ctx context.Context) error {
-			// Release the prefix before deleting the record: the release
-			// tolerates NoNode, so a retry after a partial failure still
-			// reaches it, whereas the record delete's NoNode ends the
-			// caller's retry loop as success.
-			if err := mg.ts.ReleaseGatewayPrefix(ctx, multigateway.PidPrefix); err != nil {
-				return err
-			}
-			return mg.ts.UnregisterMultigateway(ctx, multigateway.Id)
-		},
+		// The prefix claim is deliberately NOT released here: lease expiry
+		// is its only release path, so a gateway can never delete a claim
+		// that has passed to another gateway (e.g. when a prefix-lost
+		// restart shuts this process down after a competitor legitimately
+		// claimed the prefix).
+		func(ctx context.Context) error { return mg.ts.UnregisterMultigateway(ctx, multigateway.Id) },
 		toporeg.WithReassert(),
 	)
 	if err != nil {

--- a/go/services/multigateway/prefix_claim_test.go
+++ b/go/services/multigateway/prefix_claim_test.go
@@ -17,6 +17,7 @@ package multigateway
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -121,4 +122,57 @@ func TestClaimGatewayPrefix_TheftDetection(t *testing.T) {
 	err = ts.ClaimGatewayPrefix(ctx, 42, idA)
 	assert.True(t, errors.Is(err, &topoclient.TopoError{Code: topoclient.NodeExists}),
 		"previous holder's refresh should return NodeExists, got: %v", err)
+}
+
+// TestRefreshPrefixClaim_LostClaimIsFatal verifies the gateway's response to
+// losing its prefix claim: a healthy refresh triggers nothing, a transient
+// topology error triggers nothing (the next re-assertion retries), and a
+// claim held by another gateway sets prefixLost and initiates graceful
+// shutdown exactly once — a live gateway cannot renumber, so a fresh process
+// claiming a fresh prefix is the only repair.
+func TestRefreshPrefixClaim_LostClaimIsFatal(t *testing.T) {
+	ctx := context.Background()
+	const cell = "zone-1"
+	ts, factory := memorytopo.NewServerAndFactory(ctx, cell)
+	defer ts.Close()
+
+	idA := gatewayID(cell, "gw-a")
+	idB := gatewayID(cell, "gw-b")
+
+	var shutdowns atomic.Int32
+	mg := &Multigateway{ts: ts}
+	mg.shutdownOnPrefixLoss = func() { shutdowns.Add(1) }
+
+	require.NoError(t, ts.ClaimGatewayPrefix(ctx, 42, idA))
+
+	// Healthy refresh: no flag, no shutdown.
+	require.NoError(t, mg.refreshPrefixClaim(ctx, 42, idA))
+	assert.False(t, mg.prefixLost.Load())
+	assert.Zero(t, shutdowns.Load())
+
+	// Transient topology error: surfaced to the caller, but not fatal.
+	factory.SetError(errors.New("topology unavailable"))
+	err := mg.refreshPrefixClaim(ctx, 42, idA)
+	require.Error(t, err)
+	assert.False(t, mg.prefixLost.Load(), "a transient error must not be treated as a lost claim")
+	assert.Zero(t, shutdowns.Load(), "a transient error must not shut the gateway down")
+	factory.SetError(nil)
+
+	// The claim expires (simulated) and another gateway takes it.
+	conn, err := ts.ConnForCell(ctx, topoclient.GlobalCell)
+	require.NoError(t, err)
+	require.NoError(t, conn.Delete(ctx, topoclient.GatewayPrefixesPath+"/42", nil))
+	require.NoError(t, ts.ClaimGatewayPrefix(ctx, 42, idB))
+
+	// Loss detected: flag set, shutdown initiated.
+	err = mg.refreshPrefixClaim(ctx, 42, idA)
+	require.Error(t, err)
+	assert.True(t, mg.prefixLost.Load())
+	assert.Equal(t, int32(1), shutdowns.Load())
+
+	// A second detection (re-assert loop may tick again before shutdown
+	// completes) must not initiate another shutdown.
+	err = mg.refreshPrefixClaim(ctx, 42, idA)
+	require.Error(t, err)
+	assert.Equal(t, int32(1), shutdowns.Load(), "shutdown must be initiated exactly once")
 }

--- a/go/services/multigateway/prefix_claim_test.go
+++ b/go/services/multigateway/prefix_claim_test.go
@@ -91,8 +91,10 @@ func TestClaimUnusedPrefix_AvoidsRecordAdvertisedPrefixes(t *testing.T) {
 
 // TestClaimGatewayPrefix_TheftDetection verifies the store-level claim
 // semantics the re-assertion path relies on: a holder refreshes its own claim
-// freely, a competitor is rejected without overwriting it, and after a
-// release the prefix is claimable again.
+// freely, a competitor is rejected without overwriting it, and once a claim
+// expires (claims are never explicitly released — lease expiry is the only
+// release path, simulated here with a direct delete) the prefix passes to
+// the next claimant and the previous holder's refresh detects the loss.
 func TestClaimGatewayPrefix_TheftDetection(t *testing.T) {
 	ctx := context.Background()
 	const cell = "zone-1"
@@ -109,8 +111,10 @@ func TestClaimGatewayPrefix_TheftDetection(t *testing.T) {
 	err := ts.ClaimGatewayPrefix(ctx, 42, idB)
 	assert.True(t, errors.Is(err, &topoclient.TopoError{Code: topoclient.NodeExists}),
 		"competitor claim should return NodeExists, got: %v", err)
-	// After release, the competitor can claim.
-	require.NoError(t, ts.ReleaseGatewayPrefix(ctx, 42))
+	// Simulate lease expiry of A's claim; the competitor can now claim.
+	conn, err := ts.ConnForCell(ctx, topoclient.GlobalCell)
+	require.NoError(t, err)
+	require.NoError(t, conn.Delete(ctx, topoclient.GatewayPrefixesPath+"/42", nil))
 	require.NoError(t, ts.ClaimGatewayPrefix(ctx, 42, idB))
 	// And the previous holder's refresh now fails — this is how a gateway
 	// discovers its claim was lost after an expiry.

--- a/go/services/multigateway/prefix_claim_test.go
+++ b/go/services/multigateway/prefix_claim_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multigateway
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/pid"
+	"github.com/multigres/multigres/go/common/topoclient"
+	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+)
+
+func gatewayID(cell, name string) *clustermetadatapb.ID {
+	return &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIGATEWAY,
+		Cell:      cell,
+		Name:      name,
+	}
+}
+
+// TestClaimUnusedPrefix_DistinctClaims verifies that gateways claiming
+// concurrently from the same pool end up with distinct prefixes: ownership is
+// decided by the atomic claim, not by reading each other's records.
+func TestClaimUnusedPrefix_DistinctClaims(t *testing.T) {
+	ctx := context.Background()
+	const cell = "zone-1"
+	ts := memorytopo.NewServer(ctx, cell)
+	defer ts.Close()
+
+	mg := &Multigateway{ts: ts}
+
+	seen := make(map[uint32]bool)
+	for i := range 5 {
+		id := gatewayID(cell, string(rune('a'+i)))
+		prefix, err := mg.claimUnusedPrefix(ctx, id)
+		require.NoError(t, err)
+		require.NotZero(t, prefix)
+		assert.False(t, seen[prefix], "prefix %d claimed twice", prefix)
+		seen[prefix] = true
+	}
+}
+
+// TestClaimUnusedPrefix_AvoidsRecordAdvertisedPrefixes covers the
+// mixed-version case: a gateway from before prefix claims advertises its
+// prefix only in its record, with no claim file. New gateways must avoid it.
+// Every prefix except the record-advertised one is claimed, so the claim loop
+// must exhaust rather than take the advertised prefix.
+func TestClaimUnusedPrefix_AvoidsRecordAdvertisedPrefixes(t *testing.T) {
+	ctx := context.Background()
+	const cell = "zone-1"
+	ts := memorytopo.NewServer(ctx, cell)
+	defer ts.Close()
+
+	// An old-version gateway advertising prefix 7 in its record only.
+	oldGW := topoclient.NewMultigateway("old", cell, "old.example.com")
+	oldGW.PidPrefix = 7
+	require.NoError(t, ts.RegisterMultigateway(ctx, oldGW, true))
+
+	// Claim every other prefix on behalf of a third party.
+	blocker := gatewayID(cell, "blocker")
+	for p := uint32(1); p <= pid.MaxPrefix; p++ {
+		if p == 7 {
+			continue
+		}
+		require.NoError(t, ts.ClaimGatewayPrefix(ctx, p, blocker))
+	}
+
+	mg := &Multigateway{ts: ts}
+	_, err := mg.claimUnusedPrefix(ctx, gatewayID(cell, "new"))
+	require.Error(t, err, "prefix 7 is advertised by an unclaimed old-version record and must not be taken")
+	assert.Contains(t, err.Error(), "no available PID prefix")
+}
+
+// TestClaimGatewayPrefix_TheftDetection verifies the store-level claim
+// semantics the re-assertion path relies on: a holder refreshes its own claim
+// freely, a competitor is rejected without overwriting it, and after a
+// release the prefix is claimable again.
+func TestClaimGatewayPrefix_TheftDetection(t *testing.T) {
+	ctx := context.Background()
+	const cell = "zone-1"
+	ts := memorytopo.NewServer(ctx, cell)
+	defer ts.Close()
+
+	idA := gatewayID(cell, "gw-a")
+	idB := gatewayID(cell, "gw-b")
+
+	require.NoError(t, ts.ClaimGatewayPrefix(ctx, 42, idA))
+	// Refresh by the holder succeeds.
+	require.NoError(t, ts.ClaimGatewayPrefix(ctx, 42, idA))
+	// A competitor is rejected.
+	err := ts.ClaimGatewayPrefix(ctx, 42, idB)
+	assert.True(t, errors.Is(err, &topoclient.TopoError{Code: topoclient.NodeExists}),
+		"competitor claim should return NodeExists, got: %v", err)
+	// After release, the competitor can claim.
+	require.NoError(t, ts.ReleaseGatewayPrefix(ctx, 42))
+	require.NoError(t, ts.ClaimGatewayPrefix(ctx, 42, idB))
+	// And the previous holder's refresh now fails — this is how a gateway
+	// discovers its claim was lost after an expiry.
+	err = ts.ClaimGatewayPrefix(ctx, 42, idA)
+	assert.True(t, errors.Is(err, &topoclient.TopoError{Code: topoclient.NodeExists}),
+		"previous holder's refresh should return NodeExists, got: %v", err)
+}

--- a/go/services/multiorch/init.go
+++ b/go/services/multiorch/init.go
@@ -156,6 +156,7 @@ func (mo *Multiorch) Init() error {
 			defer mo.serverStatus.mu.Unlock()
 			mo.serverStatus.InitError = s
 		},
+		toporeg.WithReassert(),
 	)
 
 	mo.senv.HTTPHandleFunc("/", mo.handleIndex)

--- a/go/test/endtoend/etcd_topo_test.go
+++ b/go/test/endtoend/etcd_topo_test.go
@@ -18,8 +18,11 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strings"
 	"testing"
 	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"github.com/multigres/multigres/go/common/topoclient"
 	"github.com/multigres/multigres/go/common/topoclient/etcdtopo"
@@ -71,7 +74,104 @@ func TestEtcd2Topo(t *testing.T) {
 	testDatabaseLock(t, ts)
 	testLockNameWithTTL(t, ts)
 	testTryLockName(t, ts)
+	testEphemeralLeaseRenewal(t, ts, clientAddr)
 	ts.Close()
+
+	// The expiry test closes its server itself, so it gets its own.
+	testEphemeralExpiresOnClose(t, newServer(), clientAddr)
+}
+
+// testEphemeralLeaseRenewal verifies that ephemeral files carry a lease, that
+// files sharing a connection share it, and that after the lease ends the
+// connection grants a fresh one on the next write rather than failing
+// forever. Re-writing after a lease loss is the owner's job (toporeg's
+// re-assertion loop); this covers the half the connection owns.
+func testEphemeralLeaseRenewal(t *testing.T, ts topoclient.Store, clientAddr string) {
+	restore := etcdtopo.SetLeaseTTLForTest(2)
+	defer restore()
+
+	ctx := context.Background()
+	conn, err := ts.ConnForCell(ctx, topoclient.GlobalCell)
+	require.NoError(t, err, "ConnForCell failed")
+
+	require.NoError(t, conn.PutEphemeral(ctx, "ephemeral/gw-a", []byte("a")))
+	require.NoError(t, conn.PutEphemeral(ctx, "ephemeral/gw-b", []byte("b")))
+
+	// Raw client to inspect and revoke the lease out-of-band.
+	cli, err := clientv3.New(clientv3.Config{Endpoints: []string{clientAddr}, DialTimeout: 5 * time.Second})
+	require.NoError(t, err, "raw etcd client failed")
+	defer cli.Close()
+
+	fullKeyA, leaseID := findEphemeralKey(t, cli, "ephemeral/gw-a")
+	require.NotZero(t, leaseID, "ephemeral file must carry a lease")
+	_, leaseB := findEphemeralKey(t, cli, "ephemeral/gw-b")
+	require.Equal(t, leaseID, leaseB, "files on one connection should share its lease")
+
+	// Revoking out-of-band is what an expiry after a long outage looks like:
+	// etcd deletes every key bound to the lease.
+	_, err = cli.Revoke(ctx, clientv3.LeaseID(leaseID))
+	require.NoError(t, err, "lease revoke failed")
+	require.Eventually(t, func() bool {
+		resp, err := cli.Get(ctx, fullKeyA)
+		return err == nil && len(resp.Kvs) == 0
+	}, 10*time.Second, 100*time.Millisecond, "revoking the lease should delete its files")
+
+	// The owner re-asserting: the write must succeed on a fresh lease
+	// instead of failing against the dead one.
+	require.Eventually(t, func() bool {
+		return conn.PutEphemeral(ctx, "ephemeral/gw-a", []byte("a")) == nil
+	}, 10*time.Second, 100*time.Millisecond, "write after lease loss should grant a fresh lease")
+
+	resp, err := cli.Get(ctx, fullKeyA)
+	require.NoError(t, err)
+	require.Len(t, resp.Kvs, 1)
+	require.NotZero(t, resp.Kvs[0].Lease, "re-written file must carry a lease")
+	require.NotEqual(t, leaseID, resp.Kvs[0].Lease, "re-written file must be on a fresh lease")
+}
+
+// testEphemeralExpiresOnClose verifies the core liveness promise: when the
+// process stops renewing (here: the store is closed), etcd deletes the
+// ephemeral files on its own within one TTL. This is what prevents a
+// SIGKILLed component from leaking a permanent registration.
+func testEphemeralExpiresOnClose(t *testing.T, ts topoclient.Store, clientAddr string) {
+	restore := etcdtopo.SetLeaseTTLForTest(2)
+	defer restore()
+
+	ctx := context.Background()
+	conn, err := ts.ConnForCell(ctx, topoclient.GlobalCell)
+	require.NoError(t, err, "ConnForCell failed")
+	require.NoError(t, conn.PutEphemeral(ctx, "ephemeral/gw-dead", []byte("dead")))
+
+	cli, err := clientv3.New(clientv3.Config{Endpoints: []string{clientAddr}, DialTimeout: 5 * time.Second})
+	require.NoError(t, err, "raw etcd client failed")
+	defer cli.Close()
+
+	fullKey, leaseID := findEphemeralKey(t, cli, "ephemeral/gw-dead")
+	require.NotZero(t, leaseID, "ephemeral file must carry a lease")
+
+	// "Kill" the process: renewals stop with the store.
+	require.NoError(t, ts.Close())
+
+	require.Eventually(t, func() bool {
+		resp, err := cli.Get(ctx, fullKey)
+		return err == nil && len(resp.Kvs) == 0
+	}, 15*time.Second, 200*time.Millisecond, "ephemeral file should expire after its owner stops renewing")
+}
+
+// findEphemeralKey locates the full etcd key ending in suffix and returns it
+// with its lease ID. The full key depends on the per-test root, so it is
+// discovered by scanning rather than computed.
+func findEphemeralKey(t *testing.T, cli *clientv3.Client, suffix string) (string, int64) {
+	t.Helper()
+	resp, err := cli.Get(context.Background(), "/", clientv3.WithPrefix())
+	require.NoError(t, err, "raw etcd scan failed")
+	for _, kv := range resp.Kvs {
+		if strings.HasSuffix(string(kv.Key), suffix) {
+			return string(kv.Key), kv.Lease
+		}
+	}
+	t.Fatalf("no etcd key found with suffix %q", suffix)
+	return "", 0
 }
 
 // testDatabaseLock tests etcd-specific heartbeat (TTL).


### PR DESCRIPTION
## Problem

Multigateway and multiorch register themselves in etcd as **permanent keys** (no lease), and `toporeg.Unregister()` makes a **single delete attempt with a hardcoded 1s timeout**, logging failure and moving on. Registration, by contrast, retries with backoff until it succeeds — the asymmetry is the bug. Two ways to leak:

- **Graceful shutdown**: any etcd round-trip over ~1s loses the delete. `Unregister` also runs late inside `Shutdown()` under the shared OnClose window, so it can be skipped entirely.
- **Crash path**: SIGKILL / OOM / node loss never runs shutdown at all — no shutdown-side fix can cover this class.

Either way, one missed delete = a stale registration that lives forever. Observed on a live cluster across rolling updates, scale-downs, and node restarts (a node restart re-ran gateway containers in place; each generated a fresh random service ID, orphaning the old registrations under still-live hostnames).

This is not cosmetic: each stale gateway record permanently holds one of 2047 PID prefixes used for query-cancel routing and poisons the cancel-routing prefix cache; a stale multiorch record can be picked persistently by multiadmin's rule-change path.

## Fix

Three pieces: two for registration lifecycle, one for prefix ownership.

**1. Entries expire when their owner dies.** A new `Conn.PutEphemeral` binds gateway/orch registrations to a lease shared per connection (TTL from the existing `--topo-etcd-lease-ttl`), renewed for the connection's lifetime. When the process dies, renewals stop and etcd deletes the entries within one TTL — covering the crash path. `memorytopo` implements it as a plain upsert (no liveness concept).

**2. Entries come back when the owner is alive.** A lease can also end while the process is healthy — expiry after a topology outage, a reconnection replacing the underlying connection, or a cell reconfiguration replacing it wholesale. Only the component knows its record should exist, so re-creation lives with the component: `toporeg`'s `WithReassert` rewrites the record periodically. One loop covers every way an entry can go missing, **including ones the connection layer cannot observe**, so neither `etcdtopo` nor `WrapperConn` tracks what it wrote. The loop stops before deregistration, so it can never resurrect a record the component just removed.

**multipooler is deliberately excluded** from both: its records are persistent by design (lifecycle state plus orchestrator-side tombstone cleanup in `recovery/bookkeeping.go`), and it already republishes on its own schedule — a second writer would churn every watcher of those keys.

**3. PID prefixes are claimed atomically, decoupled from registration records.** The old allocator was scan-guess-verify: infer free prefixes from gateway records, pick one, register, then check for a concurrent duplicate. Ownership inferred from record presence is inherently racy — two starting gateways can pick the same free prefix and rely on the verify step to converge — and lease-backed records make it worse: a record absent during an outage makes its prefix look free. Prefix ownership now lives in its own claim file (`gateway_prefixes/<n>`, global topology) claimed via a new `Conn.ClaimEphemeral`: atomic create when absent, refresh when held by the same gateway (rebinding to the current lease), `NodeExists` when held by another. Two racing gateways cannot both win, so the post-registration collision check is deleted — and so is the unverified reuse of a prefix from an old record. Each process claims fresh; a dead claimant's file expires with its lease.

If a re-assertion finds the claim held by another gateway (possible only after the claim expired during an outage), the loss is fatal: a live gateway cannot renumber — its prefix is baked into its listeners and cancel manager, and clients hold PIDs stamped with it — so the gateway **fails its readiness check (draining new connections) and initiates its own graceful shutdown** via a new `ServEnv.InitiateShutdown`. The supervisor (Kubernetes `restartPolicy`, systemd, docker-compose) restarts the process, which claims a fresh prefix — encoding the restart in the process itself keeps recovery independent of probe configuration (a failing readiness probe alone restarts nothing). The graceful path also unregisters the gateway's record promptly, so no stale record advertises the reassigned prefix alongside its new owner. Claims are **never explicitly released** — lease expiry is the only release path, so a gateway can never delete a claim that has passed to another gateway (the prefix-lost restart path would otherwise do exactly that, briefly freeing the new owner's prefix for a third gateway to claim). A stopped gateway's prefix frees itself within one TTL; with 2047 slots and one claim per process, reuse has no urgency. The lease is deliberately not revoked on connection close: connections also close while the process is alive (reconnections), and an eager revoke would delete a healthy gateway's claim at every swap — the ≤TTL lingering is the grace period that bridges them.

**4. `toporeg.Unregister` retries with backoff for up to 5s** instead of one 1s attempt, for prompt cleanup on the graceful path. `NoNode` counts as success (a previous attempt's delete may have been applied even though its response was lost).

## Design note: why the connection layer keeps no bookkeeping

Re-creating lost ephemeral files from inside the connection layer looks natural but cannot be complete: a connection can be replaced wholesale — `WrapperConn` swaps its underlying conn on retriable errors, and `store.ConnForCell` replaces the cached conn when a cell's addresses change — and the replacement has no memory of what the old one wrote. Only the owner knows its registration should exist, so re-creation lives solely with the owner, and `etcdtopo`/`WrapperConn` deliberately track nothing. The cost is one idempotent rewrite every 10s per gateway/orch; nothing watches those keys, so there is no watcher fan-out.

## Mixed-version notes

- Gateways from before prefix claims advertise a prefix without holding a claim file; the claim loop scans records once and avoids their prefixes. The scan narrows nothing once the fleet writes claim files.
- Registrations leaked by earlier versions carry no lease and never expire on their own; they need one-time cleanup (`etcdctl del`, or operator-side pruning — tracked separately for the multigres-operator).

## Follow-ups (out of scope)

- **`WrapperConn.handleConnectionError` never classifies etcd timeouts as retriable** (pre-existing): `convertError` maps etcd Unavailable/DeadlineExceeded to `TopoError{Timeout}`, whose `mterrors.Code` is UNKNOWN and whose message lacks the "context " prefix, so no reconnection is scheduled for that class on any operation. Re-assertion makes registrations recover regardless, but the gap deserves its own fix.
- One-time cleanup of pre-lease leaked registrations (above).

## Tests

- Conformance suite (memorytopo **and** etcd): `checkPutEphemeral` (create/overwrite/delete/re-create) and `checkClaimEphemeral` (atomic claim, competitor rejected without overwriting the holder, holder refresh, claimable again after the claim is removed).
- etcd end-to-end: `testEphemeralLeaseRenewal` (files share the connection's lease; revoking deletes them; the next write lands on a fresh lease) and `testEphemeralExpiresOnClose` (renewals stop → etcd deletes the entry within one TTL — the SIGKILL promise).
- toporeg: re-assertion rewrites periodically, is off by default, stops before deregistration deletes, survives transient failures, and restores a record deleted out-of-band through a real store (verified to fail when re-assertion is disabled).
- Gateway prefix claims: distinct claims under concurrent claiming; mixed-version avoidance (record-advertised prefix never taken, proven by exhaustion); theft-detection round-trip (holder refresh ok → competitor rejected → claim expiry (simulated) → competitor claims → old holder's refresh fails); lost claim is fatal exactly once (healthy refresh and transient topology errors trigger nothing; a stolen claim sets the readiness flag and initiates shutdown once, never twice); `ServEnv.InitiateShutdown` queues one termination signal and never blocks on repeat calls.
- `WrapperConn`: `PutEphemeral`/`ClaimEphemeral` forward; explicitly does **not** re-create after a reconnection — pinning owner-side re-assertion as the single source of recovery.
- Full `-short` unit suite, `-race` on changed packages, `TestEtcd2Topo`, multiadmin e2e (real gateways claiming prefixes through real etcd), multiorch e2e.


