### PR TITLE
fix(multipooler): finish an in-flight pg_rewind past the RPC timeout, quarantine if it can't

### DIFF
--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -106,6 +106,17 @@ const (
 	// backups.
 	BootstrapSentinelFile = ".multigres-bootstrap-in-progress"
 
+	// RewindSentinelFile marks an in-progress pg_rewind. Written before the actual
+	// (mutating) pg_rewind runs and removed only after postgres is verified back up
+	// as a standby; its presence on startup means a prior rewind was interrupted
+	// (e.g. the pod was killed mid-rewind) and the data directory is partially
+	// rewound — unstartable and, per PostgreSQL guidance, generally unrecoverable.
+	// The monitor uses it to force the rewind-repair path instead of starting
+	// postgres on the half-rewound directory, and to quarantine if repair keeps
+	// failing. Lives in pooler_dir (not PGDATA) so it stays out of pgBackRest
+	// backups, and on the local volume so it survives a pod restart on the same PVC.
+	RewindSentinelFile = ".multigres-rewind-in-progress"
+
 	// StandbySignalFile is PostgreSQL's marker file (in PGDATA) whose presence
 	// puts the server into standby mode. Notably, postgres --single refuses to
 	// run with it present, so crash recovery removes and recreates it.

--- a/go/services/multipooler/internal/manager/actionlock/action_lock.go
+++ b/go/services/multipooler/internal/manager/actionlock/action_lock.go
@@ -183,3 +183,22 @@ func AssertActionLockHeld(ctx context.Context) error {
 
 	return nil
 }
+
+// CarryLock copies the action-lock ownership marker from src onto dst (if src
+// holds one) and returns the augmented context; it is a no-op returning dst when
+// src holds no lock.
+//
+// It exists so a context detached from the caller's cancellation (e.g. one built
+// with ctxutil.Detach, which drops all context values) can keep proving ownership
+// of a lock that was acquired on the request context. This lets a long-running,
+// must-complete operation — such as a pg_rewind that has to outlive the caller's
+// RPC deadline — continue to hold the action lock (so the monitor cannot act
+// underneath it) while running deadline-immune. The same *actionLockValue is
+// shared between the two contexts, so the caller's Release still releases the one
+// lock and AssertActionLockHeld observes the release on both.
+func CarryLock(dst, src context.Context) context.Context {
+	if val, ok := src.Value(actionLockKey{}).(*actionLockValue); ok {
+		return context.WithValue(dst, actionLockKey{}, val)
+	}
+	return dst
+}

--- a/go/services/multipooler/internal/manager/actionlock/action_lock_test.go
+++ b/go/services/multipooler/internal/manager/actionlock/action_lock_test.go
@@ -212,3 +212,26 @@ func TestActionLock_ReleasePanicsWithWrongContext(t *testing.T) {
 		lock.Release(ctx1)
 	})
 }
+
+func TestCarryLock(t *testing.T) {
+	lock := NewActionLock()
+
+	held, err := lock.Acquire(context.Background(), "op")
+	require.NoError(t, err)
+
+	// A bare context does not hold the lock; carrying it over from the held
+	// context makes it prove ownership without re-acquiring.
+	bare := context.Background()
+	require.Error(t, AssertActionLockHeld(bare), "precondition: bare context holds no lock")
+
+	carried := CarryLock(bare, held)
+	require.NoError(t, AssertActionLockHeld(carried), "carried context should prove ownership")
+
+	// The same lock value is shared: releasing via the original context also
+	// invalidates the carried one (they are the one lock, not two).
+	lock.Release(held)
+	require.Error(t, AssertActionLockHeld(carried), "carried context should observe the release")
+
+	// No-op when the source holds no lock: returns dst unchanged.
+	require.Error(t, AssertActionLockHeld(CarryLock(bare, context.Background())))
+}

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -120,6 +120,13 @@ type postgresState struct {
 	connInfo                 *multipoolermanagerdatapb.PrimaryConnInfo
 	pgMode                   pgmode.Mode
 	bootstrapSentinelPresent bool
+	// rewindSentinelPresent is true when a pg_rewind sentinel is on disk, meaning a
+	// prior rewind did not verifiably complete (see rewind_sentinel.go). It is the
+	// durable, restart-surviving signal that the data directory may be
+	// half-rewound; the monitor uses it to force the rewind-repair path rather than
+	// starting postgres on it, and to keep the unrecoverable classifier counting
+	// even when postgres appears "running" (the false-healthy waiting-for-WAL state).
+	rewindSentinelPresent bool
 	// rewindSourceReady is true when this pooler is a primary whose last completed
 	// checkpoint is on its current running timeline, so it is safe to pg_rewind
 	// from. False on standbys and on a freshly promoted primary that has not yet
@@ -135,6 +142,7 @@ func postgresStateEqual(a, b postgresState) bool {
 		a.backupsAvailable == b.backupsAvailable &&
 		a.pgMode == b.pgMode &&
 		a.bootstrapSentinelPresent == b.bootstrapSentinelPresent &&
+		a.rewindSentinelPresent == b.rewindSentinelPresent &&
 		a.rewindSourceReady == b.rewindSourceReady
 }
 
@@ -213,6 +221,16 @@ const (
 	// divergence). This replaces orch's old explicit RewindToSource RPC: the
 	// standby now self-heals a stuck-replica scenario without orch in the loop.
 	remedialActionMarkStandbyDiverged
+
+	// remedialActionMarkRewindInterrupted means a rewind sentinel is on disk (a
+	// prior pg_rewind did not verifiably complete — typically the pod was killed
+	// mid-rewind) but suspectedDivergence is not set. That in-memory flag does not
+	// survive a process restart, so the on-disk sentinel is what re-establishes it:
+	// we mark divergence so the node is never started/streamed on the possibly
+	// half-rewound directory but instead routed through the rewind-repair path
+	// (running node) or brought up "held" then rewound (down node). Purely sets the
+	// flag; the rewind itself follows on a later tick via remedialActionRewindToLeader.
+	remedialActionMarkRewindInterrupted
 )
 
 // standbyStuckDivergenceThreshold is the default for how long a standby must stay
@@ -421,6 +439,15 @@ func (pm *MultipoolerManager) discoverPostgresState(ctx context.Context) (postgr
 	}
 	state.bootstrapSentinelPresent = sentinelPresent
 
+	rewindSentinelPresent, err := pm.hasRewindSentinel()
+	if err != nil {
+		// Same reasoning as the bootstrap sentinel: an unreadable sentinel leaves
+		// the "was a rewind interrupted?" question ambiguous, so skip the tick
+		// rather than risk starting postgres on a possibly half-rewound directory.
+		return state, fmt.Errorf("check rewind sentinel: %w", err)
+	}
+	state.rewindSentinelPresent = rewindSentinelPresent
+
 	return state, nil
 }
 
@@ -614,8 +641,13 @@ func (pm *MultipoolerManager) trackRecoveryOutcome(ctx context.Context, action r
 		return
 	}
 
-	// Postgres is up: the streak (if any) is broken.
-	if state.postgresRunning {
+	// Postgres is up: the streak (if any) is broken — UNLESS a rewind sentinel is
+	// present, in which case "up" is the false-healthy state a half-rewound node
+	// reaches when it starts into recovery and then waits forever for WAL it cannot
+	// fetch. Resetting there would let that node spin indefinitely without ever
+	// being quarantined (the exact wedge this fix targets). While the sentinel is
+	// present we fall through so the failed rewind-repair attempts keep counting.
+	if state.postgresRunning && !state.rewindSentinelPresent {
 		pm.resetUnrecoverableTracking()
 		return
 	}
@@ -866,6 +898,19 @@ func (pm *MultipoolerManager) determineRemedialAction(ctx context.Context, curre
 	// Pgctld unavailable: No action possible
 	if !currentState.pgctldAvailable {
 		return remedialActionNone
+	}
+
+	// A rewind sentinel means a prior pg_rewind did not verifiably complete, so the
+	// data directory may be half-rewound. suspectedDivergence gates the whole
+	// rewind-repair path but is in-memory only and is lost on a process restart, so
+	// re-establish it from the durable sentinel. This must run before the
+	// running/not-running split so a down node is brought up "held" (rather than
+	// streaming on a possibly-corrupt directory) and a running node routes through
+	// the rewind path — and so trackRecoveryOutcome can quarantine if repair fails.
+	// Once set, restartAsStandbyLocked clears it (and removes the sentinel) on a
+	// successful rewind, so this fires at most once per incident.
+	if currentState.rewindSentinelPresent && !pm.consensusMgr.SuspectedDivergence() {
+		return remedialActionMarkRewindInterrupted
 	}
 
 	// Postgres is running: reconcile against the consensus rule. First align the
@@ -1252,6 +1297,18 @@ func (pm *MultipoolerManager) takeRemedialAction(ctx context.Context, action rem
 		}
 		// Clear the debounce timer; the rewind path now owns the incident.
 		pm.standbyStuckSince.Store(0)
+
+	case remedialActionMarkRewindInterrupted:
+		pm.setMonitorReason(ctx, reasonStartingPostgres, "MonitorPostgres: rewind sentinel present; a prior pg_rewind was interrupted")
+		pm.logger.WarnContext(ctx, "MonitorPostgres: rewind sentinel on disk from an interrupted pg_rewind; marking suspected divergence so the node is repaired (re-run pg_rewind) or quarantined rather than started on a half-rewound directory") //nolint:sloglint // message intentionally starts with an operation name or proper noun
+		// Re-establish the suspected-divergence flag lost across the restart. The
+		// rewind itself follows on a later tick via remedialActionRewindToLeader
+		// (gated on a rewind-ready leader and rate-limited); repeated failures are
+		// counted by trackRecoveryOutcome and eventually quarantine the node.
+		if err := pm.markSuspectedDivergence(ctx); err != nil {
+			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to mark suspected divergence for interrupted rewind", "error", err) //nolint:sloglint // message intentionally starts with an operation name or proper noun
+			return nil
+		}
 
 	case remedialActionRestoreFromBackup:
 		pm.setMonitorReason(ctx, reasonRestoringFromBackup, "MonitorPostgres: directory not initialized but backups available, restoring from backup")

--- a/go/services/multipooler/internal/manager/rewind_sentinel.go
+++ b/go/services/multipooler/internal/manager/rewind_sentinel.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/multigres/multigres/go/common/constants"
+)
+
+// rewind_sentinel.go implements a durable, on-disk marker for an in-progress
+// pg_rewind, mirroring the bootstrap sentinel (see rpc_first_backup.go). pg_rewind
+// mutates the target data directory in place and is not transactional: if it is
+// interrupted (typically the pod is killed mid-rewind, exceeding the shutdown
+// grace period), the directory is left partially rewound — unstartable and, per
+// PostgreSQL guidance, generally unrecoverable.
+//
+// restartAsStandbyLocked writes the sentinel just before the mutating pg_rewind
+// runs and removes it only after postgres is verified back up as a standby. Its
+// presence on a later monitor tick is therefore the authoritative signal that a
+// prior rewind did not complete — the one durable signal that survives a process
+// restart (the in-memory suspectedDivergence flag does not). The monitor uses it
+// to re-arm the rewind-repair path instead of starting postgres on the
+// half-rewound directory, and to let the unrecoverable-recovery classifier
+// quarantine the node if repair keeps failing.
+
+// rewindSentinelPath is the on-disk location of the rewind sentinel. It lives in
+// pooler_dir (not PGDATA) so it is not captured by pgBackRest backups, and on the
+// pooler's local volume so it survives a pod restart on the same PVC.
+func (pm *MultipoolerManager) rewindSentinelPath() string {
+	return filepath.Join(pm.record.PoolerDir(), constants.RewindSentinelFile)
+}
+
+// hasRewindSentinel reports whether the sentinel file exists. A non-existent file
+// is (false, nil); any other stat failure (e.g. permissions) is surfaced as an
+// error so callers don't silently treat it as "not present".
+func (pm *MultipoolerManager) hasRewindSentinel() (bool, error) {
+	_, err := os.Stat(pm.rewindSentinelPath())
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+// writeRewindSentinel creates the sentinel and fsyncs both the file and its
+// parent directory so the marker is durable across an OS crash — the sentinel is
+// only useful if it reliably outlives the very interruption it guards against.
+func (pm *MultipoolerManager) writeRewindSentinel() error {
+	path := pm.rewindSentinelPath()
+	if err := os.WriteFile(path, []byte("pg_rewind in progress\n"), 0o644); err != nil {
+		return err
+	}
+	if err := fsyncPath(path); err != nil {
+		return err
+	}
+	// fsync the directory so the new directory entry itself is durable.
+	return fsyncPath(filepath.Dir(path))
+}
+
+// removeRewindSentinel deletes the sentinel; a missing file is not an error.
+func (pm *MultipoolerManager) removeRewindSentinel() error {
+	if err := os.Remove(pm.rewindSentinelPath()); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// fsyncPath opens path (a file or directory) and fsyncs it.
+func fsyncPath(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
+}

--- a/go/services/multipooler/internal/manager/rewind_sentinel_test.go
+++ b/go/services/multipooler/internal/manager/rewind_sentinel_test.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
+)
+
+// newSentinelTestManager builds a manager whose pooler directory is a writable
+// temp dir, so the on-disk rewind-sentinel helpers can be exercised.
+func newSentinelTestManager(t *testing.T) *MultipoolerManager {
+	t.Helper()
+	return newTestManager(t, withRecord(newRecordFromProto(&clustermetadatapb.Multipooler{
+		Type:          clustermetadatapb.PoolerType_REPLICA,
+		ServingStatus: clustermetadatapb.PoolerServingStatus_DISABLED,
+		PoolerDir:     t.TempDir(),
+	})))
+}
+
+func TestRewindSentinel_RoundTrip(t *testing.T) {
+	pm := newSentinelTestManager(t)
+
+	present, err := pm.hasRewindSentinel()
+	require.NoError(t, err)
+	assert.False(t, present, "no sentinel initially")
+
+	require.NoError(t, pm.writeRewindSentinel())
+	present, err = pm.hasRewindSentinel()
+	require.NoError(t, err)
+	assert.True(t, present, "sentinel present after write")
+
+	// Writing again is idempotent.
+	require.NoError(t, pm.writeRewindSentinel())
+
+	require.NoError(t, pm.removeRewindSentinel())
+	present, err = pm.hasRewindSentinel()
+	require.NoError(t, err)
+	assert.False(t, present, "sentinel gone after remove")
+
+	// Removing a missing sentinel is not an error.
+	require.NoError(t, pm.removeRewindSentinel())
+}
+
+// TestDiscoverPostgresState_RewindSentinel verifies discoverPostgresState surfaces
+// the on-disk rewind sentinel, the durable signal the monitor gates on.
+func TestDiscoverPostgresState_RewindSentinel(t *testing.T) {
+	ctx := t.Context()
+
+	pm := NewTestMultipoolerManager(t)
+	pm.pgctldClient = &mockPgctldClient{
+		statusResponse: &pgctldpb.StatusResponse{Status: pgctldpb.ServerStatus_STOPPED},
+	}
+
+	state, err := pm.discoverPostgresState(ctx)
+	require.NoError(t, err)
+	assert.False(t, state.rewindSentinelPresent, "no rewind sentinel initially")
+
+	require.NoError(t, pm.writeRewindSentinel())
+
+	state, err = pm.discoverPostgresState(ctx)
+	require.NoError(t, err)
+	assert.True(t, state.rewindSentinelPresent, "rewind sentinel surfaced once written")
+}
+
+// TestDetermineRemedialAction_RewindSentinelRearmsDivergence verifies that a
+// rewind sentinel re-arms the (in-memory, restart-lost) suspectedDivergence flag,
+// routing the node through the rewind-repair path rather than a blind start.
+func TestDetermineRemedialAction_RewindSentinelRearmsDivergence(t *testing.T) {
+	ctx := t.Context()
+	pm := newTestManager(t)
+
+	// Sentinel present, divergence not yet suspected: re-arm.
+	state := postgresState{pgctldAvailable: true, rewindSentinelPresent: true}
+	assert.Equal(t, remedialActionMarkRewindInterrupted, pm.determineRemedialAction(ctx, state),
+		"a rewind sentinel with divergence unset must re-arm suspected divergence")
+
+	// Once divergence is already suspected, the re-arm does not fire again (it is a
+	// one-shot per incident; the rewind path takes over).
+	withLock(t, pm, func(lockCtx context.Context) {
+		_, err := pm.consensusMgr.SetSuspectedDivergence(lockCtx, true)
+		require.NoError(t, err)
+	})
+	assert.NotEqual(t, remedialActionMarkRewindInterrupted, pm.determineRemedialAction(ctx, state),
+		"re-arm must not fire once suspected divergence is already set")
+}
+
+// TestTakeRemedialAction_MarkRewindInterruptedSetsDivergence verifies the action
+// actually sets the flag the rewind path gates on.
+func TestTakeRemedialAction_MarkRewindInterruptedSetsDivergence(t *testing.T) {
+	pm := newTestManager(t)
+	require.False(t, pm.consensusMgr.SuspectedDivergence())
+
+	withLock(t, pm, func(ctx context.Context) {
+		require.NoError(t, pm.takeRemedialAction(ctx, remedialActionMarkRewindInterrupted, postgresState{}))
+	})
+
+	assert.True(t, pm.consensusMgr.SuspectedDivergence(),
+		"marking an interrupted rewind must set suspected divergence")
+}
+
+// TestTrackRecoveryOutcome_RewindSentinelCountsWhileRunning is the core of the
+// fix: a half-rewound node that starts into recovery and then waits forever for
+// unreachable WAL reports postgresRunning=true. Without the sentinel that would
+// reset the unrecoverable streak every tick and the node would spin forever. With
+// the sentinel present, failed rewind-repair attempts must keep counting so the
+// node is eventually quarantined for replacement.
+func TestTrackRecoveryOutcome_RewindSentinelCountsWhileRunning(t *testing.T) {
+	pm, clock := newQuarantineTestManager(t, 30*time.Second)
+
+	// "Running but mid-rewind": postgresRunning=true AND the sentinel is present.
+	running := postgresState{postgresRunning: true, rewindSentinelPresent: true}
+	failRewind := func(ctx context.Context) {
+		pm.trackRecoveryOutcome(ctx, remedialActionRewindToLeader, running, assert.AnError)
+	}
+
+	withLock(t, pm, func(ctx context.Context) {
+		failRewind(ctx) // attempt 1, elapsed 0
+		assert.Equal(t, 1, pm.unrecoverableFailedAttempts,
+			"a running-but-mid-rewind node must not reset the streak")
+		clock.advance(15 * time.Second)
+		failRewind(ctx) // attempt 2, elapsed 15s
+		clock.advance(20 * time.Second)
+		failRewind(ctx) // attempt 3 (floor met), elapsed 35s (>= 30s)
+	})
+
+	quarantined, reason, _ := quarantineState(pm)
+	assert.True(t, quarantined, "an unrecoverable interrupted rewind must quarantine despite postgres appearing to run")
+	assert.NotEmpty(t, reason)
+}
+
+// TestTrackRecoveryOutcome_ResetsWhenRunningWithoutSentinel guards the boundary:
+// a genuinely healthy running node (no sentinel) still breaks the streak.
+func TestTrackRecoveryOutcome_ResetsWhenRunningWithoutSentinel(t *testing.T) {
+	pm, clock := newQuarantineTestManager(t, 30*time.Second)
+
+	withLock(t, pm, func(ctx context.Context) {
+		pm.trackRecoveryOutcome(ctx, remedialActionRewindToLeader,
+			postgresState{postgresRunning: true, rewindSentinelPresent: true}, assert.AnError)
+		require.Equal(t, 1, pm.unrecoverableFailedAttempts)
+
+		clock.advance(time.Second)
+		// A clean, sentinel-free running node: the incident is over.
+		pm.trackRecoveryOutcome(ctx, remedialActionNone,
+			postgresState{postgresRunning: true}, nil)
+		assert.Equal(t, 0, pm.unrecoverableFailedAttempts,
+			"a healthy running node without a sentinel resets the streak")
+	})
+}

--- a/go/services/multipooler/internal/manager/rewind_sentinel_test.go
+++ b/go/services/multipooler/internal/manager/rewind_sentinel_test.go
@@ -16,6 +16,8 @@ package manager
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -25,7 +27,6 @@ import (
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
-	"github.com/multigres/multigres/go/tools/ctxutil"
 )
 
 // newSentinelTestManager builds a manager whose pooler directory is a writable
@@ -169,9 +170,13 @@ func TestRewindDetachOutlivesCallerCancellation(t *testing.T) {
 	callerCtx, cancel := context.WithCancel(lockCtx)
 
 	// The exact detach restartAsStandbyLocked performs at the point of no return.
-	opCtx, opCancel := context.WithTimeout(
-		actionlock.CarryLock(ctxutil.Detach(callerCtx), callerCtx), time.Minute)
+	opCtx, opCancel := pm.detachRewindOpContext(callerCtx)
 	defer opCancel()
+
+	// The detached sequence is bounded by its own backstop deadline.
+	if _, ok := opCtx.Deadline(); !ok {
+		t.Fatal("detached rewind context should carry a backstop deadline")
+	}
 
 	// The caller's deadline fires.
 	cancel()
@@ -184,6 +189,59 @@ func TestRewindDetachOutlivesCallerCancellation(t *testing.T) {
 	// calls (which assert ownership) still succeed and the monitor stays blocked.
 	assert.NoError(t, actionlock.AssertActionLockHeld(opCtx),
 		"the detached rewind context must keep proving action-lock ownership")
+}
+
+// TestRunPgRewind_SentinelBracket verifies runPgRewind writes the rewind sentinel
+// before the mutating pg_rewind on the divergence path, and writes nothing when
+// there is no divergence (so a no-op dry-run leaves no stale sentinel).
+func TestRunPgRewind_SentinelBracket(t *testing.T) {
+	t.Run("writes sentinel when servers diverged", func(t *testing.T) {
+		pm := newSentinelTestManager(t)
+		pm.pgctldClient = &mockPgctldClient{
+			pgRewindResponse: &pgctldpb.PgRewindResponse{Output: "servers diverged at 0/5000000 on timeline 2"},
+		}
+		performed, err := pm.runPgRewind(t.Context(), "leader", 5432)
+		require.NoError(t, err)
+		assert.True(t, performed, "a diverged rewind is performed")
+		present, err := pm.hasRewindSentinel()
+		require.NoError(t, err)
+		assert.True(t, present, "sentinel must be written before the mutating pg_rewind")
+	})
+
+	t.Run("no sentinel when not diverged", func(t *testing.T) {
+		pm := newSentinelTestManager(t)
+		pm.pgctldClient = &mockPgctldClient{
+			pgRewindResponse: &pgctldpb.PgRewindResponse{Output: "no rewind required"},
+		}
+		performed, err := pm.runPgRewind(t.Context(), "leader", 5432)
+		require.NoError(t, err)
+		assert.False(t, performed, "no divergence means no rewind")
+		present, err := pm.hasRewindSentinel()
+		require.NoError(t, err)
+		assert.False(t, present, "no sentinel written when there is no divergence")
+	})
+}
+
+// TestRewindSentinel_ErrorPaths covers the sentinel helpers' error branches so a
+// failure to record/clear the marker is surfaced rather than silently ignored.
+func TestRewindSentinel_ErrorPaths(t *testing.T) {
+	// fsyncPath surfaces an open error for a path that does not exist.
+	require.Error(t, fsyncPath(filepath.Join(t.TempDir(), "does-not-exist")))
+
+	// writeRewindSentinel surfaces a write error when the pooler dir is missing.
+	missingDir := newTestManager(t, withRecord(newRecordFromProto(&clustermetadatapb.Multipooler{
+		Type:      clustermetadatapb.PoolerType_REPLICA,
+		PoolerDir: filepath.Join(t.TempDir(), "no", "such", "dir"),
+	})))
+	require.Error(t, missingDir.writeRewindSentinel(), "write to a nonexistent pooler dir should error")
+
+	// removeRewindSentinel surfaces a non-NotExist error: a non-empty directory at
+	// the sentinel path cannot be removed by os.Remove.
+	pm := newSentinelTestManager(t)
+	sentinelPath := pm.rewindSentinelPath()
+	require.NoError(t, os.Mkdir(sentinelPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sentinelPath, "child"), []byte("x"), 0o644))
+	require.Error(t, pm.removeRewindSentinel(), "removing a non-empty directory at the sentinel path should error")
 }
 
 // TestTrackRecoveryOutcome_ResetsWhenRunningWithoutSentinel guards the boundary:

--- a/go/services/multipooler/internal/manager/rewind_sentinel_test.go
+++ b/go/services/multipooler/internal/manager/rewind_sentinel_test.go
@@ -24,6 +24,8 @@ import (
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
+	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
+	"github.com/multigres/multigres/go/tools/ctxutil"
 )
 
 // newSentinelTestManager builds a manager whose pooler directory is a writable
@@ -146,6 +148,42 @@ func TestTrackRecoveryOutcome_RewindSentinelCountsWhileRunning(t *testing.T) {
 	quarantined, reason, _ := quarantineState(pm)
 	assert.True(t, quarantined, "an unrecoverable interrupted rewind must quarantine despite postgres appearing to run")
 	assert.NotEmpty(t, reason)
+}
+
+// TestRewindDetachOutlivesCallerCancellation verifies the point-of-no-return
+// contract used by restartAsStandbyLocked: once the destructive stop -> pg_rewind
+// -> restart sequence is detached from the caller's context (an incoming
+// SetPrimary RPC that carries multiorch's action deadline, e.g. FixReplication's
+// 45s), the caller's cancellation neither cancels the operation nor drops the
+// action lock it holds. That is what lets a started pg_rewind run to completion
+// rather than be SIGKILLed mid-write when the RPC times out.
+func TestRewindDetachOutlivesCallerCancellation(t *testing.T) {
+	pm := newTestManager(t)
+
+	lockCtx, err := pm.actionLock.Acquire(t.Context(), "test")
+	require.NoError(t, err)
+	defer pm.actionLock.Release(lockCtx)
+
+	// The caller's RPC context (carrying a deadline in production), derived from
+	// the locked context the way an incoming RPC handler holds the action lock.
+	callerCtx, cancel := context.WithCancel(lockCtx)
+
+	// The exact detach restartAsStandbyLocked performs at the point of no return.
+	opCtx, opCancel := context.WithTimeout(
+		actionlock.CarryLock(ctxutil.Detach(callerCtx), callerCtx), time.Minute)
+	defer opCancel()
+
+	// The caller's deadline fires.
+	cancel()
+	require.Error(t, callerCtx.Err(), "precondition: caller context is cancelled")
+
+	// The detached operation continues unaffected...
+	assert.NoError(t, opCtx.Err(),
+		"a started rewind must not be cancelled when the caller's RPC deadline fires")
+	// ...and still holds the action lock, so pgctld's protected Stop/Restart/PgRewind
+	// calls (which assert ownership) still succeed and the monitor stays blocked.
+	assert.NoError(t, actionlock.AssertActionLockHeld(opCtx),
+		"the detached rewind context must keep proving action-lock ownership")
 }
 
 // TestTrackRecoveryOutcome_ResetsWhenRunningWithoutSentinel guards the boundary:

--- a/go/services/multipooler/internal/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/internal/manager/rpc_initialization_test.go
@@ -342,6 +342,9 @@ type mockPgctldClient struct {
 	restartError       error
 	reloadConfigCalled bool
 	reloadConfigError  error
+	pgRewindResponse   *pgctldpb.PgRewindResponse
+	pgRewindError      error
+	pgRewindCalls      int
 }
 
 func (m *mockPgctldClient) Status(ctx context.Context, req *pgctldpb.StatusRequest, opts ...grpc.CallOption) (*pgctldpb.StatusResponse, error) {
@@ -396,6 +399,13 @@ func (m *mockPgctldClient) Version(ctx context.Context, req *pgctldpb.VersionReq
 }
 
 func (m *mockPgctldClient) PgRewind(ctx context.Context, req *pgctldpb.PgRewindRequest, opts ...grpc.CallOption) (*pgctldpb.PgRewindResponse, error) {
+	m.pgRewindCalls++
+	if m.pgRewindError != nil {
+		return m.pgRewindResponse, m.pgRewindError
+	}
+	if m.pgRewindResponse != nil {
+		return m.pgRewindResponse, nil
+	}
 	return &pgctldpb.PgRewindResponse{}, nil
 }
 

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -1088,6 +1088,16 @@ func (pm *MultipoolerManager) restartAsStandbyLocked(
 		}
 	}
 
+	// The rewind (if any) completed and postgres is verified back up as a standby,
+	// so the data directory is no longer mid-rewind: clear the sentinel. Only
+	// meaningful when a rewind actually ran (runPgRewind writes it on the mutating
+	// path); Remove is idempotent otherwise. A failure here is not fatal — the node
+	// is healthy — but leaves a stale sentinel that the monitor's healthy path would
+	// otherwise re-arm into a benign no-op re-rewind, so surface it as a warning.
+	if err := pm.removeRewindSentinel(); err != nil {
+		pm.logger.WarnContext(ctx, "failed to remove rewind sentinel after successful restart as standby", "error", err)
+	}
+
 	return rewindPerformed, nil
 }
 
@@ -1122,6 +1132,18 @@ func (pm *MultipoolerManager) runPgRewind(ctx context.Context, sourceHost string
 	// Check if servers diverged
 	if dryRunResp.Output != "" && strings.Contains(dryRunResp.Output, "servers diverged at") {
 		pm.logger.InfoContext(ctx, "servers diverged, running pg_rewind with -R flag")
+
+		// Mark the data directory as being rewound before the mutating pg_rewind
+		// runs. pg_rewind is not transactional: an interruption here leaves a
+		// half-rewound, unstartable directory. The sentinel is the durable signal
+		// that lets the monitor detect that on the next tick (or after a pod
+		// restart) and repair-or-quarantine instead of starting postgres on it.
+		// restartAsStandbyLocked removes it once postgres is verified back as a
+		// standby. Fail-safe: if we cannot record the marker, do not mutate the
+		// directory.
+		if err := pm.writeRewindSentinel(); err != nil {
+			return false, mterrors.Wrap(err, "failed to write rewind sentinel before pg_rewind")
+		}
 
 		rewindReq := &pgctldpb.PgRewindRequest{
 			SourceHost:      sourceHost,

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -49,6 +49,17 @@ import (
 // finish rather than be abandoned mid-write.
 const rewindOperationTimeout = 30 * time.Minute
 
+// detachRewindOpContext returns the context for the destructive stop -> pg_rewind
+// -> restart-as-standby sequence: detached from the caller's cancellation
+// (ctxutil.Detach) so a started rewind is not aborted when an RPC deadline fires,
+// yet still carrying the caller's action-lock ownership (actionlock.CarryLock,
+// since Detach drops context values) and telemetry, bounded by
+// rewindOperationTimeout as a backstop against a hung operation. The caller must
+// hold the action lock and must call the returned cancel func.
+func (pm *MultipoolerManager) detachRewindOpContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(actionlock.CarryLock(ctxutil.Detach(ctx), ctx), rewindOperationTimeout)
+}
+
 // broadcastHealth broadcasts the current health state to all subscribers.
 //
 // This should be called whenever there is a state change that clients should be
@@ -965,7 +976,7 @@ func (pm *MultipoolerManager) restartAsStandbyLocked(
 	// the caller's deadline fires, its RPC returns while this sequence keeps running
 	// to a valid standby (or a definitive failure); the caller simply retries and
 	// finds the node already healed.
-	opCtx, cancel := context.WithTimeout(actionlock.CarryLock(ctxutil.Detach(ctx), ctx), rewindOperationTimeout)
+	opCtx, cancel := pm.detachRewindOpContext(ctx)
 	defer cancel()
 	ctx = opCtx
 

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -36,7 +36,18 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/actionlock"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pgmode"
+	"github.com/multigres/multigres/go/tools/ctxutil"
 )
+
+// rewindOperationTimeout bounds the detached stop -> pg_rewind ->
+// restart-as-standby sequence in restartAsStandbyLocked. Once postgres is
+// stopped that sequence runs to completion independent of the caller's deadline
+// (see the point-of-no-return detach), so this is only a backstop against a
+// genuinely hung operation holding the action lock forever. It is deliberately
+// generous: pg_rewind runtime scales with retained pg_wal (gigabytes, minutes
+// under IO throttling), and a rewind that merely runs long must be allowed to
+// finish rather than be abandoned mid-write.
+const rewindOperationTimeout = 30 * time.Minute
 
 // broadcastHealth broadcasts the current health state to all subscribers.
 //
@@ -939,6 +950,24 @@ func (pm *MultipoolerManager) restartAsStandbyLocked(
 			return false, mterrors.Wrap(err, "failed to record recruit position floor")
 		}
 	}
+
+	// Point of no return. The measurement above ran on the caller's ctx and is
+	// safe to abort — postgres is still up and the data directory is untouched.
+	// From here we stop postgres and (if diverged) pg_rewind it, which mutates the
+	// data directory in place and is not transactional: abandoning midway leaves a
+	// half-rewound, unstartable directory. This function is reached under an
+	// incoming SetPrimary RPC whose context carries multiorch's action budget (e.g.
+	// FixReplication's 45s), and a rewind can outlive that budget because its
+	// runtime scales with retained pg_wal. So detach the destructive sequence from
+	// the caller's cancellation — keeping the action lock (via CarryLock, since
+	// Detach drops context values) so the monitor still cannot start postgres
+	// underneath us, and preserving telemetry — under our own generous timeout. If
+	// the caller's deadline fires, its RPC returns while this sequence keeps running
+	// to a valid standby (or a definitive failure); the caller simply retries and
+	// finds the node already healed.
+	opCtx, cancel := context.WithTimeout(actionlock.CarryLock(ctxutil.Detach(ctx), ctx), rewindOperationTimeout)
+	defer cancel()
+	ctx = opCtx
 
 	pm.logger.InfoContext(ctx, "pausing manager and stopping Postgres to restart as standby",
 		"source_host", sourceHost, "source_port", sourcePort, "rewind_pending", wantRewind)

--- a/go/test/endtoend/multiorch/interrupted_rewind_quarantine_test.go
+++ b/go/test/endtoend/multiorch/interrupted_rewind_quarantine_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiorch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/constants"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestInterruptedRewindQuarantinesStandby exercises the interrupted-pg_rewind
+// safety net end to end with real postgres: a standby left in the state an
+// interrupted rewind produces must be driven to the terminal QUARANTINED verdict
+// (so the operator replaces it) rather than started on the half-rewound directory
+// and left to spin forever waiting for WAL it can never fetch.
+//
+// The fault reproduces the interrupted-rewind end-state directly, rather than by
+// racing a real rewind:
+//   - a rewind sentinel on disk (the durable marker restartAsStandbyLocked writes
+//     before the mutating pg_rewind and removes only after a verified-healthy
+//     standby returns), and
+//   - a truncated global/pg_control (an interrupted pg_rewind can truncate the
+//     control file; per PostgreSQL guidance such a directory is unrecoverable).
+//
+// This is what the monitor finds on the next tick — or, after a pod was SIGKILLed
+// mid-rewind, on the replacement pod's first tick. The sentinel forces the
+// rewind-repair path (re-arming the in-memory-only suspectedDivergence flag lost
+// across the restart) instead of a blind start; because the directory is
+// unrecoverable, repair keeps failing and the unrecoverable classifier quarantines
+// the node.
+//
+// Distinct from TestStandbyQuarantinesOnUnrecoverablePostgres, which reaches
+// quarantine via plain start-failure and does not exercise the rewind-sentinel
+// path. (The orchestrator follow-through — dropping a quarantined member from the
+// sync cohort — is durability-policy dependent: shrinking a minimal cohort by a
+// dead member is not always safe and multiorch may instead surface ShardAtRisk
+// for the operator, so it is intentionally not asserted here.)
+//
+// Uses NewIsolated because the fault is destructive to a data directory and must
+// not poison the shared fixture.
+func TestInterruptedRewindQuarantinesStandby(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real-postgres e2e in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("real postgres binaries not available")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(
+		t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultiorchCount(1),
+		// Quarantine quickly once repair keeps failing: a 15s continuous-failure
+		// budget (plus the built-in min-attempts floor) versus the production
+		// default of OFF.
+		shardsetup.WithMultipoolerExtraArgs("--postgres-unrecoverable-timeout=15s"),
+	)
+	defer cleanup()
+
+	setup.StartMultiorchs(t.Context(), t)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioInitialSettle)
+	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
+
+	// Pick a standby to model the interrupted rewind on — never the primary.
+	setup.RefreshPrimary(t)
+	standbys := setup.GetStandbys()
+	require.NotEmpty(t, standbys, "expected at least one standby")
+	victim := standbys[0]
+	victimName := victim.Name
+	t.Logf("Simulating interrupted rewind on standby %s (primary=%s)", victimName, setup.PrimaryName)
+
+	// Reproduce the interrupted-rewind end-state:
+	//  1. Stop postgres. StopPostgres disables the monitor's auto-restart first, so
+	//     we get a clean window to plant the fault.
+	//  2. Write the rewind sentinel — the durable marker a real interrupted rewind
+	//     leaves behind, which forces the monitor onto the repair path instead of a
+	//     blind start.
+	//  3. Truncate global/pg_control — the corruption an interrupted pg_rewind can
+	//     leave, so repair cannot succeed and the node must be quarantined.
+	//     PG_VERSION is left intact so pgctld still reports the directory
+	//     initialized.
+	//  4. Re-enable restarts. Every monitor tick now re-arms divergence, attempts a
+	//     held start / repair, fails, and advances the unrecoverable streak.
+	resume := setup.StopPostgres(t, victimName, "immediate")
+	sentinelPath := filepath.Join(victim.Pgctld.PoolerDir, constants.RewindSentinelFile)
+	require.NoError(t, os.WriteFile(sentinelPath, []byte("pg_rewind in progress\n"), 0o644),
+		"failed to plant rewind sentinel")
+	pgControl := filepath.Join(victim.Pgctld.PoolerDir, "pg_data", "global", "pg_control")
+	require.FileExists(t, pgControl, "pg_control should exist before corruption")
+	require.NoError(t, os.Truncate(pgControl, 0), "failed to truncate pg_control")
+	resume()
+
+	// The pooler reaches the terminal QUARANTINED verdict rather than spinning on
+	// the half-rewound directory — the operator-facing signal to replace the node.
+	victimID := setup.GetMultipoolerID(victimName)
+	require.Eventually(t, func() bool {
+		mp, err := setup.TopoServer.GetMultipooler(t.Context(), victimID)
+		if err != nil {
+			return false
+		}
+		return mp.GetLifecycleStatus().GetStatus() == clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_QUARANTINED
+	}, utils.ScaleTimeout(60*time.Second), 500*time.Millisecond,
+		"standby %s should quarantine itself after an unrecoverable interrupted rewind", victimName)
+}


### PR DESCRIPTION
## Situation

A crash-killed primary rejoins the cluster as a standby by running `pg_rewind` against the current leader. `pg_rewind` rewrites the target data directory in place and is **not** transactional: there is a mutating phase (overwriting data/WAL blocks, then rewriting `pg_control`/`backup_label`) that is the point of no return. If that phase is interrupted the directory is left partially rewound — unstartable and, per [PostgreSQL guidance](https://www.postgresql.org/docs/current/app-pgrewind.html), generally unrecoverable (an interrupted rewind can even truncate the control file, so a plain re-run also fails; rebuild-from-backup is the only reliable recovery).

The concrete trigger is an **RPC timeout that kills the in-flight `pg_rewind`**. multiorch drives the stale-primary demote under a bounded action budget — `FixReplicationAction` `Timeout: 45s` / `DemoteStaleLeader` `60s`, applied to the action context in `recovery_loop.go`. That deadline flows down: `SetPrimary → setPrimaryLocked →` (stale/diverged primary) `→ restartAsStandbyLocked(ctx) → runPgRewind(ctx) → pgctldClient.PgRewind(ctx) → executil.Command(ctx, "pg_rewind")`, and `executil.Command` SIGTERM/SIGKILLs its subprocess when that context is cancelled. Because rewind runtime scales with retained `pg_wal` (below), a rewind can outlive the budget — so the deadline fires mid-write and leaves the half-rewound, unstartable directory. The monitor then starts postgres on it anyway; the node comes up in recovery, waits forever for WAL it can never fetch, reports `running` (which resets the unrecoverable-recovery classifier every tick), and spins until the volume is wiped.

**This is a real field failure, not a hypothetical.** The incident logs (`multigres-pg-rewind-recreated-primary-2026-07-22`) come from a server running the earlier `RewindToSource` code: 101 `"RewindToSource RPC called"` multipooler log lines, with the node looping rewind → start-failure → re-rewind ~100 times. That `RewindToSource` RPC has since been removed, but **the same RPC-timeout hazard persists on current `main` via the `SetPrimary` path above** (and via the same 45s `FixReplication` budget).

**Why rewinds run long enough to trip the budget** (from the `pg_rewind --debug` traces): ~80% of a 58s rewind was copying 116–121 × 16 MB WAL segments (~1.8 GB) for ~120 bytes of real divergence — **runtime scales with retained `pg_wal`, not divergence** — so under load / IO-throttling a rewind of 70s+ easily exceeds a 45s budget.

## Fix

### Part A (primary) — let a started rewind finish regardless of the RPC timeout

`restartAsStandbyLocked` now detaches at the **point of no return**. The pre-stop measurement still runs on the caller's context (safe to abort — postgres is up and the directory is untouched), but the moment we stop postgres the stop → `pg_rewind` → restart-as-standby sequence runs on a context **detached from the caller's cancellation** (`ctxutil.Detach`) under its own generous timeout, while **keeping the action lock** (new `actionlock.CarryLock`, since `Detach` drops context values). When multiorch's deadline fires its RPC returns `DeadlineExceeded`, but the pooler keeps driving the rewind to a valid standby (or a definitive failure); the monitor stays blocked on the lock, so it cannot start postgres on the in-flight directory; multiorch simply retries and finds the node already healed.

```mermaid
sequenceDiagram
    participant Orch as multiorch
    participant Pool as Pooler
    participant Lock as Action lock
    participant Ctl as pgctld
    participant PG as Postgres

    Note over Pool: SetPrimary RPC handler holds the lock
    Orch->>Pool: SetPrimary, RPC deadline 45s
    Pool->>Lock: Acquire
    Note over Pool: stale primary, restartAsStandbyLocked
    Note over Pool: point of no return, detach from RPC deadline and keep the lock
    Pool->>Ctl: stop postgres
    Ctl->>PG: stop
    Pool->>Ctl: PgRewind, writes sentinel first
    Ctl->>PG: run pg_rewind on the stopped data dir
    Note over PG: rewinding, runtime scales with pg_wal, about 70s
    Note over Orch,Pool: 45s deadline elapses
    Pool-->>Orch: RPC returns DeadlineExceeded, handler keeps running
    Note over Pool,Lock: sequence continues on the detached context, lock still held
    Note over Lock: monitor blocks here, cannot start postgres mid rewind
    PG-->>Ctl: pg_rewind exits 0, Done, about 70s
    Ctl-->>Pool: PgRewind response
    Pool->>Ctl: restart as standby
    Ctl->>PG: start and verify in recovery
    Pool->>Ctl: remove sentinel
    Pool->>Lock: Release
    Orch->>Pool: SetPrimary retry next cycle
    Pool-->>Orch: already a healthy standby, no op
```

### Part B (safety net) — quarantine an interrupted rewind that cannot finish

Part A removes the RPC-timeout interruption, but a rewind can still be force-killed (a pod SIGKILLed past its shutdown grace). For that, a durable, fsynced on-disk **rewind sentinel** (mirroring the bootstrap sentinel) is written just before the mutating `pg_rewind` and removed only after a healthy standby is verified back up. On a later monitor tick (or a replacement pod's first tick) its presence forces the repair path instead of a blind start: it re-arms the `suspectedDivergence` flag (in-memory only, lost across a restart) so the node is repaired via a `pg_rewind` re-run, and it keeps the unrecoverable classifier counting even while postgres reports `running` — so a genuinely unrecoverable node is **quarantined** (`LIFECYCLE_QUARANTINED` + cohort `INELIGIBLE`) for operator replacement instead of spinning forever. A directory that can still be rewound just completes the re-run, clears the sentinel, and rejoins.

```mermaid
sequenceDiagram
    participant Life as Pod lifecycle
    participant Mon as Pooler monitor
    participant Ctl as pgctld
    participant PG as Postgres

    Note over Mon,PG: rewinding, sentinel on disk
    Life-->>Ctl: SIGKILL, shutdown grace exceeded
    Note over PG: data dir half-rewound, sentinel still present
    Note over Life,PG: replacement pod starts
    Mon->>Mon: sentinel present, re-arm suspected divergence
    alt directory still rewindable
        Mon->>Ctl: pg_rewind re-run
        Ctl-->>Mon: success
        Mon->>PG: restart as standby, verify healthy
        Mon->>Ctl: remove sentinel
        Note over Mon,PG: node rejoins the cohort
    else unrecoverable, e.g. control file truncated
        loop bounded by the unrecoverable-recovery budget
            Mon->>Ctl: pg_rewind re-run
            Ctl-->>Mon: fails
        end
        Mon->>Mon: quarantine, LIFECYCLE_QUARANTINED and cohort INELIGIBLE
        Note over Mon: operator replaces the pod, a clean node rejoins
    end
```

## What changed

- `go/services/multipooler/internal/manager/actionlock/action_lock.go` — add `CarryLock` (carry the action-lock marker across a detached context).
- `go/services/multipooler/internal/manager/rpc_manager.go` — Part A detach at the point of no return in `restartAsStandbyLocked`, under `rewindOperationTimeout`; write the rewind sentinel before the mutating `pg_rewind` and remove it after a verified-healthy standby.
- `go/common/constants/postgres.go` — add `RewindSentinelFile`.
- `go/services/multipooler/internal/manager/rewind_sentinel.go` (new) — sentinel helpers (on the pooler's local volume, fsynced).
- `go/services/multipooler/internal/manager/postgres_monitor.go` — surface `rewindSentinelPresent`; `remedialActionMarkRewindInterrupted` re-arms suspected divergence; the classifier no longer resets the failure streak on `postgresRunning` while the sentinel is present.

## Orchestrator interaction

No orchestrator change is needed; the fix relies only on existing mechanisms, but a rewinding pooler and a quarantined pooler are **two distinct states** worth spelling out:

- **While rewinding, the pooler stays `ELIGIBLE`** and remains a cohort member — it is *not* marked `INELIGIBLE`. Cohort eligibility is downgraded to `INELIGIBLE` in only two places, and the rewind path is neither: graceful shutdown, and quarantine (`markPoolerQuarantinedLocked`). What keeps a mid-rewind member from harming the shard is not eligibility but (a) the **recruit-position floor** (`SetRecruitBlockedUntil`, set before the rewind), which bars it from being counted toward a new rule-change quorum or re-ADDed to the cohort until it has caught back up, and (b) **ANY-N synchronous replication**, so its missing ack does not stall commits as long as one other cohort member is caught up.
- **Only when repair is exhausted does the pooler quarantine and flip to `INELIGIBLE`.** That is the signal the orchestrator acts on (verified end to end): an `INELIGIBLE` follower is dropped from the sync cohort (`CohortMismatchAnalyzer → ReconcileCohortAction` REMOVE), a quarantined/diverged node cannot be elected, and a quarantined ex-primary triggers re-election.

## Testing

- Unit: `CarryLock`; the point-of-no-return detach (a cancelled caller context neither cancels the operation nor drops the lock); sentinel round-trip and discovery; the divergence re-arm; and the classifier change (a running-but-mid-rewind node keeps counting and quarantines; a clean sentinel-free node still resets). Full multipooler manager suite green.
- Integration (real postgres + live multiorch): `TestInterruptedRewindQuarantinesStandby` models an interrupted rewind (sentinel + truncated `pg_control`) and asserts the terminal `LIFECYCLE_QUARANTINED` verdict; `TestRewindDivergedReplica` covers the happy-path rewind through the detached sequence.

## Follow-ups (out of scope here)

- No explicit multiorch "shard write-unavailable / durability degraded" signal for the degenerate case where a quarantined member drops a minimal cohort below its durability floor (writes stall by design). Tracked separately.
- No metric/event for `pg_rewind` **execution** time (only `rewind.checkpoint_wait.duration`, the pre-rewind wait). Worth adding given rewinds can now legitimately run long.
- `pg_rewind` copies the whole retained `pg_wal` regardless of divergence — a separate upstream-mitigation write-up.

---

Resolves [MUL-1343 — Prevent interrupted pg_rewind from wedging replicas](https://linear.app/supabase/issue/MUL-1343/prevent-interrupted-pg-rewind-from-wedging-replicas).
