### PR TITLE
fix(multiadmin): skip non-serving backup targets

### DIFF
--- a/go/services/multiadmin/backup.go
+++ b/go/services/multiadmin/backup.go
@@ -105,10 +105,10 @@ func (s *MultiadminServer) executeBackup(ctx context.Context, jobID string, pool
 }
 
 // findPoolerForBackup finds a pooler for backup operations. forceLeader=true
-// returns the consensus leader (highest-rule routing_state wins if more than
-// one pooler self-claims PRIMARY, which can happen briefly during a rule
-// change); forceLeader=false returns a follower (any pooler whose routing_state
-// role is not PRIMARY).
+// returns the serving consensus leader (highest-rule routing_state wins if more
+// than one pooler self-claims PRIMARY, which can happen briefly during a rule
+// change); forceLeader=false returns a serving follower (any serving pooler
+// whose routing_state role is not PRIMARY).
 //
 // Leader identity is read from each pooler's routing_state.role topology
 // field, never from the deprecated Multipooler.Type label — the topology Type
@@ -121,7 +121,7 @@ func (s *MultiadminServer) findPoolerForBackup(ctx context.Context, database, ta
 		return nil, fmt.Errorf("failed to get cell names: %w", err)
 	}
 
-	// Collect every pooler in the (database, tableGroup) so leader selection
+	// Collect every serving pooler in the (database, tableGroup) so leader selection
 	// can pick the highest-rule self_leadership across cells (a leader can be
 	// in any cell, and during a rule change two poolers may briefly both
 	// self-claim).
@@ -142,7 +142,9 @@ func (s *MultiadminServer) findPoolerForBackup(ctx context.Context, database, ta
 			continue
 		}
 		for _, info := range poolerInfos {
-			poolers = append(poolers, info.Multipooler)
+			if info.Multipooler.GetServingStatus() == clustermetadatapb.PoolerServingStatus_SERVING {
+				poolers = append(poolers, info.Multipooler)
+			}
 		}
 	}
 
@@ -162,7 +164,7 @@ func (s *MultiadminServer) findPoolerForBackup(ctx context.Context, database, ta
 		if bestLeader != nil {
 			return bestLeader, nil
 		}
-		return nil, fmt.Errorf("leader pooler not found for database=%s, table_group=%s, shard=%s", database, tableGroup, shard)
+		return nil, fmt.Errorf("serving leader pooler not found for database=%s, table_group=%s, shard=%s", database, tableGroup, shard)
 	}
 
 	for _, p := range poolers {
@@ -170,7 +172,7 @@ func (s *MultiadminServer) findPoolerForBackup(ctx context.Context, database, ta
 			return p, nil
 		}
 	}
-	return nil, fmt.Errorf("follower pooler not found for database=%s, table_group=%s, shard=%s", database, tableGroup, shard)
+	return nil, fmt.Errorf("serving follower pooler not found for database=%s, table_group=%s, shard=%s", database, tableGroup, shard)
 }
 
 // GetBackupJobStatus checks the status of a backup or restore job

--- a/go/services/multiadmin/backup_test.go
+++ b/go/services/multiadmin/backup_test.go
@@ -287,6 +287,27 @@ func TestGetBackups_PropagatesLSNAndPgVersion(t *testing.T) {
 	require.Equal(t, "20250104-100000.000000_replica-pooler", resp.Backups[0].JobId)
 }
 
+func TestFindPoolerForBackup_SkipsNonServingReplicas(t *testing.T) {
+	ctx := t.Context()
+	server := newTestServer(t, "cell1")
+	defer server.Stop()
+
+	disabled := makeRoutedPooler("cell1", "disabled-replica", clustermetadatapb.RoutingRole_ROUTING_ROLE_REPLICA)
+	disabled.ServingStatus = clustermetadatapb.PoolerServingStatus_DISABLED
+	require.NoError(t, server.ts.CreateMultipooler(ctx, disabled))
+
+	_, err := server.findPoolerForBackup(ctx, "db1", "default", "0-inf", false)
+	require.ErrorContains(t, err, "serving follower pooler not found")
+
+	serving := makeRoutedPooler("cell1", "serving-replica", clustermetadatapb.RoutingRole_ROUTING_ROLE_REPLICA)
+	serving.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
+	require.NoError(t, server.ts.CreateMultipooler(ctx, serving))
+
+	got, err := server.findPoolerForBackup(ctx, "db1", "default", "0-inf", false)
+	require.NoError(t, err)
+	require.Equal(t, serving.Id.Name, got.Id.Name)
+}
+
 func TestBackup_ForcePrimary(t *testing.T) {
 	ctx := t.Context()
 	ts := memorytopo.NewServer(ctx, "cell1")


### PR DESCRIPTION
## Summary

- Skip non-serving poolers during backup target selection.
- Fail before dispatch when no serving candidate exists, with regression coverage.

## Problem

Backup selection could dispatch to a disabled replica and leave the asynchronous job hanging.

## Solution

Filter candidates to `SERVING` before selecting by routing role.

## Testing

- `go test -count=1 ./go/services/multiadmin`