### PR TITLE
fix(pgprotocol): preserve File/Line/Routine error diagnostic fields

### DIFF
--- a/go/common/mterrors/grpc_test.go
+++ b/go/common/mterrors/grpc_test.go
@@ -173,6 +173,9 @@ func TestPgErrorGRPCRoundTrip(t *testing.T) {
 		Column:           "id",
 		DataType:         "integer",
 		Constraint:       "users_pkey",
+		File:             "nbtinsert.c",
+		Line:             666,
+		Routine:          "_bt_check_unique",
 	}
 
 	// Convert to gRPC
@@ -186,7 +189,7 @@ func TestPgErrorGRPCRoundTrip(t *testing.T) {
 	var diag *PgDiagnostic
 	require.True(t, errors.As(recovered, &diag))
 
-	// Verify all 14 fields are preserved
+	// Verify all fields are preserved
 	assert.Equal(t, byte(protocol.MsgErrorResponse), diag.MessageType)
 	assert.Equal(t, "ERROR", diag.Severity)
 	assert.Equal(t, "23505", diag.Code)
@@ -202,6 +205,9 @@ func TestPgErrorGRPCRoundTrip(t *testing.T) {
 	assert.Equal(t, "id", diag.Column)
 	assert.Equal(t, "integer", diag.DataType)
 	assert.Equal(t, "users_pkey", diag.Constraint)
+	assert.Equal(t, "nbtinsert.c", diag.File)
+	assert.Equal(t, int32(666), diag.Line)
+	assert.Equal(t, "_bt_check_unique", diag.Routine)
 
 	// Verify Error() message is preserved
 	assert.Equal(t, "ERROR: duplicate key value violates unique constraint", diag.Error())

--- a/go/common/mterrors/pgdiagnostic.go
+++ b/go/common/mterrors/pgdiagnostic.go
@@ -43,6 +43,9 @@ type PgDiagnostic struct {
 	Column           string
 	DataType         string
 	Constraint       string
+	File             string
+	Line             int32
+	Routine          string
 }
 
 // IsError returns true if this diagnostic represents an error (MessageType == 'E').
@@ -226,6 +229,9 @@ func PgDiagnosticToProto(d *PgDiagnostic) *query.PgDiagnostic {
 		ColumnName:       d.Column,
 		DataTypeName:     d.DataType,
 		ConstraintName:   d.Constraint,
+		File:             d.File,
+		Line:             d.Line,
+		Routine:          d.Routine,
 	}
 }
 
@@ -250,5 +256,8 @@ func PgDiagnosticFromProto(pd *query.PgDiagnostic) *PgDiagnostic {
 		Column:           pd.ColumnName,
 		DataType:         pd.DataTypeName,
 		Constraint:       pd.ConstraintName,
+		File:             pd.File,
+		Line:             pd.Line,
+		Routine:          pd.Routine,
 	}
 }

--- a/go/common/pgprotocol/client/diagnostic_test.go
+++ b/go/common/pgprotocol/client/diagnostic_test.go
@@ -123,12 +123,18 @@ func TestParseDiagnosticFieldsAllFieldsPopulated(t *testing.T) {
 	w.WriteString("text")
 	w.AppendByte(protocol.FieldConstraint)
 	w.WriteString("users_email_key")
+	w.AppendByte(protocol.FieldFile)
+	w.WriteString("nbtinsert.c")
+	w.AppendByte(protocol.FieldLine)
+	w.WriteString("666")
+	w.AppendByte(protocol.FieldRoutine)
+	w.WriteString("_bt_check_unique")
 	w.AppendByte(0) // Terminator
 
 	diag := parseDiagnosticFields(protocol.MsgErrorResponse, w.Bytes())
 	require.NotNil(t, diag)
 
-	// Verify all 14 fields
+	// Verify all fields
 	assert.Equal(t, byte(protocol.MsgErrorResponse), diag.MessageType)
 	assert.Equal(t, "ERROR", diag.Severity)
 	assert.Equal(t, "23505", diag.Code)
@@ -144,6 +150,9 @@ func TestParseDiagnosticFieldsAllFieldsPopulated(t *testing.T) {
 	assert.Equal(t, "email", diag.Column)
 	assert.Equal(t, "text", diag.DataType)
 	assert.Equal(t, "users_email_key", diag.Constraint)
+	assert.Equal(t, "nbtinsert.c", diag.File)
+	assert.Equal(t, int32(666), diag.Line)
+	assert.Equal(t, "_bt_check_unique", diag.Routine)
 
 	// Validate should pass
 	err := diag.Validate()
@@ -181,6 +190,9 @@ func TestParseDiagnosticFieldsOnlyRequiredFields(t *testing.T) {
 	assert.Empty(t, diag.Column)
 	assert.Empty(t, diag.DataType)
 	assert.Empty(t, diag.Constraint)
+	assert.Empty(t, diag.File)
+	assert.Equal(t, int32(0), diag.Line)
+	assert.Empty(t, diag.Routine)
 
 	// Validate should pass
 	err := diag.Validate()
@@ -274,6 +286,9 @@ func TestDiagnosticRoundTripParseProtoWriteParse(t *testing.T) {
 				Column:           "email",
 				DataType:         "text",
 				Constraint:       "users_email_key",
+				File:             "nbtinsert.c",
+				Line:             666,
+				Routine:          "_bt_check_unique",
 			},
 		},
 		{
@@ -643,6 +658,9 @@ func assertDiagnosticsEqual(t *testing.T, expected, actual *mterrors.PgDiagnosti
 	assert.Equal(t, expected.Column, actual.Column, "Column mismatch")
 	assert.Equal(t, expected.DataType, actual.DataType, "DataType mismatch")
 	assert.Equal(t, expected.Constraint, actual.Constraint, "Constraint mismatch")
+	assert.Equal(t, expected.File, actual.File, "File mismatch")
+	assert.Equal(t, expected.Line, actual.Line, "Line mismatch")
+	assert.Equal(t, expected.Routine, actual.Routine, "Routine mismatch")
 }
 
 // Helper function to build wire format from PgDiagnostic
@@ -704,6 +722,18 @@ func buildDiagnosticWireFormat(diag *mterrors.PgDiagnostic) []byte {
 	if diag.Constraint != "" {
 		w.AppendByte(protocol.FieldConstraint)
 		w.WriteString(diag.Constraint)
+	}
+	if diag.File != "" {
+		w.AppendByte(protocol.FieldFile)
+		w.WriteString(diag.File)
+	}
+	if diag.Line != 0 {
+		w.AppendByte(protocol.FieldLine)
+		w.WriteString(positionToString(diag.Line))
+	}
+	if diag.Routine != "" {
+		w.AppendByte(protocol.FieldRoutine)
+		w.WriteString(diag.Routine)
 	}
 
 	w.AppendByte(0) // Terminator
@@ -782,4 +812,28 @@ func TestParseDiagnosticFieldsBothSeverityFields(t *testing.T) {
 		// Should use FieldSeverity ('S') value since it unconditionally overwrites
 		assert.Equal(t, "ERREUR", diag.Severity)
 	})
+}
+
+// TestParseDiagnosticFieldsNonNumericLine tests that a non-numeric 'L' field
+// value is ignored (Line stays 0) without disturbing the rest of the parse.
+func TestParseDiagnosticFieldsNonNumericLine(t *testing.T) {
+	w := NewMessageWriter()
+	w.AppendByte(protocol.FieldSeverity)
+	w.WriteString("ERROR")
+	w.AppendByte(protocol.FieldCode)
+	w.WriteString("22012")
+	w.AppendByte(protocol.FieldMessage)
+	w.WriteString("division by zero")
+	w.AppendByte(protocol.FieldLine)
+	w.WriteString("not-a-number")
+	w.AppendByte(protocol.FieldRoutine)
+	w.WriteString("int4div")
+	w.AppendByte(0)
+
+	diag := parseDiagnosticFields(protocol.MsgErrorResponse, w.Bytes())
+	require.NotNil(t, diag)
+
+	assert.Equal(t, int32(0), diag.Line)
+	assert.Equal(t, "int4div", diag.Routine)
+	assert.Equal(t, "division by zero", diag.Message)
 }

--- a/go/common/pgprotocol/client/query.go
+++ b/go/common/pgprotocol/client/query.go
@@ -694,6 +694,14 @@ func parseDiagnosticFields(msgType byte, body []byte) *mterrors.PgDiagnostic {
 			diag.DataType = value
 		case protocol.FieldConstraint:
 			diag.Constraint = value
+		case protocol.FieldFile:
+			diag.File = value
+		case protocol.FieldLine:
+			if line, err := strconv.ParseInt(value, 10, 32); err == nil {
+				diag.Line = int32(line)
+			}
+		case protocol.FieldRoutine:
+			diag.Routine = value
 		}
 	}
 

--- a/go/common/pgprotocol/server/query.go
+++ b/go/common/pgprotocol/server/query.go
@@ -282,7 +282,7 @@ func (c *Conn) WriteError(err error) error {
 
 // writePgDiagnosticResponse writes a PostgreSQL diagnostic response (error or notice).
 // The msgType should be MsgErrorResponse ('E') or MsgNoticeResponse ('N').
-// This unified function handles all 14 PostgreSQL diagnostic fields.
+// This unified function handles all PostgreSQL diagnostic fields.
 func (c *Conn) writePgDiagnosticResponse(msgType byte, diag *mterrors.PgDiagnostic) error {
 	fields := make(map[byte]string)
 	fields[protocol.FieldSeverity] = diag.Severity
@@ -321,6 +321,15 @@ func (c *Conn) writePgDiagnosticResponse(msgType byte, diag *mterrors.PgDiagnost
 	}
 	if diag.Constraint != "" {
 		fields[protocol.FieldConstraint] = diag.Constraint
+	}
+	if diag.File != "" {
+		fields[protocol.FieldFile] = diag.File
+	}
+	if diag.Line != 0 {
+		fields[protocol.FieldLine] = strconv.Itoa(int(diag.Line))
+	}
+	if diag.Routine != "" {
+		fields[protocol.FieldRoutine] = diag.Routine
 	}
 
 	return c.writeErrorOrNotice(msgType, fields)

--- a/go/common/pgprotocol/server/query_test.go
+++ b/go/common/pgprotocol/server/query_test.go
@@ -402,6 +402,9 @@ func TestWriteError(t *testing.T) {
 		message  string
 		detail   string
 		hint     string
+		file     string
+		line     string
+		routine  string
 	}{
 		{
 			name:     "PgDiagnostic error",
@@ -425,6 +428,24 @@ func TestWriteError(t *testing.T) {
 			message:  "duplicate key value violates unique constraint",
 			detail:   "Key (id)=(1) already exists.",
 			hint:     "Use a different value for the id column.",
+		},
+		{
+			name: "PgDiagnostic with source location",
+			err: &mterrors.PgDiagnostic{
+				MessageType: 'E',
+				Severity:    "ERROR",
+				Code:        "22012",
+				Message:     "division by zero",
+				File:        "int.c",
+				Line:        870,
+				Routine:     "int4div",
+			},
+			severity: "ERROR",
+			sqlState: "22012",
+			message:  "division by zero",
+			file:     "int.c",
+			line:     "870",
+			routine:  "int4div",
 		},
 		{
 			name:     "MT error",
@@ -500,6 +521,9 @@ func TestWriteError(t *testing.T) {
 			if tt.hint != "" {
 				assert.Equal(t, tt.hint, fields[protocol.FieldHint])
 			}
+			assert.Equal(t, tt.file, fields[protocol.FieldFile])
+			assert.Equal(t, tt.line, fields[protocol.FieldLine])
+			assert.Equal(t, tt.routine, fields[protocol.FieldRoutine])
 		})
 	}
 }

--- a/go/pb/mtrpc/mtrpc.pb.go
+++ b/go/pb/mtrpc/mtrpc.pb.go
@@ -330,7 +330,7 @@ type RPCError struct {
 	Message string                 `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
 	Code    Code                   `protobuf:"varint,2,opt,name=code,proto3,enum=mtrpc.Code" json:"code,omitempty"`
 	// pg_diagnostic contains the full PostgreSQL diagnostic information when the error
-	// originated from PostgreSQL. This allows preserving all 14 PostgreSQL error fields
+	// originated from PostgreSQL. This allows preserving all PostgreSQL error fields
 	// (SQLSTATE, position, hint, detail, etc.) through gRPC serialization, enabling
 	// proper PostgreSQL-format error display to clients.
 	// When present, this should be used to format the error response to the client.

--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -561,8 +561,14 @@ type PgDiagnostic struct {
 	DataTypeName string `protobuf:"bytes,13,opt,name=data_type_name,json=dataTypeName,proto3" json:"data_type_name,omitempty"`
 	// constraint_name is the name of the constraint associated with the diagnostic (optional)
 	ConstraintName string `protobuf:"bytes,14,opt,name=constraint_name,json=constraintName,proto3" json:"constraint_name,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// file is the source-code file name where the diagnostic was reported (optional)
+	File string `protobuf:"bytes,16,opt,name=file,proto3" json:"file,omitempty"`
+	// line is the source-code line number where the diagnostic was reported (0 if not available)
+	Line int32 `protobuf:"varint,17,opt,name=line,proto3" json:"line,omitempty"`
+	// routine is the source-code routine name reporting the diagnostic (optional)
+	Routine       string `protobuf:"bytes,18,opt,name=routine,proto3" json:"routine,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PgDiagnostic) Reset() {
@@ -696,6 +702,27 @@ func (x *PgDiagnostic) GetDataTypeName() string {
 func (x *PgDiagnostic) GetConstraintName() string {
 	if x != nil {
 		return x.ConstraintName
+	}
+	return ""
+}
+
+func (x *PgDiagnostic) GetFile() string {
+	if x != nil {
+		return x.File
+	}
+	return ""
+}
+
+func (x *PgDiagnostic) GetLine() int32 {
+	if x != nil {
+		return x.Line
+	}
+	return 0
+}
+
+func (x *PgDiagnostic) GetRoutine() string {
+	if x != nil {
+		return x.Routine
 	}
 	return ""
 }
@@ -1639,7 +1666,7 @@ const file_query_proto_rawDesc = "" +
 	"\x06format\x18\b \x01(\x05R\x06format\"7\n" +
 	"\x03Row\x12\x18\n" +
 	"\alengths\x18\x01 \x03(\x12R\alengths\x12\x16\n" +
-	"\x06values\x18\x02 \x01(\fR\x06values\"\xdd\x03\n" +
+	"\x06values\x18\x02 \x01(\fR\x06values\"\x9f\x04\n" +
 	"\fPgDiagnostic\x12!\n" +
 	"\fmessage_type\x18\x0f \x01(\x05R\vmessageType\x12\x1a\n" +
 	"\bseverity\x18\x01 \x01(\tR\bseverity\x12\x12\n" +
@@ -1659,7 +1686,10 @@ const file_query_proto_rawDesc = "" +
 	"\vcolumn_name\x18\f \x01(\tR\n" +
 	"columnName\x12$\n" +
 	"\x0edata_type_name\x18\r \x01(\tR\fdataTypeName\x12'\n" +
-	"\x0fconstraint_name\x18\x0e \x01(\tR\x0econstraintName\"V\n" +
+	"\x0fconstraint_name\x18\x0e \x01(\tR\x0econstraintName\x12\x12\n" +
+	"\x04file\x18\x10 \x01(\tR\x04file\x12\x12\n" +
+	"\x04line\x18\x11 \x01(\x05R\x04line\x12\x18\n" +
+	"\aroutine\x18\x12 \x01(\tR\aroutine\"V\n" +
 	"\x0ePgNotification\x12\x10\n" +
 	"\x03pid\x18\x01 \x01(\x05R\x03pid\x12\x18\n" +
 	"\achannel\x18\x02 \x01(\tR\achannel\x12\x18\n" +

--- a/go/test/endtoend/queryserving/error_format_test.go
+++ b/go/test/endtoend/queryserving/error_format_test.go
@@ -732,3 +732,44 @@ func TestErrorFormat_ParserDiagnostics(t *testing.T) {
 		})
 	}
 }
+
+// TestErrorFormat_SourceLocationFields tests that the File, Line, and Routine
+// diagnostic fields ('F', 'L', 'R') reported by PostgreSQL are preserved.
+//
+// Each subtest runs against both direct PostgreSQL and multigateway to ensure
+// the proxy behavior matches native PostgreSQL exactly.
+func TestErrorFormat_SourceLocationFields(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping error format test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping error format tests")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	for _, target := range setup.GetComparisonTargets(t) {
+		t.Run(target.Name, func(t *testing.T) {
+			connStr := shardsetup.GetTestUserDSN("localhost", target.Port, "sslmode=disable")
+			conn, err := pgx.Connect(ctx, connStr)
+			require.NoError(t, err)
+			defer conn.Close(ctx)
+
+			_, err = conn.Exec(ctx, "SELECT 1/0")
+			require.Error(t, err)
+
+			var pgErr *pgconn.PgError
+			require.True(t, errors.As(err, &pgErr), "expected pgconn.PgError, got %T", err)
+
+			// 22012 = division_by_zero, raised by PostgreSQL itself, so the
+			// source-location triple must be present on both targets.
+			assert.Equal(t, "22012", pgErr.Code)
+			assert.NotEmpty(t, pgErr.File, "File ('F') field should be preserved")
+			assert.Greater(t, pgErr.Line, int32(0), "Line ('L') field should be preserved")
+			assert.NotEmpty(t, pgErr.Routine, "Routine ('R') field should be preserved")
+			t.Logf("Source location: %s:%d in %s", pgErr.File, pgErr.Line, pgErr.Routine)
+		})
+	}
+}

--- a/proto/mtrpc.proto
+++ b/proto/mtrpc.proto
@@ -197,7 +197,7 @@ message RPCError {
   Code code = 2;
 
   // pg_diagnostic contains the full PostgreSQL diagnostic information when the error
-  // originated from PostgreSQL. This allows preserving all 14 PostgreSQL error fields
+  // originated from PostgreSQL. This allows preserving all PostgreSQL error fields
   // (SQLSTATE, position, hint, detail, etc.) through gRPC serialization, enabling
   // proper PostgreSQL-format error display to clients.
   // When present, this should be used to format the error response to the client.

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -182,6 +182,15 @@ message PgDiagnostic {
 
   // constraint_name is the name of the constraint associated with the diagnostic (optional)
   string constraint_name = 14;
+
+  // file is the source-code file name where the diagnostic was reported (optional)
+  string file = 16;
+
+  // line is the source-code line number where the diagnostic was reported (0 if not available)
+  int32 line = 17;
+
+  // routine is the source-code routine name reporting the diagnostic (optional)
+  string routine = 18;
 }
 
 // PgNotification represents a PostgreSQL asynchronous notification.


### PR DESCRIPTION
Closes #1387
  
## Summary

Preserves the `F` (file), `L` (line), `R` (routine) ErrorResponse fields
through the stack. They were never wired through: dropped at parse time in
`parseDiagnosticFields`, absent from `PgDiagnostic` (struct and proto), 
while the server writer's `diagFieldOrder` already supported them.

## Changes

- proto: `file`/`line`/`routine` fields on `query.PgDiagnostic` (+ regen)
- mterrors: struct fields + `ToProto`/`FromProto` mapping
- pgprotocol/client: parse `F`/`L`/`R` (non-numeric `L` ignored, like `P`)
- pgprotocol/server: emit the three fields when present

## Test plan

- Unit: extended all-fields/minimal/round-trip parse tests, gRPC round-trip,
writer test with a source-location case, new non-numeric-`L` test
- E2E: `TestErrorFormat_SourceLocationFields` compares direct PostgreSQL and
multigateway (`SELECT 1/0` → fields present on both)
- `pgregress`: full PG 17 suite passes (222 tests, patch-verify mode)