### PR TITLE
fix(topo): scope component listings to requested cell

### DIFF
--- a/go/common/topoclient/multigateway.go
+++ b/go/common/topoclient/multigateway.go
@@ -149,6 +149,9 @@ func (ts *store) GetMultigatewaysByCell(ctx context.Context, cellName string) ([
 		if err := proto.Unmarshal(listResults[n].Value, multigateway); err != nil {
 			return nil, err
 		}
+		if multigateway.GetId().GetCell() != cellName {
+			continue
+		}
 		mtgateways = append(mtgateways, &MultigatewayInfo{Multigateway: multigateway, version: listResults[n].Version})
 	}
 	return mtgateways, nil

--- a/go/common/topoclient/multigateway.go
+++ b/go/common/topoclient/multigateway.go
@@ -114,13 +114,16 @@ func (ts *store) GetMultigatewayIDsByCell(ctx context.Context, cell string) ([]*
 		return nil, err
 	}
 
-	result := make([]*clustermetadatapb.ID, len(children))
-	for i, child := range children {
+	result := make([]*clustermetadatapb.ID, 0, len(children))
+	for _, child := range children {
 		multigateway := &clustermetadatapb.Multigateway{}
 		if err := proto.Unmarshal(child.Value, multigateway); err != nil {
 			return nil, err
 		}
-		result[i] = multigateway.Id
+		if multigateway.GetId().GetCell() != cell {
+			continue
+		}
+		result = append(result, multigateway.Id)
 	}
 	return result, nil
 }

--- a/go/common/topoclient/multiorch.go
+++ b/go/common/topoclient/multiorch.go
@@ -149,6 +149,9 @@ func (ts *store) GetMultiorchsByCell(ctx context.Context, cellName string) ([]*M
 		if err := proto.Unmarshal(listResults[n].Value, multiorch); err != nil {
 			return nil, err
 		}
+		if multiorch.GetId().GetCell() != cellName {
+			continue
+		}
 		mtorchs = append(mtorchs, &MultiorchInfo{Multiorch: multiorch, version: listResults[n].Version})
 	}
 	return mtorchs, nil

--- a/go/common/topoclient/multiorch.go
+++ b/go/common/topoclient/multiorch.go
@@ -114,13 +114,16 @@ func (ts *store) GetMultiorchIDsByCell(ctx context.Context, cell string) ([]*clu
 		return nil, err
 	}
 
-	result := make([]*clustermetadatapb.ID, len(children))
-	for i, child := range children {
+	result := make([]*clustermetadatapb.ID, 0, len(children))
+	for _, child := range children {
 		multiorch := &clustermetadatapb.Multiorch{}
 		if err := proto.Unmarshal(child.Value, multiorch); err != nil {
 			return nil, err
 		}
-		result[i] = multiorch.Id
+		if multiorch.GetId().GetCell() != cell {
+			continue
+		}
+		result = append(result, multiorch.Id)
 	}
 	return result, nil
 }

--- a/go/common/topoclient/multipooler.go
+++ b/go/common/topoclient/multipooler.go
@@ -216,6 +216,9 @@ func (ts *store) GetMultipoolersByCell(ctx context.Context, cellName string, opt
 		if err := proto.Unmarshal(listResults[n].Value, multipooler); err != nil {
 			return nil, err
 		}
+		if multipooler.GetId().GetCell() != cellName {
+			continue
+		}
 		if opt != nil && opt.DatabaseShard != nil && opt.DatabaseShard.Database != "" {
 			sk := multipooler.GetShardKey()
 			// Database must match

--- a/go/common/topoclient/multipooler.go
+++ b/go/common/topoclient/multipooler.go
@@ -144,13 +144,16 @@ func (ts *store) GetMultipoolerIDsByCell(ctx context.Context, cell string) ([]*c
 		return nil, err
 	}
 
-	result := make([]*clustermetadatapb.ID, len(children))
-	for i, child := range children {
+	result := make([]*clustermetadatapb.ID, 0, len(children))
+	for _, child := range children {
 		multipooler := &clustermetadatapb.Multipooler{}
 		if err := proto.Unmarshal(child.Value, multipooler); err != nil {
 			return nil, err
 		}
-		result[i] = multipooler.Id
+		if multipooler.GetId().GetCell() != cell {
+			continue
+		}
+		result = append(result, multipooler.Id)
 	}
 	return result, nil
 }

--- a/go/common/topoclient/shared_topology_test.go
+++ b/go/common/topoclient/shared_topology_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topoclient_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/topoclient"
+	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+)
+
+type sharedTopologyFactory struct {
+	*memorytopo.Factory
+}
+
+func (f sharedTopologyFactory) Create(_ string, root string, serverAddrs []string) (topoclient.Conn, error) {
+	return f.Factory.Create(topoclient.GlobalCell, root, serverAddrs)
+}
+
+func TestGetComponentsByCell_SharedTopology(t *testing.T) {
+	ctx := t.Context()
+	backingStore, factory := memorytopo.NewServerAndFactory(ctx)
+	defer backingStore.Close()
+
+	const root = "/multigres/global"
+	ts := topoclient.NewWithFactory(sharedTopologyFactory{factory}, root, []string{"global-topo:2379"}, topoclient.NewDefaultTopoConfig())
+	defer ts.Close()
+
+	cells := []string{"zone-a", "zone-b"}
+	for _, cell := range cells {
+		require.NoError(t, ts.CreateCell(ctx, cell, &clustermetadatapb.Cell{
+			Name:            cell,
+			ServerAddresses: []string{"global-topo:2379"},
+			Root:            root,
+		}))
+		require.NoError(t, ts.CreateMultipooler(ctx, topoclient.NewMultipooler("pooler", cell, "host")))
+		require.NoError(t, ts.CreateMultigateway(ctx, topoclient.NewMultigateway("gateway", cell, "host")))
+		require.NoError(t, ts.CreateMultiorch(ctx, topoclient.NewMultiorch("orch", cell, "host")))
+	}
+
+	for _, cell := range cells {
+		poolers, err := ts.GetMultipoolersByCell(ctx, cell, nil)
+		require.NoError(t, err)
+		require.Len(t, poolers, 1)
+		require.Equal(t, cell, poolers[0].GetId().GetCell())
+
+		gateways, err := ts.GetMultigatewaysByCell(ctx, cell)
+		require.NoError(t, err)
+		require.Len(t, gateways, 1)
+		require.Equal(t, cell, gateways[0].GetId().GetCell())
+
+		orchs, err := ts.GetMultiorchsByCell(ctx, cell)
+		require.NoError(t, err)
+		require.Len(t, orchs, 1)
+		require.Equal(t, cell, orchs[0].GetId().GetCell())
+	}
+}

--- a/go/common/topoclient/shared_topology_test.go
+++ b/go/common/topoclient/shared_topology_test.go
@@ -58,15 +58,27 @@ func TestGetComponentsByCell_SharedTopology(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, poolers, 1)
 		require.Equal(t, cell, poolers[0].GetId().GetCell())
+		poolerIDs, err := ts.GetMultipoolerIDsByCell(ctx, cell)
+		require.NoError(t, err)
+		require.Len(t, poolerIDs, 1)
+		require.Equal(t, cell, poolerIDs[0].GetCell())
 
 		gateways, err := ts.GetMultigatewaysByCell(ctx, cell)
 		require.NoError(t, err)
 		require.Len(t, gateways, 1)
 		require.Equal(t, cell, gateways[0].GetId().GetCell())
+		gatewayIDs, err := ts.GetMultigatewayIDsByCell(ctx, cell)
+		require.NoError(t, err)
+		require.Len(t, gatewayIDs, 1)
+		require.Equal(t, cell, gatewayIDs[0].GetCell())
 
 		orchs, err := ts.GetMultiorchsByCell(ctx, cell)
 		require.NoError(t, err)
 		require.Len(t, orchs, 1)
 		require.Equal(t, cell, orchs[0].GetId().GetCell())
+		orchIDs, err := ts.GetMultiorchIDsByCell(ctx, cell)
+		require.NoError(t, err)
+		require.Len(t, orchIDs, 1)
+		require.Equal(t, cell, orchIDs[0].GetCell())
 	}
 }


### PR DESCRIPTION
## Summary

- Scope pooler, gateway, and orch listings to the requested cell.
- Add regression coverage for cells sharing the same topology server and root.

## Problem

When cells share a topology path, each per-cell listing returns every component, causing duplicate multiadmin API results.

## Solution

Filter unmarshaled records by their own cell in the typed `Get*ByCell` methods while continuing to support shared topology layouts.