### PR TITLE
fix(multipooler): quarantine interrupted pg rewind

### DIFF
--- a/go/cmd/pgctld/testutil/grpc_helpers.go
+++ b/go/cmd/pgctld/testutil/grpc_helpers.go
@@ -77,6 +77,10 @@ type MockPgCtldService struct {
 	// postgresql.auto.conf already carries primary_conninfo before the standby
 	// comes up. Called while the mutex is held.
 	RestartFunc func(*pb.RestartRequest)
+
+	// PgRewindFunc, if non-nil, handles PgRewind requests instead of the
+	// configured response/error. Called while the mutex is held.
+	PgRewindFunc func(context.Context, *pb.PgRewindRequest) (*pb.PgRewindResponse, error)
 }
 
 func (m *MockPgCtldService) Start(ctx context.Context, req *pb.StartRequest) (*pb.StartResponse, error) {
@@ -202,6 +206,9 @@ func (m *MockPgCtldService) PgRewind(ctx context.Context, req *pb.PgRewindReques
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.PgRewindCalls = append(m.PgRewindCalls, req)
+	if m.PgRewindFunc != nil {
+		return m.PgRewindFunc(ctx, req)
+	}
 	if m.PgRewindError != nil {
 		return nil, m.PgRewindError
 	}

--- a/go/services/multiorch/recovery/actions/demote_stale_leader.go
+++ b/go/services/multiorch/recovery/actions/demote_stale_leader.go
@@ -40,10 +40,15 @@ import (
 // Compile-time assertion that DemoteStaleLeaderAction implements types.RecoveryAction.
 var _ types.RecoveryAction = (*DemoteStaleLeaderAction)(nil)
 
-// StaleLeaderDrainTimeout is a shorter drain timeout for stale leaders.
-// Stale leaders that just came back online typically have no active connections,
-// so we use a shorter timeout to speed up demotion.
-const StaleLeaderDrainTimeout = 5 * time.Second
+const (
+	// StaleLeaderDrainTimeout is a shorter drain timeout for stale leaders.
+	// Stale leaders that just came back online typically have no active connections.
+	StaleLeaderDrainTimeout = 5 * time.Second
+	// staleLeaderActionTimeout leaves room for a loaded node's pg_rewind dry-run,
+	// measured destructive pass, and restart. Pooler-side budgeting still refuses
+	// to begin the destructive pass when this remaining deadline is insufficient.
+	staleLeaderActionTimeout = 15 * time.Minute
+)
 
 // DemoteStaleLeaderAction demotes a stale leader that was detected after failover.
 // It uses the SetPrimary RPC with the correct leader's rule to force the stale leader
@@ -82,7 +87,7 @@ func (a *DemoteStaleLeaderAction) Metadata() types.RecoveryMetadata {
 	return types.RecoveryMetadata{
 		Name:        "DemoteStaleLeader",
 		Description: "Demote a stale leader that came back online after failover",
-		Timeout:     60 * time.Second,
+		Timeout:     staleLeaderActionTimeout,
 		LockTimeout: 15 * time.Second,
 		Retryable:   true,
 	}

--- a/go/services/multiorch/recovery/actions/demote_stale_leader.go
+++ b/go/services/multiorch/recovery/actions/demote_stale_leader.go
@@ -44,9 +44,8 @@ const (
 	// StaleLeaderDrainTimeout is a shorter drain timeout for stale leaders.
 	// Stale leaders that just came back online typically have no active connections.
 	StaleLeaderDrainTimeout = 5 * time.Second
-	// staleLeaderActionTimeout leaves room for a loaded node's pg_rewind dry-run,
-	// measured destructive pass, and restart. Pooler-side budgeting still refuses
-	// to begin the destructive pass when this remaining deadline is insufficient.
+	// staleLeaderActionTimeout leaves room for the pooler's bounded pg_rewind
+	// maintenance and restart while retaining action-level headroom.
 	staleLeaderActionTimeout = 15 * time.Minute
 )
 

--- a/go/services/multiorch/recovery/actions/demote_stale_leader_test.go
+++ b/go/services/multiorch/recovery/actions/demote_stale_leader_test.go
@@ -100,7 +100,7 @@ func TestDemoteStaleLeaderAction_Metadata(t *testing.T) {
 	md := action.Metadata()
 	assert.Equal(t, "DemoteStaleLeader", md.Name)
 	assert.True(t, md.Retryable)
-	assert.Equal(t, 60*time.Second, md.Timeout)
+	assert.Equal(t, 15*time.Minute, md.Timeout)
 }
 
 func TestDemoteStaleLeaderAction_RequiresHealthyLeader(t *testing.T) {

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -120,6 +120,7 @@ type postgresState struct {
 	connInfo                 *multipoolermanagerdatapb.PrimaryConnInfo
 	pgMode                   pgmode.Mode
 	bootstrapSentinelPresent bool
+	rewindSentinelPresent    bool
 	// rewindSourceReady is true when this pooler is a primary whose last completed
 	// checkpoint is on its current running timeline, so it is safe to pg_rewind
 	// from. False on standbys and on a freshly promoted primary that has not yet
@@ -135,6 +136,7 @@ func postgresStateEqual(a, b postgresState) bool {
 		a.backupsAvailable == b.backupsAvailable &&
 		a.pgMode == b.pgMode &&
 		a.bootstrapSentinelPresent == b.bootstrapSentinelPresent &&
+		a.rewindSentinelPresent == b.rewindSentinelPresent &&
 		a.rewindSourceReady == b.rewindSourceReady
 }
 
@@ -143,6 +145,10 @@ type remedialAction int
 
 const (
 	remedialActionNone remedialAction = iota
+	// remedialActionQuarantineFailedRewind handles a durable sentinel left by a
+	// real pg_rewind that did not complete. PGDATA may be partially rewritten, so
+	// postgres must not start; quarantine delegates replacement to the operator.
+	remedialActionQuarantineFailedRewind
 	remedialActionStartPostgres
 	remedialActionRestoreFromBackup
 	remedialActionCreateFirstBackup
@@ -333,6 +339,18 @@ func (pm *MultipoolerManager) discoverPostgresState(ctx context.Context) (postgr
 		return state, nil // All fields remain false
 	}
 	state.pgctldAvailable = true
+
+	// A rewind sentinel lives outside PGDATA and survives process/pod restarts.
+	// Check it before touching pgctld: its presence means a destructive rewind may
+	// have been interrupted, so no postgres probe or start is safe.
+	var err error
+	state.rewindSentinelPresent, err = pm.hasPgRewindSentinel()
+	if err != nil {
+		return state, fmt.Errorf("check pg_rewind sentinel: %w", err)
+	}
+	if state.rewindSentinelPresent {
+		return state, nil
+	}
 
 	// Get status from pgctld. On failure return both the state (with
 	// pgctldAvailable=false) and the error so the caller can log the
@@ -867,6 +885,9 @@ func (pm *MultipoolerManager) determineRemedialAction(ctx context.Context, curre
 	if !currentState.pgctldAvailable {
 		return remedialActionNone
 	}
+	if currentState.rewindSentinelPresent {
+		return remedialActionQuarantineFailedRewind
+	}
 
 	// Postgres is running: reconcile against the consensus rule. First align the
 	// role (determineRoleAction), then when the role needs no action
@@ -1110,6 +1131,10 @@ func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action rem
 	switch action {
 	case remedialActionNone:
 		// No action to take
+		return nil
+
+	case remedialActionQuarantineFailedRewind:
+		pm.markPoolerQuarantinedLocked(ctx, "pg_rewind sentinel found; PGDATA may be partially rewritten")
 		return nil
 
 	case remedialActionDemoteStalePrimary:

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -231,6 +231,28 @@ func TestDiscoverPostgresState_BootstrapSentinelPresent(t *testing.T) {
 	assert.True(t, state.bootstrapSentinelPresent)
 }
 
+func TestDiscoverPostgresState_RewindSentinelQuarantines(t *testing.T) {
+	pm := NewTestMultipoolerManager(t)
+	pm.pgctldClient = &mockPgctldClient{}
+	require.NoError(t, pm.writePgRewindSentinel())
+
+	state, err := pm.discoverPostgresState(t.Context())
+	require.NoError(t, err)
+	assert.True(t, state.rewindSentinelPresent)
+	assert.False(t, state.postgresRunning, "sentinel must short-circuit postgres probing")
+	assert.Equal(t, remedialActionQuarantineFailedRewind, pm.determineRemedialAction(t.Context(), state))
+
+	lockCtx, err := pm.actionLock.Acquire(t.Context(), "test")
+	require.NoError(t, err)
+	defer pm.actionLock.Release(lockCtx)
+	require.NoError(t, pm.takeRemedialAction(lockCtx, remedialActionQuarantineFailedRewind, state))
+
+	assert.Equal(t, clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_QUARANTINED,
+		pm.record.Snapshot().GetLifecycleStatus().GetStatus())
+	assert.True(t, pm.postgresRestartsDisabled.Load())
+	assert.False(t, pm.pgctldClient.(*mockPgctldClient).startCalled)
+}
+
 func TestDiscoverPostgresState_StatusError(t *testing.T) {
 	ctx := t.Context()
 
@@ -1608,6 +1630,7 @@ func TestPostgresStateEqual(t *testing.T) {
 		backupsAvailable:         true,
 		pgMode:                   pgmode.Primary,
 		bootstrapSentinelPresent: true,
+		rewindSentinelPresent:    true,
 	}
 
 	t.Run("equal states", func(t *testing.T) {
@@ -1624,6 +1647,7 @@ func TestPostgresStateEqual(t *testing.T) {
 		{"backupsAvailable", func() postgresState { s := base; s.backupsAvailable = false; return s }()},
 		{"pgMode", func() postgresState { s := base; s.pgMode = pgmode.InRecovery; return s }()},
 		{"bootstrapSentinelPresent", func() postgresState { s := base; s.bootstrapSentinelPresent = false; return s }()},
+		{"rewindSentinelPresent", func() postgresState { s := base; s.rewindSentinelPresent = false; return s }()},
 	}
 	for _, tc := range tests {
 		t.Run("differs in "+tc.name, func(t *testing.T) {

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -16,6 +16,7 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -798,6 +799,25 @@ func (pm *MultipoolerManager) SetPostgresRestartsEnabled(ctx context.Context, re
 // Helper methods for stale-primary demotion (used by SetPrimary)
 // ====================================================================================
 
+const (
+	pgRewindSentinelFile      = "PG_REWIND_IN_PROGRESS"
+	minRewindCompletionBudget = 30 * time.Second
+	maxRewindCompletionBudget = 10 * time.Minute
+	rewindRestartMargin       = 30 * time.Second
+)
+
+// rewindCompletionBudget gives the destructive pass twice the measured dry-run
+// duration plus time to repair config and restart postgres. The floor covers
+// tiny dry-runs where the real write is disproportionately slower; the ceiling
+// keeps maintenance bounded.
+func rewindCompletionBudget(dryRunDuration time.Duration) (time.Duration, error) {
+	budget := max(2*dryRunDuration+rewindRestartMargin, minRewindCompletionBudget)
+	if budget > maxRewindCompletionBudget {
+		return 0, fmt.Errorf("required pg_rewind completion budget %s exceeds maximum %s", budget, maxRewindCompletionBudget)
+	}
+	return budget, nil
+}
+
 // pgctldStopWithEscalation walks pgctldStopModes calling pgctld.Stop, returning
 // nil as soon as a mode succeeds or postgres is already stopped, or the last
 // error if every mode fails. Caller is responsible for any Pause()/resume()
@@ -885,6 +905,16 @@ func (pm *MultipoolerManager) restartAsStandbyLocked(
 	// pg_rewind dry-run (cheap when there's no divergence) runs whenever divergence
 	// is suspected.
 	wantRewind := pm.consensusMgr.SuspectedDivergence()
+	if wantRewind {
+		sentinelPresent, err := pm.hasPgRewindSentinel()
+		if err != nil {
+			return false, mterrors.Wrap(err, "check pg_rewind sentinel")
+		}
+		if sentinelPresent {
+			pm.markPoolerQuarantinedLocked(ctx, "pg_rewind sentinel found; PGDATA may be partially rewritten")
+			return false, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION, "refusing pg_rewind: prior rewind did not complete")
+		}
+	}
 
 	if wantRewind {
 		// pg_rewind rewinds to the last shared checkpoint, not the last common
@@ -947,11 +977,27 @@ func (pm *MultipoolerManager) restartAsStandbyLocked(
 	// self-stopping would deadlock) or holds the action lock (the monitor blocks on
 	// it before acting), so there is nothing to stop.
 	resume := pm.Pause(ctx)
-	defer resume(ctx) // safety net; explicit resume() below after restart succeeds
+	defer func() {
+		// Resume even when the initiating RPC has expired. WithoutCancel preserves
+		// the action-lock ownership value required by resume.
+		resume(context.WithoutCancel(ctx))
+	}()
 
 	if err := pm.pgctldStopWithEscalation(ctx); err != nil {
 		return false, mterrors.Wrap(err, "stop postgres")
 	}
+
+	var rewindSentinelArmed bool
+	defer func() {
+		if !rewindSentinelArmed {
+			return
+		}
+		reason := "pg_rewind did not complete; PGDATA may be partially rewritten"
+		if err != nil {
+			reason += ": " + err.Error()
+		}
+		pm.markPoolerQuarantinedLocked(context.WithoutCancel(ctx), reason)
+	}()
 
 	if wantRewind {
 		// Record how long this rewind waited for the source leader to become
@@ -969,9 +1015,44 @@ func (pm *MultipoolerManager) restartAsStandbyLocked(
 				"source_host", sourceHost, "source_port", sourcePort)
 			pm.metrics.recordRewindCheckpointWait(ctx, waited)
 		}
-		rewindPerformed, err = pm.runPgRewind(ctx, sourceHost, sourcePort)
+		var (
+			rewindNeeded   bool
+			dryRunDuration time.Duration
+		)
+		rewindNeeded, dryRunDuration, err = pm.pgRewindDryRun(ctx, sourceHost, sourcePort)
 		if err != nil {
 			return false, mterrors.Wrap(err, "pg_rewind")
+		}
+		if rewindNeeded {
+			budget, budgetErr := rewindCompletionBudget(dryRunDuration)
+			if budgetErr != nil {
+				pm.markPoolerQuarantinedLocked(context.WithoutCancel(ctx), budgetErr.Error())
+				return false, budgetErr
+			}
+			if deadline, ok := ctx.Deadline(); ok {
+				remaining := time.Until(deadline)
+				if remaining < dryRunDuration {
+					return false, mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
+						"not starting destructive pg_rewind: dry-run took %s but only %s remains",
+						dryRunDuration, max(remaining, 0))
+				}
+			}
+
+			// Keep the destructive pass and post-rewind restart synchronous under
+			// the action lock, but give them a fresh bounded context so expiry of
+			// the initiating RPC cannot kill pg_rewind midway.
+			maintenanceCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), budget)
+			defer cancel()
+			ctx = maintenanceCtx
+
+			if err := pm.writePgRewindSentinel(); err != nil {
+				return false, mterrors.Wrap(err, "write pg_rewind sentinel")
+			}
+			rewindSentinelArmed = true
+			if err := pm.runPgRewind(ctx, sourceHost, sourcePort); err != nil {
+				return false, mterrors.Wrap(err, "pg_rewind")
+			}
+			rewindPerformed = true
 		}
 		// suspectedDivergence is intentionally NOT cleared here. It is cleared only
 		// after postgres restarts and is verified in recovery mode below, because a
@@ -1088,62 +1169,121 @@ func (pm *MultipoolerManager) restartAsStandbyLocked(
 		}
 	}
 
+	if rewindSentinelArmed {
+		if err := pm.removePgRewindSentinel(); err != nil {
+			return false, mterrors.Wrap(err, "remove pg_rewind sentinel")
+		}
+		rewindSentinelArmed = false
+	}
+
 	return rewindPerformed, nil
 }
 
-// runPgRewind runs pg_rewind to sync with source.
-// Returns true if rewind was performed, false if not needed.
-func (pm *MultipoolerManager) runPgRewind(ctx context.Context, sourceHost string, sourcePort int32) (bool, error) {
+// pgRewindDryRun checks whether source and target diverged and returns how long
+// the check took so the destructive pass can receive a realistic budget.
+func (pm *MultipoolerManager) pgRewindDryRun(ctx context.Context, sourceHost string, sourcePort int32) (needed bool, duration time.Duration, err error) {
 	if pm.pgctldClient == nil {
-		return false, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION, "pgctld client not initialized")
+		return false, 0, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION, "pgctld client not initialized")
 	}
-
-	// Get application name for replication connection
-	pid := pm.servicePoolerID
 
 	pm.logger.InfoContext(ctx, "running pg_rewind dry-run (may do crash recovery)",
 		"source_host", sourceHost, "source_port", sourcePort)
-
-	// Dry-run to check if rewind is needed
-	dryRunReq := &pgctldpb.PgRewindRequest{
+	started := time.Now()
+	resp, err := pm.pgctldClient.PgRewind(ctx, &pgctldpb.PgRewindRequest{
 		SourceHost:      sourceHost,
 		SourcePort:      sourcePort,
 		DryRun:          true,
-		ApplicationName: pid.AppName(),
-	}
-	dryRunResp, err := pm.pgctldClient.PgRewind(ctx, dryRunReq)
+		ApplicationName: pm.servicePoolerID.AppName(),
+	})
+	duration = time.Since(started)
 	if err != nil {
-		if dryRunResp != nil {
-			pm.logger.ErrorContext(ctx, "pg_rewind dry-run failed", "error", err, "output", dryRunResp.Output)
+		if resp != nil {
+			pm.logger.ErrorContext(ctx, "pg_rewind dry-run failed", "error", err, "output", resp.Output)
 		}
-		return false, mterrors.Wrap(err, "pg_rewind dry-run failed")
+		return false, duration, mterrors.Wrap(err, "pg_rewind dry-run failed")
 	}
+	output := resp.GetOutput()
+	if !strings.Contains(output, "no rewind required") && strings.Contains(output, "servers diverged at") {
+		pm.logger.InfoContext(ctx, "servers diverged; destructive pg_rewind required", "dry_run_duration", duration)
+		return true, duration, nil
+	}
+	pm.logger.InfoContext(ctx, "no divergence, skipping rewind", "dry_run_duration", duration)
+	return false, duration, nil
+}
 
-	// Check if servers diverged
-	if dryRunResp.Output != "" && strings.Contains(dryRunResp.Output, "servers diverged at") {
-		pm.logger.InfoContext(ctx, "servers diverged, running pg_rewind with -R flag")
-
-		rewindReq := &pgctldpb.PgRewindRequest{
-			SourceHost:      sourceHost,
-			SourcePort:      sourcePort,
-			DryRun:          false,
-			ApplicationName: pid.AppName(),
-			ExtraArgs:       []string{"-R"},
+// runPgRewind runs the real, destructive pg_rewind. The caller must first write
+// the durable sentinel and provide a bounded context independent of the
+// initiating RPC.
+func (pm *MultipoolerManager) runPgRewind(ctx context.Context, sourceHost string, sourcePort int32) error {
+	resp, err := pm.pgctldClient.PgRewind(ctx, &pgctldpb.PgRewindRequest{
+		SourceHost:      sourceHost,
+		SourcePort:      sourcePort,
+		ApplicationName: pm.servicePoolerID.AppName(),
+		ExtraArgs:       []string{"-R"},
+	})
+	if err != nil {
+		if resp != nil {
+			pm.logger.ErrorContext(ctx, "pg_rewind failed", "error", err, "output", resp.Output)
 		}
-		rewindResp, err := pm.pgctldClient.PgRewind(ctx, rewindReq)
-		if err != nil {
-			if rewindResp != nil {
-				pm.logger.ErrorContext(ctx, "pg_rewind failed", "error", err, "output", rewindResp.Output)
-			}
-			return false, mterrors.Wrap(err, "pg_rewind failed")
-		}
+		return mterrors.Wrap(err, "pg_rewind failed")
+	}
+	pm.logger.InfoContext(ctx, "pg_rewind completed")
+	return nil
+}
 
-		pm.logger.InfoContext(ctx, "pg_rewind completed")
+func (pm *MultipoolerManager) pgRewindSentinelPath() string {
+	if pm.record == nil || pm.record.PoolerDir() == "" {
+		return ""
+	}
+	return filepath.Join(pm.record.PoolerDir(), pgRewindSentinelFile)
+}
+
+func (pm *MultipoolerManager) hasPgRewindSentinel() (bool, error) {
+	path := pm.pgRewindSentinelPath()
+	if path == "" {
+		return false, nil
+	}
+	_, err := os.Stat(path)
+	if err == nil {
 		return true, nil
 	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
 
-	pm.logger.InfoContext(ctx, "no divergence, skipping rewind")
-	return false, nil
+// writePgRewindSentinel durably records that the real pg_rewind may mutate
+// PGDATA. It lives in pooler_dir, outside PGDATA, so pg_rewind cannot overwrite
+// it. Once successfully synced, it remains until verified restart.
+func (pm *MultipoolerManager) writePgRewindSentinel() error {
+	path := pm.pgRewindSentinelPath()
+	if path == "" {
+		return errors.New("pooler directory is not configured")
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := f.WriteString("pg_rewind in progress\n"); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return err
+	}
+	return f.Close()
+}
+
+func (pm *MultipoolerManager) removePgRewindSentinel() error {
+	path := pm.pgRewindSentinelPath()
+	if path == "" {
+		return errors.New("pooler directory is not configured")
+	}
+	return os.Remove(path)
 }
 
 // fixPgBackRestPaths fixes the pgbackrest paths in postgresql.auto.conf

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -800,23 +800,9 @@ func (pm *MultipoolerManager) SetPostgresRestartsEnabled(ctx context.Context, re
 // ====================================================================================
 
 const (
-	pgRewindSentinelFile      = "PG_REWIND_IN_PROGRESS"
-	minRewindCompletionBudget = 30 * time.Second
-	maxRewindCompletionBudget = 10 * time.Minute
-	rewindRestartMargin       = 30 * time.Second
+	pgRewindSentinelFile       = "PG_REWIND_IN_PROGRESS"
+	pgRewindMaintenanceTimeout = 10 * time.Minute
 )
-
-// rewindCompletionBudget gives the destructive pass twice the measured dry-run
-// duration plus time to repair config and restart postgres. The floor covers
-// tiny dry-runs where the real write is disproportionately slower; the ceiling
-// keeps maintenance bounded.
-func rewindCompletionBudget(dryRunDuration time.Duration) (time.Duration, error) {
-	budget := max(2*dryRunDuration+rewindRestartMargin, minRewindCompletionBudget)
-	if budget > maxRewindCompletionBudget {
-		return 0, fmt.Errorf("required pg_rewind completion budget %s exceeds maximum %s", budget, maxRewindCompletionBudget)
-	}
-	return budget, nil
-}
 
 // pgctldStopWithEscalation walks pgctldStopModes calling pgctld.Stop, returning
 // nil as soon as a mode succeeds or postgres is already stopped, or the last
@@ -869,10 +855,10 @@ func (pm *MultipoolerManager) pgctldStopWithEscalation(ctx context.Context) erro
 // after an emergency demote; SetPrimary's stale-primary branch sets it; the
 // monitor sets it for a stale-primary demote, after crash recovery against a
 // different leader, and for a standby stuck unable to stream from its recorded
-// leader). When the flag is clear we
-// skip even the pg_rewind dry-run — the WAL is trusted and we just need to
-// come back as a standby. The flag is cleared only after postgres restarts and
-// is verified in recovery mode below, NOT as soon as pg_rewind returns: an early
+// leader). When the flag is clear we skip pg_rewind entirely — the WAL is
+// trusted and we just need to come back as a standby. The flag is cleared only
+// after postgres restarts and is verified in recovery mode below, NOT as soon as
+// pg_rewind returns: an early
 // rewind from a not-yet-checkpointed leader can stamp minRecoveryPoint onto the
 // wrong timeline and FATAL on startup, so a doomed restart must re-run the rewind
 // on retry (against the by-then-checkpointed leader) rather than skip it. pg_rewind
@@ -902,8 +888,8 @@ func (pm *MultipoolerManager) restartAsStandbyLocked(
 	// node as a standby of the source without first rewinding would FATAL on the
 	// node's own un-replicated WAL (it forked off the old timeline past where the
 	// surviving timeline branched), so we never restart-without-rewind here; the
-	// pg_rewind dry-run (cheap when there's no divergence) runs whenever divergence
-	// is suspected.
+	// pg_rewind runs whenever divergence is suspected and decides internally
+	// whether any rewrite is needed.
 	wantRewind := pm.consensusMgr.SuspectedDivergence()
 	if wantRewind {
 		sentinelPresent, err := pm.hasPgRewindSentinel()
@@ -1015,44 +1001,21 @@ func (pm *MultipoolerManager) restartAsStandbyLocked(
 				"source_host", sourceHost, "source_port", sourcePort)
 			pm.metrics.recordRewindCheckpointWait(ctx, waited)
 		}
-		var (
-			rewindNeeded   bool
-			dryRunDuration time.Duration
-		)
-		rewindNeeded, dryRunDuration, err = pm.pgRewindDryRun(ctx, sourceHost, sourcePort)
+		// pg_rewind itself decides whether target and source diverged, returning
+		// quickly without mutation when no rewind is required. Run that decision
+		// and any resulting writes once under the same independent bound: a
+		// caller deadline must not kill either phase midway.
+		maintenanceCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), pgRewindMaintenanceTimeout)
+		defer cancel()
+		ctx = maintenanceCtx
+
+		if err := pm.writePgRewindSentinel(); err != nil {
+			return false, mterrors.Wrap(err, "write pg_rewind sentinel")
+		}
+		rewindSentinelArmed = true
+		rewindPerformed, err = pm.runPgRewind(ctx, sourceHost, sourcePort)
 		if err != nil {
 			return false, mterrors.Wrap(err, "pg_rewind")
-		}
-		if rewindNeeded {
-			budget, budgetErr := rewindCompletionBudget(dryRunDuration)
-			if budgetErr != nil {
-				pm.markPoolerQuarantinedLocked(context.WithoutCancel(ctx), budgetErr.Error())
-				return false, budgetErr
-			}
-			if deadline, ok := ctx.Deadline(); ok {
-				remaining := time.Until(deadline)
-				if remaining < dryRunDuration {
-					return false, mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
-						"not starting destructive pg_rewind: dry-run took %s but only %s remains",
-						dryRunDuration, max(remaining, 0))
-				}
-			}
-
-			// Keep the destructive pass and post-rewind restart synchronous under
-			// the action lock, but give them a fresh bounded context so expiry of
-			// the initiating RPC cannot kill pg_rewind midway.
-			maintenanceCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), budget)
-			defer cancel()
-			ctx = maintenanceCtx
-
-			if err := pm.writePgRewindSentinel(); err != nil {
-				return false, mterrors.Wrap(err, "write pg_rewind sentinel")
-			}
-			rewindSentinelArmed = true
-			if err := pm.runPgRewind(ctx, sourceHost, sourcePort); err != nil {
-				return false, mterrors.Wrap(err, "pg_rewind")
-			}
-			rewindPerformed = true
 		}
 		// suspectedDivergence is intentionally NOT cleared here. It is cleared only
 		// after postgres restarts and is verified in recovery mode below, because a
@@ -1179,42 +1142,14 @@ func (pm *MultipoolerManager) restartAsStandbyLocked(
 	return rewindPerformed, nil
 }
 
-// pgRewindDryRun checks whether source and target diverged and returns how long
-// the check took so the destructive pass can receive a realistic budget.
-func (pm *MultipoolerManager) pgRewindDryRun(ctx context.Context, sourceHost string, sourcePort int32) (needed bool, duration time.Duration, err error) {
+// runPgRewind lets pg_rewind decide whether target and source diverged and, if
+// needed, repair PGDATA. The caller must first write the durable sentinel and
+// provide a bounded context independent of the initiating RPC.
+func (pm *MultipoolerManager) runPgRewind(ctx context.Context, sourceHost string, sourcePort int32) (bool, error) {
 	if pm.pgctldClient == nil {
-		return false, 0, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION, "pgctld client not initialized")
+		return false, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION, "pgctld client not initialized")
 	}
 
-	pm.logger.InfoContext(ctx, "running pg_rewind dry-run (may do crash recovery)",
-		"source_host", sourceHost, "source_port", sourcePort)
-	started := time.Now()
-	resp, err := pm.pgctldClient.PgRewind(ctx, &pgctldpb.PgRewindRequest{
-		SourceHost:      sourceHost,
-		SourcePort:      sourcePort,
-		DryRun:          true,
-		ApplicationName: pm.servicePoolerID.AppName(),
-	})
-	duration = time.Since(started)
-	if err != nil {
-		if resp != nil {
-			pm.logger.ErrorContext(ctx, "pg_rewind dry-run failed", "error", err, "output", resp.Output)
-		}
-		return false, duration, mterrors.Wrap(err, "pg_rewind dry-run failed")
-	}
-	output := resp.GetOutput()
-	if !strings.Contains(output, "no rewind required") && strings.Contains(output, "servers diverged at") {
-		pm.logger.InfoContext(ctx, "servers diverged; destructive pg_rewind required", "dry_run_duration", duration)
-		return true, duration, nil
-	}
-	pm.logger.InfoContext(ctx, "no divergence, skipping rewind", "dry_run_duration", duration)
-	return false, duration, nil
-}
-
-// runPgRewind runs the real, destructive pg_rewind. The caller must first write
-// the durable sentinel and provide a bounded context independent of the
-// initiating RPC.
-func (pm *MultipoolerManager) runPgRewind(ctx context.Context, sourceHost string, sourcePort int32) error {
 	resp, err := pm.pgctldClient.PgRewind(ctx, &pgctldpb.PgRewindRequest{
 		SourceHost:      sourceHost,
 		SourcePort:      sourcePort,
@@ -1225,10 +1160,14 @@ func (pm *MultipoolerManager) runPgRewind(ctx context.Context, sourceHost string
 		if resp != nil {
 			pm.logger.ErrorContext(ctx, "pg_rewind failed", "error", err, "output", resp.Output)
 		}
-		return mterrors.Wrap(err, "pg_rewind failed")
+		return false, mterrors.Wrap(err, "pg_rewind failed")
+	}
+	if strings.Contains(resp.GetOutput(), "no rewind required") {
+		pm.logger.InfoContext(ctx, "pg_rewind completed; no rewind required")
+		return false, nil
 	}
 	pm.logger.InfoContext(ctx, "pg_rewind completed")
-	return nil
+	return true, nil
 }
 
 func (pm *MultipoolerManager) pgRewindSentinelPath() string {

--- a/go/services/multipooler/internal/manager/rpc_manager_test.go
+++ b/go/services/multipooler/internal/manager/rpc_manager_test.go
@@ -1050,7 +1050,12 @@ func TestUpdateConsensusRule_RejectsWhenSelfRevoked(t *testing.T) {
 // SetPrimary's stale-primary branch and the monitor's divergence-rewind path.
 func rewindAsStandbyForTest(t *testing.T, manager *MultipoolerManager, source *clustermetadatapb.Multipooler) (bool, error) {
 	t.Helper()
-	lockCtx, err := manager.actionLock.Acquire(t.Context(), "test-rewind")
+	return rewindAsStandbyWithContextForTest(t, t.Context(), manager, source)
+}
+
+func rewindAsStandbyWithContextForTest(t *testing.T, ctx context.Context, manager *MultipoolerManager, source *clustermetadatapb.Multipooler) (bool, error) {
+	t.Helper()
+	lockCtx, err := manager.actionLock.Acquire(ctx, "test-rewind")
 	require.NoError(t, err)
 	defer manager.actionLock.Release(lockCtx)
 	if _, err := manager.consensusMgr.SetSuspectedDivergence(lockCtx, true); err != nil {
@@ -1059,11 +1064,23 @@ func rewindAsStandbyForTest(t *testing.T, manager *MultipoolerManager, source *c
 	return manager.restartAsStandbyLocked(lockCtx, source.Hostname, source.PortMap["postgres"])
 }
 
-// TestRestartAsStandby_ManagerReopenedOnError is a regression test for a bug where
-// the rewind path would leave the manager closed if an error occurred after
-// pausing. The fix uses the Pause()/resume() pattern with defer to guarantee the
-// manager is always reopened, even on error paths.
-func TestRestartAsStandby_ManagerReopenedOnError(t *testing.T) {
+func TestRewindCompletionBudget(t *testing.T) {
+	budget, err := rewindCompletionBudget(0)
+	require.NoError(t, err)
+	assert.Equal(t, minRewindCompletionBudget, budget)
+
+	budget, err = rewindCompletionBudget(time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, 2*time.Minute+rewindRestartMargin, budget)
+
+	_, err = rewindCompletionBudget(5 * time.Minute)
+	require.ErrorContains(t, err, "exceeds maximum")
+}
+
+// TestRestartAsStandby_RealRewindFailureQuarantines verifies that once the real
+// pg_rewind has started, a failure prevents any postgres start on the potentially
+// partial PGDATA and publishes a quarantine verdict for replacement.
+func TestRestartAsStandby_RealRewindFailureQuarantines(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	ctx := context.Background()
 
@@ -1091,9 +1108,14 @@ func TestRestartAsStandby_ManagerReopenedOnError(t *testing.T) {
 		},
 	}
 
-	// Start a mock pgctld server that will fail the Stop call
 	mockPgctld := &testutil.MockPgCtldService{
-		StopError: errors.New("mock error: PostgreSQL stop failed"),
+		PgRewindFunc: func(_ context.Context, req *pgctldpb.PgRewindRequest) (*pgctldpb.PgRewindResponse, error) {
+			if req.GetDryRun() {
+				return &pgctldpb.PgRewindResponse{Output: "servers diverged at WAL location 0/5000000 on timeline 1"}, nil
+			}
+			assert.FileExists(t, filepath.Join(poolerDir, pgRewindSentinelFile))
+			return nil, errors.New("mock real pg_rewind failed")
+		},
 	}
 	pgctldAddr, cleanupPgctld := testutil.StartMockPgctldServer(t, mockPgctld)
 	t.Cleanup(cleanupPgctld)
@@ -1143,21 +1165,24 @@ func TestRestartAsStandby_ManagerReopenedOnError(t *testing.T) {
 		},
 	}
 
-	// Drive the rewind core - this should fail during the Stop call
 	_, err = rewindAsStandbyForTest(t, manager, source)
+	require.ErrorContains(t, err, "mock real pg_rewind failed")
 
-	// Verify the call failed as expected
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "PostgreSQL stop failed")
+	lifecycle := manager.record.Snapshot().GetLifecycleStatus()
+	assert.Equal(t, clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_QUARANTINED, lifecycle.GetStatus())
+	assert.Contains(t, lifecycle.GetReason(), "pg_rewind failed")
+	assert.True(t, manager.postgresRestartsDisabled.Load(), "monitor must not start potentially partial PGDATA")
+	assert.Equal(t, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE, manager.consensusMgr.CohortEligibility())
+	assert.Empty(t, mockPgctld.RestartCalls)
+	assert.Empty(t, mockPgctld.StartCalls)
+	assert.FileExists(t, filepath.Join(poolerDir, pgRewindSentinelFile), "failed rewind must leave durable sentinel")
 
-	// CRITICAL REGRESSION TEST: Verify the manager was reopened despite the error.
-	// This is the bug we're testing for: if the rewind fails, the manager must
-	// still be reopened so the node can continue operating.
+	// Pause's deferred resume still reopens the manager so it can publish health.
 	require.Eventually(t, func() bool {
 		manager.mu.Lock()
 		defer manager.mu.Unlock()
 		return manager.isOpen
-	}, 2*time.Second, 50*time.Millisecond, "REGRESSION: Manager should be reopened even when the rewind fails")
+	}, 2*time.Second, 50*time.Millisecond)
 }
 
 // TestRestartAsStandby_RestoresPrimaryConnInfo is a regression test for the bug where
@@ -1193,12 +1218,22 @@ func TestRestartAsStandby_RestoresPrimaryConnInfo(t *testing.T) {
 		},
 	}
 
-	// Mock pgctld: dry-run reports divergence so actual pg_rewind runs; all else succeeds.
-	mockPgctld := &testutil.MockPgCtldService{
-		PgRewindResponse: &pgctldpb.PgRewindResponse{
+	// Cancel the initiating RPC when the real rewind starts. The bounded
+	// maintenance context must keep rewind and restart alive synchronously under
+	// the action lock rather than killing pg_rewind against partial PGDATA.
+	requestCtx, cancelRequest := context.WithTimeout(t.Context(), 15*time.Minute)
+	defer cancelRequest()
+	mockPgctld := &testutil.MockPgCtldService{}
+	mockPgctld.PgRewindFunc = func(callCtx context.Context, req *pgctldpb.PgRewindRequest) (*pgctldpb.PgRewindResponse, error) {
+		if !req.GetDryRun() {
+			assert.FileExists(t, filepath.Join(poolerDir, pgRewindSentinelFile))
+			cancelRequest()
+		}
+		require.NoError(t, callCtx.Err(), "rewind maintenance must outlive the initiating RPC")
+		return &pgctldpb.PgRewindResponse{
 			Message: "pg_rewind completed",
 			Output:  "servers diverged at WAL location 0/5000000 on timeline 1",
-		},
+		}, nil
 	}
 	pgctldAddr, cleanupPgctld := testutil.StartMockPgctldServer(t, mockPgctld)
 	t.Cleanup(cleanupPgctld)
@@ -1277,8 +1312,9 @@ func TestRestartAsStandby_RestoresPrimaryConnInfo(t *testing.T) {
 		PortMap:  map[string]int32{"postgres": 5433},
 	}
 
-	rewindPerformed, err := rewindAsStandbyForTest(t, manager, source)
+	rewindPerformed, err := rewindAsStandbyWithContextForTest(t, requestCtx, manager, source)
 	require.NoError(t, err)
+	require.ErrorIs(t, requestCtx.Err(), context.Canceled)
 	assert.True(t, rewindPerformed, "actual pg_rewind should have run (divergence detected)")
 
 	// REGRESSION TEST: primary_conninfo must already be in postgresql.auto.conf
@@ -1300,13 +1336,14 @@ func TestRestartAsStandby_RestoresPrimaryConnInfo(t *testing.T) {
 	assert.NotEmpty(t, primaryConnInfoSet, "primary_conninfo must be set after pg_rewind")
 	assert.Contains(t, primaryConnInfoSet, "source-host", "primary_conninfo must reference the source host")
 	assert.Contains(t, primaryConnInfoSet, "5433", "primary_conninfo must reference the source postgres port")
+	assert.NoFileExists(t, filepath.Join(poolerDir, pgRewindSentinelFile), "verified restart must clear rewind sentinel")
 }
 
 // TestRestartAsStandby_NoDivergence_StillSetsPrimaryConnInfo guards the helper
 // contract introduced in the unified-rewind refactor: restartAsStandbyLocked
 // sets primary_conninfo on success regardless of whether pg_rewind actually
-// ran. The dry-run reports no divergence here, so runPgRewind returns
-// rewindPerformed=false and skips the actual rewind — but the helper must
+// ran. The dry-run reports no divergence here, so pgRewindDryRun skips the
+// actual rewind and rewindPerformed remains false — but the helper must
 // still point primary_conninfo at source. Without this test, a regression
 // that gates the conninfo call on rewindPerformed would pass the divergence
 // test (TestRestartAsStandby_RestoresPrimaryConnInfo) and silently break
@@ -1339,12 +1376,12 @@ func TestRestartAsStandby_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
 		},
 	}
 
-	// Mock pgctld: dry-run output does NOT contain "servers diverged at", so
-	// runPgRewind skips the actual rewind and returns rewindPerformed=false.
+	// A dry-run can report where timelines diverged before concluding that no
+	// rewind is required. The final verdict must win and skip the real rewind.
 	mockPgctld := &testutil.MockPgCtldService{
 		PgRewindResponse: &pgctldpb.PgRewindResponse{
 			Message: "pg_rewind dry-run completed",
-			Output:  "source and target cluster are on the same timeline",
+			Output:  "servers diverged at WAL location 0/5000000 on timeline 1\nno rewind required",
 		},
 	}
 	pgctldAddr, cleanupPgctld := testutil.StartMockPgctldServer(t, mockPgctld)

--- a/go/services/multipooler/internal/manager/rpc_manager_test.go
+++ b/go/services/multipooler/internal/manager/rpc_manager_test.go
@@ -1064,19 +1064,6 @@ func rewindAsStandbyWithContextForTest(t *testing.T, ctx context.Context, manage
 	return manager.restartAsStandbyLocked(lockCtx, source.Hostname, source.PortMap["postgres"])
 }
 
-func TestRewindCompletionBudget(t *testing.T) {
-	budget, err := rewindCompletionBudget(0)
-	require.NoError(t, err)
-	assert.Equal(t, minRewindCompletionBudget, budget)
-
-	budget, err = rewindCompletionBudget(time.Minute)
-	require.NoError(t, err)
-	assert.Equal(t, 2*time.Minute+rewindRestartMargin, budget)
-
-	_, err = rewindCompletionBudget(5 * time.Minute)
-	require.ErrorContains(t, err, "exceeds maximum")
-}
-
 // TestRestartAsStandby_RealRewindFailureQuarantines verifies that once the real
 // pg_rewind has started, a failure prevents any postgres start on the potentially
 // partial PGDATA and publishes a quarantine verdict for replacement.
@@ -1110,9 +1097,7 @@ func TestRestartAsStandby_RealRewindFailureQuarantines(t *testing.T) {
 
 	mockPgctld := &testutil.MockPgCtldService{
 		PgRewindFunc: func(_ context.Context, req *pgctldpb.PgRewindRequest) (*pgctldpb.PgRewindResponse, error) {
-			if req.GetDryRun() {
-				return &pgctldpb.PgRewindResponse{Output: "servers diverged at WAL location 0/5000000 on timeline 1"}, nil
-			}
+			assert.False(t, req.GetDryRun())
 			assert.FileExists(t, filepath.Join(poolerDir, pgRewindSentinelFile))
 			return nil, errors.New("mock real pg_rewind failed")
 		},
@@ -1218,18 +1203,21 @@ func TestRestartAsStandby_RestoresPrimaryConnInfo(t *testing.T) {
 		},
 	}
 
-	// Cancel the initiating RPC when the real rewind starts. The bounded
-	// maintenance context must keep rewind and restart alive synchronously under
-	// the action lock rather than killing pg_rewind against partial PGDATA.
-	requestCtx, cancelRequest := context.WithTimeout(t.Context(), 15*time.Minute)
+	// Let the single pg_rewind call outlive the initiating RPC deadline. This
+	// models the expensive analysis phase that previously died before reaching
+	// the protected destructive pass.
+	requestCtx, cancelRequest := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancelRequest()
 	mockPgctld := &testutil.MockPgCtldService{}
 	mockPgctld.PgRewindFunc = func(callCtx context.Context, req *pgctldpb.PgRewindRequest) (*pgctldpb.PgRewindResponse, error) {
-		if !req.GetDryRun() {
-			assert.FileExists(t, filepath.Join(poolerDir, pgRewindSentinelFile))
-			cancelRequest()
+		assert.False(t, req.GetDryRun())
+		assert.FileExists(t, filepath.Join(poolerDir, pgRewindSentinelFile))
+		<-requestCtx.Done()
+		select {
+		case <-time.After(100 * time.Millisecond):
+		case <-callCtx.Done():
+			return nil, errors.New("rewind maintenance did not outlive the initiating RPC")
 		}
-		require.NoError(t, callCtx.Err(), "rewind maintenance must outlive the initiating RPC")
 		return &pgctldpb.PgRewindResponse{
 			Message: "pg_rewind completed",
 			Output:  "servers diverged at WAL location 0/5000000 on timeline 1",
@@ -1314,7 +1302,7 @@ func TestRestartAsStandby_RestoresPrimaryConnInfo(t *testing.T) {
 
 	rewindPerformed, err := rewindAsStandbyWithContextForTest(t, requestCtx, manager, source)
 	require.NoError(t, err)
-	require.ErrorIs(t, requestCtx.Err(), context.Canceled)
+	require.ErrorIs(t, requestCtx.Err(), context.DeadlineExceeded)
 	assert.True(t, rewindPerformed, "actual pg_rewind should have run (divergence detected)")
 
 	// REGRESSION TEST: primary_conninfo must already be in postgresql.auto.conf
@@ -1324,11 +1312,10 @@ func TestRestartAsStandby_RestoresPrimaryConnInfo(t *testing.T) {
 	assert.Contains(t, autoConfAtRestart, "primary_conninfo = 'host=source-host port=5433 ",
 		"auto.conf must carry the source's primary_conninfo before the standby starts")
 
-	// Verify both actual rewind calls were made (dry-run + actual).
+	// The analysis and any writes happen in one protected pg_rewind call.
 	rewindCalls := mockPgctld.PgRewindCalls
-	require.Len(t, rewindCalls, 2, "expected dry-run and actual pg_rewind calls")
-	assert.True(t, rewindCalls[0].DryRun, "first call should be dry-run")
-	assert.False(t, rewindCalls[1].DryRun, "second call should be actual rewind")
+	require.Len(t, rewindCalls, 1)
+	assert.False(t, rewindCalls[0].DryRun)
 
 	// REGRESSION TEST: primary_conninfo must be set after pg_rewind so the WAL
 	// receiver can connect to the primary. Before the fix, this was never called
@@ -1341,13 +1328,7 @@ func TestRestartAsStandby_RestoresPrimaryConnInfo(t *testing.T) {
 
 // TestRestartAsStandby_NoDivergence_StillSetsPrimaryConnInfo guards the helper
 // contract introduced in the unified-rewind refactor: restartAsStandbyLocked
-// sets primary_conninfo on success regardless of whether pg_rewind actually
-// ran. The dry-run reports no divergence here, so pgRewindDryRun skips the
-// actual rewind and rewindPerformed remains false — but the helper must
-// still point primary_conninfo at source. Without this test, a regression
-// that gates the conninfo call on rewindPerformed would pass the divergence
-// test (TestRestartAsStandby_RestoresPrimaryConnInfo) and silently break
-// callers that arrive via this path.
+// sets primary_conninfo when pg_rewind reports that no rewind is required.
 func TestRestartAsStandby_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	ctx := context.Background()
@@ -1376,11 +1357,11 @@ func TestRestartAsStandby_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
 		},
 	}
 
-	// A dry-run can report where timelines diverged before concluding that no
-	// rewind is required. The final verdict must win and skip the real rewind.
+	// The single protected call lets pg_rewind make the divergence decision and
+	// return without mutation when no rewind is required.
 	mockPgctld := &testutil.MockPgCtldService{
 		PgRewindResponse: &pgctldpb.PgRewindResponse{
-			Message: "pg_rewind dry-run completed",
+			Message: "pg_rewind completed",
 			Output:  "servers diverged at WAL location 0/5000000 on timeline 1\nno rewind required",
 		},
 	}
@@ -1454,7 +1435,7 @@ func TestRestartAsStandby_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
 
 	rewindPerformed, err := rewindAsStandbyForTest(t, manager, source)
 	require.NoError(t, err)
-	assert.False(t, rewindPerformed, "no divergence reported, so actual pg_rewind should not have run")
+	assert.False(t, rewindPerformed, "pg_rewind reported that no rewrite was required")
 
 	// The no-rewind path must also carry conninfo in auto.conf before the
 	// restart, with the stale entry replaced rather than shadowing the new one.
@@ -1463,10 +1444,10 @@ func TestRestartAsStandby_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
 	assert.NotContains(t, autoConfAtRestart, "old-leader",
 		"the stale conninfo entry must be replaced, not left behind")
 
-	// Only the dry-run should have fired; no actual rewind.
+	// One non-dry-run call performs both the decision and any needed rewrite.
 	rewindCalls := mockPgctld.PgRewindCalls
-	require.Len(t, rewindCalls, 1, "expected only the dry-run pg_rewind call")
-	assert.True(t, rewindCalls[0].DryRun, "the single call should be the dry-run")
+	require.Len(t, rewindCalls, 1)
+	assert.False(t, rewindCalls[0].DryRun)
 
 	// The contract: primary_conninfo gets set even when no rewind happens.
 	assert.NotEmpty(t, primaryConnInfoSet, "primary_conninfo must be set even when no rewind runs")


### PR DESCRIPTION
## Summary

- run one non-dry-run `pg_rewind` under a fixed 10-minute context independent of the initiating RPC while retaining the action lock
- let `pg_rewind` make the divergence decision itself, returning quickly when it reports `no rewind required` instead of paying for a caller-bound dry-run first
- persist `PG_REWIND_IN_PROGRESS` outside `PGDATA` before invoking `pg_rewind`, clearing it only after PostgreSQL restarts and is verified in recovery
- quarantine nodes when rewind fails, times out, or the sentinel is discovered after a process/pod restart, preventing PostgreSQL from starting on potentially partial data
- allow stale-leader demotion 15 minutes so the bounded rewind and restart can finish under load

## Why

`pg_rewind --dry-run` still performs the expensive analysis needed to build the copy plan. On loaded EKS nodes that analysis exceeded multiorch's 45-second repair deadline, so the dry-run was repeatedly terminated before the independently protected destructive pass could begin. When it did fit, the same analysis was paid twice.

The new flow invokes `pg_rewind` once. Its cheap no-rewind decision and any required rewrite share the same bounded context and cannot be killed by expiry of the initiating RPC.

## Safety trade-off

Removing the dry-run means there is no separate preflight proving rewind can succeed before mutation starts. The sentinel is therefore written before `pg_rewind` begins. Any error or timeout leaves it in place, marks the pooler quarantined and cohort-ineligible, disables PostgreSQL restarts, and delegates replacement/PVC recreation plus backup restore to the operator. The sentinel is removed only after PostgreSQL restarts as a verified standby with `primary_conninfo` restored.

## Testing

- `go test -short -count=1 ./go/services/multipooler/internal/manager ./go/services/multiorch/recovery/actions`
- `MULTIGRES_PORT_POOL_ADDR=/tmp/multigres-port-pool.sock go test -count=1 -run '^TestDeadPrimaryRecovery$' ./go/test/endtoend/multiorch/...`
- regression coverage holds the single rewind call past its caller's deadline and verifies it completes under the maintenance context; failure coverage verifies quarantine, no PostgreSQL start, and sentinel retention
