### PR TITLE
feat(multipooler): add logical slot primitives and slot-name helper

### DIFF
--- a/go/services/multipooler/internal/manager/logical_slots.go
+++ b/go/services/multipooler/internal/manager/logical_slots.go
@@ -1,0 +1,271 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/timeouts"
+	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
+
+	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
+)
+
+// ============================================================================
+// Logical Replication Slots
+//
+// This file contains the low-level primitives for managing multigres-owned
+// logical replication slots used by the slot-failover machinery. They run as
+// admin SQL through the same superuser query path (pm.exec / pm.query) used by
+// pg_promote() and ALTER SYSTEM.
+//
+// These primitives are deliberately standalone: nothing in the lifecycle
+// (recruit / SetPrimary / promote / demote) calls them yet. Wiring them in is a
+// later step.
+// ============================================================================
+
+const (
+	// logicalSlotNamePrefix namespaces every multigres-managed replication
+	// slot. Client-created slots never carry it, so a multigres slot can never
+	// collide with one a user made by hand. Mirrors the "multigres"
+	// sidecar-schema convention; replication slot names cannot be
+	// schema-qualified, so the namespacing has to live in the name itself. We
+	// use a short prefix to leave more room for the sanitized pooler name and
+	// potentially avoid hitting PostgreSQL's 63-character slot-name limit,
+	// which would trigger using a hash. In summary, with a short prefix we will
+	// usually get a more readable slot name, and only fall back to a hash when
+	// the pooler name is long or contains characters that need sanitizing.
+	logicalSlotNamePrefix = "mg_"
+
+	// maxReplicationSlotNameLength is PostgreSQL's limit on a replication slot
+	// name (NAMEDATALEN - 1).
+	maxReplicationSlotNameLength = 63
+
+	// logicalSlotStateTimeout bounds the pg_replication_slots reads. These are
+	// cheap catalog lookups on the local instance.
+	logicalSlotStateTimeout = 500 * time.Millisecond
+
+	// logicalSlotWriteTimeout bounds slot creation and drop. Creating a logical
+	// slot has to reach a consistent decoding point, which can wait for a
+	// running-xacts / standby-snapshot record, so it gets a generous bound
+	// rather than the sub-second read timeout.
+	logicalSlotWriteTimeout = timeouts.RemoteOperationTimeout
+)
+
+// ErrLogicalSlotNotFound is returned by GetSlotState when pg_replication_slots
+// has no slot with the requested name.
+var ErrLogicalSlotNotFound = errors.New("logical replication slot not found")
+
+// LogicalSlotState is a projection of a single pg_replication_slots row for a
+// multigres-managed logical slot.
+type LogicalSlotState struct {
+	// The slot's name.
+	Name string
+
+	// CatalogXmin is pg_replication_slots.catalog_xmin (the transaction id whose
+	// catalog rows the slot needs retained), or nil when NULL (e.g. a slot with
+	// no catalog hold). An xid is 32-bit, so int64 holds every value losslessly.
+	// Note that comparing two xids requires modular (wraparound-aware) logic,
+	// not a plain <, per the failover catalog-safety check.
+	CatalogXmin *int64
+
+	// InvalidationReason is pg_replication_slots.invalidation_reason, or nil when
+	// the slot has not been invalidated (the column is NULL).
+	InvalidationReason *string
+
+	// FailoverReady reports whether the slot can safely take over after a
+	// failover: it has been synced to this node, is not temporary, and has not
+	// been invalidated. Computed in SQL as
+	// (synced AND NOT temporary AND invalidation_reason IS NULL).
+	FailoverReady bool
+}
+
+// LogicalSlotName derives the deterministic, cluster-unique name of a
+// multigres-managed logical replication slot from a multipooler component name
+// (already cluster-unique). Pass the bare name — clustermetadata ID.Name — not
+// the "{cell}_{name}" application_name: the cell is not part of the slot name.
+// The result is prefixed with logicalSlotNamePrefix, lower-cased, restricted to
+// PostgreSQL's slot-name charset [a-z0-9_], and capped at
+// maxReplicationSlotNameLength.
+//
+// It returns an error if name contains an underscore. '_' is not a legal
+// character in a multipooler ID.Name — NewReplicaID rejects it because the
+// "{cell}_{name}" application_name uses '_' as its delimiter — so a name
+// carrying one is a violated identity invariant, not a value to sanitize.
+// Erroring here surfaces that bug instead of masking it behind a munged slot
+// name. (It also keeps the transform below collision-free: since '_' cannot
+// reach it, the only rewrite in the injective domain, '-'→'_', can never alias
+// onto a pre-existing '_'.)
+//
+// The transform is collision-free. On the expected input domain — a lower-case
+// [a-z0-9-] name — lower-casing is a no-op and the only rewrite is '-'→'_', so
+// distinct pooler names yield distinct slot names. Characters that are legal in
+// a name but not in a slot name (an upper-case letter that folds to lower case,
+// or a symbol such as '.') make the sanitizing map many-to-one; so does a
+// sanitized name that would exceed the length cap. In those cases a short
+// deterministic hash of the original name is appended (and the body truncated)
+// to keep the mapping collision-free.
+func LogicalSlotName(name string) (string, error) {
+	if strings.Contains(name, "_") {
+		return "", mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
+			"multipooler name %q contains an underscore, which is not a valid ID.Name character", name)
+	}
+
+	lowered := strings.ToLower(name)
+
+	// injective stays true only while every character is in the [a-z0-9-] domain
+	// on which the sanitizing map is one-to-one.
+	injective := name == lowered
+	var b strings.Builder
+	b.Grow(len(lowered))
+	for _, r := range lowered {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+			// A character outside [a-z0-9-] (e.g. '.'); rewriting it to '_' can
+			// alias distinct inputs, so fall back to the hash-disambiguated form
+			// below.
+			if r != '-' {
+				injective = false
+			}
+		}
+	}
+	sanitized := b.String()
+
+	candidate := logicalSlotNamePrefix + sanitized
+	if injective && len(candidate) <= maxReplicationSlotNameLength {
+		return candidate, nil
+	}
+
+	// Non-injective transform or over-length: append a short deterministic hash
+	// of the original name and truncate the sanitized body so the whole name
+	// fits within the length cap.
+	sum := sha256.Sum256([]byte(name))
+	suffix := "_" + hex.EncodeToString(sum[:4]) // '_' + 8 hex chars
+	budget := maxReplicationSlotNameLength - len(logicalSlotNamePrefix) - len(suffix)
+	if len(sanitized) > budget {
+		sanitized = sanitized[:budget]
+	}
+	return logicalSlotNamePrefix + sanitized + suffix, nil
+}
+
+// EnsureLogicalSlot creates the logical replication slot with the given name
+// using the given output plugin, requesting failover-slot behavior when
+// failover is true. It is idempotent: if a slot with that name already exists
+// it returns nil rather than raising duplicate_object.
+//
+// The multipooler is the sole manager of its own slots, so there is no
+// competing writer to race with between the existence check and the create.
+func (pm *MultipoolerManager) EnsureLogicalSlot(ctx context.Context, name, plugin string, failover bool) error {
+	exists, err := pm.LogicalSlotExists(ctx, name)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	execCtx, cancel := context.WithTimeout(ctx, logicalSlotWriteTimeout)
+	defer cancel()
+	// Bind the slot name and plugin as parameters rather than interpolating them
+	// into the statement. temporary=false and twophase=false; failover is
+	// caller-controlled (the PostgreSQL slot-sync flag that lets a standby
+	// maintain a copy of this slot).
+	if err := pm.execArgs(execCtx,
+		"SELECT pg_create_logical_replication_slot($1, $2, false, false, $3)",
+		name, plugin, failover); err != nil {
+		return mterrors.Wrap(err, "failed to create logical replication slot")
+	}
+	return nil
+}
+
+// DropLogicalSlot drops the replication slot named name.
+func (pm *MultipoolerManager) DropLogicalSlot(ctx context.Context, name string) error {
+	execCtx, cancel := context.WithTimeout(ctx, logicalSlotWriteTimeout)
+	defer cancel()
+	// Bind the slot name as a parameter rather than interpolating it.
+	if err := pm.execArgs(execCtx, "SELECT pg_drop_replication_slot($1)", name); err != nil {
+		return mterrors.Wrap(err, "failed to drop replication slot")
+	}
+	return nil
+}
+
+const fetchLogicalSlotStateSQL = `SELECT
+	slot_name,
+	catalog_xmin,
+	invalidation_reason,
+	(synced AND NOT temporary AND invalidation_reason IS NULL) AS failover_ready
+FROM pg_replication_slots
+WHERE slot_name = $1`
+
+// GetSlotState reads the pg_replication_slots row for the slot named name.
+// It returns ErrLogicalSlotNotFound (wrapped) when no such slot exists.
+func (pm *MultipoolerManager) GetSlotState(ctx context.Context, name string) (*LogicalSlotState, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, logicalSlotStateTimeout)
+	defer cancel()
+	// Bind the slot name as a parameter rather than interpolating it.
+	result, err := pm.queryArgs(queryCtx, fetchLogicalSlotStateSQL, name)
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to read replication slot state")
+	}
+	if result.RowCount() == 0 {
+		return nil, mterrors.Wrapf(ErrLogicalSlotNotFound, "slot %q", name)
+	}
+
+	var (
+		slotName           string
+		catalogXmin        *int64
+		invalidationReason *string
+		failoverReady      bool
+	)
+	if err := executor.ScanSingleRow(result, &slotName, &catalogXmin, &invalidationReason, &failoverReady); err != nil {
+		return nil, mterrors.Wrap(err, "failed to scan replication slot state")
+	}
+
+	slotState := &LogicalSlotState{
+		Name:               slotName,
+		CatalogXmin:        catalogXmin,
+		InvalidationReason: invalidationReason,
+		FailoverReady:      failoverReady,
+	}
+	return slotState, nil
+}
+
+// LogicalSlotExists reports whether a replication slot named name is present in
+// pg_replication_slots.
+func (pm *MultipoolerManager) LogicalSlotExists(ctx context.Context, name string) (bool, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, logicalSlotStateTimeout)
+	defer cancel()
+	// Bind the slot name as a parameter rather than interpolating it. SELECT
+	// EXISTS(...) returns exactly one boolean row and lets the planner stop at
+	// the first matching row; it's the existence-check idiom used elsewhere in
+	// this package (see querySchemaExists).
+	result, err := pm.queryArgs(queryCtx, "SELECT EXISTS(SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)", name)
+	if err != nil {
+		return false, mterrors.Wrap(err, "failed to check replication slot existence")
+	}
+	var exists bool
+	if err := executor.ScanSingleRow(result, &exists); err != nil {
+		return false, mterrors.Wrap(err, "failed to scan replication slot existence result")
+	}
+	return exists, nil
+}

--- a/go/services/multipooler/internal/manager/logical_slots_test.go
+++ b/go/services/multipooler/internal/manager/logical_slots_test.go
@@ -1,0 +1,322 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/services/multipooler/internal/executor/mock"
+)
+
+// slotNameCharset matches a fully-sanitized multigres slot name: the fixed
+// prefix followed only by PostgreSQL's legal slot-name characters. Derived from
+// logicalSlotNamePrefix so it tracks the prefix rather than hard-coding it.
+var slotNameCharset = regexp.MustCompile(`^` + regexp.QuoteMeta(logicalSlotNamePrefix) + `[a-z0-9_]*$`)
+
+func TestLogicalSlotName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string // exact expected output; only set for the injective (hash-free) cases
+	}{
+		{
+			name:     "simple name",
+			input:    "replica1",
+			expected: logicalSlotNamePrefix + "replica1",
+		},
+		{
+			name:     "hyphens map to underscores",
+			input:    "replica-1",
+			expected: logicalSlotNamePrefix + "replica_1",
+		},
+		{
+			name:     "multiple hyphens",
+			input:    "us-east-1a-pooler",
+			expected: logicalSlotNamePrefix + "us_east_1a_pooler",
+		},
+		{
+			name:     "digits only",
+			input:    "001",
+			expected: logicalSlotNamePrefix + "001",
+		},
+		{
+			name:     "exactly at the length cap stays verbatim",
+			input:    strings.Repeat("a", maxReplicationSlotNameLength-len(logicalSlotNamePrefix)),
+			expected: logicalSlotNamePrefix + strings.Repeat("a", maxReplicationSlotNameLength-len(logicalSlotNamePrefix)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LogicalSlotName(tt.input)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected, got)
+			assert.True(t, strings.HasPrefix(got, logicalSlotNamePrefix), "must carry the multigres slot-name prefix")
+			assert.Regexp(t, slotNameCharset, got, "must be restricted to [a-z0-9_]")
+			assert.LessOrEqual(t, len(got), maxReplicationSlotNameLength, "must respect the length cap")
+		})
+	}
+}
+
+// TestLogicalSlotName_UnderscoreRejected verifies that an underscore in the name
+// — which NewReplicaID already forbids in an ID.Name — is reported as an error
+// rather than silently sanitized into a slot name.
+func TestLogicalSlotName_UnderscoreRejected(t *testing.T) {
+	for _, input := range []string{"a_b", "_leading", "trailing_", "us_east"} {
+		t.Run(input, func(t *testing.T) {
+			_, err := LogicalSlotName(input)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "underscore")
+		})
+	}
+}
+
+// TestLogicalSlotName_Sanitization covers inputs outside the expected
+// [a-z0-9-] domain: they must still produce a legal, capped name, and because
+// the sanitizing map is lossy for them, a disambiguating hash is appended.
+func TestLogicalSlotName_Sanitization(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "uppercase is folded", input: "Replica-1"},
+		{name: "mixed case", input: "PoolerABC"},
+		{name: "dot separator", input: "pooler.zone"},
+		{name: "over length", input: strings.Repeat("x", 80)},
+		{name: "over length with hyphens", input: strings.Repeat("a-", 40)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LogicalSlotName(tt.input)
+			require.NoError(t, err)
+
+			assert.True(t, strings.HasPrefix(got, logicalSlotNamePrefix), "must carry the multigres slot-name prefix")
+			assert.Regexp(t, slotNameCharset, got, "must be restricted to [a-z0-9_]")
+			assert.LessOrEqual(t, len(got), maxReplicationSlotNameLength, "must respect the length cap")
+
+			// The disambiguating suffix is "_" + 8 hex characters.
+			assert.Regexp(t, regexp.MustCompile(`_[0-9a-f]{8}$`), got, "lossy inputs get a hash suffix")
+
+			// Deterministic: same input always yields the same slot name.
+			again, err := LogicalSlotName(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, got, again)
+		})
+	}
+}
+
+// TestLogicalSlotName_CollisionFree checks that distinct pooler names — both
+// within the injective domain and across the lossy boundary — never map to the
+// same slot name.
+func TestLogicalSlotName_CollisionFree(t *testing.T) {
+	// verbatimBodyMax is the longest sanitized body that still fits under the
+	// length cap without a hash. Computed from the prefix so these cases stay
+	// meaningful regardless of its length.
+	verbatimBodyMax := maxReplicationSlotNameLength - len(logicalSlotNamePrefix)
+
+	inputs := []string{
+		// Injective domain.
+		"replica1",
+		"replica-1",
+		"replica2",
+		"us-east-1a",
+		"us-east-1b",
+		strings.Repeat("a", verbatimBodyMax),   // exactly fits verbatim
+		strings.Repeat("a", verbatimBodyMax+1), // one over -> hashed, body truncated
+		strings.Repeat("a", verbatimBodyMax+9), // far over -> hashed, same truncated body, different original
+		// Lossy inputs that share a sanitized body and would collide without the hash.
+		"abc",
+		"aBc",
+		"AbC",
+		"a-b",
+		"pooler.zone",
+		"pooler-zone",
+	}
+
+	seen := make(map[string]string, len(inputs))
+	for _, in := range inputs {
+		got, err := LogicalSlotName(in)
+		require.NoError(t, err)
+		if prev, dup := seen[got]; dup {
+			t.Fatalf("collision: %q and %q both map to %q", prev, in, got)
+		}
+		seen[got] = in
+	}
+}
+
+func TestEnsureLogicalSlot(t *testing.T) {
+	const (
+		slotName = "multigres_replica_1"
+		plugin   = "pgoutput"
+	)
+
+	t.Run("creates slot when absent", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{false}}))
+		m.AddQueryPatternOnce("pg_create_logical_replication_slot",
+			mock.MakeQueryResult([]string{"slot_name", "lsn"}, [][]any{{slotName, "0/1500000"}}))
+
+		require.NoError(t, pm.EnsureLogicalSlot(t.Context(), slotName, plugin, true))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("idempotent when slot already exists", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		// Only the existence check is registered. If EnsureLogicalSlot tried to
+		// create the slot, the mock would return a no-matching-pattern error.
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{true}}))
+
+		require.NoError(t, pm.EnsureLogicalSlot(t.Context(), slotName, plugin, true))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("propagates existence-check error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnceWithError("SELECT EXISTS", errors.New("boom"))
+
+		err := pm.EnsureLogicalSlot(t.Context(), slotName, plugin, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to check replication slot existence")
+	})
+
+	t.Run("propagates create error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{false}}))
+		m.AddQueryPatternOnceWithError("pg_create_logical_replication_slot", errors.New("boom"))
+
+		err := pm.EnsureLogicalSlot(t.Context(), slotName, plugin, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create logical replication slot")
+	})
+}
+
+func TestDropLogicalSlot(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("pg_drop_replication_slot", mock.MakeQueryResult(nil, nil))
+
+		require.NoError(t, pm.DropLogicalSlot(t.Context(), "multigres_replica_1"))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnceWithError("pg_drop_replication_slot", errors.New("boom"))
+
+		err := pm.DropLogicalSlot(t.Context(), "multigres_replica_1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to drop replication slot")
+	})
+}
+
+func TestGetSlotState(t *testing.T) {
+	const slotName = "multigres_replica_1"
+
+	stateColumns := []string{"slot_name", "catalog_xmin", "invalidation_reason", "failover_ready"}
+
+	t.Run("failover-ready slot", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("failover_ready",
+			mock.MakeQueryResult(stateColumns, [][]any{{slotName, "12345", nil, true}}))
+
+		state, err := pm.GetSlotState(t.Context(), slotName)
+		require.NoError(t, err)
+		assert.Equal(t, slotName, state.Name)
+		require.NotNil(t, state.CatalogXmin)
+		assert.Equal(t, int64(12345), *state.CatalogXmin)
+		assert.Nil(t, state.InvalidationReason)
+		assert.True(t, state.FailoverReady)
+	})
+
+	t.Run("invalidated slot is not failover-ready", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("failover_ready",
+			mock.MakeQueryResult(stateColumns, [][]any{{slotName, "12345", "wal_removed", false}}))
+
+		state, err := pm.GetSlotState(t.Context(), slotName)
+		require.NoError(t, err)
+		require.NotNil(t, state.InvalidationReason)
+		assert.Equal(t, "wal_removed", *state.InvalidationReason)
+		assert.False(t, state.FailoverReady)
+	})
+
+	t.Run("null catalog_xmin", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("failover_ready",
+			mock.MakeQueryResult(stateColumns, [][]any{{slotName, nil, nil, false}}))
+
+		state, err := pm.GetSlotState(t.Context(), slotName)
+		require.NoError(t, err)
+		assert.Nil(t, state.CatalogXmin)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("failover_ready", mock.MakeQueryResult(stateColumns, nil))
+
+		_, err := pm.GetSlotState(t.Context(), slotName)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrLogicalSlotNotFound)
+	})
+
+	t.Run("propagates query error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnceWithError("failover_ready", errors.New("boom"))
+
+		_, err := pm.GetSlotState(t.Context(), slotName)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read replication slot state")
+	})
+}
+
+func TestLogicalSlotExists(t *testing.T) {
+	const slotName = "mg_replica_1"
+
+	t.Run("slot present", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{true}}))
+
+		exists, err := pm.LogicalSlotExists(t.Context(), slotName)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("slot absent", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{false}}))
+
+		exists, err := pm.LogicalSlotExists(t.Context(), slotName)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("propagates query error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnceWithError("SELECT EXISTS", errors.New("boom"))
+
+		_, err := pm.LogicalSlotExists(t.Context(), slotName)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to check replication slot existence")
+	})
+}


### PR DESCRIPTION
## Summary

First of six steps implementing logical replication slot-failover ([MUL-482](https://linear.app/supabase/issue/MUL-482)). This step adds the multipooler-manager slot primitives and the deterministic slot-name helper. It is deliberately dormant: nothing in the lifecycle (recruit / SetPrimary / promote / demote) calls the new code yet, so there is no runtime behaviour change in a running cluster. Later steps wire it in.

Closes [MUL-1316](https://linear.app/supabase/issue/MUL-1316/slot-failover-slot-primitives-and-naming).

## What's included

- `EnsureLogicalSlot(name, plugin, failover)` → `pg_create_logical_replication_slot(...)`, idempotent (checks `pg_replication_slots` first; no error if the slot already exists).
- `DropLogicalSlot(name)`.
- `GetSlotState(name)` — projects a `pg_replication_slots` row into `LogicalSlotState{Name, CatalogXmin *int64, InvalidationReason *string, FailoverReady bool}`, where `FailoverReady` is computed in SQL as `synced AND NOT temporary AND invalidation_reason IS NULL`. Returns a wrapped `ErrLogicalSlotNotFound` when the slot is absent. Nullable columns are surfaced as `nil` rather than a sentinel.
- `LogicalSlotExists(name)` — canonical `SELECT EXISTS(...)` existence check, matching the idiom already used in this package.
- `LogicalSlotName(name)` — derives a deterministic, cluster-unique slot name from the multipooler component name (`ID.Name`, not the `{cell}_{name}` application_name): lower-cased, `-`→`_`, restricted to `[a-z0-9_]`, capped at 63 characters, and prefixed `mg_` so managed slots cannot collide with client-created ones. Returns an error if the name contains `_` (not a valid `ID.Name` character). The transform is collision-free; a short deterministic hash is appended (and the body truncated) only when the input leaves the injective `[a-z0-9-]` domain or would exceed the length cap.

All slot operations run as admin SQL through the pooler's existing superuser query path (the same `pm.exec` / `pm.query` mechanism used for `pg_promote()` and `ALTER SYSTEM`), and bind slot names as query parameters — never string-interpolated.

## Design

Part of the logical slot-failover design, Part 3 §3.2.1 and §3.2.3. The primary creates one slot per follower, named after that follower via `LogicalSlotName`, and each follower independently computes the same name for its `primary_slot_name` — hence `LogicalSlotName` is a standalone helper and the slot operations take the name as a parameter rather than deriving it from the local node's own identity.

## Testing

Unit tests cover the naming helper (sanitization, lower-casing, `-`→`_`, length cap, `mg_` prefix, underscore rejection, and collision-freeness across the injective/lossy boundary) and the slot operations (idempotent create, create-when-absent, drop, state read including NULL `catalog_xmin`/`invalidation_reason` and not-found, and the existence check). Run via the `/mt-dev` skill.
