### PR TITLE
fix(ci): tolerate elapsed-less final test events in coverage reporting

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -91,6 +91,17 @@ jobs:
           name: coverage-direct
           path: coverage-direct.txt
           retention-days: 7
+      # The golang-json reporter below fails the whole job if any test group's
+      # final event lacks an "elapsed" field ("missing elapsed on final test
+      # event"). A complete, all-passing `go test -json` stream can still end a
+      # group on an elapsed-less event (stray async output from the integration
+      # suite attributed to a test after its pass), which turns a green run red
+      # for a purely cosmetic reason. Normalize the stream first so the reporter
+      # never chokes on it; genuine failures are preserved. See the gotestjson
+      # package doc for details.
+      - name: Normalize test results for the reporter
+        if: ${{ !cancelled() }}
+        run: go run ./go/tools/gotestjson/normalize coverage-direct-test-results.jsonl
       - name: Test Report
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: ${{ !cancelled() }}
@@ -169,6 +180,12 @@ jobs:
           name: coverage-subprocess
           path: coverage-subprocess.txt
           retention-days: 7
+      # See the note in coverage-direct: normalize the stream so the reporter
+      # cannot fail the job on an elapsed-less final event while genuine test
+      # failures are preserved.
+      - name: Normalize test results for the reporter
+        if: ${{ !cancelled() }}
+        run: go run ./go/tools/gotestjson/normalize coverage-subprocess-test-results.jsonl
       - name: Test Report
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: ${{ !cancelled() }}

--- a/go/tools/gotestjson/gotestjson.go
+++ b/go/tools/gotestjson/gotestjson.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gotestjson normalizes a `go test -json` event stream so that a
+// downstream test reporter can parse it even when the stream is imperfect.
+//
+// The immediate motivation is dorny/test-reporter's golang-json parser, which
+// groups events by (Package, Test), takes the last event of each group, and
+// fails the whole job with "missing elapsed on final test event" if that last
+// event has no Elapsed field. Only terminal events (pass / fail / skip) carry
+// Elapsed; run / output / pause / cont events do not. So a single test group
+// whose last recorded event is, say, an output line makes the reporter abort —
+// turning an otherwise-green test run red for a purely cosmetic reason.
+//
+// Two real situations produce such a group even when every test actually
+// passed:
+//
+//   - Stray asynchronous output. In the integration suite, background
+//     goroutines and child processes write to stdout/stderr. test2json wraps
+//     that output into an "output" event and attributes it to whichever test
+//     was most recently active. If a line lands in the narrow window after a
+//     test's terminal event but before the next test starts, that test's group
+//     ends on an elapsed-less output event.
+//   - A truncated stream. If the test binary is killed (timeout SIGQUIT, panic,
+//     OOM) mid-test, the terminal event for the in-flight test never arrives and
+//     the final line may even be partial JSON.
+//
+// Normalize repairs both without hiding real failures: it guarantees every
+// output group ends on a terminal event that carries Elapsed, preserving the
+// test's actual result when a real terminal was seen, and marking a test that
+// never reached a terminal as failed (an interrupted test is a failure, not a
+// silent pass). Unparseable lines are dropped so the reporter never chokes on
+// partial JSON from a killed process.
+package gotestjson
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// event captures the subset of `go test -json` fields Normalize reasons about.
+// Elapsed is a pointer so we can distinguish "absent" (run / output / pause /
+// cont events) from a real zero value.
+type event struct {
+	Action  string   `json:"Action"`
+	Package string   `json:"Package"`
+	Test    string   `json:"Test"`
+	Elapsed *float64 `json:"Elapsed"`
+}
+
+// synthetic is a minimal terminal event Normalize appends to close out a group
+// whose last real event lacked Elapsed. It carries exactly the fields the
+// reporter needs: the action determines the reported result and Elapsed
+// satisfies the "final event must have elapsed" contract.
+type synthetic struct {
+	Action  string  `json:"Action"`
+	Package string  `json:"Package"`
+	Test    string  `json:"Test"`
+	Elapsed float64 `json:"Elapsed"`
+}
+
+// groupState tracks, for one (Package, Test) pair, what the reporter would see
+// as the group's final event and what terminal result (if any) the test
+// actually reached.
+type groupState struct {
+	pkg, test      string
+	lastHasElapsed bool    // did the most recent event for this group carry Elapsed?
+	termAction     string  // most recent terminal action (pass/fail/skip); "" if none seen
+	termElapsed    float64 // Elapsed of that terminal event
+}
+
+// Stats reports what Normalize did, for CI logging.
+type Stats struct {
+	Events      int // parseable event lines passed through unchanged
+	Dropped     int // unparseable lines dropped (e.g. a truncated final line)
+	Repaired    int // groups that received a synthetic terminal event
+	Interrupted int // subset of Repaired that never reached a terminal (marked failed)
+}
+
+// isTerminal reports whether an action ends a test: these are the only actions
+// go test emits with an Elapsed field.
+func isTerminal(action string) bool {
+	switch action {
+	case "pass", "fail", "skip":
+		return true
+	default:
+		return false
+	}
+}
+
+// Normalize copies the `go test -json` stream from r to w, passing every
+// parseable line through byte-for-byte, then appends a synthetic terminal
+// event for any (Package, Test) group whose last event lacked Elapsed. See the
+// package doc for the guarantees. It returns after the whole stream is read; an
+// I/O error on r or w is returned, but malformed content never is.
+func Normalize(r io.Reader, w io.Writer) (Stats, error) {
+	var stats Stats
+
+	// Preserve first-seen order so synthetic events are emitted deterministically.
+	order := make([]string, 0)
+	groups := make(map[string]*groupState)
+
+	br := bufio.NewReader(r)
+	bw := bufio.NewWriter(w)
+
+	for {
+		line, readErr := br.ReadString('\n')
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed != "" {
+			var ev event
+			if json.Unmarshal([]byte(trimmed), &ev) != nil {
+				// Not valid JSON — a truncated final line or stray text. Drop it
+				// rather than let the reporter abort on "Invalid JSON".
+				stats.Dropped++
+			} else {
+				// Pass the original line through unchanged so the reporter still
+				// sees every field (Output, Time, ...) exactly as go test wrote it.
+				if _, err := bw.WriteString(trimmed + "\n"); err != nil {
+					return stats, err
+				}
+				stats.Events++
+
+				if ev.Test != "" {
+					key := ev.Package + "\x00" + ev.Test
+					g := groups[key]
+					if g == nil {
+						g = &groupState{pkg: ev.Package, test: ev.Test}
+						groups[key] = g
+						order = append(order, key)
+					}
+					g.lastHasElapsed = ev.Elapsed != nil
+					if isTerminal(ev.Action) && ev.Elapsed != nil {
+						g.termAction = ev.Action
+						g.termElapsed = *ev.Elapsed
+					}
+				}
+			}
+		}
+
+		if readErr != nil {
+			if readErr == io.EOF {
+				break
+			}
+			return stats, readErr
+		}
+	}
+
+	// Close out any group whose last event lacked Elapsed.
+	for _, key := range order {
+		g := groups[key]
+		if g.lastHasElapsed {
+			continue
+		}
+		s := synthetic{Package: g.pkg, Test: g.test}
+		if g.termAction != "" {
+			// The test reached a real terminal earlier; a later event (e.g. stray
+			// output) displaced it as the group's last event. Re-emit the real
+			// result and duration so the reported outcome is unchanged.
+			s.Action = g.termAction
+			s.Elapsed = g.termElapsed
+		} else {
+			// The test never reached a terminal — the stream was interrupted.
+			// Surface it as a failure rather than dropping or silently passing it.
+			s.Action = "fail"
+			s.Elapsed = 0
+			stats.Interrupted++
+		}
+		encoded, err := json.Marshal(s)
+		if err != nil {
+			return stats, err
+		}
+		if _, err := bw.Write(append(encoded, '\n')); err != nil {
+			return stats, err
+		}
+		stats.Repaired++
+	}
+
+	return stats, bw.Flush()
+}
+
+// String renders Stats as a compact one-line summary for CI logs.
+func (s Stats) String() string {
+	return fmt.Sprintf("events=%d dropped=%d repaired=%d interrupted=%d",
+		s.Events, s.Dropped, s.Repaired, s.Interrupted)
+}

--- a/go/tools/gotestjson/gotestjson_test.go
+++ b/go/tools/gotestjson/gotestjson_test.go
@@ -1,0 +1,250 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gotestjson
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dornyMissingElapsedGroup mirrors dorny/test-reporter's golang-json parser:
+// it groups events by "Package/Test", takes each group's LAST event, and the
+// reporter throws "missing elapsed on final test event" when that last event
+// has no Elapsed field. This helper returns the key of the first such group in
+// first-seen order (matching the reporter's insertion-ordered Map), or "" when
+// every group's final event carries Elapsed. It lets these tests assert that a
+// stream that WOULD crash the real reporter no longer does after Normalize —
+// the local reproduction of the CI flake, and the guard against regressing it.
+func dornyMissingElapsedGroup(t *testing.T, jsonl string) string {
+	t.Helper()
+	type rawEvent struct {
+		Package string   `json:"Package"`
+		Test    string   `json:"Test"`
+		Elapsed *float64 `json:"Elapsed"`
+	}
+	order := []string{}
+	last := map[string]*float64{}
+	for line := range strings.SplitSeq(strings.TrimSpace(jsonl), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var e rawEvent
+		require.NoError(t, json.Unmarshal([]byte(line), &e),
+			"dorny would also fail to JSON-parse this line: %q", line)
+		if e.Test == "" {
+			continue // reporter ignores package-level events
+		}
+		key := e.Package + "/" + e.Test
+		if _, seen := last[key]; !seen {
+			order = append(order, key)
+		}
+		last[key] = e.Elapsed
+	}
+	for _, key := range order {
+		if last[key] == nil {
+			return key
+		}
+	}
+	return ""
+}
+
+// lastSyntheticEventFor returns the last event in jsonl for the given package
+// and test, decoded as a generic map, or nil if none.
+func lastSyntheticEventFor(t *testing.T, jsonl, pkg, test string) map[string]any {
+	t.Helper()
+	var found map[string]any
+	for line := range strings.SplitSeq(strings.TrimSpace(jsonl), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &m))
+		if m["Package"] == pkg && m["Test"] == test {
+			found = m
+		}
+	}
+	return found
+}
+
+func normalizeString(t *testing.T, in string) (string, Stats) {
+	t.Helper()
+	var out strings.Builder
+	stats, err := Normalize(strings.NewReader(in), &out)
+	require.NoError(t, err)
+	return out.String(), stats
+}
+
+// TestStrayOutputAfterPass is the exact CI flake: a test passes, then a stray
+// asynchronous output line is attributed to it, so its group's final event has
+// no Elapsed and the reporter aborts. Normalize must re-close the group with
+// the real pass result and its real duration.
+func TestStrayOutputAfterPass(t *testing.T) {
+	in := strings.Join([]string{
+		`{"Action":"run","Package":"pkg","Test":"TestA"}`,
+		`{"Action":"output","Package":"pkg","Test":"TestA","Output":"--- PASS: TestA (0.10s)\n"}`,
+		`{"Action":"pass","Package":"pkg","Test":"TestA","Elapsed":0.1}`,
+		`{"Action":"output","Package":"pkg","Test":"TestA","Output":"pooler-1 terminated with error: exit status 2\n"}`,
+	}, "\n") + "\n"
+
+	// Reproduce: the raw stream would crash the reporter.
+	require.Equal(t, "pkg/TestA", dornyMissingElapsedGroup(t, in),
+		"expected the raw stream to trip the reporter's missing-elapsed check")
+
+	out, stats := normalizeString(t, in)
+
+	// Fix: after normalization the reporter would parse it cleanly.
+	assert.Equal(t, "", dornyMissingElapsedGroup(t, out))
+	assert.Equal(t, 1, stats.Repaired)
+	assert.Equal(t, 0, stats.Interrupted, "a passed test must not be counted as interrupted")
+
+	last := lastSyntheticEventFor(t, out, "pkg", "TestA")
+	require.NotNil(t, last)
+	assert.Equal(t, "pass", last["Action"], "the real pass result must be preserved")
+	assert.Equal(t, 0.1, last["Elapsed"], "the real elapsed must be preserved")
+}
+
+// TestRealFailurePreserved guards the "do not paper over failures" requirement:
+// a genuinely failing test whose group ends on stray output must be re-closed
+// as a failure, never flipped to a pass.
+func TestRealFailurePreserved(t *testing.T) {
+	in := strings.Join([]string{
+		`{"Action":"run","Package":"pkg","Test":"TestB"}`,
+		`{"Action":"output","Package":"pkg","Test":"TestB","Output":"--- FAIL: TestB (0.20s)\n"}`,
+		`{"Action":"fail","Package":"pkg","Test":"TestB","Elapsed":0.2}`,
+		`{"Action":"output","Package":"pkg","Test":"TestB","Output":"stray line after the failure\n"}`,
+	}, "\n") + "\n"
+
+	require.Equal(t, "pkg/TestB", dornyMissingElapsedGroup(t, in))
+
+	out, stats := normalizeString(t, in)
+
+	assert.Equal(t, "", dornyMissingElapsedGroup(t, out))
+	assert.Equal(t, 1, stats.Repaired)
+	last := lastSyntheticEventFor(t, out, "pkg", "TestB")
+	require.NotNil(t, last)
+	assert.Equal(t, "fail", last["Action"], "a real failure must stay a failure")
+	assert.Equal(t, 0.2, last["Elapsed"])
+}
+
+// TestInterruptedTestMarkedFailed covers a stream truncated mid-test (timeout,
+// panic, OOM): the test never reached a terminal event. Normalize must surface
+// it as a failure rather than dropping it or letting it read as a pass.
+func TestInterruptedTestMarkedFailed(t *testing.T) {
+	in := strings.Join([]string{
+		`{"Action":"run","Package":"pkg","Test":"TestC"}`,
+		`{"Action":"output","Package":"pkg","Test":"TestC","Output":"panic: boom\n"}`,
+	}, "\n") + "\n"
+
+	require.Equal(t, "pkg/TestC", dornyMissingElapsedGroup(t, in))
+
+	out, stats := normalizeString(t, in)
+
+	assert.Equal(t, "", dornyMissingElapsedGroup(t, out))
+	assert.Equal(t, 1, stats.Repaired)
+	assert.Equal(t, 1, stats.Interrupted)
+	last := lastSyntheticEventFor(t, out, "pkg", "TestC")
+	require.NotNil(t, last)
+	assert.Equal(t, "fail", last["Action"], "an interrupted test must be surfaced as failed")
+}
+
+// TestTruncatedFinalLineDropped covers a process killed mid-write: the last
+// line is partial JSON. dorny throws "Invalid JSON" on it; Normalize drops it
+// (and still closes out the now-terminal-less group).
+func TestTruncatedFinalLineDropped(t *testing.T) {
+	in := strings.Join([]string{
+		`{"Action":"run","Package":"pkg","Test":"TestD"}`,
+		`{"Action":"output","Package":"pkg","Test":"TestD","Output":"working...\n"}`,
+		`{"Action":"ru`, // truncated: process killed mid-write
+	}, "\n") // deliberately no trailing newline
+
+	out, stats := normalizeString(t, in)
+
+	assert.Equal(t, 1, stats.Dropped)
+	assert.Equal(t, 1, stats.Repaired)
+	assert.Equal(t, 1, stats.Interrupted)
+	// dornyMissingElapsedGroup require.NoError-parses every output line, so its
+	// success also proves the truncated partial line did not survive into output.
+	assert.Equal(t, "", dornyMissingElapsedGroup(t, out))
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		assert.True(t, json.Valid([]byte(line)), "every output line must be valid JSON, got %q", line)
+	}
+}
+
+// TestCleanStreamUnchanged: a well-formed all-terminal stream needs no repair
+// and passes through unchanged (aside from a normalized trailing newline).
+func TestCleanStreamUnchanged(t *testing.T) {
+	lines := []string{
+		`{"Action":"run","Package":"pkg","Test":"TestOK"}`,
+		`{"Action":"output","Package":"pkg","Test":"TestOK","Output":"--- PASS: TestOK (0.01s)\n"}`,
+		`{"Action":"pass","Package":"pkg","Test":"TestOK","Elapsed":0.01}`,
+		`{"Action":"output","Package":"pkg","Output":"ok  \tpkg\t0.02s\n"}`,
+		`{"Action":"pass","Package":"pkg","Elapsed":0.02}`,
+	}
+	in := strings.Join(lines, "\n") + "\n"
+
+	require.Equal(t, "", dornyMissingElapsedGroup(t, in), "clean stream should already be fine")
+
+	out, stats := normalizeString(t, in)
+
+	assert.Equal(t, 0, stats.Repaired)
+	assert.Equal(t, 0, stats.Dropped)
+	assert.Equal(t, len(lines), stats.Events)
+	assert.Equal(t, in, out, "a clean stream must pass through byte-for-byte")
+}
+
+// TestPackageLevelEventsIgnored: events without a Test field are package-level
+// and must not spawn synthetic per-test events.
+func TestPackageLevelEventsIgnored(t *testing.T) {
+	in := strings.Join([]string{
+		`{"Action":"start","Package":"pkg"}`,
+		`{"Action":"output","Package":"pkg","Output":"some package output\n"}`,
+		`{"Action":"pass","Package":"pkg","Elapsed":0.42}`,
+	}, "\n") + "\n"
+
+	out, stats := normalizeString(t, in)
+
+	assert.Equal(t, 0, stats.Repaired)
+	assert.Equal(t, in, out)
+}
+
+// TestMultipleGroupsMixedOutcomes exercises all three group shapes in one
+// stream, and checks synthetic events are appended in first-seen order.
+func TestMultipleGroupsMixedOutcomes(t *testing.T) {
+	in := strings.Join([]string{
+		`{"Action":"run","Package":"pkg","Test":"TestPass"}`,
+		`{"Action":"pass","Package":"pkg","Test":"TestPass","Elapsed":0.1}`,
+		`{"Action":"output","Package":"pkg","Test":"TestPass","Output":"stray\n"}`,
+		`{"Action":"run","Package":"pkg","Test":"TestInterrupted"}`,
+		`{"Action":"output","Package":"pkg","Test":"TestInterrupted","Output":"hang\n"}`,
+	}, "\n") + "\n"
+
+	out, stats := normalizeString(t, in)
+
+	assert.Equal(t, 2, stats.Repaired)
+	assert.Equal(t, 1, stats.Interrupted)
+	assert.Equal(t, "", dornyMissingElapsedGroup(t, out))
+
+	// Synthetic events are appended after the original stream, TestPass before
+	// TestInterrupted (first-seen order).
+	idxPass := strings.LastIndex(out, `"Test":"TestPass"`)
+	idxInterrupted := strings.LastIndex(out, `"Test":"TestInterrupted"`)
+	assert.Less(t, idxPass, idxInterrupted, "synthetic events should follow first-seen order")
+}

--- a/go/tools/gotestjson/normalize/main.go
+++ b/go/tools/gotestjson/normalize/main.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command normalize repairs a `go test -json` JSONL file so the CI test
+// reporter (dorny/test-reporter, golang-json) can parse it even when a test
+// group's final event lacks an Elapsed field. See the gotestjson package doc
+// for the why and the exact guarantees.
+//
+// Usage:
+//
+//	normalize FILE [FILE...]   # rewrite each file in place
+//	normalize                  # read stdin, write stdout
+//
+// It is deliberately tolerant: a missing input file is reported and skipped
+// (exit 0) rather than failing the job, matching the timing-summary tool, so a
+// not-yet-created results file never turns a green run red. Repaired groups
+// that never reached a terminal (an interrupted/killed test) are surfaced as a
+// GitHub Actions warning but do not, on their own, fail this step — the test
+// run's own exit code is what gates the job.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/multigres/multigres/go/tools/gotestjson"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1) //nolint:forbidigo // os.Exit is fine in main()
+	}
+}
+
+func run(args []string) error {
+	if len(args) == 0 {
+		stats, err := gotestjson.Normalize(os.Stdin, os.Stdout)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "normalized stdin: %s\n", stats)
+		return nil
+	}
+	for _, path := range args {
+		if err := normalizeFile(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// normalizeFile rewrites path in place. It writes the normalized output to a
+// temporary file in the same directory and atomically renames it over the
+// original, so a crash mid-write can never leave a half-written results file.
+func normalizeFile(path string) error {
+	// #nosec G703 -- path is a CI-controlled argument (this tool's own workflow
+	// invocations), not external/untrusted input.
+	in, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "No %s found — skipping normalization\n", path)
+			return nil
+		}
+		return err
+	}
+	defer in.Close()
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".norm-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op after a successful rename
+
+	stats, err := gotestjson.Normalize(in, tmp)
+	if err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := in.Close(); err != nil {
+		return err
+	}
+	// #nosec G703 -- path is a CI-controlled argument (this tool's own workflow
+	// invocations), not external/untrusted input.
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "normalized %s: %s\n", path, stats)
+	if stats.Interrupted > 0 {
+		// A test that never reached a terminal event means the stream was
+		// interrupted (timeout, panic, OOM). Make it visible; the failing test
+		// run itself is what fails the job.
+		fmt.Printf("::warning::%s: %d test(s) had no terminal event and were marked failed (interrupted stream)\n",
+			path, stats.Interrupted)
+	}
+	return nil
+}


### PR DESCRIPTION
## Problem

The **Code Coverage** jobs (`Direct test coverage` and `Subprocess coverage`) flake intermittently across PRs, failing a run in which every test actually passed. The failure is always the same, and it comes from the reporting step — not the tests:

```
Error: missing elapsed on final test event
Processing test results from coverage-direct-test-results.jsonl failed
```

These jobs pipe `go test -json` to a `*-test-results.jsonl` file and hand it to `dorny/test-reporter`'s `golang-json` parser. That parser groups events by `(Package, Test)`, takes each group's **last** event, and aborts the whole job if that event has no `elapsed` field. Only terminal events (`pass`/`fail`/`skip`) carry `elapsed`; `run`/`output`/`pause`/`cont` events do not.

A complete, all-passing stream can still end a group on an elapsed-less event. In the integration suite, background goroutines and child processes write directly to stdout/stderr; `test2json` wraps that stray output into an `output` event and attributes it to whichever test was most recently active. When a line lands in the narrow window *after* a test's terminal event but *before* the next test starts, that test's group ends on an `output` event — and the reporter throws. A killed test binary (timeout `SIGQUIT`, panic, OOM) produces the same shape via a truncated stream. This is why a green run turns red for a purely cosmetic reason, and why only the coverage jobs are affected: they consume raw `go test -json`, whereas the `gotestsum`-based jobs (`test-short`, `test-race`, `test-integration`) do not.

In the run that prompted this (PR #1365, job `Direct test coverage`), all packages reported `ok` and the go-test step succeeded; the job failed solely because the reporter choked on one such group.

## Fix

Add `go/tools/gotestjson.Normalize` and a thin `normalize` CLI, and run it over each results file *before* the reporter step in both coverage jobs. `Normalize` guarantees every `(Package, Test)` group ends on a terminal event that carries `elapsed`, **without hiding real failures**:

- If the group already reached a real terminal earlier (a later stray line displaced it as the last event), it re-emits that real result and duration — a passed test stays a pass, a failed test stays a fail.
- If the group never reached a terminal (interrupted/truncated stream), it appends a synthetic `fail` — an interrupted test is surfaced as a failure, not a silent pass.
- Unparseable trailing lines from a killed process are dropped so the reporter never hits `Invalid JSON`.

The reporter step keeps gating nothing on its own; the go-test step's exit code (with its existing whole-suite retry) is still what fails the job on a genuine test failure. An interrupted-stream repair also emits a `::warning::` so it stays visible.

No new GitHub Actions are introduced (the step is a `go run` of in-repo tooling), and job permissions are unchanged.

## Testing

- `go/tools/gotestjson/gotestjson_test.go` mirrors dorny's exact grouping check to **reproduce the crash on the raw stream and confirm it is gone after normalization**, and covers: stray-output-after-pass (pass preserved), a real failure followed by stray output (failure preserved), an interrupted test (marked failed), a truncated final line (dropped), a clean stream (byte-for-byte unchanged), and package-level events (ignored).
- Verified end to end with the `normalize` CLI against a crafted results file matching the CI shape: before, the reporter's contract is violated on the passing test's group; after, it parses cleanly with the pass preserved and a sibling failing test still reported as failed.
- `golangci-lint` clean; `gofmt`/`gofumpt` clean.

## Notes

The same `golang-json` reporter is used by several other workflows; they use `gotestsum` output and have not shown this flake, so this PR intentionally scopes the change to the two coverage jobs where it recurs. The normalizer is reusable if we want to extend it later.

Tracked in Linear (project MUL).
