### PR TITLE
feat(query-serving): chunk large DataRows across gRPC frames

### DIFF
--- a/go/common/pgprotocol/client/extended.go
+++ b/go/common/pgprotocol/client/extended.go
@@ -451,7 +451,7 @@ func (c *Conn) processExecuteResponses(ctx context.Context, callback func(ctx co
 	}
 
 	for {
-		msgType, body, streamed, err := c.readBatchMessage(batcher, flushBatch)
+		msgType, body, dataRowStreamed, err := c.readQueryResponseMessage(batcher, flushBatch)
 		if err != nil {
 			return false, responseReadError(firstErr, err)
 		}
@@ -469,7 +469,7 @@ func (c *Conn) processExecuteResponses(ctx context.Context, callback func(ctx co
 			}
 
 		case protocol.MsgDataRow:
-			if streamed {
+			if dataRowStreamed {
 				break
 			}
 			if err := batcher.addDataRow(body); err != nil {
@@ -854,7 +854,7 @@ func (c *Conn) processBindAndExecuteResponses(ctx context.Context, callback func
 	}
 
 	for {
-		msgType, body, streamed, err := c.readBatchMessage(batcher, flushBatch)
+		msgType, body, dataRowStreamed, err := c.readQueryResponseMessage(batcher, flushBatch)
 		if err != nil {
 			return false, responseReadError(firstErr, err)
 		}
@@ -875,7 +875,7 @@ func (c *Conn) processBindAndExecuteResponses(ctx context.Context, callback func
 			}
 
 		case protocol.MsgDataRow:
-			if streamed {
+			if dataRowStreamed {
 				break
 			}
 			if err := batcher.addDataRow(body); err != nil {
@@ -1064,7 +1064,7 @@ func (c *Conn) processPrepareAndExecuteResponses(ctx context.Context, callback f
 	}
 
 	for {
-		msgType, body, streamed, err := c.readBatchMessage(batcher, flushBatch)
+		msgType, body, dataRowStreamed, err := c.readQueryResponseMessage(batcher, flushBatch)
 		if err != nil {
 			return responseReadError(firstErr, err)
 		}
@@ -1088,7 +1088,7 @@ func (c *Conn) processPrepareAndExecuteResponses(ctx context.Context, callback f
 			}
 
 		case protocol.MsgDataRow:
-			if streamed {
+			if dataRowStreamed {
 				break
 			}
 			if err := batcher.addDataRow(body); err != nil {
@@ -1185,7 +1185,7 @@ func (c *Conn) processBindDescribeAndExecuteResponses(ctx context.Context, callb
 	}
 
 	for {
-		msgType, body, streamed, err := c.readBatchMessage(batcher, flushBatch)
+		msgType, body, dataRowStreamed, err := c.readQueryResponseMessage(batcher, flushBatch)
 		if err != nil {
 			return false, responseReadError(firstErr, err)
 		}
@@ -1208,7 +1208,7 @@ func (c *Conn) processBindDescribeAndExecuteResponses(ctx context.Context, callb
 			// No fields — batcher.fields stays nil.
 
 		case protocol.MsgDataRow:
-			if streamed {
+			if dataRowStreamed {
 				break
 			}
 			if err := batcher.addDataRow(body); err != nil {

--- a/go/common/pgprotocol/client/extended.go
+++ b/go/common/pgprotocol/client/extended.go
@@ -445,16 +445,13 @@ func (c *Conn) processExecuteResponses(ctx context.Context, callback func(ctx co
 
 	// flushBatch sends accumulated rows via callback and resets the batch.
 	flushBatch := func() {
-		if callback == nil {
-			return
-		}
-		if result := batcher.flush(); result != nil && firstErr == nil {
+		if result := batcher.flush(); result != nil && callback != nil && firstErr == nil {
 			firstErr = callback(ctx, result)
 		}
 	}
 
 	for {
-		msgType, body, err := c.readMessage()
+		msgType, body, streamed, err := c.readBatchMessage(batcher, flushBatch)
 		if err != nil {
 			return false, responseReadError(firstErr, err)
 		}
@@ -472,6 +469,9 @@ func (c *Conn) processExecuteResponses(ctx context.Context, callback func(ctx co
 			}
 
 		case protocol.MsgDataRow:
+			if streamed {
+				break
+			}
 			if err := batcher.addDataRow(body); err != nil {
 				if firstErr == nil {
 					firstErr = err
@@ -848,16 +848,13 @@ func (c *Conn) processBindAndExecuteResponses(ctx context.Context, callback func
 
 	// flushBatch sends accumulated rows via callback and resets the batch.
 	flushBatch := func() {
-		if callback == nil {
-			return
-		}
-		if result := batcher.flush(); result != nil && firstErr == nil {
+		if result := batcher.flush(); result != nil && callback != nil && firstErr == nil {
 			firstErr = callback(ctx, result)
 		}
 	}
 
 	for {
-		msgType, body, err := c.readMessage()
+		msgType, body, streamed, err := c.readBatchMessage(batcher, flushBatch)
 		if err != nil {
 			return false, responseReadError(firstErr, err)
 		}
@@ -878,6 +875,9 @@ func (c *Conn) processBindAndExecuteResponses(ctx context.Context, callback func
 			}
 
 		case protocol.MsgDataRow:
+			if streamed {
+				break
+			}
 			if err := batcher.addDataRow(body); err != nil {
 				if firstErr == nil {
 					firstErr = err
@@ -1058,16 +1058,13 @@ func (c *Conn) processPrepareAndExecuteResponses(ctx context.Context, callback f
 
 	// flushBatch sends accumulated rows via callback and resets the batch.
 	flushBatch := func() {
-		if callback == nil {
-			return
-		}
-		if result := batcher.flush(); result != nil && firstErr == nil {
+		if result := batcher.flush(); result != nil && callback != nil && firstErr == nil {
 			firstErr = callback(ctx, result)
 		}
 	}
 
 	for {
-		msgType, body, err := c.readMessage()
+		msgType, body, streamed, err := c.readBatchMessage(batcher, flushBatch)
 		if err != nil {
 			return responseReadError(firstErr, err)
 		}
@@ -1091,6 +1088,9 @@ func (c *Conn) processPrepareAndExecuteResponses(ctx context.Context, callback f
 			}
 
 		case protocol.MsgDataRow:
+			if streamed {
+				break
+			}
 			if err := batcher.addDataRow(body); err != nil {
 				if firstErr == nil {
 					firstErr = err
@@ -1179,16 +1179,13 @@ func (c *Conn) processBindDescribeAndExecuteResponses(ctx context.Context, callb
 	completed := false
 
 	flushBatch := func() {
-		if callback == nil {
-			return
-		}
-		if result := batcher.flush(); result != nil && firstErr == nil {
+		if result := batcher.flush(); result != nil && callback != nil && firstErr == nil {
 			firstErr = callback(ctx, result)
 		}
 	}
 
 	for {
-		msgType, body, err := c.readMessage()
+		msgType, body, streamed, err := c.readBatchMessage(batcher, flushBatch)
 		if err != nil {
 			return false, responseReadError(firstErr, err)
 		}
@@ -1211,6 +1208,9 @@ func (c *Conn) processBindDescribeAndExecuteResponses(ctx context.Context, callb
 			// No fields — batcher.fields stays nil.
 
 		case protocol.MsgDataRow:
+			if streamed {
+				break
+			}
 			if err := batcher.addDataRow(body); err != nil {
 				if firstErr == nil {
 					firstErr = err

--- a/go/common/pgprotocol/client/opaque_response_test.go
+++ b/go/common/pgprotocol/client/opaque_response_test.go
@@ -159,6 +159,26 @@ func TestProcessResponseLoops(t *testing.T) {
 				if opaque {
 					assert.Equal(t, 2, passthroughRows, "both rows delivered opaquely")
 					assert.Zero(t, structRows, "opaque mode must not parse structured rows")
+
+					var blocks [][]byte
+					var sawRowFragment bool
+					for _, r := range *got {
+						if len(r.PassthroughBlock) == 0 {
+							continue
+						}
+						blocks = append(blocks, r.PassthroughBlock)
+						assert.LessOrEqual(t, len(r.PassthroughBlock), DefaultStreamingBatchSize,
+							"every opaque result must remain bounded")
+						if r.PassthroughRowCount == 0 {
+							sawRowFragment = true
+						}
+					}
+					expected := appendRawDataRow(nil, dataRowBody(bigValue))
+					expected = appendRawDataRow(expected, dataRowBody("small"))
+					assert.Equal(t, expected, bytes.Join(blocks, nil),
+						"concatenating chunks must reconstruct the exact DataRow stream")
+					assert.True(t, sawRowFragment,
+						"a row larger than the batch size must produce an intermediate zero-count fragment")
 				} else {
 					assert.Equal(t, 2, structRows, "both rows delivered structured")
 					assert.Zero(t, passthroughRows, "structured mode must not produce opaque blocks")

--- a/go/common/pgprotocol/client/opaque_response_test.go
+++ b/go/common/pgprotocol/client/opaque_response_test.go
@@ -171,6 +171,11 @@ func TestProcessResponseLoops(t *testing.T) {
 							"every opaque result must remain bounded")
 						if r.PassthroughRowCount == 0 {
 							sawRowFragment = true
+							assert.True(t, r.PassthroughRowInProgress,
+								"an intermediate fragment must mark the DataRow incomplete")
+						} else {
+							assert.False(t, r.PassthroughRowInProgress,
+								"a block that completes the oversized row must restore a frame boundary")
 						}
 					}
 					expected := appendRawDataRow(nil, dataRowBody(bigValue))

--- a/go/common/pgprotocol/client/packet.go
+++ b/go/common/pgprotocol/client/packet.go
@@ -98,12 +98,7 @@ func (c *Conn) returnOutboundBuffer() {
 
 // readMessage reads a complete message (type, length, body).
 func (c *Conn) readMessage() (byte, []byte, error) {
-	msgType, err := c.readMessageType()
-	if err != nil {
-		return 0, nil, err
-	}
-
-	bodyLen, err := c.readMessageLength()
+	msgType, bodyLen, err := c.readMessageHeader()
 	if err != nil {
 		return 0, nil, err
 	}
@@ -114,6 +109,23 @@ func (c *Conn) readMessage() (byte, []byte, error) {
 	}
 
 	return msgType, body, nil
+}
+
+// readMessageHeader reads a PostgreSQL message's type and length, leaving the
+// reader positioned at the first byte of the message body. Keeping this split
+// from readMessageBody lets callers stream large opaque message bodies without
+// first allocating a buffer for the complete message.
+func (c *Conn) readMessageHeader() (byte, int, error) {
+	msgType, err := c.readMessageType()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	bodyLen, err := c.readMessageLength()
+	if err != nil {
+		return 0, 0, err
+	}
+	return msgType, bodyLen, nil
 }
 
 // ReadRawMessage reads a single protocol message (type byte + body).

--- a/go/common/pgprotocol/client/query.go
+++ b/go/common/pgprotocol/client/query.go
@@ -265,12 +265,13 @@ func appendRawDataRow(dst, body []byte) []byte {
 // It centralizes the batching that every response loop shares so opaque handling
 // lives in one place rather than being copied per loop.
 type resultBatcher struct {
-	c      *Conn
-	fields []*query.Field
-	rows   []*sqltypes.Row
-	raw    []byte
-	rawN   int
-	size   int
+	c                *Conn
+	fields           []*query.Field
+	rows             []*sqltypes.Row
+	raw              []byte
+	rawN             int
+	rawRowInProgress bool
+	size             int
 }
 
 // addDataRow accumulates one DataRow message body. Returns any parse error
@@ -334,6 +335,7 @@ func (b *resultBatcher) streamPassthroughDataRow(bodyLen int, flush func()) erro
 	// field and excludes the one-byte message type.
 	b.raw = append(b.raw, protocol.MsgDataRow)
 	b.raw = binary.BigEndian.AppendUint32(b.raw, uint32(bodyLen+4))
+	b.rawRowInProgress = true
 	b.size += protocol.MessageHeaderSize
 
 	remaining := bodyLen
@@ -353,6 +355,7 @@ func (b *resultBatcher) streamPassthroughDataRow(bodyLen int, flush func()) erro
 
 		if remaining == 0 {
 			b.rawN++
+			b.rawRowInProgress = false
 		}
 		if b.size >= DefaultStreamingBatchSize || remaining == 0 {
 			flush()
@@ -395,7 +398,10 @@ func (b *resultBatcher) flush() *sqltypes.Result {
 		if len(b.raw) == 0 {
 			return nil
 		}
-		r = &sqltypes.Result{Fields: b.fields, PassthroughBlock: b.raw, PassthroughRowCount: b.rawN}
+		r = &sqltypes.Result{
+			Fields: b.fields, PassthroughBlock: b.raw, PassthroughRowCount: b.rawN,
+			PassthroughRowInProgress: b.rawRowInProgress,
+		}
 		b.raw = nil
 		b.rawN = 0
 	} else {
@@ -416,6 +422,7 @@ func (b *resultBatcher) final(tag string) *sqltypes.Result {
 	if b.c.passthroughRow.Load() {
 		r.PassthroughBlock = b.raw
 		r.PassthroughRowCount = b.rawN
+		r.PassthroughRowInProgress = b.rawRowInProgress
 	} else {
 		r.Rows = b.rows
 	}
@@ -423,6 +430,7 @@ func (b *resultBatcher) final(tag string) *sqltypes.Result {
 	b.rows = nil
 	b.raw = nil
 	b.rawN = 0
+	b.rawRowInProgress = false
 	b.size = 0
 	return r
 }

--- a/go/common/pgprotocol/client/query.go
+++ b/go/common/pgprotocol/client/query.go
@@ -17,7 +17,9 @@ package client
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"maps"
 	"strconv"
@@ -288,6 +290,95 @@ func (b *resultBatcher) addDataRow(body []byte) error {
 	return nil
 }
 
+// streamPassthroughDataRow reads a DataRow body directly into bounded raw
+// batches. The original PostgreSQL frame header is included in the byte stream,
+// but an individual Result may begin or end in the middle of that frame. The
+// row is counted on the batch containing its final byte.
+func (b *resultBatcher) streamPassthroughDataRow(bodyLen int, flush func()) error {
+	if !b.c.passthroughRow.Load() {
+		return errors.New("streamPassthroughDataRow called with passthrough disabled")
+	}
+
+	frameLen := bodyLen + 5
+	if frameLen <= DefaultStreamingBatchSize {
+		// Preserve complete small rows and the existing multi-row batching
+		// behavior. Flush first when this row would cross the boundary.
+		if b.size > 0 && b.size+frameLen > DefaultStreamingBatchSize {
+			flush()
+		}
+		b.raw = append(b.raw, protocol.MsgDataRow)
+		b.raw = binary.BigEndian.AppendUint32(b.raw, uint32(bodyLen+4))
+		start := len(b.raw)
+		b.raw = append(b.raw, make([]byte, bodyLen)...)
+		if _, err := io.ReadFull(b.c.bufferedReader, b.raw[start:]); err != nil {
+			return err
+		}
+		b.size += frameLen
+		b.rawN++
+		if b.size >= DefaultStreamingBatchSize {
+			flush()
+		}
+		return nil
+	}
+
+	// Keep complete rows already accumulated in their own block. All blocks
+	// below belong exclusively to this oversized row, which makes zero-count
+	// intermediate fragments unambiguous and preserves row boundaries for the
+	// ordinary batching path.
+	if b.size > 0 {
+		flush()
+	}
+
+	// Preserve the exact PostgreSQL DataRow frame header stripped by the normal
+	// message reader. A PostgreSQL message length includes its four-byte length
+	// field and excludes the one-byte message type.
+	b.raw = append(b.raw, protocol.MsgDataRow)
+	b.raw = binary.BigEndian.AppendUint32(b.raw, uint32(bodyLen+4))
+	b.size += 5
+
+	remaining := bodyLen
+	for remaining > 0 {
+		if b.size >= DefaultStreamingBatchSize {
+			flush()
+		}
+
+		chunkLen := min(remaining, DefaultStreamingBatchSize-b.size)
+		start := len(b.raw)
+		b.raw = append(b.raw, make([]byte, chunkLen)...)
+		if _, err := io.ReadFull(b.c.bufferedReader, b.raw[start:]); err != nil {
+			return err
+		}
+		b.size += chunkLen
+		remaining -= chunkLen
+
+		if remaining == 0 {
+			b.rawN++
+		}
+		if b.size >= DefaultStreamingBatchSize || remaining == 0 {
+			flush()
+		}
+	}
+	return nil
+}
+
+// readBatchMessage reads the next response message. In opaque passthrough mode
+// DataRows are consumed incrementally and may invoke flush multiple times;
+// other message types retain the complete-body behavior required by parsers.
+func (c *Conn) readBatchMessage(b *resultBatcher, flush func()) (msgType byte, body []byte, streamed bool, err error) {
+	msgType, bodyLen, err := c.readMessageHeader()
+	if err != nil {
+		return 0, nil, false, err
+	}
+	if msgType == protocol.MsgDataRow && c.passthroughRow.Load() {
+		if err := b.streamPassthroughDataRow(bodyLen, flush); err != nil {
+			return 0, nil, false, err
+		}
+		return msgType, nil, true, nil
+	}
+	body, err = c.readMessageBody(bodyLen)
+	return msgType, body, false, err
+}
+
 // overThreshold reports whether the accumulated batch has reached the streaming
 // flush size.
 func (b *resultBatcher) overThreshold() bool { return b.size >= DefaultStreamingBatchSize }
@@ -297,7 +388,7 @@ func (b *resultBatcher) overThreshold() bool { return b.size >= DefaultStreaming
 func (b *resultBatcher) flush() *sqltypes.Result {
 	var r *sqltypes.Result
 	if b.c.passthroughRow.Load() {
-		if b.rawN == 0 {
+		if len(b.raw) == 0 {
 			return nil
 		}
 		r = &sqltypes.Result{Fields: b.fields, PassthroughBlock: b.raw, PassthroughRowCount: b.rawN}
@@ -353,17 +444,14 @@ func (c *Conn) processQueryResponses(ctx context.Context, callback func(ctx cont
 	// flushBatch sends accumulated rows via callback and resets the batch.
 	// Does not reset fields as they may be needed for subsequent batches.
 	flushBatch := func() {
-		if callback == nil {
-			return
-		}
-		if result := batcher.flush(); result != nil && firstErr == nil {
+		if result := batcher.flush(); result != nil && callback != nil && firstErr == nil {
 			firstErr = callback(ctx, result)
 		}
 	}
 
 	for {
 		// Read message.
-		msgType, body, err := c.readMessage()
+		msgType, body, streamed, err := c.readBatchMessage(batcher, flushBatch)
 		if err != nil {
 			return responseReadError(firstErr, err)
 		}
@@ -381,6 +469,9 @@ func (c *Conn) processQueryResponses(ctx context.Context, callback func(ctx cont
 			batcher.fields = fields
 
 		case protocol.MsgDataRow:
+			if streamed {
+				break
+			}
 			// Accumulate via the shared batcher. A parse failure (structured
 			// mode only) means the stream is desynced; stop immediately.
 			if err := batcher.addDataRow(body); err != nil {

--- a/go/common/pgprotocol/client/query.go
+++ b/go/common/pgprotocol/client/query.go
@@ -299,7 +299,7 @@ func (b *resultBatcher) streamPassthroughDataRow(bodyLen int, flush func()) erro
 		return errors.New("streamPassthroughDataRow called with passthrough disabled")
 	}
 
-	frameLen := bodyLen + 5
+	frameLen := bodyLen + protocol.MessageHeaderSize
 	if frameLen <= DefaultStreamingBatchSize {
 		// Preserve complete small rows and the existing multi-row batching
 		// behavior. Flush first when this row would cross the boundary.
@@ -334,7 +334,7 @@ func (b *resultBatcher) streamPassthroughDataRow(bodyLen int, flush func()) erro
 	// field and excludes the one-byte message type.
 	b.raw = append(b.raw, protocol.MsgDataRow)
 	b.raw = binary.BigEndian.AppendUint32(b.raw, uint32(bodyLen+4))
-	b.size += 5
+	b.size += protocol.MessageHeaderSize
 
 	remaining := bodyLen
 	for remaining > 0 {

--- a/go/common/pgprotocol/client/query.go
+++ b/go/common/pgprotocol/client/query.go
@@ -361,10 +361,12 @@ func (b *resultBatcher) streamPassthroughDataRow(bodyLen int, flush func()) erro
 	return nil
 }
 
-// readBatchMessage reads the next response message. In opaque passthrough mode
-// DataRows are consumed incrementally and may invoke flush multiple times;
-// other message types retain the complete-body behavior required by parsers.
-func (c *Conn) readBatchMessage(b *resultBatcher, flush func()) (msgType byte, body []byte, streamed bool, err error) {
+// readQueryResponseMessage reads the next query response message. In opaque
+// passthrough mode DataRows are consumed incrementally and may invoke flush
+// multiple times; other message types retain the complete-body behavior
+// required by parsers. dataRowStreamed reports that the DataRow body was
+// already consumed and delivered, so callers must not pass body to addDataRow.
+func (c *Conn) readQueryResponseMessage(b *resultBatcher, flush func()) (msgType byte, body []byte, dataRowStreamed bool, err error) {
 	msgType, bodyLen, err := c.readMessageHeader()
 	if err != nil {
 		return 0, nil, false, err
@@ -388,6 +390,8 @@ func (b *resultBatcher) overThreshold() bool { return b.size >= DefaultStreaming
 func (b *resultBatcher) flush() *sqltypes.Result {
 	var r *sqltypes.Result
 	if b.c.passthroughRow.Load() {
+		// A fragmented DataRow may have bytes with rawN == 0, so check the
+		// byte buffer rather than the completed-row count.
 		if len(b.raw) == 0 {
 			return nil
 		}
@@ -451,7 +455,7 @@ func (c *Conn) processQueryResponses(ctx context.Context, callback func(ctx cont
 
 	for {
 		// Read message.
-		msgType, body, streamed, err := c.readBatchMessage(batcher, flushBatch)
+		msgType, body, dataRowStreamed, err := c.readQueryResponseMessage(batcher, flushBatch)
 		if err != nil {
 			return responseReadError(firstErr, err)
 		}
@@ -469,7 +473,7 @@ func (c *Conn) processQueryResponses(ctx context.Context, callback func(ctx cont
 			batcher.fields = fields
 
 		case protocol.MsgDataRow:
-			if streamed {
+			if dataRowStreamed {
 				break
 			}
 			// Accumulate via the shared batcher. A parse failure (structured

--- a/go/common/pgprotocol/protocol/constants.go
+++ b/go/common/pgprotocol/protocol/constants.go
@@ -129,8 +129,9 @@ const (
 
 // Packet length constants
 const (
-	MaxStartupPacketLength = 10000 // Maximum startup packet length
-	PacketHeaderSize       = 4     // Size of packet length field (does not include message type byte)
+	MaxStartupPacketLength = 10000                // Maximum startup packet length
+	PacketHeaderSize       = 4                    // Size of packet length field (does not include message type byte)
+	MessageHeaderSize      = 1 + PacketHeaderSize // Message type byte plus packet length field
 )
 
 // ALPN protocol identifier for PostgreSQL

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -643,6 +643,21 @@ func (c *Conn) endWriterBuffering() error {
 	return flushErr
 }
 
+// abortWriterBuffering discards buffered bytes and returns the writer to its
+// pool without flushing. It is used when the pgwire stream ends inside a frame:
+// flushing or appending an ErrorResponse would expose malformed protocol data.
+func (c *Conn) abortWriterBuffering() {
+	c.bufMu.Lock()
+	defer c.bufMu.Unlock()
+
+	if c.bufferedWriter == nil {
+		return
+	}
+	c.bufferedWriter.Reset(nil)
+	c.listener.writersPool.Put(c.bufferedWriter)
+	c.bufferedWriter = nil
+}
+
 // canSendPlaintextStartupError reports whether a best-effort plaintext
 // ErrorResponse during the startup phase would be intelligible to the
 // client. If the client sent SSLRequest and the server already answered
@@ -864,6 +879,12 @@ func (c *Conn) serve() error {
 			if errors.Is(err, errFatalDiagnosticSent) {
 				_ = c.endWriterBuffering()
 				return nil
+			}
+			// The client is still inside an incomplete DataRow. No subsequent
+			// pgwire frame would be parseable, so discard buffered output and close.
+			if errors.Is(err, errIncompleteDataRow) {
+				c.abortWriterBuffering()
+				return err
 			}
 			c.logger.Error("error handling message", "type", string(msgType), "error", err)
 			// Send error response and continue (unless it's a fatal error).
@@ -1095,6 +1116,7 @@ func (c *Conn) handleQuery() error {
 	// Track state for current result set.
 	// This is reset when we complete a result set (when CommandTag is set).
 	sentRowDescription := false
+	passthroughRowInProgress := false
 
 	// Execute the query via the handler with streaming callback.
 	// The callback will be invoked multiple times for:
@@ -1133,6 +1155,9 @@ func (c *Conn) handleQuery() error {
 		if err := c.writeResultRows(result); err != nil {
 			return err
 		}
+		if result.PassthroughBlock != nil {
+			passthroughRowInProgress = result.PassthroughRowInProgress
+		}
 
 		// If CommandTag is set, this is the last packet of the current result set.
 		if result.CommandTag != "" {
@@ -1159,6 +1184,9 @@ func (c *Conn) handleQuery() error {
 	if err != nil {
 		err = queryContextError(queryCtx, err)
 		c.logger.Error("query execution failed", "query", queryStr, "error", err)
+		if passthroughRowInProgress {
+			return fmt.Errorf("%w: %w", errIncompleteDataRow, err)
+		}
 		if writeErr := c.writeError(err); writeErr != nil {
 			return writeErr
 		}
@@ -1431,6 +1459,7 @@ func (c *Conn) handleExecute() error {
 
 	// Track state for streaming results.
 	sentRowDescription := false
+	passthroughRowInProgress := false
 
 	// Call the handler to execute the portal with streaming callback.
 	// The handler is responsible for retrieving the portal and executing it.
@@ -1473,6 +1502,9 @@ func (c *Conn) handleExecute() error {
 		if err := c.writeResultRows(result); err != nil {
 			return err
 		}
+		if result.PassthroughBlock != nil {
+			passthroughRowInProgress = result.PassthroughRowInProgress
+		}
 
 		// If CommandTag is set, this is the last packet.
 		if result.CommandTag != "" {
@@ -1504,6 +1536,9 @@ func (c *Conn) handleExecute() error {
 	})
 	if err != nil {
 		err = queryContextError(queryCtx, err)
+		if passthroughRowInProgress {
+			return fmt.Errorf("%w: %w", errIncompleteDataRow, err)
+		}
 		return c.writeExtendedQueryError(err)
 	}
 

--- a/go/common/pgprotocol/server/fatal_close_test.go
+++ b/go/common/pgprotocol/server/fatal_close_test.go
@@ -17,6 +17,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +27,8 @@ import (
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/sqltypes"
 )
+
+var errInterruptedDataRow = errors.New("backend connection lost")
 
 // PostgreSQL ends a session after a FATAL: the ErrorResponse is the last
 // frame, no ReadyForQuery follows, and the server closes the connection.
@@ -87,6 +90,103 @@ func TestHandleQuery_NonFatalErrorKeepsSessionAlive(t *testing.T) {
 	msgType, _, _ = readMessageTypeAndLength(t, &writeBuf)
 	assert.Equal(t, byte(protocol.MsgReadyForQuery), msgType,
 		"a plain ERROR is followed by ReadyForQuery as usual")
+}
+
+func TestHandleQuery_IncompleteDataRowClosesWithoutErrorFrames(t *testing.T) {
+	partial := []byte("D\x00\x00\x10\x00partial-row")
+	var readBuf, writeBuf bytes.Buffer
+	handler := &testHandler{
+		queryFunc: func(ctx context.Context, conn *Conn, queryStr string, callback func(context.Context, *sqltypes.Result) error) error {
+			require.NoError(t, callback(ctx, &sqltypes.Result{
+				PassthroughBlock:         partial,
+				PassthroughRowInProgress: true,
+			}))
+			return errInterruptedDataRow
+		},
+	}
+	conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, handler)
+
+	sql := "SELECT huge_value"
+	writeTestInt32(&readBuf, int32(4+len(sql)+1))
+	writeTestString(&readBuf, sql)
+
+	conn.startWriterBuffering()
+	err := conn.handleMessage(protocol.MsgQuery)
+	require.ErrorIs(t, err, errIncompleteDataRow)
+	require.ErrorIs(t, err, errInterruptedDataRow)
+	require.NoError(t, conn.endWriterBuffering())
+	assert.Equal(t, partial, writeBuf.Bytes(),
+		"an ErrorResponse or ReadyForQuery must not follow an incomplete DataRow")
+}
+
+func TestHandleQuery_ErrorAfterCompleteOpaqueRowRemainsFrameSafe(t *testing.T) {
+	complete := []byte("D\x00\x00\x00\x04")
+	var readBuf, writeBuf bytes.Buffer
+	handler := &testHandler{
+		queryFunc: func(ctx context.Context, conn *Conn, queryStr string, callback func(context.Context, *sqltypes.Result) error) error {
+			require.NoError(t, callback(ctx, &sqltypes.Result{
+				PassthroughBlock:         complete,
+				PassthroughRowCount:      1,
+				PassthroughRowInProgress: false,
+			}))
+			return errInterruptedDataRow
+		},
+	}
+	conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, handler)
+
+	sql := "SELECT rows_then_error"
+	writeTestInt32(&readBuf, int32(4+len(sql)+1))
+	writeTestString(&readBuf, sql)
+
+	conn.startWriterBuffering()
+	require.NoError(t, conn.handleMessage(protocol.MsgQuery))
+	require.NoError(t, conn.endWriterBuffering())
+
+	msgType, _, _ := readMessageTypeAndLength(t, &writeBuf)
+	assert.Equal(t, byte(protocol.MsgDataRow), msgType)
+	msgType, _, _ = readMessageTypeAndLength(t, &writeBuf)
+	assert.Equal(t, byte(protocol.MsgErrorResponse), msgType)
+	msgType, _, _ = readMessageTypeAndLength(t, &writeBuf)
+	assert.Equal(t, byte(protocol.MsgReadyForQuery), msgType)
+}
+
+func TestAbortWriterBufferingDiscardsIncompleteFrame(t *testing.T) {
+	var readBuf, writeBuf bytes.Buffer
+	conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, &testHandler{})
+	conn.startWriterBuffering()
+	require.NoError(t, conn.WriteRawMessage([]byte("buffered partial frame")))
+
+	conn.abortWriterBuffering()
+
+	assert.Empty(t, writeBuf.Bytes(), "aborting must not flush an incomplete frame")
+	assert.Nil(t, conn.bufferedWriter, "Close must not later flush the discarded writer")
+}
+
+func TestHandleExecute_IncompleteDataRowClosesWithoutErrorFrames(t *testing.T) {
+	partial := []byte("D\x00\x00\x10\x00partial-row")
+	var readBuf, writeBuf bytes.Buffer
+	handler := &testHandler{
+		executeFunc: func(ctx context.Context, conn *Conn, portalName string, maxRows int32, callback func(context.Context, *sqltypes.Result) error) error {
+			require.NoError(t, callback(ctx, &sqltypes.Result{
+				PassthroughBlock:         partial,
+				PassthroughRowInProgress: true,
+			}))
+			return errInterruptedDataRow
+		},
+	}
+	conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, handler)
+
+	writeTestInt32(&readBuf, 4+1+4) // length + empty portal name + maxRows
+	writeTestString(&readBuf, "")
+	writeTestInt32(&readBuf, 0)
+
+	conn.startWriterBuffering()
+	err := conn.handleExecute()
+	require.ErrorIs(t, err, errIncompleteDataRow)
+	require.ErrorIs(t, err, errInterruptedDataRow)
+	require.NoError(t, conn.endWriterBuffering())
+	assert.Equal(t, partial, writeBuf.Bytes(),
+		"an ErrorResponse must not follow an incomplete DataRow")
 }
 
 func TestWriteExtendedQueryError_FatalReturnsCloseSentinel(t *testing.T) {

--- a/go/common/pgprotocol/server/query.go
+++ b/go/common/pgprotocol/server/query.go
@@ -223,6 +223,12 @@ func (c *Conn) writeNoticeResponse(diag *mterrors.PgDiagnostic) error {
 // down without emitting its own error reply.
 var errFatalDiagnosticSent = errors.New("fatal diagnostic sent; closing connection")
 
+// errIncompleteDataRow signals that opaque passthrough already wrote the
+// beginning of a DataRow but the upstream stream ended before that frame was
+// completed. No PostgreSQL message can be appended safely because the client
+// would interpret it as row data.
+var errIncompleteDataRow = errors.New("upstream failed during a DataRow frame")
+
 // fatalDiagnostic returns the *PgDiagnostic that writeError would put on the
 // wire if it carries a FATAL/PANIC severity, nil otherwise. It mirrors
 // writeError's extraction (RootCause + errors.As) so the close decision always

--- a/go/common/sqltypes/opaque_test.go
+++ b/go/common/sqltypes/opaque_test.go
@@ -48,22 +48,25 @@ func TestResultStructuredRows(t *testing.T) {
 func TestResultOpaqueRoundTrip(t *testing.T) {
 	block := []byte("D\x00\x00\x00\x0eraw-frame-bytes")
 	r := &Result{
-		PassthroughBlock:    block,
-		PassthroughRowCount: 4,
-		CommandTag:          "SELECT 4",
-		RowsAffected:        4,
+		PassthroughBlock:         block,
+		PassthroughRowCount:      4,
+		PassthroughRowInProgress: true,
+		CommandTag:               "SELECT 4",
+		RowsAffected:             4,
 	}
 
 	pr := r.ToProto()
 	require.NotNil(t, pr)
 	assert.Equal(t, block, pr.PassthroughBlock)
 	assert.Equal(t, uint32(4), pr.PassthroughRowCount)
+	assert.True(t, pr.PassthroughRowInProgress)
 	assert.Empty(t, pr.Rows, "opaque result must not carry structured Row messages")
 
 	back := ResultFromProto(pr)
 	require.NotNil(t, back)
 	assert.Equal(t, block, back.PassthroughBlock)
 	assert.Equal(t, 4, back.PassthroughRowCount)
+	assert.True(t, back.PassthroughRowInProgress)
 	assert.Nil(t, back.Rows, "opaque result must not reconstruct structured Rows")
 	assert.Equal(t, "SELECT 4", back.CommandTag)
 }

--- a/go/common/sqltypes/sqltypes.go
+++ b/go/common/sqltypes/sqltypes.go
@@ -181,6 +181,11 @@ type Result struct {
 	// row and preserves row accounting while Rows is empty.
 	PassthroughRowCount int
 
+	// PassthroughRowInProgress reports that PassthroughBlock ends inside a
+	// DataRow frame. A downstream pgwire server must close the client connection
+	// if the upstream stream fails before a later block completes that frame.
+	PassthroughRowInProgress bool
+
 	// CommandTag is the PostgreSQL command tag for this result set.
 	// Examples: "SELECT 42", "INSERT 0 5", "UPDATE 10", "DELETE 3"
 	CommandTag string
@@ -249,14 +254,15 @@ func (r *Result) ToProto() *query.QueryResult {
 	// each row into a proto Row. Rows is empty in this mode.
 	if len(r.PassthroughBlock) > 0 {
 		return &query.QueryResult{
-			Fields:              r.Fields,
-			HasFields:           r.Fields != nil,
-			RowsAffected:        r.RowsAffected,
-			PassthroughBlock:    r.PassthroughBlock,
-			PassthroughRowCount: uint32(r.PassthroughRowCount),
-			CommandTag:          r.CommandTag,
-			Notices:             protoNotices,
-			ParameterStatus:     r.ParameterStatus,
+			Fields:                   r.Fields,
+			HasFields:                r.Fields != nil,
+			RowsAffected:             r.RowsAffected,
+			PassthroughBlock:         r.PassthroughBlock,
+			PassthroughRowCount:      uint32(r.PassthroughRowCount),
+			PassthroughRowInProgress: r.PassthroughRowInProgress,
+			CommandTag:               r.CommandTag,
+			Notices:                  protoNotices,
+			ParameterStatus:          r.ParameterStatus,
 		}
 	}
 	protoRows := make([]*query.Row, len(r.Rows))
@@ -294,13 +300,14 @@ func ResultFromProto(pr *query.QueryResult) *Result {
 	// nil; the multigateway writes PassthroughBlock straight to the client.
 	if pr.PassthroughBlock != nil {
 		return &Result{
-			Fields:              fields,
-			RowsAffected:        pr.RowsAffected,
-			PassthroughBlock:    pr.PassthroughBlock,
-			PassthroughRowCount: int(pr.PassthroughRowCount),
-			CommandTag:          pr.CommandTag,
-			Notices:             notices,
-			ParameterStatus:     pr.ParameterStatus,
+			Fields:                   fields,
+			RowsAffected:             pr.RowsAffected,
+			PassthroughBlock:         pr.PassthroughBlock,
+			PassthroughRowCount:      int(pr.PassthroughRowCount),
+			PassthroughRowInProgress: pr.PassthroughRowInProgress,
+			CommandTag:               pr.CommandTag,
+			Notices:                  notices,
+			ParameterStatus:          pr.ParameterStatus,
 		}
 	}
 	rows := make([]*Row, len(pr.Rows))

--- a/go/common/sqltypes/sqltypes.go
+++ b/go/common/sqltypes/sqltypes.go
@@ -170,16 +170,15 @@ type Result struct {
 	// Rows contains the actual data rows.
 	Rows []*Row
 
-	// PassthroughBlock, when non-nil, holds the opaque row-passthrough payload: the
-	// concatenated raw PostgreSQL DataRow frames for this batch, exactly as read
-	// from the backend. When set, Rows is empty and the rows are never parsed
-	// into columns. The multigateway writes PassthroughBlock straight to the client. See
-	// QueryResult.passthrough_block.
+	// PassthroughBlock, when non-nil, holds the next ordered chunk of opaque
+	// PostgreSQL DataRow wire bytes. It may contain complete frames or a frame
+	// fragment. Rows is empty and the multigateway writes the bytes directly to
+	// the client. See QueryResult.passthrough_block.
 	PassthroughBlock []byte
 
-	// PassthroughRowCount is the number of DataRow frames packed into PassthroughBlock. Preserves
-	// the row count for metrics and row-limit accounting, since Rows is empty in
-	// passthrough mode.
+	// PassthroughRowCount is the number of DataRow frames completed in
+	// PassthroughBlock. It may be zero for an intermediate fragment of a large
+	// row and preserves row accounting while Rows is empty.
 	PassthroughRowCount int
 
 	// CommandTag is the PostgreSQL command tag for this result set.

--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -253,8 +253,13 @@ type QueryResult struct {
 	// client, covering the paths that run the real statement on PostgreSQL
 	// (SET/RESET inside a transaction, and the revert on ROLLBACK).
 	ParameterStatus map[string]string `protobuf:"bytes,9,rep,name=parameter_status,json=parameterStatus,proto3" json:"parameter_status,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// passthrough_row_in_progress reports that this block ends inside a DataRow
+	// frame. If the upstream stream fails before a later block completes that
+	// frame, the gateway must close the client connection instead of appending
+	// an ErrorResponse to the incomplete DataRow.
+	PassthroughRowInProgress bool `protobuf:"varint,10,opt,name=passthrough_row_in_progress,json=passthroughRowInProgress,proto3" json:"passthrough_row_in_progress,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *QueryResult) Reset() {
@@ -348,6 +353,13 @@ func (x *QueryResult) GetParameterStatus() map[string]string {
 		return x.ParameterStatus
 	}
 	return nil
+}
+
+func (x *QueryResult) GetPassthroughRowInProgress() bool {
+	if x != nil {
+		return x.PassthroughRowInProgress
+	}
+	return false
 }
 
 // Field represents metadata about a column in the result set.
@@ -1610,7 +1622,7 @@ const file_query_proto_rawDesc = "" +
 	"diagnostic\x18\x02 \x01(\v2\x13.query.PgDiagnosticH\x00R\n" +
 	"diagnostic\x12;\n" +
 	"\fnotification\x18\x03 \x01(\v2\x15.query.PgNotificationH\x00R\fnotificationB\t\n" +
-	"\apayload\"\xe0\x03\n" +
+	"\apayload\"\x9f\x04\n" +
 	"\vQueryResult\x12$\n" +
 	"\x06fields\x18\x01 \x03(\v2\f.query.FieldR\x06fields\x12#\n" +
 	"\rrows_affected\x18\x02 \x01(\x04R\frowsAffected\x12\x1e\n" +
@@ -1623,7 +1635,9 @@ const file_query_proto_rawDesc = "" +
 	"\anotices\x18\x06 \x03(\v2\x13.query.PgDiagnosticR\anotices\x12+\n" +
 	"\x11passthrough_block\x18\a \x01(\fR\x10passthroughBlock\x122\n" +
 	"\x15passthrough_row_count\x18\b \x01(\rR\x13passthroughRowCount\x12R\n" +
-	"\x10parameter_status\x18\t \x03(\v2'.query.QueryResult.ParameterStatusEntryR\x0fparameterStatus\x1aB\n" +
+	"\x10parameter_status\x18\t \x03(\v2'.query.QueryResult.ParameterStatusEntryR\x0fparameterStatus\x12=\n" +
+	"\x1bpassthrough_row_in_progress\x18\n" +
+	" \x01(\bR\x18passthroughRowInProgress\x1aB\n" +
 	"\x14ParameterStatusEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x89\x02\n" +

--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -235,17 +235,16 @@ type QueryResult struct {
 	// diagnostics for zero-buffering delivery; unary RPCs (for example COMMIT via
 	// ConcludeTransaction) use this field to preserve backend notice ordering.
 	Notices []*PgDiagnostic `protobuf:"bytes,6,rep,name=notices,proto3" json:"notices,omitempty"`
-	// passthrough_block is the opaque row-passthrough representation. When set, it
-	// contains the concatenated raw PostgreSQL DataRow ('D') frames for this
-	// batch, exactly as read from the backend, and rows is empty. The multipooler
-	// captures the frames without parsing them into columns and the multigateway
-	// writes the block straight to the client socket, avoiding per-row
-	// marshalling and re-framing on both ends. Requested via
-	// ExecuteOptions.passthrough_row. fields (RowDescription) still travel structured.
+	// passthrough_block is the opaque row-passthrough representation. When set,
+	// it contains the next ordered chunk of raw PostgreSQL DataRow ('D') wire
+	// bytes and rows is empty. A block may contain complete frames or a frame
+	// fragment; concatenating blocks in stream order reconstructs the exact
+	// DataRow byte stream from the backend. The multigateway writes the block
+	// straight to the client socket. fields (RowDescription) remain structured.
 	PassthroughBlock []byte `protobuf:"bytes,7,opt,name=passthrough_block,json=passthroughBlock,proto3" json:"passthrough_block,omitempty"`
-	// passthrough_row_count is the number of DataRow frames packed into
-	// passthrough_block. rows is empty in passthrough mode, so this preserves the
-	// row count for metrics and row-limit accounting.
+	// passthrough_row_count is the number of DataRow frames completed in this
+	// block. It may be zero when the block contains only a fragment of a large
+	// DataRow. This preserves row accounting while rows is empty.
 	PassthroughRowCount uint32 `protobuf:"varint,8,opt,name=passthrough_row_count,json=passthroughRowCount,proto3" json:"passthrough_row_count,omitempty"`
 	// parameter_status carries GUC_REPORT values (keyed by PostgreSQL's exact
 	// ParameterStatus display name, e.g. "DateStyle") that a routed statement

--- a/go/test/endtoend/queryserving/large_result_test.go
+++ b/go/test/endtoend/queryserving/large_result_test.go
@@ -26,11 +26,10 @@ import (
 	"github.com/multigres/multigres/go/test/utils"
 )
 
-// TestLargeResultThroughGateway is the regression for the gRPC 4 MiB result cap.
-// A query result larger than the gRPC client default (4194304 bytes) must stream
-// back through the pooler->gateway gRPC channel without RESOURCE_EXHAUSTED. The
-// server limit is grpccommon.MaxMessageSize() (16 MiB default); 8 MiB exceeds the
-// old client default but stays under the server limit.
+// TestLargeResultThroughGateway verifies that a single DataRow larger than the
+// gRPC message limit is chunked across stream responses and reconstructed by the
+// gateway without RESOURCE_EXHAUSTED. The default gRPC limit is 16 MiB, so the
+// test uses one 20 MiB field rather than merely a large multi-row result set.
 func TestLargeResultThroughGateway(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping in short mode")
@@ -42,13 +41,12 @@ func TestLargeResultThroughGateway(t *testing.T) {
 	setup := getSharedSetup(t)
 	ctx := utils.WithTimeout(t, 60*time.Second)
 
-	const sizeBytes = 8 * 1024 * 1024 // 8 MiB: > 4 MiB client default, < 16 MiB server limit
-	query := "SELECT repeat('x', 8388608)"
+	const sizeBytes = 20 * 1024 * 1024 // One DataRow larger than the 16 MiB gRPC default.
+	query := "SELECT repeat('x', 20971520)"
 
 	for _, target := range setup.GetComparisonTargets(t) {
 		t.Run(target.Name, func(t *testing.T) {
-			// Low-level pgprotocol client (simple protocol) — a single 8 MiB row
-			// forces one gRPC message > 4 MiB on the pooler->gateway hop.
+			// Low-level pgprotocol client exercises the simple-query response loop.
 			t.Run("low-level", func(t *testing.T) {
 				conn := connectLowLevelToPort(t, ctx, target.Port)
 				defer conn.Close()
@@ -62,7 +60,7 @@ func TestLargeResultThroughGateway(t *testing.T) {
 						got = len(row.Values[0])
 					}
 				}
-				assert.Equal(t, sizeBytes, got, "full 8 MiB value should come back")
+				assert.Equal(t, sizeBytes, got, "full 20 MiB value should come back")
 			})
 
 			// pgx (extended protocol) — mirrors the real Postgrex/Ecto failure mode.

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -84,6 +84,12 @@ message QueryResult {
   // client, covering the paths that run the real statement on PostgreSQL
   // (SET/RESET inside a transaction, and the revert on ROLLBACK).
   map<string, string> parameter_status = 9;
+
+  // passthrough_row_in_progress reports that this block ends inside a DataRow
+  // frame. If the upstream stream fails before a later block completes that
+  // frame, the gateway must close the client connection instead of appending
+  // an ErrorResponse to the incomplete DataRow.
+  bool passthrough_row_in_progress = 10;
 }
 
 // Field represents metadata about a column in the result set.

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -64,18 +64,17 @@ message QueryResult {
   // ConcludeTransaction) use this field to preserve backend notice ordering.
   repeated PgDiagnostic notices = 6;
 
-  // passthrough_block is the opaque row-passthrough representation. When set, it
-  // contains the concatenated raw PostgreSQL DataRow ('D') frames for this
-  // batch, exactly as read from the backend, and rows is empty. The multipooler
-  // captures the frames without parsing them into columns and the multigateway
-  // writes the block straight to the client socket, avoiding per-row
-  // marshalling and re-framing on both ends. Requested via
-  // ExecuteOptions.passthrough_row. fields (RowDescription) still travel structured.
+  // passthrough_block is the opaque row-passthrough representation. When set,
+  // it contains the next ordered chunk of raw PostgreSQL DataRow ('D') wire
+  // bytes and rows is empty. A block may contain complete frames or a frame
+  // fragment; concatenating blocks in stream order reconstructs the exact
+  // DataRow byte stream from the backend. The multigateway writes the block
+  // straight to the client socket. fields (RowDescription) remain structured.
   bytes passthrough_block = 7;
 
-  // passthrough_row_count is the number of DataRow frames packed into
-  // passthrough_block. rows is empty in passthrough mode, so this preserves the
-  // row count for metrics and row-limit accounting.
+  // passthrough_row_count is the number of DataRow frames completed in this
+  // block. It may be zero when the block contains only a fragment of a large
+  // DataRow. This preserves row accounting while rows is empty.
   uint32 passthrough_row_count = 8;
 
   // parameter_status carries GUC_REPORT values (keyed by PostgreSQL's exact


### PR DESCRIPTION
## Problem

Query results are already streamed from multipooler to multigateway in roughly 2 MiB batches, but batching currently happens only after the PostgreSQL client has read a complete DataRow. A single row larger than --grpc-max-message-size therefore becomes one oversized QueryResult protobuf message and fails with RESOURCE_EXHAUSTED. Raising the client and server limits only moves that ceiling; PostgreSQL permits individual values far larger than the default 16 MiB gRPC limit.

The opaque row path also materializes the complete DataRow body before batching it. Raising the gRPC limit toward PostgreSQL's maximum would consequently increase both transport exposure and peak multipooler memory rather than provide robust large-row support.

## Fix

**1. Opaque DataRows are read incrementally into bounded passthrough blocks**:

- The PostgreSQL message reader can now read the type and length header separately, leaving the reader positioned at the message body.
- Client-facing opaque DataRows larger than the 2 MiB streaming batch size are copied directly from the PostgreSQL buffered reader into bounded blocks. The complete row is never allocated in the multipooler.
- The original DataRow type and length header are preserved in the first block. Concatenating blocks in stream order reconstructs the exact PostgreSQL wire bytes.
- Existing complete rows already accumulated in a batch are flushed before an oversized row. Intermediate fragments carry a row count of zero; the final fragment carries one and is flushed immediately.
- The five-byte PostgreSQL message header is represented by `protocol.MessageHeaderSize` (`1 + PacketHeaderSize`) instead of repeated literals, keeping frame-size accounting explicit and consistent.

**2. Existing small-row behavior is preserved**:

- DataRows that fit within the streaming batch size remain complete and continue to be packed together efficiently.
- All five response readers use the same incremental path: simple query, Execute, Bind+Execute, Prepare+Execute, and Bind+Describe+Execute.
- Structured result consumers retain the existing parsed-row path.

**3. The protobuf envelope is extended compatibly**:

- passthrough_block now means the next ordered chunk of raw DataRow wire bytes; it may contain complete frames or a frame fragment.
- passthrough_row_count is the number of DataRows completed in that block and may be zero for an intermediate fragment.
- Existing passthrough field numbers and RPC shapes do not change. A new boolean field records whether a block ends inside a DataRow; existing poolers continue to send complete blocks with its default value of false.

**4. Interrupted rows terminate the client connection safely**:

- `passthrough_row_in_progress` explicitly reports whether a block ends inside a DataRow frame.
- If PostgreSQL or the gRPC stream fails after an incomplete row fragment reached the gateway, the pgwire server discards buffered output and closes the client connection. It does not append an ErrorResponse or ReadyForQuery that the client would misinterpret as row bytes.
- Failures between complete rows retain the existing frame-safe behavior and can still return a normal PostgreSQL error.

## Known trade-off

The bounded path applies to opaque client-facing rows. Structured internal query consumers still materialize and decode complete DataRows because they inspect column values rather than forwarding wire bytes. Those paths are intentionally used for small control queries and are not the arbitrary client result path addressed here.

## Tests

- Response-loop matrix covers all five simple/extended readers in opaque and structured modes. It uses a DataRow larger than the batch threshold and verifies bounded block size, a zero-count intermediate fragment, exact byte-for-byte reconstruction, and final row accounting.
- Affected package suites pass for pgprotocol/client, sqltypes, multipooler/grpcpoolerservice, and multigateway/poolergateway.
- Query-serving end-to-end regression now returns one 20 MiB field through both simple and extended protocols, exceeding the default 16 MiB gRPC message limit.
- Simple- and extended-protocol regressions verify that an interrupted DataRow produces no trailing ErrorResponse/ReadyForQuery, while an error after a complete opaque row remains frame-safe.
- Writer teardown coverage verifies buffered partial-frame bytes are discarded rather than flushed.
- Full production binary build passes.
