### PR TITLE
chore(proto): clean up field definitions before MVP freeze

### DIFF
--- a/go/pb/multiadmin/multiadminservice.pb.go
+++ b/go/pb/multiadmin/multiadminservice.pb.go
@@ -1538,33 +1538,28 @@ type BackupInfo struct {
 	Type string `protobuf:"bytes,5,opt,name=type,proto3" json:"type,omitempty"`
 	// status of the backup
 	Status BackupStatus `protobuf:"varint,6,opt,name=status,proto3,enum=multiadmin.BackupStatus" json:"status,omitempty"`
-	// backup_time is when the backup was created
-	// Deprecated: use start_timestamp/stop_timestamp instead.
-	//
-	// Deprecated: Marked as deprecated in multiadminservice.proto.
-	BackupTime *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=backup_time,json=backupTime,proto3" json:"backup_time,omitempty"`
 	// backup_size_bytes is the size of the backup in bytes
-	BackupSizeBytes uint64 `protobuf:"varint,8,opt,name=backup_size_bytes,json=backupSizeBytes,proto3" json:"backup_size_bytes,omitempty"`
+	BackupSizeBytes uint64 `protobuf:"varint,7,opt,name=backup_size_bytes,json=backupSizeBytes,proto3" json:"backup_size_bytes,omitempty"`
 	// multipooler_service_id is the ID of the multipooler that reported the backup
-	MultipoolerServiceId string `protobuf:"bytes,9,opt,name=multipooler_service_id,json=multipoolerServiceId,proto3" json:"multipooler_service_id,omitempty"`
+	MultipoolerServiceId string `protobuf:"bytes,8,opt,name=multipooler_service_id,json=multipoolerServiceId,proto3" json:"multipooler_service_id,omitempty"`
 	// routing_role is the routing role of the multipooler that created the backup
 	// (PRIMARY or REPLICA)
-	RoutingRole clustermetadata.RoutingRole `protobuf:"varint,10,opt,name=routing_role,json=routingRole,proto3,enum=clustermetadata.RoutingRole" json:"routing_role,omitempty"`
+	RoutingRole clustermetadata.RoutingRole `protobuf:"varint,9,opt,name=routing_role,json=routingRole,proto3,enum=clustermetadata.RoutingRole" json:"routing_role,omitempty"`
 	// start_lsn is the WAL start LSN of the backup (pgbackrest backup[].lsn.start)
-	StartLsn string `protobuf:"bytes,11,opt,name=start_lsn,json=startLsn,proto3" json:"start_lsn,omitempty"`
+	StartLsn string `protobuf:"bytes,10,opt,name=start_lsn,json=startLsn,proto3" json:"start_lsn,omitempty"`
 	// stop_lsn is the WAL stop LSN of the backup (pgbackrest backup[].lsn.stop)
-	StopLsn string `protobuf:"bytes,12,opt,name=stop_lsn,json=stopLsn,proto3" json:"stop_lsn,omitempty"`
+	StopLsn string `protobuf:"bytes,11,opt,name=stop_lsn,json=stopLsn,proto3" json:"stop_lsn,omitempty"`
 	// pg_version is the full PostgreSQL server_version the backup was taken from (e.g. "16.2")
-	PgVersion string `protobuf:"bytes,13,opt,name=pg_version,json=pgVersion,proto3" json:"pg_version,omitempty"`
+	PgVersion string `protobuf:"bytes,12,opt,name=pg_version,json=pgVersion,proto3" json:"pg_version,omitempty"`
 	// start_timestamp is when the backup started, from pgbackrest info backup[].timestamp.start.
 	// Unset if unknown.
-	StartTimestamp *timestamppb.Timestamp `protobuf:"bytes,14,opt,name=start_timestamp,json=startTimestamp,proto3" json:"start_timestamp,omitempty"`
+	StartTimestamp *timestamppb.Timestamp `protobuf:"bytes,13,opt,name=start_timestamp,json=startTimestamp,proto3" json:"start_timestamp,omitempty"`
 	// stop_timestamp is when the backup completed, from pgbackrest info backup[].timestamp.stop.
 	// Unset if unknown.
-	StopTimestamp *timestamppb.Timestamp `protobuf:"bytes,15,opt,name=stop_timestamp,json=stopTimestamp,proto3" json:"stop_timestamp,omitempty"`
+	StopTimestamp *timestamppb.Timestamp `protobuf:"bytes,14,opt,name=stop_timestamp,json=stopTimestamp,proto3" json:"stop_timestamp,omitempty"`
 	// job_id is the multiadmin backup job ID that produced this backup, if known
 	// (from the pgbackrest job_id annotation).
-	JobId         string `protobuf:"bytes,16,opt,name=job_id,json=jobId,proto3" json:"job_id,omitempty"`
+	JobId         string `protobuf:"bytes,15,opt,name=job_id,json=jobId,proto3" json:"job_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1639,14 +1634,6 @@ func (x *BackupInfo) GetStatus() BackupStatus {
 		return x.Status
 	}
 	return BackupStatus_BACKUP_STATUS_UNKNOWN
-}
-
-// Deprecated: Marked as deprecated in multiadminservice.proto.
-func (x *BackupInfo) GetBackupTime() *timestamppb.Timestamp {
-	if x != nil {
-		return x.BackupTime
-	}
-	return nil
 }
 
 func (x *BackupInfo) GetBackupSizeBytes() uint64 {
@@ -2547,7 +2534,7 @@ const file_multiadminservice_proto_rawDesc = "" +
 	"\x15VerifyBackupsResponse\x125\n" +
 	"\bduration\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\bduration\x12\x1d\n" +
 	"\n" +
-	"raw_output\x18\x02 \x01(\tR\trawOutput\"\x9c\x05\n" +
+	"raw_output\x18\x02 \x01(\tR\trawOutput\"\xdb\x04\n" +
 	"\n" +
 	"BackupInfo\x12\x1b\n" +
 	"\tbackup_id\x18\x01 \x01(\tR\bbackupId\x12\x1a\n" +
@@ -2556,20 +2543,18 @@ const file_multiadminservice_proto_rawDesc = "" +
 	"tableGroup\x12\x14\n" +
 	"\x05shard\x18\x04 \x01(\tR\x05shard\x12\x12\n" +
 	"\x04type\x18\x05 \x01(\tR\x04type\x120\n" +
-	"\x06status\x18\x06 \x01(\x0e2\x18.multiadmin.BackupStatusR\x06status\x12?\n" +
-	"\vbackup_time\x18\a \x01(\v2\x1a.google.protobuf.TimestampB\x02\x18\x01R\n" +
-	"backupTime\x12*\n" +
-	"\x11backup_size_bytes\x18\b \x01(\x04R\x0fbackupSizeBytes\x124\n" +
-	"\x16multipooler_service_id\x18\t \x01(\tR\x14multipoolerServiceId\x12?\n" +
-	"\frouting_role\x18\n" +
-	" \x01(\x0e2\x1c.clustermetadata.RoutingRoleR\vroutingRole\x12\x1b\n" +
-	"\tstart_lsn\x18\v \x01(\tR\bstartLsn\x12\x19\n" +
-	"\bstop_lsn\x18\f \x01(\tR\astopLsn\x12\x1d\n" +
+	"\x06status\x18\x06 \x01(\x0e2\x18.multiadmin.BackupStatusR\x06status\x12*\n" +
+	"\x11backup_size_bytes\x18\a \x01(\x04R\x0fbackupSizeBytes\x124\n" +
+	"\x16multipooler_service_id\x18\b \x01(\tR\x14multipoolerServiceId\x12?\n" +
+	"\frouting_role\x18\t \x01(\x0e2\x1c.clustermetadata.RoutingRoleR\vroutingRole\x12\x1b\n" +
+	"\tstart_lsn\x18\n" +
+	" \x01(\tR\bstartLsn\x12\x19\n" +
+	"\bstop_lsn\x18\v \x01(\tR\astopLsn\x12\x1d\n" +
 	"\n" +
-	"pg_version\x18\r \x01(\tR\tpgVersion\x12C\n" +
-	"\x0fstart_timestamp\x18\x0e \x01(\v2\x1a.google.protobuf.TimestampR\x0estartTimestamp\x12A\n" +
-	"\x0estop_timestamp\x18\x0f \x01(\v2\x1a.google.protobuf.TimestampR\rstopTimestamp\x12\x15\n" +
-	"\x06job_id\x18\x10 \x01(\tR\x05jobId\"J\n" +
+	"pg_version\x18\f \x01(\tR\tpgVersion\x12C\n" +
+	"\x0fstart_timestamp\x18\r \x01(\v2\x1a.google.protobuf.TimestampR\x0estartTimestamp\x12A\n" +
+	"\x0estop_timestamp\x18\x0e \x01(\v2\x1a.google.protobuf.TimestampR\rstopTimestamp\x12\x15\n" +
+	"\x06job_id\x18\x0f \x01(\tR\x05jobId\"J\n" +
 	"\x16GetPoolerStatusRequest\x120\n" +
 	"\tpooler_id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\bpoolerId\"\x9e\x01\n" +
 	"\x17GetPoolerStatusResponse\x126\n" +
@@ -2707,8 +2692,8 @@ var file_multiadminservice_proto_goTypes = []any{
 	(*clustermetadata.Multipooler)(nil),                   // 45: clustermetadata.Multipooler
 	(*clustermetadata.Multiorch)(nil),                     // 46: clustermetadata.Multiorch
 	(*durationpb.Duration)(nil),                           // 47: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),                         // 48: google.protobuf.Timestamp
-	(clustermetadata.RoutingRole)(0),                      // 49: clustermetadata.RoutingRole
+	(clustermetadata.RoutingRole)(0),                      // 48: clustermetadata.RoutingRole
+	(*timestamppb.Timestamp)(nil),                         // 49: google.protobuf.Timestamp
 	(*clustermetadata.ID)(nil),                            // 50: clustermetadata.ID
 	(*multipoolermanagerdata.Status)(nil),                 // 51: multipoolermanagerdata.Status
 	(*clustermetadata.ConsensusStatus)(nil),               // 52: clustermetadata.ConsensusStatus
@@ -2731,67 +2716,66 @@ var file_multiadminservice_proto_depIdxs = []int32{
 	41, // 8: multiadmin.ExpireBackupsRequest.overrides:type_name -> multiadmin.ExpireBackupsRequest.OverridesEntry
 	47, // 9: multiadmin.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
 	2,  // 10: multiadmin.BackupInfo.status:type_name -> multiadmin.BackupStatus
-	48, // 11: multiadmin.BackupInfo.backup_time:type_name -> google.protobuf.Timestamp
-	49, // 12: multiadmin.BackupInfo.routing_role:type_name -> clustermetadata.RoutingRole
-	48, // 13: multiadmin.BackupInfo.start_timestamp:type_name -> google.protobuf.Timestamp
-	48, // 14: multiadmin.BackupInfo.stop_timestamp:type_name -> google.protobuf.Timestamp
-	50, // 15: multiadmin.GetPoolerStatusRequest.pooler_id:type_name -> clustermetadata.ID
-	51, // 16: multiadmin.GetPoolerStatusResponse.status:type_name -> multipoolermanagerdata.Status
-	52, // 17: multiadmin.GetPoolerStatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
-	50, // 18: multiadmin.SetPostgresRestartsEnabledRequest.pooler_id:type_name -> clustermetadata.ID
-	50, // 19: multiadmin.GetGatewayQueriesRequest.gateway_id:type_name -> clustermetadata.ID
-	53, // 20: multiadmin.GetGatewayQueriesResponse.snapshot:type_name -> multigatewaymanagerdata.QueryRegistrySnapshot
-	50, // 21: multiadmin.GetGatewayConsolidatorRequest.gateway_id:type_name -> clustermetadata.ID
-	54, // 22: multiadmin.GetGatewayConsolidatorResponse.stats:type_name -> multigatewaymanagerdata.ConsolidatorStats
-	55, // 23: multiadmin.ApplyCertifiedRuleChangeRequest.shard_key:type_name -> clustermetadata.ShardKey
-	56, // 24: multiadmin.ApplyCertifiedRuleChangeRequest.proposed_transition:type_name -> clustermetadata.RulePosition
-	57, // 25: multiadmin.ApplyCertifiedRuleChangeRequest.cert:type_name -> clustermetadata.ExternallyCertifiedRevocation
-	37, // 26: multiadmin.ApplyCertifiedRuleChangeRequest.unsafe_derive_cert:type_name -> multiadmin.UnsafeDeriveCertOptions
-	58, // 27: multiadmin.ApplyCertifiedRuleChangeResponse.installed_rule:type_name -> clustermetadata.ShardRule
-	57, // 28: multiadmin.ApplyCertifiedRuleChangeResponse.cert_used:type_name -> clustermetadata.ExternallyCertifiedRevocation
-	55, // 29: multiadmin.SwitchPrimaryRequest.shard_key:type_name -> clustermetadata.ShardKey
-	50, // 30: multiadmin.SwitchPrimaryResponse.old_leader_id:type_name -> clustermetadata.ID
-	3,  // 31: multiadmin.MultiadminService.GetCell:input_type -> multiadmin.GetCellRequest
-	5,  // 32: multiadmin.MultiadminService.GetDatabase:input_type -> multiadmin.GetDatabaseRequest
-	7,  // 33: multiadmin.MultiadminService.GetCellNames:input_type -> multiadmin.GetCellNamesRequest
-	9,  // 34: multiadmin.MultiadminService.GetDatabaseNames:input_type -> multiadmin.GetDatabaseNamesRequest
-	11, // 35: multiadmin.MultiadminService.GetGateways:input_type -> multiadmin.GetGatewaysRequest
-	13, // 36: multiadmin.MultiadminService.GetPoolers:input_type -> multiadmin.GetPoolersRequest
-	15, // 37: multiadmin.MultiadminService.GetOrchs:input_type -> multiadmin.GetOrchsRequest
-	17, // 38: multiadmin.MultiadminService.Backup:input_type -> multiadmin.BackupRequest
-	19, // 39: multiadmin.MultiadminService.GetBackupJobStatus:input_type -> multiadmin.GetBackupJobStatusRequest
-	21, // 40: multiadmin.MultiadminService.GetBackups:input_type -> multiadmin.GetBackupsRequest
-	23, // 41: multiadmin.MultiadminService.ExpireBackups:input_type -> multiadmin.ExpireBackupsRequest
-	25, // 42: multiadmin.MultiadminService.VerifyBackups:input_type -> multiadmin.VerifyBackupsRequest
-	28, // 43: multiadmin.MultiadminService.GetPoolerStatus:input_type -> multiadmin.GetPoolerStatusRequest
-	30, // 44: multiadmin.MultiadminService.SetPostgresRestartsEnabled:input_type -> multiadmin.SetPostgresRestartsEnabledRequest
-	32, // 45: multiadmin.MultiadminService.GetGatewayQueries:input_type -> multiadmin.GetGatewayQueriesRequest
-	34, // 46: multiadmin.MultiadminService.GetGatewayConsolidator:input_type -> multiadmin.GetGatewayConsolidatorRequest
-	36, // 47: multiadmin.MultiadminService.ApplyCertifiedRuleChange:input_type -> multiadmin.ApplyCertifiedRuleChangeRequest
-	39, // 48: multiadmin.MultiadminService.SwitchPrimary:input_type -> multiadmin.SwitchPrimaryRequest
-	4,  // 49: multiadmin.MultiadminService.GetCell:output_type -> multiadmin.GetCellResponse
-	6,  // 50: multiadmin.MultiadminService.GetDatabase:output_type -> multiadmin.GetDatabaseResponse
-	8,  // 51: multiadmin.MultiadminService.GetCellNames:output_type -> multiadmin.GetCellNamesResponse
-	10, // 52: multiadmin.MultiadminService.GetDatabaseNames:output_type -> multiadmin.GetDatabaseNamesResponse
-	12, // 53: multiadmin.MultiadminService.GetGateways:output_type -> multiadmin.GetGatewaysResponse
-	14, // 54: multiadmin.MultiadminService.GetPoolers:output_type -> multiadmin.GetPoolersResponse
-	16, // 55: multiadmin.MultiadminService.GetOrchs:output_type -> multiadmin.GetOrchsResponse
-	18, // 56: multiadmin.MultiadminService.Backup:output_type -> multiadmin.BackupResponse
-	20, // 57: multiadmin.MultiadminService.GetBackupJobStatus:output_type -> multiadmin.GetBackupJobStatusResponse
-	22, // 58: multiadmin.MultiadminService.GetBackups:output_type -> multiadmin.GetBackupsResponse
-	24, // 59: multiadmin.MultiadminService.ExpireBackups:output_type -> multiadmin.ExpireBackupsResponse
-	26, // 60: multiadmin.MultiadminService.VerifyBackups:output_type -> multiadmin.VerifyBackupsResponse
-	29, // 61: multiadmin.MultiadminService.GetPoolerStatus:output_type -> multiadmin.GetPoolerStatusResponse
-	31, // 62: multiadmin.MultiadminService.SetPostgresRestartsEnabled:output_type -> multiadmin.SetPostgresRestartsEnabledResponse
-	33, // 63: multiadmin.MultiadminService.GetGatewayQueries:output_type -> multiadmin.GetGatewayQueriesResponse
-	35, // 64: multiadmin.MultiadminService.GetGatewayConsolidator:output_type -> multiadmin.GetGatewayConsolidatorResponse
-	38, // 65: multiadmin.MultiadminService.ApplyCertifiedRuleChange:output_type -> multiadmin.ApplyCertifiedRuleChangeResponse
-	40, // 66: multiadmin.MultiadminService.SwitchPrimary:output_type -> multiadmin.SwitchPrimaryResponse
-	49, // [49:67] is the sub-list for method output_type
-	31, // [31:49] is the sub-list for method input_type
-	31, // [31:31] is the sub-list for extension type_name
-	31, // [31:31] is the sub-list for extension extendee
-	0,  // [0:31] is the sub-list for field type_name
+	48, // 11: multiadmin.BackupInfo.routing_role:type_name -> clustermetadata.RoutingRole
+	49, // 12: multiadmin.BackupInfo.start_timestamp:type_name -> google.protobuf.Timestamp
+	49, // 13: multiadmin.BackupInfo.stop_timestamp:type_name -> google.protobuf.Timestamp
+	50, // 14: multiadmin.GetPoolerStatusRequest.pooler_id:type_name -> clustermetadata.ID
+	51, // 15: multiadmin.GetPoolerStatusResponse.status:type_name -> multipoolermanagerdata.Status
+	52, // 16: multiadmin.GetPoolerStatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	50, // 17: multiadmin.SetPostgresRestartsEnabledRequest.pooler_id:type_name -> clustermetadata.ID
+	50, // 18: multiadmin.GetGatewayQueriesRequest.gateway_id:type_name -> clustermetadata.ID
+	53, // 19: multiadmin.GetGatewayQueriesResponse.snapshot:type_name -> multigatewaymanagerdata.QueryRegistrySnapshot
+	50, // 20: multiadmin.GetGatewayConsolidatorRequest.gateway_id:type_name -> clustermetadata.ID
+	54, // 21: multiadmin.GetGatewayConsolidatorResponse.stats:type_name -> multigatewaymanagerdata.ConsolidatorStats
+	55, // 22: multiadmin.ApplyCertifiedRuleChangeRequest.shard_key:type_name -> clustermetadata.ShardKey
+	56, // 23: multiadmin.ApplyCertifiedRuleChangeRequest.proposed_transition:type_name -> clustermetadata.RulePosition
+	57, // 24: multiadmin.ApplyCertifiedRuleChangeRequest.cert:type_name -> clustermetadata.ExternallyCertifiedRevocation
+	37, // 25: multiadmin.ApplyCertifiedRuleChangeRequest.unsafe_derive_cert:type_name -> multiadmin.UnsafeDeriveCertOptions
+	58, // 26: multiadmin.ApplyCertifiedRuleChangeResponse.installed_rule:type_name -> clustermetadata.ShardRule
+	57, // 27: multiadmin.ApplyCertifiedRuleChangeResponse.cert_used:type_name -> clustermetadata.ExternallyCertifiedRevocation
+	55, // 28: multiadmin.SwitchPrimaryRequest.shard_key:type_name -> clustermetadata.ShardKey
+	50, // 29: multiadmin.SwitchPrimaryResponse.old_leader_id:type_name -> clustermetadata.ID
+	3,  // 30: multiadmin.MultiadminService.GetCell:input_type -> multiadmin.GetCellRequest
+	5,  // 31: multiadmin.MultiadminService.GetDatabase:input_type -> multiadmin.GetDatabaseRequest
+	7,  // 32: multiadmin.MultiadminService.GetCellNames:input_type -> multiadmin.GetCellNamesRequest
+	9,  // 33: multiadmin.MultiadminService.GetDatabaseNames:input_type -> multiadmin.GetDatabaseNamesRequest
+	11, // 34: multiadmin.MultiadminService.GetGateways:input_type -> multiadmin.GetGatewaysRequest
+	13, // 35: multiadmin.MultiadminService.GetPoolers:input_type -> multiadmin.GetPoolersRequest
+	15, // 36: multiadmin.MultiadminService.GetOrchs:input_type -> multiadmin.GetOrchsRequest
+	17, // 37: multiadmin.MultiadminService.Backup:input_type -> multiadmin.BackupRequest
+	19, // 38: multiadmin.MultiadminService.GetBackupJobStatus:input_type -> multiadmin.GetBackupJobStatusRequest
+	21, // 39: multiadmin.MultiadminService.GetBackups:input_type -> multiadmin.GetBackupsRequest
+	23, // 40: multiadmin.MultiadminService.ExpireBackups:input_type -> multiadmin.ExpireBackupsRequest
+	25, // 41: multiadmin.MultiadminService.VerifyBackups:input_type -> multiadmin.VerifyBackupsRequest
+	28, // 42: multiadmin.MultiadminService.GetPoolerStatus:input_type -> multiadmin.GetPoolerStatusRequest
+	30, // 43: multiadmin.MultiadminService.SetPostgresRestartsEnabled:input_type -> multiadmin.SetPostgresRestartsEnabledRequest
+	32, // 44: multiadmin.MultiadminService.GetGatewayQueries:input_type -> multiadmin.GetGatewayQueriesRequest
+	34, // 45: multiadmin.MultiadminService.GetGatewayConsolidator:input_type -> multiadmin.GetGatewayConsolidatorRequest
+	36, // 46: multiadmin.MultiadminService.ApplyCertifiedRuleChange:input_type -> multiadmin.ApplyCertifiedRuleChangeRequest
+	39, // 47: multiadmin.MultiadminService.SwitchPrimary:input_type -> multiadmin.SwitchPrimaryRequest
+	4,  // 48: multiadmin.MultiadminService.GetCell:output_type -> multiadmin.GetCellResponse
+	6,  // 49: multiadmin.MultiadminService.GetDatabase:output_type -> multiadmin.GetDatabaseResponse
+	8,  // 50: multiadmin.MultiadminService.GetCellNames:output_type -> multiadmin.GetCellNamesResponse
+	10, // 51: multiadmin.MultiadminService.GetDatabaseNames:output_type -> multiadmin.GetDatabaseNamesResponse
+	12, // 52: multiadmin.MultiadminService.GetGateways:output_type -> multiadmin.GetGatewaysResponse
+	14, // 53: multiadmin.MultiadminService.GetPoolers:output_type -> multiadmin.GetPoolersResponse
+	16, // 54: multiadmin.MultiadminService.GetOrchs:output_type -> multiadmin.GetOrchsResponse
+	18, // 55: multiadmin.MultiadminService.Backup:output_type -> multiadmin.BackupResponse
+	20, // 56: multiadmin.MultiadminService.GetBackupJobStatus:output_type -> multiadmin.GetBackupJobStatusResponse
+	22, // 57: multiadmin.MultiadminService.GetBackups:output_type -> multiadmin.GetBackupsResponse
+	24, // 58: multiadmin.MultiadminService.ExpireBackups:output_type -> multiadmin.ExpireBackupsResponse
+	26, // 59: multiadmin.MultiadminService.VerifyBackups:output_type -> multiadmin.VerifyBackupsResponse
+	29, // 60: multiadmin.MultiadminService.GetPoolerStatus:output_type -> multiadmin.GetPoolerStatusResponse
+	31, // 61: multiadmin.MultiadminService.SetPostgresRestartsEnabled:output_type -> multiadmin.SetPostgresRestartsEnabledResponse
+	33, // 62: multiadmin.MultiadminService.GetGatewayQueries:output_type -> multiadmin.GetGatewayQueriesResponse
+	35, // 63: multiadmin.MultiadminService.GetGatewayConsolidator:output_type -> multiadmin.GetGatewayConsolidatorResponse
+	38, // 64: multiadmin.MultiadminService.ApplyCertifiedRuleChange:output_type -> multiadmin.ApplyCertifiedRuleChangeResponse
+	40, // 65: multiadmin.MultiadminService.SwitchPrimary:output_type -> multiadmin.SwitchPrimaryResponse
+	48, // [48:66] is the sub-list for method output_type
+	30, // [30:48] is the sub-list for method input_type
+	30, // [30:30] is the sub-list for extension type_name
+	30, // [30:30] is the sub-list for extension extendee
+	0,  // [0:30] is the sub-list for field type_name
 }
 
 func init() { file_multiadminservice_proto_init() }

--- a/go/pb/multipoolerservice/multipoolerservice.pb.go
+++ b/go/pb/multipoolerservice/multipoolerservice.pb.go
@@ -49,7 +49,6 @@ type ReplicationMode int32
 const (
 	ReplicationMode_REPLICATION_MODE_UNSPECIFIED ReplicationMode = 0
 	ReplicationMode_REPLICATION_MODE_DATABASE    ReplicationMode = 1 // replication=database (logical)
-	ReplicationMode_REPLICATION_MODE_TRUE        ReplicationMode = 2 // replication=true (physical) — reserved, not used in v1
 )
 
 // Enum value maps for ReplicationMode.
@@ -57,12 +56,10 @@ var (
 	ReplicationMode_name = map[int32]string{
 		0: "REPLICATION_MODE_UNSPECIFIED",
 		1: "REPLICATION_MODE_DATABASE",
-		2: "REPLICATION_MODE_TRUE",
 	}
 	ReplicationMode_value = map[string]int32{
 		"REPLICATION_MODE_UNSPECIFIED": 0,
 		"REPLICATION_MODE_DATABASE":    1,
-		"REPLICATION_MODE_TRUE":        2,
 	}
 )
 
@@ -1485,10 +1482,7 @@ type StreamReplicationRequest struct {
 	//
 	//	*StreamReplicationRequest_Init
 	//	*StreamReplicationRequest_Data
-	Msg isStreamReplicationRequest_Msg `protobuf_oneof:"msg"`
-	// Reserved for future end-to-end latency measurement; unused in v1.
-	// Carried in the envelope, never inside `data`, to stay protocol-blind.
-	SendUnixnano  int64 `protobuf:"varint,3,opt,name=send_unixnano,json=sendUnixnano,proto3" json:"send_unixnano,omitempty"`
+	Msg           isStreamReplicationRequest_Msg `protobuf_oneof:"msg"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1546,13 +1540,6 @@ func (x *StreamReplicationRequest) GetData() []byte {
 		}
 	}
 	return nil
-}
-
-func (x *StreamReplicationRequest) GetSendUnixnano() int64 {
-	if x != nil {
-		return x.SendUnixnano
-	}
-	return 0
 }
 
 type isStreamReplicationRequest_Msg interface {
@@ -1659,7 +1646,6 @@ type StreamReplicationResponse struct {
 	//	*StreamReplicationResponse_Data
 	//	*StreamReplicationResponse_Error
 	Msg           isStreamReplicationResponse_Msg `protobuf_oneof:"msg"`
-	SendUnixnano  int64                           `protobuf:"varint,4,opt,name=send_unixnano,json=sendUnixnano,proto3" json:"send_unixnano,omitempty"` // reserved, unused in v1
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1726,13 +1712,6 @@ func (x *StreamReplicationResponse) GetError() *StreamReplicationError {
 		}
 	}
 	return nil
-}
-
-func (x *StreamReplicationResponse) GetSendUnixnano() int64 {
-	if x != nil {
-		return x.SendUnixnano
-	}
-	return 0
 }
 
 type isStreamReplicationResponse_Msg interface {
@@ -2598,22 +2577,20 @@ const file_multipoolerservice_proto_rawDesc = "" +
 	"\tcaller_id\x18\x02 \x01(\v2\x0f.mtrpc.CallerIDR\bcallerId\x127\n" +
 	"\x04mode\x18\x03 \x01(\x0e2#.multipoolerservice.ReplicationModeR\x04mode\x12\x12\n" +
 	"\x04user\x18\x04 \x01(\tR\x04user\x12,\n" +
-	"\tuser_auth\x18\x05 \x01(\v2\x0f.query.UserAuthR\buserAuth\"\x9d\x01\n" +
+	"\tuser_auth\x18\x05 \x01(\v2\x0f.query.UserAuthR\buserAuth\"x\n" +
 	"\x18StreamReplicationRequest\x12?\n" +
 	"\x04init\x18\x01 \x01(\v2).multipoolerservice.StreamReplicationInitH\x00R\x04init\x12\x14\n" +
-	"\x04data\x18\x02 \x01(\fH\x00R\x04data\x12#\n" +
-	"\rsend_unixnano\x18\x03 \x01(\x03R\fsendUnixnanoB\x05\n" +
+	"\x04data\x18\x02 \x01(\fH\x00R\x04dataB\x05\n" +
 	"\x03msg\"\x18\n" +
 	"\x16StreamReplicationReady\"M\n" +
 	"\x16StreamReplicationError\x123\n" +
 	"\n" +
 	"diagnostic\x18\x01 \x01(\v2\x13.query.PgDiagnosticR\n" +
-	"diagnostic\"\xe5\x01\n" +
+	"diagnostic\"\xc0\x01\n" +
 	"\x19StreamReplicationResponse\x12B\n" +
 	"\x05ready\x18\x01 \x01(\v2*.multipoolerservice.StreamReplicationReadyH\x00R\x05ready\x12\x14\n" +
 	"\x04data\x18\x02 \x01(\fH\x00R\x04data\x12B\n" +
-	"\x05error\x18\x03 \x01(\v2*.multipoolerservice.StreamReplicationErrorH\x00R\x05error\x12#\n" +
-	"\rsend_unixnano\x18\x04 \x01(\x03R\fsendUnixnanoB\x05\n" +
+	"\x05error\x18\x03 \x01(\v2*.multipoolerservice.StreamReplicationErrorH\x00R\x05errorB\x05\n" +
 	"\x03msg\"\xce\x03\n" +
 	"\x1aConcludeTransactionRequest\x12%\n" +
 	"\x06target\x18\x01 \x01(\v2\r.query.TargetR\x06target\x12,\n" +
@@ -2662,11 +2639,10 @@ const file_multipoolerservice_proto_rawDesc = "" +
 	"\x0funsubscribe_all\x18\x04 \x01(\bR\x0eunsubscribeAll\"m\n" +
 	"\x1aNotificationStreamResponse\x129\n" +
 	"\fnotification\x18\x01 \x01(\v2\x15.query.PgNotificationR\fnotification\x12\x14\n" +
-	"\x05ready\x18\x02 \x01(\bR\x05ready*m\n" +
+	"\x05ready\x18\x02 \x01(\bR\x05ready*R\n" +
 	"\x0fReplicationMode\x12 \n" +
 	"\x1cREPLICATION_MODE_UNSPECIFIED\x10\x00\x12\x1d\n" +
-	"\x19REPLICATION_MODE_DATABASE\x10\x01\x12\x19\n" +
-	"\x15REPLICATION_MODE_TRUE\x10\x02*\xf9\x02\n" +
+	"\x19REPLICATION_MODE_DATABASE\x10\x01*\xf9\x02\n" +
 	"\x11ReservationReason\x12\"\n" +
 	"\x1eRESERVATION_REASON_UNSPECIFIED\x10\x00\x12\"\n" +
 	"\x1eRESERVATION_REASON_TRANSACTION\x10\x01\x12!\n" +

--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -1297,24 +1297,24 @@ type ExecuteOptions struct {
 	User string `protobuf:"bytes,2,opt,name=user,proto3" json:"user,omitempty"`
 	// max_rows is the maximum number of rows to return from Execute.
 	// 0 means return all rows. Used by the Execute message in the extended query protocol.
-	MaxRows uint64 `protobuf:"varint,4,opt,name=max_rows,json=maxRows,proto3" json:"max_rows,omitempty"`
+	MaxRows uint64 `protobuf:"varint,3,opt,name=max_rows,json=maxRows,proto3" json:"max_rows,omitempty"`
 	// reserved_connection_id is the ID of a reserved connection on the multipooler.
 	// Used for connection pinning - this tells the multipooler which specific
 	// connection to use for executing this query.
-	ReservedConnectionId uint64 `protobuf:"varint,5,opt,name=reserved_connection_id,json=reservedConnectionId,proto3" json:"reserved_connection_id,omitempty"`
+	ReservedConnectionId uint64 `protobuf:"varint,4,opt,name=reserved_connection_id,json=reservedConnectionId,proto3" json:"reserved_connection_id,omitempty"`
 	// user_auth carries SCRAM-SHA-256 passthrough keys captured during the
 	// client's authentication handshake at the multigateway. When the
 	// multipooler has SCRAM passthrough enabled, it uses these keys to
 	// authenticate to the backing PostgreSQL as the session's real user
 	// instead of relying on trust on the local connection. Unset for
 	// sessions that did not authenticate via SCRAM.
-	UserAuth *UserAuth `protobuf:"bytes,7,opt,name=user_auth,json=userAuth,proto3" json:"user_auth,omitempty"`
+	UserAuth *UserAuth `protobuf:"bytes,5,opt,name=user_auth,json=userAuth,proto3" json:"user_auth,omitempty"`
 	// client_connection_id is the multigateway's virtual PID for this client
 	// connection. The multipooler can register it against the underlying
 	// PostgreSQL backend PID so lock-detection functions can map virtual PIDs
 	// (visible to clients) back to real backend PIDs without altering the
 	// client-visible application_name.
-	ClientConnectionId uint32 `protobuf:"varint,8,opt,name=client_connection_id,json=clientConnectionId,proto3" json:"client_connection_id,omitempty"`
+	ClientConnectionId uint32 `protobuf:"varint,6,opt,name=client_connection_id,json=clientConnectionId,proto3" json:"client_connection_id,omitempty"`
 	// execute_sql_prepared_statement, if set, describes a SQL-level EXECUTE
 	// wrapper that references a gateway-managed prepared statement. The
 	// multipooler first prepares the underlying query using pooler-level
@@ -1324,7 +1324,7 @@ type ExecuteOptions struct {
 	//
 	// This field is only consumed by StreamExecute. PortalStreamExecute has its
 	// own top-level prepared_statement field.
-	ExecuteSqlPreparedStatement *ExecuteSqlPreparedStatement `protobuf:"bytes,9,opt,name=execute_sql_prepared_statement,json=executeSqlPreparedStatement,proto3" json:"execute_sql_prepared_statement,omitempty"`
+	ExecuteSqlPreparedStatement *ExecuteSqlPreparedStatement `protobuf:"bytes,7,opt,name=execute_sql_prepared_statement,json=executeSqlPreparedStatement,proto3" json:"execute_sql_prepared_statement,omitempty"`
 	// passthrough_row requests opaque row passthrough for this query: the
 	// multipooler returns rows as concatenated raw DataRow frames in
 	// QueryResult.passthrough_block instead of structured Row messages, and the
@@ -1332,7 +1332,7 @@ type ExecuteOptions struct {
 	// for straight client pass-through queries and leaves it false for results it
 	// must interpret itself (SET, SHOW, catalog rewrites). Defaulting to false
 	// keeps non-gateway callers (multiadmin, multiorch) on the structured path.
-	PassthroughRow bool `protobuf:"varint,12,opt,name=passthrough_row,json=passthroughRow,proto3" json:"passthrough_row,omitempty"`
+	PassthroughRow bool `protobuf:"varint,8,opt,name=passthrough_row,json=passthroughRow,proto3" json:"passthrough_row,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -1699,32 +1699,31 @@ const file_query_proto_rawDesc = "" +
 	"\x16reserved_connection_id\x18\x01 \x01(\x04R\x14reservedConnectionId\x120\n" +
 	"\tpooler_id\x18\x02 \x01(\v2\x13.clustermetadata.IDR\bpoolerId\x12/\n" +
 	"\x13reservation_reasons\x18\x03 \x01(\rR\x12reservationReasons\x12,\n" +
-	"\x12backend_process_id\x18\x04 \x01(\rR\x10backendProcessId\"\x8e\x04\n" +
+	"\x12backend_process_id\x18\x04 \x01(\rR\x10backendProcessId\"\x82\x04\n" +
 	"\x0eExecuteOptions\x12U\n" +
 	"\x10session_settings\x18\x01 \x03(\v2*.query.ExecuteOptions.SessionSettingsEntryR\x0fsessionSettings\x12\x12\n" +
 	"\x04user\x18\x02 \x01(\tR\x04user\x12\x19\n" +
-	"\bmax_rows\x18\x04 \x01(\x04R\amaxRows\x124\n" +
-	"\x16reserved_connection_id\x18\x05 \x01(\x04R\x14reservedConnectionId\x12,\n" +
-	"\tuser_auth\x18\a \x01(\v2\x0f.query.UserAuthR\buserAuth\x120\n" +
-	"\x14client_connection_id\x18\b \x01(\rR\x12clientConnectionId\x12g\n" +
-	"\x1eexecute_sql_prepared_statement\x18\t \x01(\v2\".query.ExecuteSqlPreparedStatementR\x1bexecuteSqlPreparedStatement\x12'\n" +
-	"\x0fpassthrough_row\x18\f \x01(\bR\x0epassthroughRow\x1aB\n" +
+	"\bmax_rows\x18\x03 \x01(\x04R\amaxRows\x124\n" +
+	"\x16reserved_connection_id\x18\x04 \x01(\x04R\x14reservedConnectionId\x12,\n" +
+	"\tuser_auth\x18\x05 \x01(\v2\x0f.query.UserAuthR\buserAuth\x120\n" +
+	"\x14client_connection_id\x18\x06 \x01(\rR\x12clientConnectionId\x12g\n" +
+	"\x1eexecute_sql_prepared_statement\x18\a \x01(\v2\".query.ExecuteSqlPreparedStatementR\x1bexecuteSqlPreparedStatement\x12'\n" +
+	"\x0fpassthrough_row\x18\b \x01(\bR\x0epassthroughRow\x1aB\n" +
 	"\x14SessionSettingsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\n" +
-	"\x10\vJ\x04\b\v\x10\f\"R\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"R\n" +
 	"\bUserAuth\x12\"\n" +
 	"\n" +
 	"client_key\x18\x01 \x01(\fB\x03\x80\x01\x01R\tclientKey\x12\"\n" +
 	"\n" +
-	"server_key\x18\x02 \x01(\fB\x03\x80\x01\x01R\tserverKey\"\xe7\x01\n" +
+	"server_key\x18\x02 \x01(\fB\x03\x80\x01\x01R\tserverKey\"\xe1\x01\n" +
 	"\x12ReservationOptions\x12\x18\n" +
 	"\areasons\x18\x01 \x01(\rR\areasons\x12\x1f\n" +
 	"\vbegin_query\x18\x02 \x01(\tR\n" +
 	"beginQuery\x12(\n" +
 	"\x10pin_portal_names\x18\x03 \x03(\tR\x0epinPortalNames\x120\n" +
 	"\x14release_portal_names\x18\x04 \x03(\tR\x12releasePortalNames\x124\n" +
-	"\x16recheck_advisory_locks\x18\x05 \x01(\bR\x14recheckAdvisoryLocksJ\x04\b\x06\x10\a*[\n" +
+	"\x16recheck_advisory_locks\x18\x05 \x01(\bR\x14recheckAdvisoryLocks*[\n" +
 	"\x04Mode\x12\x14\n" +
 	"\x10MODE_UNSPECIFIED\x10\x00\x12\x11\n" +
 	"\rMODE_WRITABLE\x10\x01\x12\x13\n" +

--- a/go/services/multipooler/grpcpoolerservice/stream_replication_test.go
+++ b/go/services/multipooler/grpcpoolerservice/stream_replication_test.go
@@ -111,7 +111,9 @@ func dataReq(b string) *multipoolerpb.StreamReplicationRequest {
 func TestStreamReplication_RejectsUnimplementedModes(t *testing.T) {
 	for _, mode := range []multipoolerpb.ReplicationMode{
 		multipoolerpb.ReplicationMode_REPLICATION_MODE_UNSPECIFIED,
-		multipoolerpb.ReplicationMode_REPLICATION_MODE_TRUE,
+		// An unknown/unimplemented mode value (e.g. a future physical-replication
+		// mode) must also be rejected before the handler touches the pooler.
+		multipoolerpb.ReplicationMode(99),
 	} {
 		t.Run(mode.String(), func(t *testing.T) {
 			s := &poolerService{} // nil pooler: mode check must reject before use

--- a/proto/multiadminservice.proto
+++ b/proto/multiadminservice.proto
@@ -399,31 +399,28 @@ message BackupInfo {
   string type = 5;
   // status of the backup
   BackupStatus status = 6;
-  // backup_time is when the backup was created
-  // Deprecated: use start_timestamp/stop_timestamp instead.
-  google.protobuf.Timestamp backup_time = 7 [deprecated = true];
   // backup_size_bytes is the size of the backup in bytes
-  uint64 backup_size_bytes = 8;
+  uint64 backup_size_bytes = 7;
   // multipooler_service_id is the ID of the multipooler that reported the backup
-  string multipooler_service_id = 9;
+  string multipooler_service_id = 8;
   // routing_role is the routing role of the multipooler that created the backup
   // (PRIMARY or REPLICA)
-  clustermetadata.RoutingRole routing_role = 10;
+  clustermetadata.RoutingRole routing_role = 9;
   // start_lsn is the WAL start LSN of the backup (pgbackrest backup[].lsn.start)
-  string start_lsn = 11;
+  string start_lsn = 10;
   // stop_lsn is the WAL stop LSN of the backup (pgbackrest backup[].lsn.stop)
-  string stop_lsn = 12;
+  string stop_lsn = 11;
   // pg_version is the full PostgreSQL server_version the backup was taken from (e.g. "16.2")
-  string pg_version = 13;
+  string pg_version = 12;
   // start_timestamp is when the backup started, from pgbackrest info backup[].timestamp.start.
   // Unset if unknown.
-  google.protobuf.Timestamp start_timestamp = 14;
+  google.protobuf.Timestamp start_timestamp = 13;
   // stop_timestamp is when the backup completed, from pgbackrest info backup[].timestamp.stop.
   // Unset if unknown.
-  google.protobuf.Timestamp stop_timestamp = 15;
+  google.protobuf.Timestamp stop_timestamp = 14;
   // job_id is the multiadmin backup job ID that produced this backup, if known
   // (from the pgbackrest job_id annotation).
-  string job_id = 16;
+  string job_id = 15;
 }
 
 // BackupStatus indicates the state of a backup artifact

--- a/proto/multipoolerservice.proto
+++ b/proto/multipoolerservice.proto
@@ -368,7 +368,6 @@ message CopyBidiExecuteResponse {
 enum ReplicationMode {
   REPLICATION_MODE_UNSPECIFIED = 0;
   REPLICATION_MODE_DATABASE = 1;  // replication=database (logical)
-  REPLICATION_MODE_TRUE = 2;      // replication=true (physical) — reserved, not used in v1
 }
 
 message StreamReplicationInit {
@@ -392,9 +391,6 @@ message StreamReplicationRequest {
     StreamReplicationInit init = 1;  // MUST be the first message
     bytes data = 2;                  // opaque client->server bytes
   }
-  // Reserved for future end-to-end latency measurement; unused in v1.
-  // Carried in the envelope, never inside `data`, to stay protocol-blind.
-  int64 send_unixnano = 3;
 }
 
 message StreamReplicationReady {
@@ -411,7 +407,6 @@ message StreamReplicationResponse {
     bytes data = 2;                    // opaque server->client bytes
     StreamReplicationError error = 3;  // infrastructure error (NOT a PG ErrorResponse)
   }
-  int64 send_unixnano = 4;             // reserved, unused in v1
 }
 
 // ReservationReason indicates why a connection needs to be reserved.

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -380,12 +380,12 @@ message ExecuteOptions {
 
   // max_rows is the maximum number of rows to return from Execute.
   // 0 means return all rows. Used by the Execute message in the extended query protocol.
-  uint64 max_rows = 4;
+  uint64 max_rows = 3;
 
   // reserved_connection_id is the ID of a reserved connection on the multipooler.
   // Used for connection pinning - this tells the multipooler which specific
   // connection to use for executing this query.
-  uint64 reserved_connection_id = 5;
+  uint64 reserved_connection_id = 4;
 
   // user_auth carries SCRAM-SHA-256 passthrough keys captured during the
   // client's authentication handshake at the multigateway. When the
@@ -393,14 +393,14 @@ message ExecuteOptions {
   // authenticate to the backing PostgreSQL as the session's real user
   // instead of relying on trust on the local connection. Unset for
   // sessions that did not authenticate via SCRAM.
-  UserAuth user_auth = 7;
+  UserAuth user_auth = 5;
 
   // client_connection_id is the multigateway's virtual PID for this client
   // connection. The multipooler can register it against the underlying
   // PostgreSQL backend PID so lock-detection functions can map virtual PIDs
   // (visible to clients) back to real backend PIDs without altering the
   // client-visible application_name.
-  uint32 client_connection_id = 8;
+  uint32 client_connection_id = 6;
 
   // execute_sql_prepared_statement, if set, describes a SQL-level EXECUTE
   // wrapper that references a gateway-managed prepared statement. The
@@ -411,9 +411,7 @@ message ExecuteOptions {
   //
   // This field is only consumed by StreamExecute. PortalStreamExecute has its
   // own top-level prepared_statement field.
-  ExecuteSqlPreparedStatement execute_sql_prepared_statement = 9;
-
-  reserved 10, 11;
+  ExecuteSqlPreparedStatement execute_sql_prepared_statement = 7;
 
   // passthrough_row requests opaque row passthrough for this query: the
   // multipooler returns rows as concatenated raw DataRow frames in
@@ -422,7 +420,7 @@ message ExecuteOptions {
   // for straight client pass-through queries and leaves it false for results it
   // must interpret itself (SET, SHOW, catalog rewrites). Defaulting to false
   // keeps non-gateway callers (multiadmin, multiorch) on the structured path.
-  bool passthrough_row = 12;
+  bool passthrough_row = 8;
 }
 
 // UserAuth carries cryptographic material extracted from the client's SCRAM
@@ -490,6 +488,4 @@ message ReservationOptions {
   // pg_try_advisory_lock — or a release), so the probe runs only when it can
   // matter rather than after every query on a pinned connection.
   bool recheck_advisory_locks = 5;
-
-  reserved 6;
 }

--- a/web/multiadmin/lib/api/generated/multiadminservice_pb.ts
+++ b/web/multiadmin/lib/api/generated/multiadminservice_pb.ts
@@ -1346,25 +1346,16 @@ export class BackupInfo extends Message<BackupInfo> {
   status = BackupStatus.UNKNOWN;
 
   /**
-   * backup_time is when the backup was created
-   * Deprecated: use start_timestamp/stop_timestamp instead.
-   *
-   * @generated from field: google.protobuf.Timestamp backup_time = 7 [deprecated = true];
-   * @deprecated
-   */
-  backupTime?: Timestamp;
-
-  /**
    * backup_size_bytes is the size of the backup in bytes
    *
-   * @generated from field: uint64 backup_size_bytes = 8;
+   * @generated from field: uint64 backup_size_bytes = 7;
    */
   backupSizeBytes = protoInt64.zero;
 
   /**
    * multipooler_service_id is the ID of the multipooler that reported the backup
    *
-   * @generated from field: string multipooler_service_id = 9;
+   * @generated from field: string multipooler_service_id = 8;
    */
   multipoolerServiceId = "";
 
@@ -1372,28 +1363,28 @@ export class BackupInfo extends Message<BackupInfo> {
    * routing_role is the routing role of the multipooler that created the backup
    * (PRIMARY or REPLICA)
    *
-   * @generated from field: clustermetadata.RoutingRole routing_role = 10;
+   * @generated from field: clustermetadata.RoutingRole routing_role = 9;
    */
   routingRole = RoutingRole.UNKNOWN;
 
   /**
    * start_lsn is the WAL start LSN of the backup (pgbackrest backup[].lsn.start)
    *
-   * @generated from field: string start_lsn = 11;
+   * @generated from field: string start_lsn = 10;
    */
   startLsn = "";
 
   /**
    * stop_lsn is the WAL stop LSN of the backup (pgbackrest backup[].lsn.stop)
    *
-   * @generated from field: string stop_lsn = 12;
+   * @generated from field: string stop_lsn = 11;
    */
   stopLsn = "";
 
   /**
    * pg_version is the full PostgreSQL server_version the backup was taken from (e.g. "16.2")
    *
-   * @generated from field: string pg_version = 13;
+   * @generated from field: string pg_version = 12;
    */
   pgVersion = "";
 
@@ -1401,7 +1392,7 @@ export class BackupInfo extends Message<BackupInfo> {
    * start_timestamp is when the backup started, from pgbackrest info backup[].timestamp.start.
    * Unset if unknown.
    *
-   * @generated from field: google.protobuf.Timestamp start_timestamp = 14;
+   * @generated from field: google.protobuf.Timestamp start_timestamp = 13;
    */
   startTimestamp?: Timestamp;
 
@@ -1409,7 +1400,7 @@ export class BackupInfo extends Message<BackupInfo> {
    * stop_timestamp is when the backup completed, from pgbackrest info backup[].timestamp.stop.
    * Unset if unknown.
    *
-   * @generated from field: google.protobuf.Timestamp stop_timestamp = 15;
+   * @generated from field: google.protobuf.Timestamp stop_timestamp = 14;
    */
   stopTimestamp?: Timestamp;
 
@@ -1417,7 +1408,7 @@ export class BackupInfo extends Message<BackupInfo> {
    * job_id is the multiadmin backup job ID that produced this backup, if known
    * (from the pgbackrest job_id annotation).
    *
-   * @generated from field: string job_id = 16;
+   * @generated from field: string job_id = 15;
    */
   jobId = "";
 
@@ -1435,16 +1426,15 @@ export class BackupInfo extends Message<BackupInfo> {
     { no: 4, name: "shard", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 5, name: "type", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 6, name: "status", kind: "enum", T: proto3.getEnumType(BackupStatus) },
-    { no: 7, name: "backup_time", kind: "message", T: Timestamp },
-    { no: 8, name: "backup_size_bytes", kind: "scalar", T: 4 /* ScalarType.UINT64 */ },
-    { no: 9, name: "multipooler_service_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 10, name: "routing_role", kind: "enum", T: proto3.getEnumType(RoutingRole) },
-    { no: 11, name: "start_lsn", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 12, name: "stop_lsn", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 13, name: "pg_version", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 14, name: "start_timestamp", kind: "message", T: Timestamp },
-    { no: 15, name: "stop_timestamp", kind: "message", T: Timestamp },
-    { no: 16, name: "job_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 7, name: "backup_size_bytes", kind: "scalar", T: 4 /* ScalarType.UINT64 */ },
+    { no: 8, name: "multipooler_service_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 9, name: "routing_role", kind: "enum", T: proto3.getEnumType(RoutingRole) },
+    { no: 10, name: "start_lsn", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 11, name: "stop_lsn", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 12, name: "pg_version", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 13, name: "start_timestamp", kind: "message", T: Timestamp },
+    { no: 14, name: "stop_timestamp", kind: "message", T: Timestamp },
+    { no: 15, name: "job_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): BackupInfo {


### PR DESCRIPTION
## What

Phase 1a of the pre-MVP protobuf cleanup (MUL-524): remove reserved field numbers and prune dead field definitions so the schema starts from a clean slate before the release freeze, when field churn is still cheap and there are no wire-compatible deployed consumers to protect.

- **query.proto** — drop `reserved 10, 11` (`ExecuteOptions`) and `reserved 6` (`ReservationOptions`), and densely renumber `ExecuteOptions` from `1,2,4,5,7,8,9,12` to `1..8`.
- **multiadminservice.proto** — delete the deprecated `BackupInfo.backup_time` field (already superseded by `start_timestamp`/`stop_timestamp`) and renumber the message to `1..15`.
- **multipoolerservice.proto** — delete the "unused in v1" placeholders: `ReplicationMode.REPLICATION_MODE_TRUE` and both `send_unixnano` fields.

Go and TypeScript bindings are regenerated. The stream-replication test now uses an out-of-range mode value instead of the removed `REPLICATION_MODE_TRUE` constant, preserving its "reject unimplemented mode" coverage.

## Scope decisions

- **Targeted renumber, not a blanket one.** A full gap scan showed most numbering gaps are intentional design — grouped fields in `multiorchdata.PoolerHealthState`, the deliberate `reserved_state = 5` symmetry across the multipooler response messages, and the powers-of-2 `ReservationReason` bitmask. Only the two messages actually edited here (which carry no cross-message constraint) were renumbered; intentional numbering is left untouched.
- **`PoolerType.type` and `DRAINED` are deliberately not removed here.** They were deprecated-in-place specifically to flush out remaining readers, so removal is deferred to a Phase 1b that first confirms no in-repo, operator, or persisted-metadata readers remain.

## Verification

- `go build` of affected packages: OK
- `go test -short ./go/services/multipooler/grpcpoolerservice/... ./go/pb/...`: pass (including the query redact-annotation lock test)
- No remaining references to the removed symbols in hand-written Go or the multiadmin web app

## Note for reviewers

This is an intentionally wire-breaking change, which is safe pre-MVP. It's exactly the kind of change the planned `buf breaking` CI gate (a later phase) is meant to block once the schema is frozen.
