### PR TITLE
feat: logical replication slot failover via native PostgreSQL 17 slot sync

### DIFF
--- a/demo/k8s/k8s-multigateway.yaml
+++ b/demo/k8s/k8s-multigateway.yaml
@@ -32,6 +32,9 @@ spec:
             - --topo-global-root=/multigres/test/global
             - --cell=zone1
             - --pprof-http=true
+            # Logical-slot failover (PR #1394): admit non-temporary logical
+            # replication slots registered for failover through the gateway.
+            - --enable-slot-based-replication=true
           env:
             - name: POD_IP
               valueFrom:

--- a/demo/k8s/k8s-multipooler-statefulset.yaml
+++ b/demo/k8s/k8s-multipooler-statefulset.yaml
@@ -130,6 +130,10 @@ spec:
             - --pgbackrest-ca-file=/certs/ca.crt
             - --pgbackrest-port=8432
             - --pprof-http=true
+            # Logical-slot failover (PR #1394): admit non-temporary failover
+            # slots and enable per-follower physical slots, primary_slot_name,
+            # synchronized_standby_slots, wal_level=logical, hot_standby_feedback.
+            - --enable-slot-based-replication=true
           ports:
             - containerPort: 16000
               name: http
@@ -159,6 +163,14 @@ spec:
             - name: host-data
               mountPath: /data
               subPathExpr: $(POD_NAME)
+            # macOS/kind fix: the postgres unix socket lives at
+            # /data/pg_sockets, but on Docker Desktop the hostPath /data is a
+            # virtiofs mount that rejects fchmod on socket files ("could not
+            # set permissions ... Invalid argument"). Overlay just the socket
+            # dir with a pod-local emptyDir (real Linux fs) shared by both
+            # containers so postgres can create its socket.
+            - name: pg-sockets
+              mountPath: /data/pg_sockets
             # certs and backup-data must be common for all pods.
             - name: certs
               mountPath: /certs
@@ -221,6 +233,10 @@ spec:
             - name: host-data
               mountPath: /data
               subPathExpr: $(POD_NAME)
+            # macOS/kind fix: pod-local emptyDir for the postgres unix socket
+            # (see the multipooler container above for why).
+            - name: pg-sockets
+              mountPath: /data/pg_sockets
             - name: certs
               mountPath: /certs
             - name: backup-data
@@ -253,6 +269,10 @@ spec:
           hostPath:
             path: /data
             type: DirectoryOrCreate
+        # Pod-local socket dir (see volumeMounts above): keeps the postgres
+        # unix socket off the macOS-backed hostPath so socket creation works.
+        - name: pg-sockets
+          emptyDir: {}
         - name: certs-secret
           secret:
             secretName: pgbackrest-tls

--- a/docs/ha/README.md
+++ b/docs/ha/README.md
@@ -43,6 +43,7 @@ Point-in-time records of specific HA decisions and their rationale:
 - [Use `synchronous_commit = on`](decision-log/2026-02-12-synchronous-commit-on.md)
 - [Wait for WAL replay to stabilize during standby revoke](decision-log/2026-02-12-wait-for-replay-stabilize-during-revoke.md)
 - [Block user changes to `synchronous_commit`](decision-log/2026-05-29-block-synchronous-commit-changes.md)
+- [Failover-slot readiness before promotion](decision-log/2026-08-17-failover-slot-readiness-before-promotion.md)
 
 ## Status of these docs
 

--- a/docs/ha/decision-log/2026-08-17-failover-slot-readiness-before-promotion.md
+++ b/docs/ha/decision-log/2026-08-17-failover-slot-readiness-before-promotion.md
@@ -1,0 +1,72 @@
+# Failover-slot readiness before promotion
+
+**Date:** 2026-08-17
+**Status:** Decided
+**Participants:** Mats Kindahl
+
+## Context
+
+With native PostgreSQL 17 logical-slot failover, a consumer can resume on a promoted standby only if that
+standby's synced failover slots are _failover-ready_ (`synced AND NOT temporary AND invalidation_reason IS
+NULL`). At promotion the startup process stops the slot-sync worker, so a slot that is not ready by then
+cannot become ready afterward — the consumer would be forced into a full re-seed.
+
+The question: when a standby is promoted and one of its synced failover slots is not yet failover-ready, what
+should the pooler do?
+
+## Options considered
+
+- **Advisory** — check once, log the not-ready slots, and promote anyway.
+- **Hard gate** — refuse to promote a node whose failover slots aren't ready.
+- **Advertise readiness to multiorch** — expose readiness in the pooler's health so the chooser prefers ready
+  candidates.
+- **Bounded wait** — wait a bounded time for readiness before `pg_promote`, then fall back.
+
+## Decision
+
+**Advisory.** Before `pg_promote` — while the node is still a standby — check once whether the node's synced
+failover slots are failover-ready and log any that are not. Then promote regardless. Do **not** wait.
+
+An earlier iteration used a bounded wait; it was superseded once durable slot creation was added to the design
+(see below), which removes the transient the wait was meant to ride out.
+
+## Rationale
+
+- **Durable slot creation makes the wait redundant.** A failover slot's creation is not acknowledged to the
+  client until the slot is `failover_ready` on the standbys the write-durability policy requires (see the
+  durable-slot-creation section of the design doc). PostgreSQL creates a synced slot as `temporary` and only
+  persists it once the standby has caught up — and persistence is sticky (a persisted slot never reverts to
+  `temporary`). So the "temporary / catching-up" transient that a bounded wait was designed to ride out cannot
+  occur at promotion on a node that passed the durability gate.
+- **What remains is terminal.** Any slot that is still not failover-ready at promotion is in a state a wait
+  cannot recover: `invalidation_reason` is set (permanent), or `synced = false` because the sync machinery is
+  broken (not "not finished yet"). Waiting would only add latency. The check still tests `synced` (the readiness
+  query already does), so a broken sync is surfaced in the log.
+- **Failover is never blocked.** Logging and proceeding keeps failover the priority: the worst case is that a
+  consumer re-seeds — correctness is preserved — never a stuck cluster. A hard gate could block failover
+  indefinitely in exactly the moments HA matters most.
+
+## Tradeoffs
+
+**Pros:**
+
+- No added promotion latency — a single catalog read, no polling loop or timeout.
+- Never blocks failover; no change to the safety-critical guarantee.
+- Pooler-local — no multiorch/cross-service change.
+- Surfaces broken sync (`synced = false`) and invalidation in the promotion log.
+
+**Cons:**
+
+- The advisory check relies on durable slot creation to hold the "no transient at promotion" property. Durable
+  creation ships later in the implementation order than the readiness handling, so in the interim a genuinely
+  mid-sync slot on a planned switchover would re-seed rather than being waited out. This is a between-merges
+  state, not a deployed one, and the feature is flag-gated.
+- A consumer whose slot is in a terminal not-ready state still re-seeds; the check reports it but cannot recover
+  it.
+
+## Notes
+
+- Gated behind `--enable-slot-based-replication` (dynamic, default off), so there is no effect until slot-based
+  replication is enabled and failover slots exist.
+- Implemented in the promotion path (`promoteLocked`) before `pg_promote` as `logUnreadyFailoverSlots`, reusing
+  the `unreadyFailoverSlots` readiness query.

--- a/docs/ha/logical_slot_failover_design.md
+++ b/docs/ha/logical_slot_failover_design.md
@@ -1,0 +1,1642 @@
+# Logical Replication Slot Failover in Multigres
+
+## Context
+
+Multigres proxies logical replication from a client, through the Multigateway, through a Multipooler, to
+PostgreSQL. Today this only works for **temporary** slots: the gateway preamble explicitly rejects any
+non-temporary `CREATE_REPLICATION_SLOT` / `pg_create_logical_replication_slot(...)` because Multigres cannot
+yet transition a replication slot's position across a primary failover. A mid-stream failover simply tears the
+tunnel down and closes the replication stream.
+
+The goal of this work is to make a _persistent_ logical replication slot survive a primary failover, so a
+logical subscriber can keep consuming across a promotion without a full re-seed. The end goal is that it
+should look like a single server and there should be no loss of data during a failover.
+
+This document describes how logical replication and its failover work in PostgreSQL, then the implementation,
+which is based on native PostgreSQL 17 slot sync. A fully-DIY catch-up alternative (the Patroni model) was
+considered and is recorded in Appendix A.
+
+Failover requires Postgres version 17 or later, so Postgres native sync-slot feature is available. If
+necessary to support earlier versions, there are extensions that can handle the logical slot failover.
+
+### Current state
+
+Logical replication already works through Multigres today, but only for the lifetime of a single connection to
+a single primary:
+
+- A client connects in walsender logical mode; the gateway relays the `CREATE_REPLICATION_SLOT` /
+  `START_REPLICATION` handshake to the primary's Postgres and then hands the connection off to a byte-blind
+  tunnel that relays the stream verbatim. The gateway never interprets the stream, so it tracks no LSN and keeps
+  no state.
+- The stream is pinned to the **primary** (the writable leader) through a single pooler backend reserved for the
+  session.
+- Only **temporary** slots are allowed. A temporary slot lives only for that session and Postgres drops it when
+  the connection closes.
+- With no durable slot state and no LSN tracking, a primary failover simply tears the tunnel down and the
+  consumer must reconnect and re-seed from scratch.
+
+Rejecting non-temporary slots is deliberate: a persistent slot would not exist on a promoted standby (slot
+state is not in the WAL) and would leak WAL retention on the primary after the client disconnected. A
+temporary slot has neither problem because it is inherently ephemeral. Everything below exists to lift this
+restriction.
+
+---
+
+## Part 1. Background: how logical replication and its failover work
+
+Before going into details about the problems that we need to solve to handle logical replication failover, it
+is useful to discuss how logical replication is set up, what the effect of each step is, and why they are
+necessary. To avoid confusion, we will call a Postgres server an _instance_ rather than the traditional term
+_cluster_ since the word "cluster" can mean "cluster of servers" or "cluster of databases". We will refer to a
+cluster of Postgres instances as a _cluster_.
+
+On a high level, logical replication can be used to replicate changes from a _source instance_ (or just
+_source_) to a _consumer_. Note that the consumer is _not_ part of the cohort and is, for example, an external
+Postgres server with a completely different setup.
+
+### 1.1 Configuring for logical replication failover
+
+This section sets up logical replication whose slot can **fail over** to a standby. That takes two parts: the
+consumer-side publication and subscription shown here (created with `failover = true`), and the source-cluster
+configuration that lets the slot be synced to standbys — most importantly a [physical replication
+slot](https://www.postgresql.org/docs/17/warm-standby.html#STREAMING-REPLICATION-SLOTS) between the primary
+and each standby, together with the standby-side settings — which §1.5 covers in full. Both are required:
+without the cluster-side setup a `failover = true` subscription still creates a slot, but nothing propagates
+it to a standby, so it cannot actually fail over.
+
+As an example, to set up a physical replication slot for a standby, you need to pick a name for the standby,
+say `standby_1`, and create the physical replication slot on the primary using
+[`pg_create_physical_replication_slot`](https://www.postgresql.org/docs/17/functions-admin.html#FUNCTIONS-REPLICATION):
+
+```sql
+SELECT pg_create_physical_replication_slot('standby_1');
+```
+
+You then point the standby at that slot by setting
+[`primary_slot_name`](https://www.postgresql.org/docs/17/runtime-config-replication.html#GUC-PRIMARY-SLOT-NAME)
+and reloading the configuration. `primary_slot_name` is reload-only (no restart needed), takes effect only
+while the node is a standby, and `ALTER SYSTEM` persists it to `postgresql.auto.conf`:
+
+```sql
+ALTER SYSTEM SET primary_slot_name = 'standby_1';
+SELECT pg_reload_conf();
+```
+
+In Multigres the manager creates and names these per-follower physical slots automatically (§4.3); the calls
+above are what the vanilla-PostgreSQL equivalent looks like.
+
+### 1.2 Setting up logical replication
+
+Once the servers are configured for [logical
+replication](https://www.postgresql.org/docs/17/logical-replication.html), you can actually use it to
+replicate from a cluster to a _consumer_ (for example, a Postgres server outside the cluster, or a CDC
+pipeline).
+
+To set up [logical replication](https://www.postgresql.org/docs/17/logical-replication.html), it is necessary
+to create a _publication_ on the source instance using the [`CREATE
+PUBLICATION`](https://www.postgresql.org/docs/17/sql-createpublication.html) command for the tables that you
+want replicated. This makes it possible for consumers to connect and read the WAL. The publication contains
+information about what tables are published and some information about how they are published (for example, it
+allows partitioned tables to publish rows as if they belong to the partitioned root table rather than an
+individual partition).
+
+For example, to create a publication for the tables `orders` and `order_details` you can use:
+
+```sql
+CREATE PUBLICATION orders_pub FOR TABLE orders, order_details;
+```
+
+This allows subscribers to read all columns of the two tables, but not any other tables.
+
+Once the publication is created, you can create a subscription on the consumer Postgres instance, which will
+refer to the publication on the source.
+
+Note that you need to create all the tables that you want to replicate _before_ you create the subscription.
+This is easiest done using something like:
+
+```bash
+# Dump the table definitions from the source, then load them into the consumer.
+pg_dump --schema-only --no-owner --no-privileges -t public.orders -t public.order_details \
+  "host=primary port=5432 dbname=postgres user=postgres" >schema.sql
+psql "host=consumer port=5432 dbname=postgres user=postgres" -f schema.sql
+```
+
+For example, to create a subscription with [`CREATE
+SUBSCRIPTION`](https://www.postgresql.org/docs/17/sql-createsubscription.html) that reads all tables in the
+publication and allows the logical replication slot to fail over to a standby you use:
+
+```sql
+CREATE SUBSCRIPTION orders_sub
+  CONNECTION 'host=primary port=5432 dbname=postgres user=postgres'
+  PUBLICATION orders_pub
+  WITH (failover = true, copy_data = true);
+```
+
+Since the option `copy_data` is enabled, it will also do an initial copy of the tables before starting logical
+replication. You will see how the `failover = true` is used below.
+
+> **NOTE:** If you try to create a subscription on a different database but in the same instance, the command
+> will hang. There are workarounds for this, but since that is not a normal setup they are omitted here.
+
+### 1.3 How does logical replication work?
+
+Logical replication works by reading the physical events written to the WAL and then extracting logical
+replication events from the WAL. There are no special "logical events" written to the WAL, it is all a matter
+of [logical decoding](https://www.postgresql.org/docs/17/logicaldecoding.html) of what has always been written
+to the WAL as part of normal transaction execution. As a result, enough WAL needs to be available on the
+instance to decode events from the LSN that the client has requested.
+
+To ensure that enough WAL is kept for all subscribers, each subscriber creates a _replication slot_ on the
+source. The slot will track how much of the WAL the consumer has read. This allows the server to decide which
+WAL segments need to be kept to replicate data to the consumer.
+
+The slot contains, among other data, the fields [`restart_lsn` and
+`catalog_xmin`](https://www.postgresql.org/docs/17/view-pg-replication-slots.html), which are important for
+deciding how much WAL needs to be kept.
+
+**Field `restart_lsn`** tracks the oldest WAL it may still need to re-read. A source instance keeps WAL back
+to the minimum `restart_lsn` across its slots and recycles anything older. If no slot holds on to the LSN that
+is needed, the segments are recycled and decoding fails with _"requested WAL segment has already been
+removed"_. So the slot is what stops the WAL it needs from being thrown away.
+
+**Field `catalog_xmin`** is used to ensure that catalog rows are kept so that decoding the WAL can work.
+Decoding turns physical WAL back into logical row changes using the catalog _as it was at the time of each
+change_. If the schema has changed since, the older catalog definitions are required, and `catalog_xmin` is
+used to ensure that the old catalog definitions are available.
+
+Both fields, along with the rest of a slot's state, are exposed by the
+[`pg_replication_slots`](https://www.postgresql.org/docs/17/view-pg-replication-slots.html) view — the primary
+way to inspect a slot on the server that owns it:
+
+```sql
+SELECT slot_name, slot_type, active, restart_lsn, catalog_xmin
+  FROM pg_replication_slots
+ WHERE slot_name = 'orders_sub';
+```
+
+```text
+ slot_name  | slot_type | active | restart_lsn | catalog_xmin
+------------+-----------+--------+-------------+--------------
+ orders_sub | logical   | t      | 0/1A2B3C8   |          748
+```
+
+The same view carries the failover-related columns (`failover`, `synced`, `temporary`, `invalidation_reason`)
+used later in §1.5 and §3.1.2.
+
+Two PostgreSQL settings extend this picture to a _standby_, and understanding why they exist here — with the
+mechanism — makes the later configuration (Part 2) obvious:
+
+- **`hot_standby_feedback`** is the standby-side counterpart to `catalog_xmin`. The retention above only holds
+  catalog rows on the server that _owns_ the slot; a standby, replaying the primary's vacuum, would drop exactly
+  the catalog rows a slot on that standby needs to decode older WAL, invalidating it. With `hot_standby_feedback
+= on` the standby continuously reports its oldest needed xmin back to the primary, so the primary holds its
+  _own_ vacuum horizon back and never removes catalog rows a standby still needs. That is what keeps a slot on a
+  standby decodable.
+- **`sync_replication_slots`** exists because slot state is not in the WAL stream: physical replication ships a
+  standby all the _data_ but none of the _slots_ (a slot lives in `pg_replslot` on the server that owns it).
+  With it `on`, a dedicated slot-sync worker on the standby connects back to the primary and copies the
+  `failover = true` slots across, which is the only way a slot comes to exist on a standby at all.
+
+These are the two knobs that make it possible for a replication slot to survive a failover; §1.5 and Part 2
+describe how they are used together.
+
+### 1.4 Options to control WAL retention
+
+The amount of WAL kept on disk is bounded by three settings:
+
+- **Option [`max_wal_size`](https://www.postgresql.org/docs/17/runtime-config-wal.html#GUC-MAX-WAL-SIZE)** is a
+  _soft_ target for how much WAL accumulates between checkpoints. Exceeding it triggers a checkpoint so older
+  segments can be recycled. It bounds routine WAL, not slot or standby retention, and is not a hard cap.
+- **Option
+  [`wal_keep_size`](https://www.postgresql.org/docs/17/runtime-config-replication.html#GUC-WAL-KEEP-SIZE)** is a
+  minimum amount of recent WAL to retain for standbys that connect _without a slot_, so a briefly disconnected
+  replica can reconnect without a reseed.
+- **Option
+  [`max_slot_wal_keep_size`](https://www.postgresql.org/docs/17/runtime-config-replication.html#GUC-MAX-SLOT-WAL-KEEP-SIZE)**
+  is the maximum WAL a replication slot may pin. If a slot's `restart_lsn` would force retention beyond this,
+  the slot is invalidated at the next checkpoint instead of letting WAL grow unbounded.
+
+> **NOTE:** Once a slot is invalidated (`pg_replication_slots.wal_status = 'lost'`, `invalidation_reason =
+'wal_removed'`), the WAL it needed is gone and there is no incremental recovery. The consumer must re-seed:
+> drop the dead slot and re-create the subscription with `copy_data = true`, which starts a fresh slot at the
+> current position and re-copies every table into a consistent base before resuming. That full re-copy is
+> exactly the re-seed this design exists to avoid, which is why the failover machinery must keep the slot
+> continuously WAL- and catalog-retained rather than letting it lag past `max_slot_wal_keep_size`.
+
+### 1.5 Logical slot sync worker and failover
+
+In the `CREATE SUBSCRIPTION` above we used `failover = true` to make sure that the replication slot [fails
+over to standbys](https://www.postgresql.org/docs/17/logical-replication-failover.html). The slot is not
+written to the WAL, so there is no replication that can make sure that the slot exists on the standbys.
+
+Instead, Postgres implements a dedicated _slot-sync worker_ whose only purpose is to synchronize replication
+slots between the primary and a standby. Adding the `failover = true` means that this background worker will
+look at the slot and replicate the state to the standby.
+
+In addition, we have the following requirements for the primary and the standby:
+
+- For the primary it is mandatory to have a [physical replication
+  slot](https://www.postgresql.org/docs/17/warm-standby.html#STREAMING-REPLICATION-SLOTS) between the primary
+  and the standby: [slot synchronization](https://www.postgresql.org/docs/17/logical-replication-failover.html)
+  relies on it so the standby can durably hold back the WAL and `catalog_xmin` the synced slots need.
+- For the standby, it is necessary to set
+  [`sync_replication_slots`](https://www.postgresql.org/docs/17/runtime-config-replication.html#GUC-SYNC-REPLICATION-SLOTS)
+  to `true`,
+  [`primary_slot_name`](https://www.postgresql.org/docs/17/runtime-config-replication.html#GUC-PRIMARY-SLOT-NAME)
+  should be configured to contain the physical replication slot, and
+  [`hot_standby_feedback`](https://www.postgresql.org/docs/17/runtime-config-replication.html#GUC-HOT-STANDBY-FEEDBACK)
+  must be `on`. It is also necessary to specify a valid dbname in the
+  [`primary_conninfo`](https://www.postgresql.org/docs/17/runtime-config-replication.html#GUC-PRIMARY-CONNINFO).
+
+> **NOTE:** A replication slot name may contain only lower-case letters, digits, and the underscore character
+> (`[a-z0-9_]`), and be at most 63 characters long. An identifier that contains hyphens or upper-case letters
+> must therefore be sanitized to this character set before it can be used as a slot name.
+
+There is an important timing constraint in _when_ the slot-sync worker can persist a slot. When it first
+copies a `failover = true` slot to a standby it creates it as _temporary_ (`temporary = true`) and only
+promotes it to a persistent, failover-ready slot once the standby has caught up and it is safe to do so. The
+safety check is the subtle part: slot-sync **refuses to persist a synced slot whose `catalog_xmin` is behind
+the standby's own catalog horizon**, because advancing a slot onto a standby that has already vacuumed away
+the catalog rows the slot would need to decode from is exactly the data-loss it must prevent.
+
+This interacts awkwardly with a _freshly created_ slot. A new slot's `catalog_xmin` is **frozen at its
+creation point** and only advances once a consumer actually starts consuming: as the consumer streams,
+applies, and flushes its position back (the `StandbyStatusUpdate` messages of §1.2), `catalog_xmin` moves
+forward. Meanwhile an idle standby's catalog horizon creeps forward on its own (from the periodic
+running-xacts snapshots the primary writes). So a brand-new slot that nobody has consumed yet is precisely the
+slot that slot-sync will _not_ persist — its `catalog_xmin` sits behind the standby's advancing horizon until
+consumption catches it up.
+
+The practical consequence is that a `failover = true` slot is **not immediately failover-ready after
+creation**. There is a window — from creation until a consumer streams and advances `catalog_xmin` past the
+standbys' horizon — in which the slot exists only on the primary and no standby holds a persistent copy. On an
+idle or low-traffic shard that window can be arbitrarily long (nothing advances `catalog_xmin`). This window
+is central to the failover semantics and its consequences are examined in detail in §4.4.
+
+The full lifecycle, from creation to a persistent failover-ready slot — note that it is _consumption_ (the
+flushes that advance `catalog_xmin`), not the passage of time, that triggers the temporary-to-persistent
+transition:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as consumer
+    participant P as primary Postgres
+    box Standby
+        participant SS as slot-sync worker
+        participant S as standby Postgres
+    end
+
+    C->>P: CREATE_REPLICATION_SLOT orders_sub LOGICAL failover=true
+    Note over P: slot created, catalog_xmin frozen at C
+    P-->>C: slot created (consistent_point)
+
+    SS->>P: sync cycle - read failover slots
+    P-->>SS: orders_sub at catalog_xmin C
+    Note over SS,S: C is behind the standby's catalog horizon<br/>persisting now could lose data - create as TEMPORARY
+    SS->>S: create synced orders_sub (temporary=true, not failover_ready)
+
+    C->>P: START_REPLICATION orders_sub LOGICAL
+    loop steady state - consumption
+        P->>C: XLogData
+        C->>P: StandbyStatusUpdate flushed
+        Note over P: catalog_xmin advances past C
+    end
+
+    SS->>P: next sync cycle - read orders_sub
+    P-->>SS: catalog_xmin now ahead of the standby horizon
+    Note over SS,S: safe to persist - THIS is the trigger for permanence
+    SS->>S: persist orders_sub (temporary=false)
+    Note over S: synced AND NOT temporary AND not invalidated<br/>orders_sub is now failover_ready
+```
+
+### 1.6 Summary: the problem to solve
+
+Sections 1.1–1.5 explain the mechanics; this is the problem they add up to. Suppose a consumer has replicated
+up to some LSN _lsn_, the primary A fails, and a standby B is promoted. For the consumer to **resume** on B —
+rather than re-seed from scratch — three things must be true on B:
+
+1. **The logical slot exists on B** under the same name as on A. Slot state is not in the WAL stream: it lives in
+   the `pg_replslot` directory _on the server that owns the slot_, so physical replication ships B all of A's
+   committed _data_ but none of A's _slots_. Only the slot-sync worker (§1.5) puts the slot on B, and because the
+   promotion target is not known in advance, the slot must be synced onto _every_ standby that could be promoted.
+2. **The WAL needed to decode from _lsn_ is retained on B** — held by the slot's `restart_lsn` (§1.3–§1.4).
+3. **The historical catalog rows needed to interpret that WAL are retained on B** — held by the slot's
+   `catalog_xmin` (§1.3), which itself depends on `hot_standby_feedback` and the physical replication slot
+   (§1.5).
+
+Two constraints, both established above, make this a _before-the-fact_ problem that cannot be fixed at
+promotion time:
+
+- **You cannot create-then-rewind a slot.** A slot created after the fact starts decoding at "now"
+  (`pg_replication_slot_advance` is forward-only), and by then the catalog rows for _lsn_ have already been
+  vacuumed away. So the slot must exist and be catalog-safe on B _before_ the changes the consumer will replay.
+- **A fresh slot is not immediately failover-ready.** Even once created with `failover = true`, the slot becomes
+  persistent on a standby only after consumption advances its `catalog_xmin` past the standby's horizon (§1.5) —
+  so there is always a window after creation in which no standby holds a usable copy.
+
+Everything in Parts 2–5 exists to satisfy these requirements: keep a named failover slot present,
+WAL-retained, and catalog-safe on every standby ahead of any promotion — and define what happens during the
+window in which that is not yet true.
+
+---
+
+## Part 2. Implementation: native PostgreSQL 17 slot sync
+
+Starting with Postgres 17, the failover logical slots themselves are created on the primary when a consumer
+subscribes with `failover = true` and the native slot-sync worker then copies them to every standby. The
+configuration below is the physical-replication and slot-sync plumbing that makes that propagation work,
+grouped by _when_ it is applied.
+
+Physical replication slots are named deterministically from each server's own identity (a stable, sanitized,
+cluster-unique name). That keeps every server's `primary_slot_name` fixed for its lifetime, and lets whichever
+node is currently primary compute exactly which slot names to create for its followers.
+
+Native sync is chosen because it enforces the WAL-retention and catalog-safety guarantees that are otherwise
+easy to get subtly wrong (silent data loss). The one significant architectural change it requires is
+reintroducing physical replication slots — reversing Multigres's current slot-less posture — whose
+WAL-retention risk is bounded by `max_slot_wal_keep_size`.
+
+### 2.1 Changes needed for when the pod starts
+
+These configuration changes are needed when the pod starts, but can remain for the lifetime of the pod. These
+changes apply to any member of the cohort.
+
+- Option `wal_level` is set to `logical` to enable logical replication.
+- Options `hot_standby_feedback` and `sync_replication_slots` are set to `on`. Both only take effect while the
+  node is a standby and are harmless on a primary, so they can be set unconditionally.
+- Option `primary_slot_name` should be set to the server's deterministic slot name. It is ignored while the node
+  is a primary and used while it is a standby, so it never has to change on promotion or demotion.
+- Options `max_wal_senders` and `max_replication_slots` need to be sized for the fan-out. There is one
+  additional physical slot per follower, and we need margin for the failover logical slots.
+- Whenever `primary_conninfo` is written it must include a valid `dbname`. Slot sync worker connects to that
+  database to decide where to read the slot (the `dbname` is ignored for streaming replication).
+
+### 2.2 Changes needed for when a standby is promoted
+
+- Create a physical replication slot for each current follower (using each follower's deterministic name).
+  Physical slots are not synced, so a freshly promoted node has none and must create them before its followers
+  can attach.
+- Set `synchronized_standby_slots` to those followers' physical slots. If no follower has attached yet, leave it
+  empty to avoid stalling logical decoding, and set it once they do.
+- **Log** (do not gate on) the readiness of the node's synced failover slots. This is advisory only — promotion
+  proceeds regardless. A fresh slot's `catalog_xmin` does not advance until a consumer has begun consuming
+  (§1.5), so a not-yet-ready slot at promotion is _expected_, not an error; blocking the promotion until
+  readiness could hang indefinitely on an idle shard and can never be reached once the source primary is gone. A
+  slot that is not ready is handled downstream by degrading the consumer to a client-driven re-seed (§3.1.1),
+  not by delaying the promotion.
+
+### 2.3 Changes needed for when a primary is demoted
+
+- Repoint `primary_conninfo` at the new primary, keeping the static user / `dbname` / application_name.
+- Drop the physical replication slots it held for its former followers. They have no consumer now and would
+  otherwise pin WAL indefinitely.
+- `RESET synchronized_standby_slots`. Primary does not have any followers. The option does not make a difference
+  for the standby since it is not consulted for standbys, but if the standby is promoted, the list would be
+  wrong.
+
+> **NOTE:** These same steps apply when a _former primary rejoins after a crash_. It never ran a graceful
+> demotion, so it comes back still holding physical slots for its old followers and a stale
+> `synchronized_standby_slots`; both must be cleaned as it rejoins as a standby.
+
+### 2.4 Changes needed for when a server is added as a new standby to the cohort
+
+- On the current primary: create a physical replication slot named for the new standby and add it to
+  `synchronized_standby_slots`.
+- On the new standby: point `primary_conninfo` at the current primary (with a valid `dbname`);
+  `primary_slot_name`, `hot_standby_feedback`, and `sync_replication_slots` are already in place from pod start.
+- The primary's failover logical slots are copied to the new standby by its slot-sync worker automatically.
+  Their readiness on the new standby is _observed_, not waited on: a freshly synced slot only becomes
+  failover-ready once consumption has advanced its `catalog_xmin` past the standby's horizon (§1.5), so a
+  not-yet-ready slot here is expected rather than a fault. The readiness is surfaced through the standby's
+  health stream (`failover_slots_ready` / `_total`) and feeds slot-aware leader appointment (Part 5 #11) as a
+  tiebreak — it does not block the standby from joining, and a promotion onto a not-ready slot degrades to a
+  client-driven re-seed (§3.1.1).
+- Repointing an existing standby onto a freshly promoted primary after a failover uses these same steps — from
+  the primary's side, every follower attaches the same way.
+
+### 2.5 Changes needed for when a standby is removed from the cohort
+
+- On the current primary: drop the physical replication slot that backed that standby and remove it from
+  `synchronized_standby_slots`. This is not optional cleanup — an orphaned physical slot pins WAL on the primary
+  indefinitely, and a slot still listed in `synchronized_standby_slots` whose standby is gone **stalls logical
+  decoding on the primary** until it is removed.
+
+### 2.6 Ordering constraint: a follower's physical slot must exist before it can stream
+
+A follower's physical slot `mg_<follower>` is created on the **primary** but named for the **follower**, and the
+follower sets `primary_slot_name = mg_<self>` unconditionally at startup (it is inert while the node is a
+primary, §2.1). A standby's WAL receiver therefore cannot begin streaming until that slot already exists on the
+current primary. This makes slot creation a strict _pre-condition_ of streaming, which imposes an ordering rule
+on the implementation: **the primary must create a follower's slot independently of whether that follower is
+already streaming or already a committed cohort member.**
+
+Getting this ordering wrong deadlocks a follower that joins _after_ the primary was promoted. If the only
+triggers that create a follower slot are the promotion hook (over the cohort committed _at promotion_) and a
+cohort-add event — and the cohort-add path itself only admits a standby whose WAL receiver is _already
+streaming_ — then a late-joining standby can never be slotted: it cannot stream without its slot, and its slot
+is never created because it is not streaming. During a staggered bootstrap this typically strands whichever
+standby was not yet up at promotion (e.g. the primary creates `mg_2` for the standby it saw and never creates
+`mg_0` for the one that came up a moment later). The orchestrator's `FixReplication` remediation then loops on
+no-op recovery (re-issuing `SetPrimary` and a `pg_rewind` that reports "no rewind required", WAL receiver never
+streaming) because none of its recovery actions create a slot on the primary. A planned switchover of an already-healthy cohort does **not** hit this — every
+standby is a committed member at promotion, so the promoting node slots them all in its promotion hook.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant O as Multiorch
+    participant T as Topology
+    participant P as New primary
+    participant S as Standby S0 pooler
+    participant W as S0 WAL receiver
+    Note over O,W: Primary already elected with cohort P and S2 — S0 is a new standby just starting
+    Note over P: at promotion the hook created mg_2 for S2 — S0 was absent so mg_0 was not created
+    S->>T: register pooler in topology
+    O->>T: list the shard poolers (each cycle)
+    T-->>O: poolers now include S0
+    Note over O: S0 discovered
+    O->>S: SetPrimary points S0 at the primary
+    Note over S: S0 sets primary_slot_name to mg_0
+    S->>W: start WAL receiver using slot mg_0
+    W->>P: START_REPLICATION SLOT mg_0
+    P-->>W: ERROR — replication slot mg_0 does not exist
+    Note over O,W: DEADLOCK — S0 cannot stream, so it is never added to the cohort, so mg_0 is never created
+```
+
+The invariant that avoids this: whichever node is currently primary ensures a physical slot for **every
+discovered non-leader member of the shard**, as a standing reconcile, rather than only at consensus cohort
+transitions. The scope is deliberately _membership-based, not streaming-gated_ — cohort-**eligible** (a
+discovered member that is not the leader), not cohort-**committed** (committed membership is the streaming-gated
+state the deadlock hinges on). The leader is identified from consensus state — the highest known shard rule —
+never from the topology `Multipooler.Type`, which multiorch must not consult for identity; the eligible set is
+therefore exactly the non-leader members the orchestrator already fans `SetPrimary` out to. Creating the slot on
+demand when such a member first tries to attach, or reconciling against the discovered non-leader set, both
+satisfy the invariant; gating creation on the member's own streaming state does not.
+
+Today the primary only learns about followers through consensus rule updates (`UpdateConsensusRule`, `Recruit`,
+`Promote`, `SetPrimary`) — all gated on cohort eligibility, which for an _add_ requires the follower to be
+streaming already. There is no discovery-time signal to the primary. The natural home for the early create is
+therefore a **discovery-driven reconcile**: the orchestrator already discovers shard members from topology and
+health ahead of any streaming (its cycle re-lists the shard's poolers from the topology store), so on
+discovering a new **non-leader member** it ensures that follower's physical slot on the primary (idempotently),
+and issues the corresponding drop when the member disappears (§2.5). This keeps the primary as the actor that
+owns its own PostgreSQL, fires strictly before the standby is pointed at the primary, and — being level-checked
+against the discovered non-leader set each cycle — self-heals a missed event or a primary restart on the next
+pass.
+
+**On observers.** Multigres does not today model a distinct observer or async-replica role in the shard-member
+set multiorch reconciles over: there is no such `PoolerType`, and every pooler the orchestrator discovers for the
+shard is treated as a cohort member. The reconcile above therefore covers every discovered member that is not the
+leader — the same set `SetPrimary` is already fanned out to — with no role or `Type` filter (multiorch must not
+consult `Multipooler.Type`). What keeps a lagging or not-yet-streaming member from doing harm is not exclusion
+from the reconcile but the narrow scoping of the durability lists: a member is added to
+`synchronized_standby_slots` (whose over-broad membership would stall logical decoding, §2.5) and
+`synchronous_standby_names` (durability-quorum membership) only once it is streaming and caught up (below).
+Creating an unused physical slot ahead of that is cheap (`restart_lsn = NULL`, pins no WAL). If a genuinely
+asynchronous, non-failover-target class of node is introduced later, excluding it from this reconcile must come
+from the shard-membership set (or a consensus-derived signal), not from the topology role.
+
+The corrected flow splits the single cohort-add action into an **early create** and a **late register**. The
+primary ensures the follower's physical slot as soon as the orchestrator _discovers_ that non-leader
+member — before it is pointed at the primary and therefore before it streams — a freshly created, unused slot has `restart_lsn = NULL`
+and pins no WAL until a consumer connects, so creating it ahead of time is cheap. Only once the standby is streaming
+and caught up does the primary add it to `synchronized_standby_slots` and `synchronous_standby_names`; doing
+either earlier would stall logical decoding or block commits. The slot therefore exists before it is needed, and
+the streaming gate that deadlocks the old flow is never on the critical path.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant O as Multiorch
+    participant T as Topology
+    participant P as New primary
+    participant S as Standby S0 pooler
+    participant W as S0 WAL receiver
+    Note over O,W: Primary already elected with cohort P and S2 — S0 is a new standby just starting
+    Note over P: at promotion the hook created mg_2 for S2 — S0 was absent so mg_0 was not created
+    S->>T: register pooler in topology
+    O->>T: list the shard poolers (each cycle)
+    T-->>O: poolers now include S0
+    Note over O: S0 discovered
+    Note over O,P: ADDED — on discovery, reconcile the primary's follower set
+    O->>P: ReconcileFollowers with S2 and S0
+    Note over P: reconciles per-follower slots — mg_2 exists, creates mg_0
+    O->>S: SetPrimary points S0 at the primary
+    Note over S: S0 sets primary_slot_name to mg_0
+    S->>W: start WAL receiver using slot mg_0
+    W->>P: START_REPLICATION SLOT mg_0
+    P-->>W: streaming — slot mg_0 now exists so it succeeds
+    Note over O,W: No deadlock — discovery drove the slot-ensure before S0 needed to stream
+```
+
+Only the later `synchronized_standby_slots` / `synchronous_standby_names` registration (once S0 is streaming and
+caught up) is omitted from the diagram above; it is unchanged from the old flow and, per the split, happens only
+after S0 catches up.
+
+On the wire this is a **level-triggered, declarative** call rather than a per-slot imperative: the orchestrator
+sends the primary the current set of non-leader followers — call it `ReconcileFollowers` — and the primary
+reconciles its per-follower physical slots to match, creating any that are missing and dropping any whose member
+has left (§2.5). The request carries only the followers' IDs, no topology role; slot naming (§4.3) stays inside
+the pooler, which owns its own PostgreSQL, and `EnsurePhysicalSlot` becomes the internal primitive the handler
+calls, not part of the RPC surface. Because the set is re-sent each cycle, a missed event or a primary restart
+self-heals on the next pass.
+
+Two complementary hooks make this robust. The **proactive** one is the discovery reconcile above — slots are
+ensured before a member is pointed at the primary. The **reactive** one extends the recovery path:
+`FixReplication` (the orchestrator's remediation for a cohort member found not replicating) should, as one of
+its steps, ensure that member's physical slot exists on the current primary. So if a slot was somehow not
+created up front — a race, a lost event, or a restart between discovery and `SetPrimary` — the very recovery
+that observes the non-replicating standby also repairs the cause, instead of looping on a no-op `pg_rewind` as
+the old flow did. The proactive reconcile keeps the deadlock from arising; the reactive `FixReplication` step
+guarantees it cannot persist.
+
+#### 2.6.1 `synchronized_standby_slots` must track cohort membership, not slot activeness
+
+The split above adds a follower to `synchronized_standby_slots` only once it is streaming and caught up, and the
+reconcile that maintains that list is driven by **cohort membership**: the list is edited when a follower joins or
+leaves the cohort, never in response to a slot flipping active or inactive. This subsection records why — the choice
+is a deliberate safety/availability call, not an accident of implementation.
+
+`synchronized_standby_slots` is the only thing that holds logical decoding back to the physical standbys, and it is
+_not_ redundant with synchronous replication: PostgreSQL logical decoding does **not** wait for
+`synchronous_standby_names`. A transaction is decoded and streamed to the consumer at its commit WAL record, which is
+flushed locally _before_ synchronous replication has acknowledged it on a standby. The two GUCs gate different things
+— one the client's `COMMIT`, the other the logical stream — so only `synchronized_standby_slots` keeps the consumer
+from outrunning the standbys.
+
+**Filtering the list to active slots is safe in the common case.** It is tempting, when a listed-but-inactive slot
+stalls decoding (§2.5; Part 5 #7), to drop the inactive entries — `... AND active`. Under a single primary failure
+that is in fact safe, provided the active set is non-empty. Decoding is held to the _slowest_ listed slot, so
+`consumer ≤ min(active standbys)`; the survivors of a primary-only fault include those active standbys, and leader
+appointment promotes the furthest-advanced survivor, giving `consumer ≤ min(active) ≤ max(survivors) = new primary`.
+The consumer can never outrun the promoted node. Concretely, with primary A and standbys B (holding `{1,2}`) and C
+(holding `{1}`): if C falls inactive and is de-listed, decoding is still held to B, so transaction 2 — already
+acknowledged on B under AT_LEAST_2 — is streamed only after B has it; if A then crashes, B is promoted and 2 survives.
+De-listing the lagging follower lost nothing.
+
+**It is unsafe only when the holdback collapses below the durability set.** The inequality above has one hole:
+`min(∅)`. If the active set _empties_ — every standby momentarily inactive at once, e.g. a total replication outage
+during failover churn — decoding has no holdback, and because it does not wait for `synchronous_standby_names` it can
+stream a transaction that exists only in the primary's local WAL: flushed and decoded, but not yet acknowledged by any
+standby (its `COMMIT` still blocked). A single primary crash then leaves that transaction _only_ downstream — a change
+the cluster never durably committed, now live in the subscriber:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant W as Client
+    participant C as Consumer
+    participant O as Multiorch
+    participant P as Primary
+    participant S1 as Standby 1
+    participant S2 as Standby 2
+    Note over P,S2: synchronized_standby_slots = mg_s1,mg_s2 holds logical decoding back to both standbys
+    C-->>P: streaming sub
+    Note over S1,S2: failover churn, both WAL receivers briefly reconnect, mg_s1 and mg_s2 go inactive
+    Note over P: active-only filter rewrites synchronized_standby_slots to empty
+    Note over P: logical decoding is no longer held back to any standby
+    W->>P: BEGIN, write T, COMMIT
+    Note over P: T written to WAL, still waiting on sync-standby ack, COMMIT not yet returned to W
+    P-->>C: emit decoded T, logical decoding does not wait for sync rep
+    Note over C: apply T downstream and confirm
+    Note over P: P crashes before any standby received T and before COMMIT returned to W
+    O->>S1: promote, highest surviving WAL
+    Note over S1: new primary, never received T
+    C->>S1: reconnect and resume after T
+    Note over W,S2: W never saw COMMIT succeed, yet T is live downstream and absent from the cluster — a phantom change
+```
+
+In the sequence above the phantom transaction `T` is streamed to the consumer only after the active-only filter has
+emptied `synchronized_standby_slots`, so nothing holds decoding back; `T` reaches the consumer before any standby has
+it and before its own `COMMIT` has returned to the writer, and a single primary crash then strands it downstream. A
+second, out-of-budget shape exists — the primary _plus_ every standby ahead of the consumer fail, promoting a
+de-listed lagging standby — but AT_LEAST_2 tolerates only a single fault, so there the cluster has already lost
+acknowledged data on its own and the subscriber divergence is incremental, not new.
+
+**The chosen rule.** Because the failure is specifically decoding _ahead of the durability point_, and because a
+membership-driven list is already correct whenever the cohort is stable, Multigres edits `synchronized_standby_slots`
+only on a cohort change: a follower is added when it joins and removed when it leaves, never on slot activeness. In the
+normal case nothing changes, so a membership edit is only ever a _delayed_ update of an already-correct list — there
+is no window in which it risks data loss or a phantom change. A transiently-inactive follower stays listed, and the
+only cost is a **bounded stall** of logical decoding until it reconnects or the cohort-remove path drops it: a delay,
+never a loss. That is the safe direction in which to fail.
+
+**A cleaner fix likely belongs upstream (out of scope).** The stall exists only because logical decoding gates on
+`synchronized_standby_slots` membership rather than on how far `synchronous_standby_names` has actually acknowledged.
+Teaching PostgreSQL to let decoding advance up to the LSN the synchronous quorum has already confirmed would drop the
+stall _and_ still never let decoding run ahead of the durability point. That needs an upstream change and is out of
+scope for this PR; it is noted here as a potential future contribution.
+
+---
+
+## Part 3. Changes to Multigateway
+
+Beyond the PostgreSQL-side configuration of Part 2, the implementation needs changes in two Multigres
+services: the **Multigateway** (this part), which relays the consumer's replication stream, and the
+**Multipooler** manager (Part 4), which owns the slot lifecycle on PostgreSQL.
+
+The gateway is the client-facing relay. Its replication relay is byte-blind in both directions today. The
+changes:
+
+### 3.1 Failing over the replication stream
+
+A failover can be handled two ways, described below. The one this design implements is **client-driven**: the
+consumer observes the dropped stream and drives its own reconnect, so the gateway needs no new failover
+machinery. Consumers such as another Postgres server already persist their own LSN and reconnect automatically
+— the apply worker retries the subscription's connection (the gateway, here) at `wal_retrieve_retry_interval`
+and resumes from its replication origin. The second, **gateway-driven**, carries the stream across the
+promotion transparently — the single-server goal — but needs an **LSN-aware tap** so the gateway knows the
+client's position; it buys transparency, not correctness, and is deferred to a later step. Both depend on the
+same underlying question — whether the slot survives the promotion on the new primary — which §3.1.2 examines
+in detail.
+
+#### 3.1.1 Client-driven failover
+
+If the client is allowed to observe the failover as a dropped stream, the tap is unnecessary and
+**Multigateway needs no new failover machinery**. On a leader change the gateway does exactly what it does
+today — tear the tunnel down and route the next connection to the current leader; the client reconnects and
+re-issues `START_REPLICATION` from its _own_ durably-tracked position (a subscriber's replication origin, or a
+`pg_recvlogical` flush file), and the slot synced to the new primary guarantees that LSN is still decodable.
+What newly makes the resume succeed is on the PostgreSQL side — the slot now survives on the new primary via
+native sync — not in the gateway; the one gateway-side change, lifting the non-temporary-slot guard (§3.2), is
+shared by both approaches. This is the standard PostgreSQL resume model and is simpler (the gateway tracks no
+LSN and needs no stream decoding), but it does _not_ look like a single server: the consumer must notice the
+disconnect and drive its own reconnect. The tap is precisely what buys the transparent experience.
+
+The client-driven alternative, without the tap — the consumer sees the stream drop and reconnects itself:
+
+```mermaid
+sequenceDiagram
+    participant C as Consumer
+    participant G as Gateway
+    participant A as Primary A
+    participant B as Standby B
+
+    C->>G: START_REPLICATION SLOT foo LOGICAL X
+    G->>A: START_REPLICATION (relayed)
+    loop steady state, byte-blind, no tap
+        A->>G: XLogData 'w'
+        G->>C: XLogData (relayed verbatim)
+        C->>G: StandbyStatusUpdate 'r'
+        G->>A: StandbyStatusUpdate (relayed verbatim)
+    end
+    Note over A,B: Primary A fails, B is promoted
+    G--)C: stream torn down
+    Note over C: reads its own origin / flush LSN = L
+    C->>G: reconnect and START_REPLICATION SLOT foo LOGICAL L
+    G->>B: START_REPLICATION SLOT foo LOGICAL L
+    B->>G: XLogData resuming at L
+    G->>C: XLogData (relayed)
+```
+
+#### 3.1.2 Gateway-driven failover
+
+For the design goal that the cluster looks like a single server, the gateway should carry the stream to the
+new primary under the _same_ client connection — without the client ever seeing a disconnect. To resume the
+stream on the client's behalf, the gateway must know how far the client has consumed; but it relays
+byte-for-byte and so does not track that position. The only place the position appears is _inside_ the stream
+— the client's `StandbyStatusUpdate` acknowledgements. So the gateway adds an opt-in tap (persistent failover
+slots only; temporary slots keep the byte-blind fast path) that decodes the `CopyData` sub-type byte: on the
+**upstream** path `StandbyStatusUpdate` ('r') to capture the client's `flushed` LSN (the resume point), and
+optionally `XLogData` / `PrimaryKeepalive` downstream to track the server's WAL end.
+
+On a leader change the gateway does not tear the tunnel down — it carries the stream to the new primary. It
+already elects the leader from live health streams (`load_balancer.go`) and forces replication to the leader,
+so on failover it waits for the new leader to serve, verifies the slot is `failover_ready` and that the
+tracked confirmed LSN is within the WAL the new primary holds (surface/refuse the async tail-loss gap, never
+silently skip), and re-opens the stream at the confirmed LSN — the client's `START_REPLICATION` positions it
+there, so no explicit slot advance is needed.
+
+The transparent flow the tap enables — the consumer's connection is never dropped:
+
+```mermaid
+sequenceDiagram
+    participant C as Consumer
+    participant G as Gateway
+    participant A as Primary A
+    participant B as Standby B
+
+    C->>G: START_REPLICATION SLOT foo LOGICAL X
+    G->>A: START_REPLICATION (relayed)
+    loop steady state
+        A->>G: XLogData 'w'
+        G->>C: XLogData (relayed)
+        C->>G: StandbyStatusUpdate 'r' flushed=L
+        Note over G: tap records confirmed LSN = L
+        G->>A: StandbyStatusUpdate (relayed)
+    end
+    Note over A,B: Primary A fails, B is promoted
+    G->>B: check slot foo is failover_ready
+    G->>B: START_REPLICATION SLOT foo LOGICAL L
+    B->>G: XLogData resuming at L
+    G->>C: XLogData on the same connection
+    Note over C: never observed a failover
+```
+
+The failure this prevents — today, with no repoint, the tunnel is torn down at failover and the consumer
+cannot resume on the new primary, so it is forced into a full re-seed:
+
+```mermaid
+sequenceDiagram
+    participant C as Consumer
+    participant G as Gateway
+    participant A as Primary A
+    participant B as Standby B
+
+    C->>G: START_REPLICATION SLOT foo LOGICAL X
+    G->>A: START_REPLICATION (relayed)
+    loop steady state
+        A->>G: XLogData 'w'
+        G->>C: XLogData (relayed)
+    end
+    Note over A,B: Primary A fails, B is promoted — without slot machinery, slot foo is not on B
+    G--)C: tunnel torn down, stream closed
+    Note over C: reconnect to resume at L
+    C->>G: START_REPLICATION SLOT foo LOGICAL L
+    G->>B: START_REPLICATION SLOT foo LOGICAL L
+    B--)G: ERROR slot foo does not exist
+    G--)C: ERROR (relayed)
+    Note over C,B: forced full re-seed — DROP and re-CREATE SUBSCRIPTION, re-COPY every table
+    Note over A,B: with native slot sync (Part 2) slot foo is already on B, so this failure does not occur and the repoint resumes at L
+```
+
+The package `github.com/jackc/pglogrepl` can be used to read the logical replication stream as a client and is
+already a direct dependency but used only for the scalar `LSN` type (`pgutil/lsn.go`). Its message decoders
+aren't wired and the gateway doesn't import it yet, so this is new wiring on an already-vendored library.
+Parse incrementally; treat any decode failure as fall-back-to-teardown, never as stream corruption.
+
+The repoint above only lands cleanly if the new primary's failover slot is already `failover_ready`. That is
+the promoted node's responsibility, not the gateway's: in its promotion hook — while still a standby, before
+`pg_promote` — the pooler checks once whether its synced failover slots are failover-ready
+(`logUnreadyFailoverSlots`, using the `unreadyFailoverSlots` query) and logs any that are not, then promotes
+regardless. It does not wait: a slot that is not ready at promotion is in a state a wait could not recover —
+invalidated, `synced = false` from broken sync, or simply not yet synced from a source primary that is now
+gone — so a wait would only add latency for a state it cannot fix (see the [decision
+log](decision-log/2026-08-17-failover-slot-readiness-before-promotion.md)). A slot that had synced is already
+ready and usable; one caught mid-sync at the crash degrades to a client-driven re-seed (§3.1.1), which loses
+no committed data.
+
+```mermaid
+sequenceDiagram
+    participant O as Multiorch
+    box This node (promoting standby, becomes new primary)
+        participant M as Multipooler
+        participant PG as Postgres
+        participant SS as slot-sync worker
+    end
+    box Old primary
+        participant P0 as Postgres
+    end
+
+    Note over M,SS: node is a standby, in recovery
+    SS-->>P0: pull failover-slot state
+    SS-->>PG: advance THIS node's synced failover slots
+
+    O->>M: Recruit (pause replication, accept term)
+    O->>M: Promote
+    activate M
+    Note over M: promoteLocked runs the promotion hook<br/>still a standby, before pg_promote
+    M->>PG: ensureFollowerPhysicalSlots — create per-follower physical slots
+
+    Note over M,SS: logUnreadyFailoverSlots (advisory, flag-gated)<br/>a single local check of THIS node's own slots<br/>durable creation already made them ready, so there is no wait
+    M->>PG: unreadyFailoverSlots() — query THIS node's pg_replication_slots
+    PG-->>M: count and names of not-ready failover slots
+    Note over M: if count > 0, log them — a terminal state a wait could not fix — and proceed
+
+    M->>PG: promoteStandbyToPrimary then pg_promote()
+    Note over PG,SS: startup process stops the slot-sync worker
+    M-->>O: Promote OK — now primary
+    deactivate M
+```
+
+**What makes a slot `failover_ready` — and what promoting without it costs.** `failover_ready` is `synced AND
+NOT temporary AND invalidation_reason IS NULL`, and each flag is the product of machinery that only runs while
+the source primary is alive and reachable. `synced` means the slot-sync worker created the slot here by
+reading the primary's `failover = true` slots. `NOT temporary` is the load-bearing one: PostgreSQL 17 creates
+a synced slot as _temporary_ and persists it only once this standby has caught up — replayed WAL past the
+`restart_lsn` / `catalog_xmin` it pulled from the primary's slot — so a slot that has not caught up sits
+`synced = true, temporary = true` and is _not_ ready. `invalidation_reason IS NULL` means the catalog rows
+needed to decode from the slot's position were never vacuumed away, which is exactly what
+`hot_standby_feedback` plus the physical slot (§2.1–§2.2) hold. So the `SS-->>PG: advance` step in the diagram
+above is really "keep pulling from the live primary until the local slot catches up and flips from temporary
+to persistent."
+
+This is why a crash can leave a slot permanently not-ready _on this node_. If the primary crashes before a
+given slot has caught up, that slot is frozen `temporary` (and temporary synced slots are dropped at
+promotion), and the only thing that could finish it — continued sync from the primary — is now gone; no action
+on the promoted node can reconstruct the missing retention. The condition is _per-slot_, not per-server: the
+promoted node is a perfectly healthy new primary, every slot that _had_ caught up is ready and usable, and
+only the specific slots caught mid-sync are stuck. That is why promotion only logs the not-ready slots and
+proceeds (see the [decision log](decision-log/2026-08-17-failover-slot-readiness-before-promotion.md)) — a
+hard gate would hang the promotion forever in exactly this case, since readiness can never be reached once the
+source primary is gone, and a wait would only add latency for a state it cannot fix. A slot caught mid-sync at
+the crash is the pre-sync window §4.4 describes: the consumer degrades to a client-driven re-seed (§3.1.1),
+which loses no committed data.
+
+Promoting with a not-ready slot does _not_ lose committed data: the new primary's heap and WAL already hold
+every transaction it received (the async tail-loss window in Part 5 is a separate matter). What is lost is the
+_decode context_ — the `catalog_xmin` retention — for the range between the consumer's last confirmed LSN and
+now, so the new primary can no longer deliver the incremental change stream for that window even though the
+underlying rows are present. The consequence depends on the consumer. A state-replicating consumer (a logical
+replica that only needs matching final state) recovers correct state by re-seeding (`DROP` / `CREATE
+SUBSCRIPTION` → full re-`COPY`) — expensive, but lossless. An event- or CDC-oriented consumer (an audit log, a
+warehouse, a queue — where each change matters) permanently loses the discrete events in the gap: the re-seed
+snapshot shows only final state, so a row inserted _and_ deleted within the window never appears, and an
+`UPDATE a→b→c` collapses to `c`. That permanent loss for event consumers is the residual cost of a crash in
+the pre-sync window (§4.4) — a window Multigres shrinks by creating the slot up front and syncing
+continuously, but does not eliminate. It is not _silent_: the readiness check flags an absent or not-ready
+slot on the new primary and degrades to a re-seed rather than resuming into a gap.
+
+**Worked example: a primary crash with two standbys.** The diagrams below trace one topology — a primary `P`
+with standbys `S1` and `S2`, all carrying the client-facing slot `mg_sub` (`failover = true`) — through a
+crash of `P` in which `S1` is promoted and `S2` is re-based onto it. Both hinge on a single question: **had
+`mg_sub` already been synced onto the standbys before `P` died?** The arrows in the first diagram are numbered
+so the two cases can refer to the same points in the cycle.
+
+_Case 1 — the slot was already synced (the steady state this design maintains)._ Slot-sync (arrows 4–5) runs
+**continuously**, not once, so in steady state `S1` and `S2` each already hold a `failover_ready` copy of
+`mg_sub`. On the crash `S1` simply adopts its existing copy at promotion, `S2` re-bases its copy to sync from
+the new primary, and the consumer repoints and resumes from `confirmed_lsn` — **no re-seed**. A crash at _any_
+instant in the continuous cycle is survivable this way, because the copy already exists; at worst the synced
+copy lags `P` by one sync cycle, which is the _safe_ direction (it retained slightly more WAL and catalog than
+strictly needed, so the consumer's own resume LSN stays serviceable, and the only visible effect is
+at-least-once redelivery of the tail).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as logical consumer
+    participant O as Multiorch
+    box Old primary
+        participant P as Postgres P
+    end
+    box Surviving nodes
+        participant S1 as standby S1
+        participant S2 as standby S2
+    end
+
+    Note over C,S2: steady state - mg_sub is non-temporary, failover=true, not invalidated
+    C->>P: streaming mg_sub from confirmed_lsn
+    P-->>S1: physical WAL via S1 physical slot
+    P-->>S2: physical WAL via S2 physical slot
+    S1-->>P: slot-sync pulls mg_sub state
+    S2-->>P: slot-sync pulls mg_sub state
+    Note over S1,S2: each holds a synced, failover-ready COPY of mg_sub
+
+    Note over P: CRASH - all connections from P drop
+
+    Note over O: detect P down, elect S1 as leader
+    O->>S1: Recruit and Promote
+    activate S1
+    Note over S1: promotion hook, still a standby<br/>ensureFollowerPhysicalSlots creates physical slot for S2<br/>logUnreadyFailoverSlots - mg_sub already ready, nothing to log
+    Note over S1: pg_promote, now PRIMARY<br/>its synced COPY of mg_sub becomes the live slot, still failover=true
+    deactivate S1
+
+    O->>S2: SetPrimary S1
+    Note over S2: primary_conninfo to S1, primary_slot_name to S2 slot on S1
+    S2-->>S1: physical WAL from S1
+    S2-->>S1: slot-sync now pulls mg_sub from S1
+    Note over S1: add S2 physical slot to synchronized_standby_slots
+    Note over S2: mg_sub stays synced and failover-ready for the NEXT failover
+
+    Note over C,S1: Multigateway repoints the consumer to new primary S1
+    C->>S1: START_REPLICATION mg_sub LOGICAL confirmed_lsn
+    Note over S1: slot existed and was ready - resume decoding, NO re-seed<br/>at-least-once tail redelivery, consumer must be idempotent
+    S1->>C: logical stream resumes
+```
+
+_Case 2 — the slot had not been synced yet._ If `P` crashes in the window **between shipping WAL (arrows 2–3)
+and slot-sync's first successful pass (arrows 4–5)**, no standby holds a copy of `mg_sub` at all. Physical
+replication carried the _data_ but never the _slot_ — slot state is not in the WAL stream (§1.6). The promoted
+`S1` therefore has no `mg_sub`: the readiness check finds nothing to flag (an _absent_ slot is not counted as
+"unready"), the consumer's `START_REPLICATION` fails, and the slot cannot be rebuilt after the fact — you
+cannot create-then-rewind a slot to a past LSN, and the catalog rows needed to decode from the old LSN were
+already vacuumed on the standby because no synced slot was pinning them. The consumer must re-seed.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as logical consumer
+    participant O as Multiorch
+    box Old primary
+        participant P as Postgres P
+    end
+    box Surviving nodes
+        participant S1 as standby S1
+        participant S2 as standby S2
+    end
+
+    Note over C,S2: mg_sub just created on P (failover=true) - not yet synced to standbys
+    C->>P: streaming mg_sub from confirmed_lsn
+    P-->>S1: physical WAL via S1 physical slot
+    P-->>S2: physical WAL via S2 physical slot
+    Note over S1,S2: slot-sync has NOT pulled mg_sub yet - no copy on either standby
+
+    Note over P: CRASH - before slot-sync ran
+
+    Note over O: detect P down, elect S1 as leader
+    O->>S1: Recruit and Promote
+    activate S1
+    Note over S1: promotion hook, still a standby<br/>logUnreadyFailoverSlots - mg_sub absent so nothing to log
+    Note over S1: pg_promote, now PRIMARY - but mg_sub does not exist here
+    deactivate S1
+
+    Note over C,S1: Multigateway checks failover_ready on S1 - slot is absent
+    C->>S1: START_REPLICATION mg_sub LOGICAL confirmed_lsn
+    S1->>C: ERROR replication slot mg_sub does not exist
+    Note over C,S1: slot state never left P and is not in the WAL<br/>cannot create-then-rewind, and catalog rows for the old LSN already vacuumed<br/>consumer must DROP and CREATE SUBSCRIPTION - full re-COPY
+```
+
+**The re-seed outcome belongs to Case 2 only.** Once `mg_sub` is `failover_ready` on the standbys, a primary
+crash is survivable without a re-seed; the sole unrecoverable case is a crash before the slot's _first_ sync
+completed. That is precisely the window `failover_ready` exists to flag — and why the gateway verifies
+`failover_ready` on the new primary before repointing, degrading to a clean client-driven re-seed (§3.1.1)
+rather than a silent gap.
+
+### 3.2 Remove non-temporary slot guard
+
+The gateway currently _rejects_ every non-temporary slot outright, precisely because it could not carry one
+across a failover (the guard this design removes). The change is to relax the preamble
+(`replication_preamble.go`) to reject only non-temporary slots that are _not_ registered for failover. The
+persistent failover slots this admits are propagated to the standbys by native slot-sync (§2) and protected
+across promotion by the failover-time readiness check (§3.1.2); a failover before a freshly created slot has
+synced degrades to a client-driven re-seed (§3.1.1), never a silent gap (§4.4).
+
+The sticky per-backend reservation (`protoutil.ReasonLogicalReplication`) is deliberately left unchanged here.
+A live walsender stream is physically one backend, and on the client-driven path (§3.1.1) it tears down on
+failover and the consumer reconnects to the new primary with a fresh reservation — so nothing needs to be
+tracked shard-wide for the feature to work. Un-pinning the reservation so a stream can be _carried_ across a
+promotion without teardown is only needed for the transparent repoint, and is deferred to that step (§3.1.2);
+the SQL-function path (`pg_create_logical_replication_slot` on an ordinary connection) also stays guarded by
+the planner until then.
+
+Admitting these slots is gated behind a dynamic Multigateway flag, `enable-slot-based-replication` (default
+off, mirroring the Multipooler flag of the same name and read live so it is reloadable). With the flag off the
+preamble rejects every non-temporary slot exactly as it does today, so the guard change is inert until an
+operator enables the feature. Physical (non-logical) slots and non-temporary logical slots _not_ registered
+for failover stay rejected regardless of the flag.
+
+## Part 4. Changes to Multipooler
+
+The pooler owns the slot lifecycle on PostgreSQL — the gateway cannot create, drop, or query slots itself.
+Net-new operations, run as admin SQL through the pooler's existing superuser path (as `pg_promote()` / `ALTER
+SYSTEM` are today):
+
+### 4.1 Slot operations
+
+The rest of the design keeps needing to do one of two things to a slot: create the failover slot on the
+primary, and read a slot's failover-readiness before trusting a node as a target. So the manager exposes
+`EnsureLogicalSlot(name, plugin, failover)` → `pg_create_logical_replication_slot(...)` (idempotent);
+`DropLogicalSlot` for cleanup; and `GetSlotState` → a `pg_replication_slots` row (`failover_ready`,
+`invalidation_reason`, `catalog_xmin`). It does **not** advance slots: native sync keeps the standbys' slots
+caught up on its own, and at the repoint the consumer's `START_REPLICATION ... <lsn>` positions the stream.
+
+### 4.2 Driven on shard events
+
+Because a slot cannot be created after the fact and rewound, the failover logical slot must exist on the
+primary _before_ any change the consumer will replay — so it is ensured up front (with `failover = true`) when
+a persistent slot is first requested, not at failover time. Native sync then propagates it to the standbys
+automatically; Multigres never creates logical slots on standbys, it only verifies they have reached
+failover-ready before trusting one as a promotion target (hook the recruit / `SetPrimary` paths).
+
+### 4.3 Slot naming
+
+The primary creates the physical slot and the follower sets its `primary_slot_name` to match, so each must
+compute the same name independently. The slot name needs to be unique within the cluster, but does not need to
+be unique compared to other clusters.
+
+We derive the slot name from the follower's component `name`, which is already unique cluster-wide. Hence it
+stays unique on the primary even when standbys span cells, and no cell qualifier is needed.
+
+The name is sanitized to PostgreSQL's slot-name rules (`[a-z0-9_]`, ≤63 characters — see §1.5) and given a
+`mg_` prefix (the short prefix Multigres already uses for its own identifiers, e.g. metrics) so they cannot
+collide with a client-created slot of the same name. A slot name cannot be schema-qualified, so the prefix is
+the flat-identifier equivalent of the `multigres` schema that namespaces Multigres-owned objects elsewhere.
+The name is lower-cased unconditionally so the slot name is well-formed whether or not `name` can contain
+upper-case letters, and `-` is mapped to `_`.
+
+This transform must stay collision-free: underscores are already disallowed in `name`, so if `name` is limited
+to lower-case `[a-z0-9-]` the lower-casing is a no-op and `-`→`_` is injective, needing no disambiguator; if
+upper-case or other characters are possible, lower-casing (or folding them out) can collapse two distinct
+names onto the same slot name, so append a short deterministic hash to preserve uniqueness.
+
+### 4.4 Durability without a creation barrier
+
+Creating the failover slot on the primary (§4.2) makes it exist there, but slot state is not in the WAL
+(§1.6): for a window the slot exists _only_ on the primary, until the slot-sync worker copies it to the
+standbys. A primary crash inside that window leaves no standby with a copy and forces the consumer to re-seed
+(the Case-2 failure in §3.1.2). It is tempting to close that window the way Multigres closes the equivalent
+window for writes — refuse to acknowledge the client's `CREATE_REPLICATION_SLOT` until the slot is
+`failover_ready` on the standbys the write-durability policy requires. Such an ack-hold barrier was built and
+then removed, because it cannot deliver the guarantee it promises. This section records why, and what
+durability actually rests on instead.
+
+**Why an ack-hold cannot make creation durable.** A fresh slot's `catalog_xmin` is frozen at its creation
+point and only advances **when the slot is consumed** (the consumer streams, applies, and flushes its position
+back). Slot-sync refuses to persist a synced slot whose `catalog_xmin` is _behind_ the standby's catalog
+horizon — doing so "could lead to data loss," since the standby has already vacuumed past the rows the slot
+would need. Meanwhile an idle standby's horizon creeps forward on its own (periodic running-xacts snapshots).
+So a brand-new, unconsumed slot is precisely the one slot-sync will _not_ persist, and holding the creation
+acknowledgement blocks the consumption that is the only thing that would make it persistable — a deadlock. Two
+scenarios make the trap concrete:
+
+- **`CREATE_REPLICATION_SLOT`, then a crash, nothing consumed.** The slot exists on the primary but was never
+  streamed. We cannot _resume_ it on the promoted standby: a reconstructed slot lands at "now" (§1.6,
+  can't-create-then-rewind), while the subscriber's origin and initial `COPY` sit at the slot's
+  `consistent_point`; resuming would silently skip `[consistent_point, now)`, leaving the already-copied tables
+  permanently inconsistent — worse than no slot. What _is_ safe is a **re-seed**: nothing was consumed, so
+  re-`COPY`ing from the new primary (which holds all committed data via physical replication) loses nothing. A
+  creation barrier adds nothing here — the safe outcome is a re-seed either way.
+- **`CREATE_REPLICATION_SLOT`, then `START_REPLICATION`.** Once streaming begins the slot _can_ sync — flushing
+  advances `catalog_xmin` until it overtakes the standby's horizon and slot-sync persists it. But there is
+  nothing to hold: the "acknowledgement" that opens the stream is the `CopyBothResponse`, and syncing requires
+  the stream to flow (receive → apply → flush). Holding it, or buffering `XLogData`, starves the very flushing
+  that produces the sync — the same deadlock, moved. Logical replication also has **no server→client durability
+  acknowledgement** to hang a barrier on: the subscriber flushes _its own_ position upstream; the publisher
+  never signals "your position is now failover-safe."
+
+**The reframe: this is an avoid-re-`COPY` optimization, not data-loss prevention.** A clean re-seed never
+loses committed data for a table-replica subscriber — the re-`COPY` reconstructs correct current state from
+the new primary. So the whole feature is an optimization to avoid the expensive re-`COPY` (and, for CDC-style
+consumers, to preserve intermediate change-event granularity), _not_ a data-loss-prevention mechanism. The
+only true silent-loss risk in the space is the reconstruct-at-now-and-resume of the first scenario, which
+Multigres must **never** do. Given that, native slot-sync (during streaming) plus a client-driven re-seed
+(§3.1.1) for the pre-sync window already deliver "no committed data loss," and "usually no re-`COPY` either."
+An ack-hold would only add latency and, on an idle shard, deadlock but for a degrade that made it inert
+anyway.
+
+**What durability rests on, then.** `CREATE_REPLICATION_SLOT` (and the plain-SQL
+`pg_create_logical_replication_slot(...)` form) relays byte-blind and returns immediately, exactly as a
+temporary slot does today. The slot then becomes durable the way PostgreSQL intends: the subscriber streams,
+the slot's `catalog_xmin` advances, slot-sync persists it onto the standbys shortly after, and §2's machinery
+(physical slots, `hot_standby_feedback`, `sync_replication_slots`, `synchronized_standby_slots`) keeps it WAL-
+and catalog-retained continuously. For the window before that first sync completes, a failover degrades to a
+clean client-driven re-seed (§3.1.1) — safe, occasionally costing a re-`COPY`. Slot-aware leader appointment
+(Part 5 #11) then prefers a `failover_ready` candidate among WAL-equal nodes, so once a slot has synced a
+promotion lands, whenever possible, on a node that can serve it without a re-seed. The failover-time readiness
+check (§3.1.2) is what keeps the pre-sync window from ever becoming a _silent_ gap: it flags an absent or
+not-ready slot on the new primary and re-seeds rather than resuming into it.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as consumer
+    participant G as Multigateway
+    box Primary
+        participant P as primary pooler
+        participant PG as primary Postgres
+    end
+    box Standbys
+        participant S1 as standby S1
+        participant S2 as standby S2
+    end
+
+    C->>G: CREATE_REPLICATION_SLOT mg_sub LOGICAL failover
+    G->>P: relay byte-blind
+    P->>PG: CREATE_REPLICATION_SLOT mg_sub failover=true
+    PG-->>P: slot created (consistent_point, snapshot)
+    P-->>G: response
+    G-->>C: CREATE_REPLICATION_SLOT ok (returned immediately, no hold)
+    Note over C,S2: pre-sync window - a crash here degrades to a client-driven re-seed
+
+    C->>G: START_REPLICATION SLOT mg_sub LOGICAL consistent_point
+    G->>PG: relay stream
+    loop steady state
+        PG->>C: XLogData (relayed)
+        C->>PG: StandbyStatusUpdate flushed - advances catalog_xmin
+    end
+    S1-->>PG: slot-sync persists mg_sub once catalog_xmin overtakes the horizon
+    S2-->>PG: slot-sync persists mg_sub
+    Note over S1,S2: mg_sub now failover_ready - a crash from here is survivable without re-seed
+```
+
+#### 4.4.1 When data can actually be lost
+
+It helps to separate three things that all get called "data loss," because only one of them is caused by this
+feature:
+
+- **Committed rows gone from the database** — the classic async-failover tail-loss window: the old primary
+  commits past what it shipped, and the promoted standby never received it. This **does not apply to
+  Multigres**, which always runs synchronous replication — a commit is not acknowledged until the durability
+  policy's standbys have it, and `synchronized_standby_slots` additionally holds a logical consumer back to what
+  those standbys have flushed — so a committed transaction (and a consumer's confirmed position) can never
+  outrun the promotion target. It is a real window only for an asynchronous PostgreSQL deployment.
+- **A silent subscriber gap** — the database on the new primary still holds every committed row, but the
+  subscriber silently skips a range. This is the _only_ slot-related loss, and it is **mistake-triggered**: it
+  happens only if the subscriber _resumes_ across a window where the slot's decode context is not yet durably
+  established on the promotion target. Multigres never resumes there — the failover-readiness check (§3.1.2)
+  refuses and re-seeds instead. The MSCs below are what that guard protects against.
+- **Re-seed cost** — a re-`COPY` loses no committed data for a table-replica subscriber; for a CDC/event
+  subscriber it loses intermediate change granularity. This is the price of the pre-sync window, not
+  committed-data loss.
+
+The silent-gap window has two shapes.
+
+**Resuming before the slot has synced.** The slot exists only on the primary; a crash leaves the promotion
+target without it. Reconstructing it there lands at "now" and resuming skips everything the subscriber had
+already copied but not yet consumed — a silent, permanent gap. A re-seed is always safe here.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as consumer
+    participant P as primary P
+    participant S as standby S
+    Note over C,S: CREATE SUBSCRIPTION failover=true, copy_data=true
+    C->>P: CREATE_REPLICATION_SLOT mg_sub failover=true
+    P-->>C: created at consistent_point C
+    C->>P: initial COPY of tables at a snapshot near C
+    Note over P,S: mg_sub NOT yet synced to S - catalog_xmin frozen at C, S horizon has moved past C
+    Note over P: CRASH before mg_sub reaches S
+    Note over S: promoted to primary - mg_sub does not exist here
+    alt SAFE path - re-seed, what Multigres does
+        C->>S: readiness check finds mg_sub absent
+        Note over C,S: DROP and CREATE SUBSCRIPTION, re-COPY from S - no committed data lost
+    else UNSAFE - reconstruct at now and resume
+        C->>S: recreate mg_sub, it lands at now N
+        C->>S: START_REPLICATION mg_sub from origin C
+        S-->>C: slot restart_lsn is N, stream begins at N
+        Note over C,S: changes between C and N are never delivered - SILENT PERMANENT GAP
+    end
+```
+
+**Failover during initial table sync.** The apply worker's failover slot may itself have synced, but the
+per-table `tablesync` workers use _temporary_ slots that never fail over, and the tables sit at mixed,
+incomplete positions. The subscription is not in a consistent, resumable state, so a resume can permanently
+miss the changes carried by a lost `tablesync` slot. A re-seed restarts `tablesync` cleanly.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant AW as apply worker
+    participant TS as tablesync worker
+    participant P as primary P
+    participant S as standby S
+    Note over AW,S: CREATE SUBSCRIPTION failover=true, copy_data=true - initial sync running
+    AW->>P: CREATE_REPLICATION_SLOT mg_sub failover=true at C
+    TS->>P: create TEMPORARY tablesync slot - not failover
+    TS->>P: COPY table_a at its own snapshot
+    Note over TS,P: table_b not started, table_a still catching up
+    AW->>P: stream mg_sub, apply changes for ready tables
+    Note over P: CRASH during initial sync
+    Note over S: promoted - tablesync TEMP slots are gone, per-table sync state incomplete
+    alt SAFE path - re-seed
+        Note over AW,S: DROP and CREATE SUBSCRIPTION, tablesync re-COPY every table from S - no committed data lost
+    else UNSAFE - resume the half-synced subscription
+        AW->>S: resume mg_sub, tables resume from their recorded srsublsn
+        Note over AW,S: changes during a table copy window were carried by the lost temp slot - SILENT ROW LOSS
+    end
+```
+
+**The safe boundary.** Once initial sync is complete _and_ `mg_sub` is `failover_ready` on the required
+standbys, a crash is survivable with a plain resume — no re-seed, at-least-once tail redelivery. The two
+conditions are not merely "the apply worker has run for a while": reaching `failover_ready` needs
+_consumption_ to advance `catalog_xmin` past each standby's horizon plus one slot-sync cycle, so on an idle
+shard with no change traffic the slot may never become ready no matter how long it sits. And the boundary is
+the slot-sync worker actually _persisting_ the slot (step 2 in the MSC), not `catalog_xmin` merely catching
+up: a crash after the slot becomes syncable but before the worker's next run — its nap is adaptive, roughly
+200 ms to 30 s — still finds the slot absent on the standby and forces a re-seed, exactly as in the first
+shape above.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as consumer
+    participant P as primary P
+    participant S as standby S
+    Note over C,S: initial sync complete, apply worker streaming and flushing
+    C->>P: apply changes and StandbyStatusUpdate flushed
+    Note over P: catalog_xmin advances past C as changes are consumed
+    Note over P,S: catalog_xmin overtakes S catalog horizon
+    S-->>P: slot-sync persists mg_sub - failover_ready on S
+    Note over C,S: SAFE boundary - initial sync done AND slot durable on required standbys
+    Note over P: CRASH now
+    Note over S: promoted - mg_sub already present and failover_ready
+    C->>S: readiness check passes
+    C->>S: START_REPLICATION mg_sub from origin L
+    Note over C,S: slot sits at or behind L, at-least-once redelivery of tail - NO loss, NO re-seed
+```
+
+#### 4.4.2 Operational note: making a new subscription failover-safe
+
+The failover machinery only protects a subscription **after its first slot-sync has persisted `mg_sub` on the
+required standbys** (the safe boundary above). A newly created subscription is therefore _not_ failover-safe for a
+window after `CREATE SUBSCRIPTION`, and on an idle shard it may never become safe on its own. This is a normal,
+expected state — not a bug — but it must be operated deliberately.
+
+**When a new subscription is not yet protected.** From `CREATE SUBSCRIPTION` (which issues
+`CREATE_REPLICATION_SLOT ... failover=true`) until _both_ (a) the initial table sync has finished and (b) `mg_sub`
+is `failover_ready` and persisted on the durability-policy standbys. Two things extend this window (§4.4.1): the
+per-table `tablesync` workers use temporary slots that never fail over, so an incomplete initial sync is unsafe
+regardless of `mg_sub`; and `failover_ready` needs _consumption_ to advance `catalog_xmin` past each standby's
+horizon plus one slot-sync cycle, so **on an idle shard with no change traffic the slot can sit not-ready
+indefinitely**.
+
+**How to recover if a failover lands in the window.** The promotion target has no usable slot. The gateway's
+failover-readiness check (§3.1.2) detects the absent / not-ready slot and **refuses to resume** — it never
+resumes into a silent gap (§4.4.1). Recovery is a **client-driven re-seed**:
+
+```sql
+DROP SUBSCRIPTION sub;
+CREATE SUBSCRIPTION sub CONNECTION '...' PUBLICATION pub WITH (copy_data = true, failover = true);
+```
+
+A consumer behind the Multigateway is degraded to this automatically; a raw consumer that manages its own
+subscription must issue the `DROP` / `CREATE` itself. No committed data is lost for a table-replica subscriber —
+the re-`COPY` reconstructs current state from the new primary — but a CDC / event consumer loses the intermediate
+change granularity in the gap (§4.4.1).
+
+**How to reach the safe boundary deliberately (the workaround for the idle-shard case).** To make a fresh
+subscription failover-safe rather than waiting and hoping:
+
+1. **Let the initial sync finish.** Confirm every table is in the ready state — `srsubstate = 'r'` in
+   `pg_subscription_rel` — before relying on failover; the `tablesync` temporary slots must be gone.
+2. **Drive change traffic.** `catalog_xmin` only advances as changes are consumed, so on a quiet shard generate
+   some write traffic (any trivial write, or a periodic keepalive) so the slot becomes syncable.
+3. **Optionally force a sync cycle** on each standby instead of waiting out the worker's adaptive nap
+   (~200 ms–30 s): `SELECT pg_sync_replication_slots();`.
+4. **Verify readiness** on each durability-policy standby before treating the subscription as HA-safe:
+
+   ```sql
+   SELECT slot_name,
+          (synced AND NOT temporary AND invalidation_reason IS NULL) AS failover_ready
+     FROM pg_replication_slots
+    WHERE slot_name = 'mg_sub';
+   ```
+
+   Until this returns `failover_ready = true` on the required standbys, treat a failover as a re-seed.
+
+---
+
+## Part 5. Caveats and considerations
+
+1. **Can't create-then-rewind (§4.2).** Followers' slots must be pre-created and kept caught up _before_ the
+   changes they'll replay. Lazily creating a slot on the new primary at failover time and rewinding it is
+   impossible. Native slot sync satisfies this by creating the slot on the primary and propagating it to every
+   standby ahead of any promotion; there is no lightweight create-at-failover shortcut.
+2. **Catalog-row invalidation (§1.4).** If `catalog_xmin` isn't durably held, a follower's synced slot is
+   silently invalidated and useless at promotion. Native sync keeps the hold durable through
+   `hot_standby_feedback` plus the physical replication slot — reversing Multigres's current slot-less posture,
+   and the reason both are mandatory.
+3. **Async tail-loss.** In an asynchronous deployment a failover can lose the last δ of WAL the old primary had,
+   and resuming at `confirmed_lsn` could leave the subscriber ahead of the new primary's surviving data —
+   persistent slots don't change that. Multigres closes this window at the source: it always runs synchronous
+   replication (a commit is not acknowledged until the durability policy's standbys have it) plus
+   `synchronized_standby_slots` (which holds the logical consumer back to what those standbys have flushed), so
+   committed data is always on the promotion target and the subscriber can never be ahead of it. The
+   failover-repoint guard (§3.1.2) is the backstop that would still _detect_ (not _recover_) such a gap were
+   synchronous replication ever disabled.
+4. **Breaking protocol-blindness.** The LSN tap makes the gateway parse a sub-protocol it deliberately never
+   interpreted (§3.1). Risks: parser bugs on adversarial/streaming-framed input, hot-path performance, coupling
+   to protocol versions. Mitigation: opt-in tap only, incremental parsing, decode-failure ⇒ teardown.
+5. **Transparent failover is not durable across a gateway crash.** The tap's confirmed LSN lives only in gateway
+   memory — there is no durable Multigres-side resume record. If the gateway itself fails, that position is lost
+   and the single-connection experience (§3.1.2) cannot be preserved: recovery degrades to the client-driven path
+   (§3.1.1), where the consumer notices the dropped stream and reconnects at its _own_ durably-tracked LSN (a
+   replication origin or `pg_recvlogical` flush file, §1.2), which the synced slot on the new primary can still
+   serve. Correctness is preserved — the consumer, not the gateway, is the source of truth — but transparency is
+   best-effort. And because the confirmed LSN always lags the client's true position, resume is at-least-once
+   regardless of who drives it, so consumers must be idempotent.
+6. **Idle/lagging follower slots pin resources.** Every pre-created follower slot holds `restart_lsn` +
+   `catalog_xmin`; if it is not advanced, WAL and catalog rows bloat on that node. Native sync advances synced
+   slots automatically, clamped to each standby's replay LSN. They also draw on `max_replication_slots` (template
+   default 25) alongside physical and client slots — a fan-out budget concern.
+7. **`synchronized_standby_slots` can stall the primary.** Used for tail-loss safety, a listed-but-down follower
+   blocks logical decoding on the primary until removed. Membership churn (recruit/leave) must update the list
+   promptly, or a dead follower freezes all logical replication.
+8. **Subscriber repoint semantics.** Native semantics require the downstream `ALTER SUBSCRIPTION ... CONNECTION`.
+   In the Multigres model the client connects _to the gateway_, so the gateway can hide the repoint for stream
+   continuity — but if the client is a full PostgreSQL subscriber with its own origin bookkeeping, its LSN
+   expectations and ours must agree, or resume is rejected.
+9. **Multi-shard / routing assumptions.** The relay pins one shard/leader (`DefaultTableGroup`/`DefaultShard`,
+   `MODE_WRITABLE`). Failover repoint must re-resolve the leader for exactly that shard and not silently rebind;
+   interaction with the buffering path (which replication currently bypasses) needs deliberate handling.
+10. **Security / trust boundary.** Parsing bytes from a client replication stream and issuing slot-management SQL
+    derived from client-named slots crosses a trust boundary. Slot names/LSNs from the wire must be validated;
+    slot-management SQL must use the existing quoting/`InternalQueryService` path, never string interpolation.
+11. **Leader appointment is slot-aware (was slot-blind).** Multiorch's `AppointLeader` picks the new primary by
+    WAL position — the most-advanced viable candidate — which alone is _slot-blind_: a candidate can be ahead on
+    WAL yet carry a temporary (not-yet-persisted) or invalidated slot, and promoting it forces the subscriber into
+    a re-seed even when a WAL-equal candidate could have served the slot (§4.4). This is now handled as a
+    **tiebreak among WAL-equal candidates**: each pooler reports its failover-slot readiness
+    (`failover_slots_ready` / `_total`, computed only when slot-based replication is on) in its health snapshot,
+    and `poolerHealthStateLess` prefers the candidate with more failover-ready slots once WAL position and the
+    resign signal are tied. Because it only reorders the already-WAL-tied `EligibleLeaders`, it never trades data
+    safety (WAL position always wins) or a resign intent for slot readiness; when no WAL-viable candidate is
+    slot-ready, the WAL-best node is still promoted and the subscriber re-seeds. Slot-aware appointment is what
+    keeps a promotion landing, whenever possible, on a node that can serve the durable slot without a re-seed.
+
+---
+
+## Recommendation
+
+Adopt native PostgreSQL 17 slot sync (Part 2), built on the Multigateway and Multipooler machinery (Parts 3
+and 4). Native sync enforces the WAL-retention and catalog-safety guarantees that are otherwise easy to get
+subtly wrong (silent data loss), and its Multigres-side cost is bounded and concrete: add `dbname` to
+`primary_conninfo`, set `hot_standby_feedback` / `sync_replication_slots` in the template, and introduce
+per-follower physical replication slots plus `synchronized_standby_slots` — reversing Multigres's current
+slot-less posture, which is the one significant architectural change. The gateway owns only what PostgreSQL
+cannot: carrying the consumer's stream across a promotion (the LSN tap and failover repoint, §3.1.2) and
+lifting the non-temporary-slot guard (§3.2). The fully-DIY alternative (Appendix A) is documented but not
+recommended — it reimplements the catalog-safety native sync provides for free and accepts a documented
+silent-data-loss risk — and should be revisited only if reintroducing physical replication slots is rejected.
+
+---
+
+## Implementation order
+
+Each step below is a single pull request, merged in the order given, and must not break anything already
+merged. That is possible because no step depends on a later one: every step is either dormant (new code
+nothing calls yet), an inert configuration change, or strictly additive. The feature first works end-to-end at
+step 5; steps 1–4 are foundations that change nothing a client can observe, and step 6 is the optional
+transparency layer. There is deliberately no creation-time durability-barrier step: a barrier that holds the
+`CREATE_REPLICATION_SLOT` acknowledgement until the slot is durable was considered and rejected (§4.4) — it
+cannot deliver that guarantee, and durability rests on slot-sync during streaming plus a client-driven re-seed
+for the pre-sync window instead.
+
+1. **Slot primitives and naming (§4.1, §4.3).** Add the manager operations `EnsureLogicalSlot`,
+   `DropLogicalSlot`, and `GetSlotState`, plus the deterministic slot-name helper. Nothing calls them yet, so
+   this is new, unit-testable surface with no runtime behavior change.
+
+2. **Inert node configuration (part of §2.1).** Set `wal_level = logical`, add a valid `dbname` to
+   `primary_conninfo`, and size `max_wal_senders` / `max_replication_slots` for the fan-out. Each is inert on its
+   own — `wal_level = logical` only widens what the WAL records, `dbname` is ignored by streaming replication,
+   and the limits are pure capacity — so replication continues exactly as today (still slot-less).
+   `primary_slot_name` is deliberately left unset until step 3.
+
+3. **Physical replication slots and their lifecycle (rest of §2.1, §2.2–§2.5).** Turn on `hot_standby_feedback`
+   and `sync_replication_slots`, and introduce the per-follower physical slot: the current primary creates a slot
+   (named by the step-1 helper) for each follower and maintains `synchronized_standby_slots`, while each standby
+   sets `primary_slot_name` to its own slot — wired into the promote, demote, add-standby, and remove-standby
+   paths (hook recruit / `SetPrimary`). This is the one change to existing plumbing (slot-less → slot-based
+   physical replication), so it must create the slot on the primary before the standby points at it, and is best
+   gated behind a flag for rollout. It touches only physical replication, not the client path, and
+   `sync_replication_slots` has nothing to sync yet. Deliverable on its own: standbys hold WAL and catalog rows
+   through a durable slot (§1.5) rather than best-effort `wal_keep_size`.
+
+4. **Failover-slot handling on the primary (§4.2, §2.2).** When a persistent slot is requested, ensure it exists
+   on the primary with `failover = true`, and verify standbys reach failover-ready before trusting one as a
+   promotion target. Still invisible end-to-end, because the gateway guard (step 5) has not yet let any client
+   create a persistent failover slot, and existing temporary-slot streams are untouched.
+
+5. **Lift the non-temporary slot guard (§3.2).** Relax the preamble to admit non-temporary failover slots (still
+   rejecting non-temporary, non-failover slots), gated behind the dynamic Multigateway flag
+   `enable-slot-based-replication` (default off). This is the activation step: temporary slots keep working
+   unchanged, and a client can now create a persistent failover slot that steps 3–4 keep synced and catalog-safe.
+   The feature works end-to-end here via the client-driven path (§3.1.1) — on failover the consumer reconnects
+   and resumes on the new primary — with no gateway relay changes.
+
+6. **Gateway tap and transparent repoint (§3.1.2).** Add the opt-in LSN-aware tap and the repoint that carries
+   the stream to the new primary under the same connection. This is also where the sticky per-backend reservation
+   (`ReasonLogicalReplication`) is relaxed so a stream can move to the new primary's backend without teardown —
+   the client-driven path (step 5) needs no such change because it reconnects fresh. It is strictly additive and
+   opt-in (persistent failover slots only; temporary slots keep the byte-blind fast path; any decode failure
+   falls back to teardown), so deferring it — or hitting a decode bug — simply degrades to the client-driven
+   failover from step 5. This is the "looks like a single server" layer and ships last.
+
+---
+
+## Appendix A — Considered alternative: fully-DIY catch-up (Patroni model)
+
+Also uses all of Parts 3 and 4, but **replaces native sync**: Multigres owns the follower slots itself. Choose
+this only if reintroducing physical replication slots (Part 2) is rejected.
+
+The key insight that shapes this proposal: a follower slot only needs to be _positioned_ at the client's exact
+resume LSN **once, at repoint** (§3.1.2) — not continuously. During normal operation Multigres does **not**
+track the client's LSN into every follower slot; it only keeps the slots _pre-created, valid, and coarsely
+bounded_. The precise advance is a failover-time action.
+
+What it entails:
+
+1. **Pre-created, un-synced follower slots.** Each follower has its own persistent logical slot (created via
+   `EnsureLogicalSlot`, §4.1, with `failover => false` — nothing syncs them). They must exist before any change
+   the client might replay (§1.6); they are _not_ kept at the client's position.
+2. **Keep slots valid continuously (the unavoidable part).** `hot_standby_feedback = on` on every follower, so
+   the primary holds `catalog_xmin` back and its vacuum WAL doesn't invalidate the idle follower slots on replay
+   (recovery-conflict invalidation). This hold is only durable _while connected_; a brief follower disconnect
+   drops it and the next vacuum-replay can invalidate the slot — exactly the fragility a physical slot would
+   remove, and the reason this path is riskier than native sync (Part 2).
+3. **Coarse, periodic advance to bound bloat (retention hygiene, not client tracking).** An idle slot parked at
+   its creation LSN pins `catalog_xmin`/`restart_lsn` there forever → unbounded WAL/catalog bloat (caveat #6). A
+   lazy manager loop advances each follower slot forward to a _recent safe bound_ (well behind the client — just
+   enough to release old WAL/catalog), gated by the step-4 safety check below. This is coarse and infrequent,
+   unlike a tight per-confirmation loop.
+4. **Precise positioning at repoint (§3.1.2), gated by a hand-rolled `catalog_xmin` safety check (the
+   load-bearing part).** On failover the gateway advances the new primary's slot to the persisted `confirmed_lsn`
+   `X` via `AdvanceLogicalSlot` (forward-only, clamped to the node's replay LSN), then resumes. Before _any_
+   advance (this one and the coarse ones in step 3), verify the node still holds the catalog rows needed to
+   decode from the target — the Patroni rule: the relevant `catalog_xmin` is non-null and not newer than the
+   target. Advancing past retained catalog rows is the documented **silent-data-loss** failure: the slot would
+   claim changes were consumed that the node never actually had.
+5. **No `synchronized_standby_slots`.** Without it, nothing stops the subscriber from getting ahead of a
+   follower, so the async tail-loss window is wider and must be handled purely by the failover-repoint guard
+   (§3.1.2, detect-and-refuse) or by synchronous replication.
+
+**Trade-off vs. native sync (Part 2):** avoids reintroducing physical slots (preserves Multigres's current
+slot-less disk-safety posture), and deferring precise positioning to repoint means only a coarse
+bloat-bounding loop runs in steady state — cheaper than continuously syncing exact positions. But Multigres
+must still run the continuous liveness machinery (steps 2–3) and correctly reimplement the catalog-safety
+check (step 4) that native sync enforces for free, and it accepts a larger tail-loss window and the
+silent-data-loss risk if the safety check is wrong. Strictly more code and more risk than native sync;
+documented here so the cost of "no physical slots" is explicit.
+
+**DIY-specific problems.** These are absent from Part 5 because they exist only under this alternative — they
+are the failure modes native sync removes:
+
+- **Fragile catalog hold** (step 2): the `catalog_xmin` hold rests on `hot_standby_feedback` alone. A brief
+  follower disconnect drops it, and the next vacuum-replay can invalidate the slot — the disconnect-window,
+  timing-skew, and recovery-conflict failures the physical replication slot would prevent.
+- **Silent data loss on a wrong advance** (step 4): the hand-rolled `catalog_xmin` safety check is load-bearing.
+  Advancing a slot past the catalog rows the node still holds silently claims changes were consumed that the
+  node never had.
+- **Wider tail-loss window** (step 5): without `synchronized_standby_slots`, nothing holds the subscriber back
+  from getting ahead of a follower, so the async tail-loss window is larger and rests entirely on the repoint
+  guard or synchronous replication.
+
+## Appendix B — Considered alternative: table-based slot sync with a custom materialization primitive
+
+Like Appendix A, this is a **considered, unimplemented** alternative to native sync (Part 2), recorded for future
+reference. It keeps native sync's _retention_ model but replaces its _transport_: instead of the standby's
+slot-sync worker opening a SQL connection back to the primary (why native sync needs a `dbname` in
+`primary_conninfo`), the slot metadata is replicated **forward** through a table, and a custom C primitive
+materializes the slot on each standby. The motivation is removing the standby → primary back-connection.
+
+### B.1 The missing primitive
+
+There is no SQL way to create a logical slot at a _past_ position. `pg_create_logical_replication_slot()` always
+starts the new slot at "now" (its `restart_lsn` / `catalog_xmin` are pinned at creation), and
+`pg_replication_slot_advance()` is forward-only. You cannot create a slot and rewind it — a fresh slot only
+begins pinning `catalog_xmin` from its creation point, so the historical catalog rows needed to decode from an
+earlier LSN may already be gone (the can't-create-then-rewind invariant, Part 1). So plain SQL cannot reconstruct
+on a standby a slot positioned where the primary's slot actually is.
+
+### B.2 Writing the primitive as a C extension
+
+The primitive is missing from _SQL_ because it is unsafe to expose casually — not because the machinery is
+missing. The backend already does exactly this in `src/backend/replication/logical/slotsync.c`:
+`synchronize_one_slot()` calls `ReplicationSlotCreate()`, stamps the copied `restart_lsn` / `confirmed_flush` /
+`catalog_xmin` / `two_phase` onto `slot->data`, and persists with `ReplicationSlotMarkDirty()` /
+`ReplicationSlotSave()` once it is safe. A C extension can expose the same, e.g.:
+
+```text
+mg_materialize_slot(name text, plugin text, restart_lsn pg_lsn, confirmed_flush pg_lsn,
+                    catalog_xmin xid, two_phase bool, failover bool)
+```
+
+**Prior art:** EDB's `pg_failover_slots` extension did precisely this (an extension plus a background worker
+recreating logical failover slots on standbys) for PG 11–15, before native sync landed in PG 16/17. So the
+pattern is proven, and `supabase/postgres:17` already supports loading extensions.
+
+### B.3 What the primitive does not remove
+
+The primitive is the easy part. Materializing a slot at LSN `X` is only _valid_ if the node still holds the WAL
+back to `restart_lsn` **and** the historical catalog rows to decode from `X` (`catalog_xmin`). The table
+transport does not change that — it is the same envelope Part 2 relies on:
+
+- **Catalog retention** still needs `hot_standby_feedback` plus a per-follower physical slot (the durable
+  `catalog_xmin` hold), so replayed vacuum does not discard the rows the materialized slot needs.
+- **Clamp to replay / persist-when-safe:** the standby must have replayed to at least `confirmed_flush` before
+  the copy is real — the same gate native sync applies (keep the synced slot temporary until safe, then persist).
+  Skipping it re-introduces silent data loss.
+
+So the table + primitive replaces the **transport and the worker**, not the retention/safety requirements.
+
+### B.4 Flow for adding a slot
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Consumer
+    participant P as Primary
+    participant T as slotmeta table
+    participant W as Standby bgworker
+    participant S as Standby slot
+    C->>P: request failover slot foo
+    Note over P: pg_create_logical_replication_slot(foo) blocks — slot EPHEMERAL, restart_lsn and catalog_xmin pinned, SnapBuild BUILDING
+    Note over P: SnapBuild reaches CONSISTENT at L1 — catalog_xmin settles, confirmed_flush = L1, slot persisted
+    Note over P: only now (catalog_xmin advanced, valid confirmed_flush) is foo publishable
+    P->>T: write row foo(restart_lsn, confirmed_flush, catalog_xmin, plugin, two_phase)
+    Note over T: row rides physical WAL to the standby
+    T-->>W: row replayed on the standby
+    W->>S: mg_materialize_slot(foo, ...) once replay >= confirmed_flush and catalog rows retained
+    Note over P,S: on later advances, P updates the row and W advances the standby copy
+    Note over S: after a failover foo already exists at a valid position, so the consumer resumes
+```
+
+### B.5 The snapshot progression, and why a slot is published only after `catalog_xmin` has advanced
+
+`pg_create_logical_replication_slot` does not finish instantly — it blocks while the snapshot builder
+(`SnapBuild`) reaches a consistent point:
+
+1. The slot is created **`RS_EPHEMERAL`** (dropped if the creating backend errors before it persists);
+   `restart_lsn` is stamped and `catalog_xmin` is set to the oldest xid of the snapshot _still in progress_ (e.g.
+   `xid 100`, protecting an open `Txn_A`). `confirmed_flush` is unset.
+2. `SnapBuild` walks `xl_running_xacts`, waiting for the in-flight transactions to finish:
+   `BUILDING → FULL_SNAPSHOT → CONSISTENT`.
+3. At **`CONSISTENT`** (LSN `L1`) the slot gets `confirmed_flush = L1`, `catalog_xmin` settles to its final value
+   (e.g. `100 → 140`), and the slot is **persisted**. Only then does the create call return.
+
+"The xmin is inside a snapshot that has not yet finished" is exactly the pre-`CONSISTENT` window.
+
+Publishing during that window is **not a stream-corruption problem** — worth stating, because the intuition that
+"it seems fine" is largely right:
+
+- The decoder **re-derives consistency** on use: a consumer connecting post-promotion restarts decoding from
+  `restart_lsn`, rebuilds `SnapBuild`, and re-reaches the consistent point before emitting anything. It never
+  emits pre-consistent changes.
+- The provisional `catalog_xmin` is **over-retentive, never under** (`100` is older than the final `140`), so it
+  pins a superset of the needed rows — safe, just wasteful.
+
+The reasons to wait are **readiness**, not correctness:
+
+1. **No resume point yet:** before `CONSISTENT` there is no `confirmed_flush`, so nothing a promoted standby could
+   resume from.
+2. **The slot is still ephemeral:** if creation does not complete, the primary drops it — and a standby that
+   already materialized it holds an **orphan** of a slot that never persisted.
+3. Minor: the provisional `catalog_xmin` pins extra catalog rows on every standby for the window.
+
+So "publish only once `catalog_xmin` has advanced and the slot is persistent" is a **readiness gate**.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant W as Writer
+    participant C as Consumer
+    participant P as Primary
+    participant J as Sync job
+    participant S as Standby
+    W->>P: BEGIN Txn_A xid 100, stays open
+    C->>P: create logical slot foo (call blocks)
+    Note over P: foo is EPHEMERAL, restart_lsn set, catalog_xmin = 100 (oldest xid of the in-progress snapshot)
+    Note over P: SnapBuild BUILDING, no consistent point, confirmed_flush unset
+    J->>P: scan pg_replication_slots
+    P-->>J: foo, catalog_xmin 100, confirmed_flush NULL
+    Note over J: publishes a pre-consistent, still-ephemeral slot
+    J->>S: materialize foo (catalog_xmin 100, no confirmed_flush)
+    alt creation never completes
+        C-xP: create call canceled or backend dies
+        Note over P: EPHEMERAL foo dropped, never persisted
+        Note over S: orphan foo, a slot the primary never actually had
+    else a failover lands in the window
+        W->>P: COMMIT Txn_A
+        Note over P: SnapBuild CONSISTENT at L1, catalog_xmin advances 100 to 140, confirmed_flush = L1
+        Note over P: P crashes before J republishes (L1, 140)
+        Note over S: promoted with foo pinned pre-consistent
+        C->>S: resume foo
+        Note over S: no confirmed_flush to resume from, not yet a valid failover target
+    end
+    Note over P,S: correctness is preserved (decoder re-derives consistency), but the copy is not usable/real until L1
+```
+
+**Confirmed against PostgreSQL 17 (`REL_17_STABLE`).** In `pg_create_logical_replication_slot`
+(`src/backend/replication/slotfuncs.c`) the slot is created `RS_EPHEMERAL`, the start point is found while
+blocking, and it is persisted only at the end:
+
+```c
+ReplicationSlotCreate(name, true, temporary ? RS_TEMPORARY : RS_EPHEMERAL, two_phase, failover, false);
+ctx = CreateInitDecodingContext(plugin, NIL, ...);
+if (find_startpoint)
+    DecodingContextFindStartpoint(ctx);   /* blocks until CONSISTENT */
+if (!temporary)
+    ReplicationSlotPersist();
+```
+
+`pg_get_replication_slots` (the view) filters only on `in_use`, with no persistency filter, so an ephemeral slot
+mid-creation is shown, with `confirmed_flush_lsn` reported `NULL` while it is `InvalidXLogRecPtr`. And the
+slot-sync worker fetches `... FROM pg_catalog.pg_replication_slots WHERE failover and NOT temporary` — an
+ephemeral failover slot matches — then drops any fetched slot whose positions are still invalid:
+
+```c
+if ((XLogRecPtrIsInvalid(remote_slot->restart_lsn) ||
+     XLogRecPtrIsInvalid(remote_slot->confirmed_lsn) ||
+     !TransactionIdIsValid(remote_slot->catalog_xmin)) &&
+    remote_slot->invalidated == RS_INVAL_NONE)
+    pfree(remote_slot);   /* skip, retry next cycle */
+```
+
+with the comment that it has "fetched the remote_slot in its RS_EPHEMERAL state … sync it in the next sync cycle
+when the remote_slot is persisted and has valid lsn(s) and xmin values." That is exactly the readiness gate this
+scheme must reproduce.
+
+### B.6 What the table transport buys
+
+- **No standby → primary back-connection:** metadata flows forward on the stream that already exists; native
+  sync's libpq fetch from the standby is gone.
+- **Free ordering on physical WAL:** a "foo is at position X" row arrives on the standby exactly when it has
+  replayed to where the row was written, so "standby has WAL ≥ published position" holds by construction — no
+  clamp race.
+
+### B.7 Costs, risks, and status
+
+- **Unstable internal API:** `slot->data`, `ReplicationSlotCreate()`'s signature (gained `two_phase` in 16,
+  `failover` in 17), and the persist path are backend internals — version-coupled, maintained across majors.
+- **Re-deriving the safety checks:** the "replay ≥ `confirmed_flush`, catalog horizon safe, handle invalidation,
+  skip while ephemeral" logic from `slotsync.c` must be reproduced or the scheme risks silent divergence.
+- **ROI:** on a base image that already ships native sync, this only buys removing the back-connection — worth it
+  only if that back-connection is a real deployment problem.
+
+**Status:** not implemented. If pursued, the next step is a spike — prototype `mg_materialize_slot` against PG 17
+to prove the internal-API path compiles and materializes a valid slot, plus a small standby bgworker that applies
+the table rows, reusing Part 2's retention GUCs (`hot_standby_feedback`, per-follower physical slots) for
+correctness.

--- a/go/common/parser/ast/replication_slot.go
+++ b/go/common/parser/ast/replication_slot.go
@@ -36,6 +36,17 @@ var ReplicationSlotFuncTemporaryArgIndex = map[string]int{
 	"pg_create_logical_replication_slot":  2,
 }
 
+// ReplicationSlotFuncFailoverArgIndex maps the logical slot builtin to the
+// zero-based index of its `failover` parameter:
+//
+//	pg_create_logical_replication_slot(slot_name, plugin, temporary DEFAULT false, twophase DEFAULT false, failover DEFAULT false)
+//
+// Only the logical function has one — a physical slot cannot be a logical
+// failover slot — so the physical builtin is deliberately absent.
+var ReplicationSlotFuncFailoverArgIndex = map[string]int{
+	"pg_create_logical_replication_slot": 4,
+}
+
 // FindNonTemporaryReplicationSlotCall walks stmt for a call to one of
 // ReplicationSlotFuncTemporaryArgIndex's functions whose `temporary`
 // argument is missing, non-literal, or false, and returns that function's
@@ -43,6 +54,28 @@ var ReplicationSlotFuncTemporaryArgIndex = map[string]int{
 // matching the planner's own check: a missing, bound, or non-literal
 // argument is treated the same as an explicit `false`.
 func FindNonTemporaryReplicationSlotCall(stmt Stmt) (string, bool) {
+	return findRejectableReplicationSlotCall(stmt, isTemporaryReplicationSlotCall)
+}
+
+// FindNonTemporaryNonFailoverReplicationSlotCall is like
+// FindNonTemporaryReplicationSlotCall but additionally admits a non-temporary
+// logical slot created with `failover => true`. Such a slot is safe to keep
+// persistently because multigres syncs it to the standbys and can transition
+// it across a primary failover. It returns the name of a replication-slot-
+// creating call that is neither temporary nor an admissible failover slot, or
+// ("", false) if none. Used by the multigateway replication preamble once the
+// slot-based-replication feature is enabled.
+func FindNonTemporaryNonFailoverReplicationSlotCall(stmt Stmt) (string, bool) {
+	return findRejectableReplicationSlotCall(stmt, func(name string, fc *FuncCall) bool {
+		return isTemporaryReplicationSlotCall(name, fc) || isFailoverReplicationSlotCall(name, fc)
+	})
+}
+
+// findRejectableReplicationSlotCall walks stmt for a replication-slot-creating
+// builtin that admissible reports false for, returning the first such call's
+// name. admissible receives the resolved (lower-cased, pg_catalog-stripped)
+// function name and its FuncCall and returns true when the call is allowed.
+func findRejectableReplicationSlotCall(stmt Stmt, admissible func(name string, fc *FuncCall) bool) (string, bool) {
 	if stmt == nil {
 		return "", false
 	}
@@ -56,19 +89,46 @@ func FindNonTemporaryReplicationSlotCall(stmt Stmt) (string, bool) {
 			return true
 		}
 		name := replicationSlotFuncCallName(fc.Funcname)
-		temporaryArgIndex, isReplicationSlotFunc := ReplicationSlotFuncTemporaryArgIndex[name]
-		if !isReplicationSlotFunc {
+		if _, isReplicationSlotFunc := ReplicationSlotFuncTemporaryArgIndex[name]; !isReplicationSlotFunc {
 			return true
 		}
-		if fc.Args != nil && fc.Args.Len() > temporaryArgIndex {
-			if isTemp, ok := literalBoolArg(fc.Args.Items[temporaryArgIndex]); ok && isTemp {
-				return true
-			}
+		if admissible(name, fc) {
+			return true
 		}
 		found = name
 		return false
 	}, nil)
 	return found, found != ""
+}
+
+// isTemporaryReplicationSlotCall reports whether fc's `temporary` argument is a
+// literal true. Fails closed: a missing, bound, or non-literal argument reads
+// as not-temporary.
+func isTemporaryReplicationSlotCall(name string, fc *FuncCall) bool {
+	return literalBoolArgAt(fc, ReplicationSlotFuncTemporaryArgIndex[name])
+}
+
+// isFailoverReplicationSlotCall reports whether fc's `failover` argument is a
+// literal true. Only the logical builtin has a failover parameter; for any
+// other function it returns false. Fails closed, like
+// isTemporaryReplicationSlotCall.
+func isFailoverReplicationSlotCall(name string, fc *FuncCall) bool {
+	idx, ok := ReplicationSlotFuncFailoverArgIndex[name]
+	if !ok {
+		return false
+	}
+	return literalBoolArgAt(fc, idx)
+}
+
+// literalBoolArgAt reports whether fc's argument at index idx is a literal
+// boolean true.
+func literalBoolArgAt(fc *FuncCall, idx int) bool {
+	if fc.Args != nil && fc.Args.Len() > idx {
+		if isTrue, ok := literalBoolArg(fc.Args.Items[idx]); ok && isTrue {
+			return true
+		}
+	}
+	return false
 }
 
 // replicationSlotFuncCallName resolves a FuncCall's name for comparison

--- a/go/common/rpcclient/client.go
+++ b/go/common/rpcclient/client.go
@@ -204,6 +204,14 @@ type MultipoolerClient interface {
 	// ResignLeadership gracefully resigns the pooler from leadership for a planned failover.
 	ResignLeadership(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.ResignLeadershipRequest) (*multipoolermanagerdatapb.ResignLeadershipResponse, error)
 
+	// ReconcileFollowers declares to the primary pooler the full set of
+	// cohort-eligible follower members it should hold per-follower physical
+	// replication slots for; the primary creates missing slots and drops managed
+	// slots for members no longer in the set. Used by the orchestrator's
+	// discovery-driven reconcile so a late-joining standby's slot exists before it
+	// streams.
+	ReconcileFollowers(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.ReconcileFollowersRequest) (*multipoolermanagerdatapb.ReconcileFollowersResponse, error)
+
 	// SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts on a pooler.
 	SetPostgresRestartsEnabled(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse, error)
 

--- a/go/common/rpcclient/fake_client.go
+++ b/go/common/rpcclient/fake_client.go
@@ -74,6 +74,7 @@ type FakeClient struct {
 	GetBackupsResponses                 map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupsResponse
 	GetBackupByJobIdResponses           map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupByJobIdResponse
 	ResignLeadershipResponses           map[topoclient.ComponentID]*multipoolermanagerdatapb.ResignLeadershipResponse
+	ReconcileFollowersResponses         map[topoclient.ComponentID]*multipoolermanagerdatapb.ReconcileFollowersResponse
 	SetPostgresRestartsEnabledResponses map[topoclient.ComponentID]*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse
 	ReloadConfigResponses               map[topoclient.ComponentID]*multipoolermanagerdatapb.ReloadConfigResponse
 
@@ -118,6 +119,7 @@ func NewFakeClient() *FakeClient {
 		GetBackupsResponses:                 make(map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupsResponse),
 		GetBackupByJobIdResponses:           make(map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupByJobIdResponse),
 		ResignLeadershipResponses:           make(map[topoclient.ComponentID]*multipoolermanagerdatapb.ResignLeadershipResponse),
+		ReconcileFollowersResponses:         make(map[topoclient.ComponentID]*multipoolermanagerdatapb.ReconcileFollowersResponse),
 		SetPostgresRestartsEnabledResponses: make(map[topoclient.ComponentID]*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse),
 		ReloadConfigResponses:               make(map[topoclient.ComponentID]*multipoolermanagerdatapb.ReloadConfigResponse),
 		Errors:                              make(map[topoclient.ComponentID]error),
@@ -195,6 +197,13 @@ func (f *FakeClient) SetResignLeadershipResponse(poolerID topoclient.ComponentID
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.ResignLeadershipResponses[poolerID] = resp
+}
+
+// SetReconcileFollowersResponse sets a ReconcileFollowers response for a pooler.
+func (f *FakeClient) SetReconcileFollowersResponse(poolerID topoclient.ComponentID, resp *multipoolermanagerdatapb.ReconcileFollowersResponse) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ReconcileFollowersResponses[poolerID] = resp
 }
 
 // SetPostgresRestartsEnabledResponse sets a SetPostgresRestartsEnabled response for a pooler.
@@ -492,6 +501,23 @@ func (f *FakeClient) ResignLeadership(ctx context.Context, pooler *clustermetada
 		return resp, nil
 	}
 	return &multipoolermanagerdatapb.ResignLeadershipResponse{}, nil
+}
+
+// ReconcileFollowers records the call and returns a scripted or empty response.
+func (f *FakeClient) ReconcileFollowers(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.ReconcileFollowersRequest) (*multipoolermanagerdatapb.ReconcileFollowersResponse, error) {
+	poolerID := f.getPoolerID(pooler)
+	f.logCall("ReconcileFollowers", poolerID)
+
+	if err := f.checkError(poolerID); err != nil {
+		return nil, err
+	}
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if resp, ok := f.ReconcileFollowersResponses[poolerID]; ok {
+		return resp, nil
+	}
+	return &multipoolermanagerdatapb.ReconcileFollowersResponse{}, nil
 }
 
 //

--- a/go/common/rpcclient/grpc_client.go
+++ b/go/common/rpcclient/grpc_client.go
@@ -267,6 +267,20 @@ func (c *Client) ResignLeadership(ctx context.Context, pooler *clustermetadatapb
 	return conn.managerClient.ResignLeadership(ctx, request)
 }
 
+// ReconcileFollowers declares the full set of cohort-eligible follower members
+// the primary should hold per-follower physical replication slots for.
+func (c *Client) ReconcileFollowers(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.ReconcileFollowersRequest) (*multipoolermanagerdatapb.ReconcileFollowersResponse, error) {
+	conn, closer, err := c.dialPersistent(ctx, pooler)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = closer()
+	}()
+
+	return conn.managerClient.ReconcileFollowers(ctx, request)
+}
+
 // SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts on a pooler.
 func (c *Client) SetPostgresRestartsEnabled(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse, error) {
 	conn, closer, err := c.dialPersistent(ctx, pooler)

--- a/go/pb/multipoolermanager/multipoolermanagerconnect/multipoolermanagerservice.connect.go
+++ b/go/pb/multipoolermanager/multipoolermanagerconnect/multipoolermanagerservice.connect.go
@@ -81,6 +81,9 @@ const (
 	// MultipoolerManagerSetPostgresRestartsEnabledProcedure is the fully-qualified name of the
 	// MultipoolerManager's SetPostgresRestartsEnabled RPC.
 	MultipoolerManagerSetPostgresRestartsEnabledProcedure = "/multipoolermanager.MultipoolerManager/SetPostgresRestartsEnabled"
+	// MultipoolerManagerReconcileFollowersProcedure is the fully-qualified name of the
+	// MultipoolerManager's ReconcileFollowers RPC.
+	MultipoolerManagerReconcileFollowersProcedure = "/multipoolermanager.MultipoolerManager/ReconcileFollowers"
 	// MultipoolerManagerReloadConfigProcedure is the fully-qualified name of the MultipoolerManager's
 	// ReloadConfig RPC.
 	MultipoolerManagerReloadConfigProcedure = "/multipoolermanager.MultipoolerManager/ReloadConfig"
@@ -128,6 +131,15 @@ type MultipoolerManagerClient interface {
 	// PostgreSQL instance. Used by tests and demos to prevent premature restarts during
 	// controlled failovers.
 	SetPostgresRestartsEnabled(context.Context, *connect.Request[multipoolermanagerdata.SetPostgresRestartsEnabledRequest]) (*connect.Response[multipoolermanagerdata.SetPostgresRestartsEnabledResponse], error)
+	// ReconcileFollowers declares to the primary the full set of cohort-eligible
+	// follower members it should hold per-follower physical replication slots for.
+	// The primary creates any missing slot and drops managed slots for members no
+	// longer in the set. It is level-triggered and declarative: the orchestrator
+	// re-sends the set each cycle, so a missed event or a primary restart
+	// self-heals. It creates only the physical slots (so a late-joining standby
+	// can stream); it does NOT touch synchronized_standby_slots — a follower is
+	// added there only once it is streaming and caught up, via the cohort path.
+	ReconcileFollowers(context.Context, *connect.Request[multipoolermanagerdata.ReconcileFollowersRequest]) (*connect.Response[multipoolermanagerdata.ReconcileFollowersResponse], error)
 	// ReloadConfig triggers a PostgreSQL configuration reload (SIGHUP via pgctld)
 	// on this multipooler's local PostgreSQL and confirms it took effect by
 	// waiting for pg_conf_load_time() to advance. The returned config_load_time
@@ -227,6 +239,12 @@ func NewMultipoolerManagerClient(httpClient connect.HTTPClient, baseURL string, 
 			connect.WithSchema(multipoolerManagerMethods.ByName("SetPostgresRestartsEnabled")),
 			connect.WithClientOptions(opts...),
 		),
+		reconcileFollowers: connect.NewClient[multipoolermanagerdata.ReconcileFollowersRequest, multipoolermanagerdata.ReconcileFollowersResponse](
+			httpClient,
+			baseURL+MultipoolerManagerReconcileFollowersProcedure,
+			connect.WithSchema(multipoolerManagerMethods.ByName("ReconcileFollowers")),
+			connect.WithClientOptions(opts...),
+		),
 		reloadConfig: connect.NewClient[multipoolermanagerdata.ReloadConfigRequest, multipoolermanagerdata.ReloadConfigResponse](
 			httpClient,
 			baseURL+MultipoolerManagerReloadConfigProcedure,
@@ -255,6 +273,7 @@ type multipoolerManagerClient struct {
 	verifyBackups              *connect.Client[multipoolermanagerdata.VerifyBackupsRequest, multipoolermanagerdata.VerifyBackupsResponse]
 	resignLeadership           *connect.Client[multipoolermanagerdata.ResignLeadershipRequest, multipoolermanagerdata.ResignLeadershipResponse]
 	setPostgresRestartsEnabled *connect.Client[multipoolermanagerdata.SetPostgresRestartsEnabledRequest, multipoolermanagerdata.SetPostgresRestartsEnabledResponse]
+	reconcileFollowers         *connect.Client[multipoolermanagerdata.ReconcileFollowersRequest, multipoolermanagerdata.ReconcileFollowersResponse]
 	reloadConfig               *connect.Client[multipoolermanagerdata.ReloadConfigRequest, multipoolermanagerdata.ReloadConfigResponse]
 	managerHealthStream        *connect.Client[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse]
 }
@@ -315,6 +334,11 @@ func (c *multipoolerManagerClient) SetPostgresRestartsEnabled(ctx context.Contex
 	return c.setPostgresRestartsEnabled.CallUnary(ctx, req)
 }
 
+// ReconcileFollowers calls multipoolermanager.MultipoolerManager.ReconcileFollowers.
+func (c *multipoolerManagerClient) ReconcileFollowers(ctx context.Context, req *connect.Request[multipoolermanagerdata.ReconcileFollowersRequest]) (*connect.Response[multipoolermanagerdata.ReconcileFollowersResponse], error) {
+	return c.reconcileFollowers.CallUnary(ctx, req)
+}
+
 // ReloadConfig calls multipoolermanager.MultipoolerManager.ReloadConfig.
 func (c *multipoolerManagerClient) ReloadConfig(ctx context.Context, req *connect.Request[multipoolermanagerdata.ReloadConfigRequest]) (*connect.Response[multipoolermanagerdata.ReloadConfigResponse], error) {
 	return c.reloadConfig.CallUnary(ctx, req)
@@ -365,6 +389,15 @@ type MultipoolerManagerHandler interface {
 	// PostgreSQL instance. Used by tests and demos to prevent premature restarts during
 	// controlled failovers.
 	SetPostgresRestartsEnabled(context.Context, *connect.Request[multipoolermanagerdata.SetPostgresRestartsEnabledRequest]) (*connect.Response[multipoolermanagerdata.SetPostgresRestartsEnabledResponse], error)
+	// ReconcileFollowers declares to the primary the full set of cohort-eligible
+	// follower members it should hold per-follower physical replication slots for.
+	// The primary creates any missing slot and drops managed slots for members no
+	// longer in the set. It is level-triggered and declarative: the orchestrator
+	// re-sends the set each cycle, so a missed event or a primary restart
+	// self-heals. It creates only the physical slots (so a late-joining standby
+	// can stream); it does NOT touch synchronized_standby_slots — a follower is
+	// added there only once it is streaming and caught up, via the cohort path.
+	ReconcileFollowers(context.Context, *connect.Request[multipoolermanagerdata.ReconcileFollowersRequest]) (*connect.Response[multipoolermanagerdata.ReconcileFollowersResponse], error)
 	// ReloadConfig triggers a PostgreSQL configuration reload (SIGHUP via pgctld)
 	// on this multipooler's local PostgreSQL and confirms it took effect by
 	// waiting for pg_conf_load_time() to advance. The returned config_load_time
@@ -460,6 +493,12 @@ func NewMultipoolerManagerHandler(svc MultipoolerManagerHandler, opts ...connect
 		connect.WithSchema(multipoolerManagerMethods.ByName("SetPostgresRestartsEnabled")),
 		connect.WithHandlerOptions(opts...),
 	)
+	multipoolerManagerReconcileFollowersHandler := connect.NewUnaryHandler(
+		MultipoolerManagerReconcileFollowersProcedure,
+		svc.ReconcileFollowers,
+		connect.WithSchema(multipoolerManagerMethods.ByName("ReconcileFollowers")),
+		connect.WithHandlerOptions(opts...),
+	)
 	multipoolerManagerReloadConfigHandler := connect.NewUnaryHandler(
 		MultipoolerManagerReloadConfigProcedure,
 		svc.ReloadConfig,
@@ -496,6 +535,8 @@ func NewMultipoolerManagerHandler(svc MultipoolerManagerHandler, opts ...connect
 			multipoolerManagerResignLeadershipHandler.ServeHTTP(w, r)
 		case MultipoolerManagerSetPostgresRestartsEnabledProcedure:
 			multipoolerManagerSetPostgresRestartsEnabledHandler.ServeHTTP(w, r)
+		case MultipoolerManagerReconcileFollowersProcedure:
+			multipoolerManagerReconcileFollowersHandler.ServeHTTP(w, r)
 		case MultipoolerManagerReloadConfigProcedure:
 			multipoolerManagerReloadConfigHandler.ServeHTTP(w, r)
 		case MultipoolerManagerManagerHealthStreamProcedure:
@@ -551,6 +592,10 @@ func (UnimplementedMultipoolerManagerHandler) ResignLeadership(context.Context, 
 
 func (UnimplementedMultipoolerManagerHandler) SetPostgresRestartsEnabled(context.Context, *connect.Request[multipoolermanagerdata.SetPostgresRestartsEnabledRequest]) (*connect.Response[multipoolermanagerdata.SetPostgresRestartsEnabledResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("multipoolermanager.MultipoolerManager.SetPostgresRestartsEnabled is not implemented"))
+}
+
+func (UnimplementedMultipoolerManagerHandler) ReconcileFollowers(context.Context, *connect.Request[multipoolermanagerdata.ReconcileFollowersRequest]) (*connect.Response[multipoolermanagerdata.ReconcileFollowersResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("multipoolermanager.MultipoolerManager.ReconcileFollowers is not implemented"))
 }
 
 func (UnimplementedMultipoolerManagerHandler) ReloadConfig(context.Context, *connect.Request[multipoolermanagerdata.ReloadConfigRequest]) (*connect.Response[multipoolermanagerdata.ReloadConfigResponse], error) {

--- a/go/pb/multipoolermanager/multipoolermanagerservice.pb.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice.pb.go
@@ -39,7 +39,7 @@ var File_multipoolermanagerservice_proto protoreflect.FileDescriptor
 
 const file_multipoolermanagerservice_proto_rawDesc = "" +
 	"\n" +
-	"\x1fmultipoolermanagerservice.proto\x12\x12multipoolermanager\x1a\x1cmultipoolermanagerdata.proto2\xd1\v\n" +
+	"\x1fmultipoolermanagerservice.proto\x12\x12multipoolermanager\x1a\x1cmultipoolermanagerdata.proto2\xce\f\n" +
 	"\x12MultipoolerManager\x12c\n" +
 	"\n" +
 	"WaitForLSN\x12).multipoolermanagerdata.WaitForLSNRequest\x1a*.multipoolermanagerdata.WaitForLSNResponse\x12u\n" +
@@ -53,7 +53,8 @@ const file_multipoolermanagerservice_proto_rawDesc = "" +
 	"\rExpireBackups\x12,.multipoolermanagerdata.ExpireBackupsRequest\x1a-.multipoolermanagerdata.ExpireBackupsResponse\x12l\n" +
 	"\rVerifyBackups\x12,.multipoolermanagerdata.VerifyBackupsRequest\x1a-.multipoolermanagerdata.VerifyBackupsResponse\x12u\n" +
 	"\x10ResignLeadership\x12/.multipoolermanagerdata.ResignLeadershipRequest\x1a0.multipoolermanagerdata.ResignLeadershipResponse\x12\x93\x01\n" +
-	"\x1aSetPostgresRestartsEnabled\x129.multipoolermanagerdata.SetPostgresRestartsEnabledRequest\x1a:.multipoolermanagerdata.SetPostgresRestartsEnabledResponse\x12i\n" +
+	"\x1aSetPostgresRestartsEnabled\x129.multipoolermanagerdata.SetPostgresRestartsEnabledRequest\x1a:.multipoolermanagerdata.SetPostgresRestartsEnabledResponse\x12{\n" +
+	"\x12ReconcileFollowers\x121.multipoolermanagerdata.ReconcileFollowersRequest\x1a2.multipoolermanagerdata.ReconcileFollowersResponse\x12i\n" +
 	"\fReloadConfig\x12+.multipoolermanagerdata.ReloadConfigRequest\x1a,.multipoolermanagerdata.ReloadConfigResponse\x12\x88\x01\n" +
 	"\x13ManagerHealthStream\x128.multipoolermanagerdata.ManagerHealthStreamClientMessage\x1a3.multipoolermanagerdata.ManagerHealthStreamResponse(\x010\x01B9Z7github.com/multigres/multigres/go/pb/multipoolermanagerb\x06proto3"
 
@@ -69,21 +70,23 @@ var file_multipoolermanagerservice_proto_goTypes = []any{
 	(*multipoolermanagerdata.VerifyBackupsRequest)(nil),               // 8: multipoolermanagerdata.VerifyBackupsRequest
 	(*multipoolermanagerdata.ResignLeadershipRequest)(nil),            // 9: multipoolermanagerdata.ResignLeadershipRequest
 	(*multipoolermanagerdata.SetPostgresRestartsEnabledRequest)(nil),  // 10: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	(*multipoolermanagerdata.ReloadConfigRequest)(nil),                // 11: multipoolermanagerdata.ReloadConfigRequest
-	(*multipoolermanagerdata.ManagerHealthStreamClientMessage)(nil),   // 12: multipoolermanagerdata.ManagerHealthStreamClientMessage
-	(*multipoolermanagerdata.WaitForLSNResponse)(nil),                 // 13: multipoolermanagerdata.WaitForLSNResponse
-	(*multipoolermanagerdata.StartReplicationResponse)(nil),           // 14: multipoolermanagerdata.StartReplicationResponse
-	(*multipoolermanagerdata.StopReplicationResponse)(nil),            // 15: multipoolermanagerdata.StopReplicationResponse
-	(*multipoolermanagerdata.StatusResponse)(nil),                     // 16: multipoolermanagerdata.StatusResponse
-	(*multipoolermanagerdata.BackupResponse)(nil),                     // 17: multipoolermanagerdata.BackupResponse
-	(*multipoolermanagerdata.GetBackupsResponse)(nil),                 // 18: multipoolermanagerdata.GetBackupsResponse
-	(*multipoolermanagerdata.GetBackupByJobIdResponse)(nil),           // 19: multipoolermanagerdata.GetBackupByJobIdResponse
-	(*multipoolermanagerdata.ExpireBackupsResponse)(nil),              // 20: multipoolermanagerdata.ExpireBackupsResponse
-	(*multipoolermanagerdata.VerifyBackupsResponse)(nil),              // 21: multipoolermanagerdata.VerifyBackupsResponse
-	(*multipoolermanagerdata.ResignLeadershipResponse)(nil),           // 22: multipoolermanagerdata.ResignLeadershipResponse
-	(*multipoolermanagerdata.SetPostgresRestartsEnabledResponse)(nil), // 23: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	(*multipoolermanagerdata.ReloadConfigResponse)(nil),               // 24: multipoolermanagerdata.ReloadConfigResponse
-	(*multipoolermanagerdata.ManagerHealthStreamResponse)(nil),        // 25: multipoolermanagerdata.ManagerHealthStreamResponse
+	(*multipoolermanagerdata.ReconcileFollowersRequest)(nil),          // 11: multipoolermanagerdata.ReconcileFollowersRequest
+	(*multipoolermanagerdata.ReloadConfigRequest)(nil),                // 12: multipoolermanagerdata.ReloadConfigRequest
+	(*multipoolermanagerdata.ManagerHealthStreamClientMessage)(nil),   // 13: multipoolermanagerdata.ManagerHealthStreamClientMessage
+	(*multipoolermanagerdata.WaitForLSNResponse)(nil),                 // 14: multipoolermanagerdata.WaitForLSNResponse
+	(*multipoolermanagerdata.StartReplicationResponse)(nil),           // 15: multipoolermanagerdata.StartReplicationResponse
+	(*multipoolermanagerdata.StopReplicationResponse)(nil),            // 16: multipoolermanagerdata.StopReplicationResponse
+	(*multipoolermanagerdata.StatusResponse)(nil),                     // 17: multipoolermanagerdata.StatusResponse
+	(*multipoolermanagerdata.BackupResponse)(nil),                     // 18: multipoolermanagerdata.BackupResponse
+	(*multipoolermanagerdata.GetBackupsResponse)(nil),                 // 19: multipoolermanagerdata.GetBackupsResponse
+	(*multipoolermanagerdata.GetBackupByJobIdResponse)(nil),           // 20: multipoolermanagerdata.GetBackupByJobIdResponse
+	(*multipoolermanagerdata.ExpireBackupsResponse)(nil),              // 21: multipoolermanagerdata.ExpireBackupsResponse
+	(*multipoolermanagerdata.VerifyBackupsResponse)(nil),              // 22: multipoolermanagerdata.VerifyBackupsResponse
+	(*multipoolermanagerdata.ResignLeadershipResponse)(nil),           // 23: multipoolermanagerdata.ResignLeadershipResponse
+	(*multipoolermanagerdata.SetPostgresRestartsEnabledResponse)(nil), // 24: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	(*multipoolermanagerdata.ReconcileFollowersResponse)(nil),         // 25: multipoolermanagerdata.ReconcileFollowersResponse
+	(*multipoolermanagerdata.ReloadConfigResponse)(nil),               // 26: multipoolermanagerdata.ReloadConfigResponse
+	(*multipoolermanagerdata.ManagerHealthStreamResponse)(nil),        // 27: multipoolermanagerdata.ManagerHealthStreamResponse
 }
 var file_multipoolermanagerservice_proto_depIdxs = []int32{
 	0,  // 0: multipoolermanager.MultipoolerManager.WaitForLSN:input_type -> multipoolermanagerdata.WaitForLSNRequest
@@ -97,23 +100,25 @@ var file_multipoolermanagerservice_proto_depIdxs = []int32{
 	8,  // 8: multipoolermanager.MultipoolerManager.VerifyBackups:input_type -> multipoolermanagerdata.VerifyBackupsRequest
 	9,  // 9: multipoolermanager.MultipoolerManager.ResignLeadership:input_type -> multipoolermanagerdata.ResignLeadershipRequest
 	10, // 10: multipoolermanager.MultipoolerManager.SetPostgresRestartsEnabled:input_type -> multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	11, // 11: multipoolermanager.MultipoolerManager.ReloadConfig:input_type -> multipoolermanagerdata.ReloadConfigRequest
-	12, // 12: multipoolermanager.MultipoolerManager.ManagerHealthStream:input_type -> multipoolermanagerdata.ManagerHealthStreamClientMessage
-	13, // 13: multipoolermanager.MultipoolerManager.WaitForLSN:output_type -> multipoolermanagerdata.WaitForLSNResponse
-	14, // 14: multipoolermanager.MultipoolerManager.StartReplication:output_type -> multipoolermanagerdata.StartReplicationResponse
-	15, // 15: multipoolermanager.MultipoolerManager.StopReplication:output_type -> multipoolermanagerdata.StopReplicationResponse
-	16, // 16: multipoolermanager.MultipoolerManager.Status:output_type -> multipoolermanagerdata.StatusResponse
-	17, // 17: multipoolermanager.MultipoolerManager.Backup:output_type -> multipoolermanagerdata.BackupResponse
-	18, // 18: multipoolermanager.MultipoolerManager.GetBackups:output_type -> multipoolermanagerdata.GetBackupsResponse
-	19, // 19: multipoolermanager.MultipoolerManager.GetBackupByJobId:output_type -> multipoolermanagerdata.GetBackupByJobIdResponse
-	20, // 20: multipoolermanager.MultipoolerManager.ExpireBackups:output_type -> multipoolermanagerdata.ExpireBackupsResponse
-	21, // 21: multipoolermanager.MultipoolerManager.VerifyBackups:output_type -> multipoolermanagerdata.VerifyBackupsResponse
-	22, // 22: multipoolermanager.MultipoolerManager.ResignLeadership:output_type -> multipoolermanagerdata.ResignLeadershipResponse
-	23, // 23: multipoolermanager.MultipoolerManager.SetPostgresRestartsEnabled:output_type -> multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	24, // 24: multipoolermanager.MultipoolerManager.ReloadConfig:output_type -> multipoolermanagerdata.ReloadConfigResponse
-	25, // 25: multipoolermanager.MultipoolerManager.ManagerHealthStream:output_type -> multipoolermanagerdata.ManagerHealthStreamResponse
-	13, // [13:26] is the sub-list for method output_type
-	0,  // [0:13] is the sub-list for method input_type
+	11, // 11: multipoolermanager.MultipoolerManager.ReconcileFollowers:input_type -> multipoolermanagerdata.ReconcileFollowersRequest
+	12, // 12: multipoolermanager.MultipoolerManager.ReloadConfig:input_type -> multipoolermanagerdata.ReloadConfigRequest
+	13, // 13: multipoolermanager.MultipoolerManager.ManagerHealthStream:input_type -> multipoolermanagerdata.ManagerHealthStreamClientMessage
+	14, // 14: multipoolermanager.MultipoolerManager.WaitForLSN:output_type -> multipoolermanagerdata.WaitForLSNResponse
+	15, // 15: multipoolermanager.MultipoolerManager.StartReplication:output_type -> multipoolermanagerdata.StartReplicationResponse
+	16, // 16: multipoolermanager.MultipoolerManager.StopReplication:output_type -> multipoolermanagerdata.StopReplicationResponse
+	17, // 17: multipoolermanager.MultipoolerManager.Status:output_type -> multipoolermanagerdata.StatusResponse
+	18, // 18: multipoolermanager.MultipoolerManager.Backup:output_type -> multipoolermanagerdata.BackupResponse
+	19, // 19: multipoolermanager.MultipoolerManager.GetBackups:output_type -> multipoolermanagerdata.GetBackupsResponse
+	20, // 20: multipoolermanager.MultipoolerManager.GetBackupByJobId:output_type -> multipoolermanagerdata.GetBackupByJobIdResponse
+	21, // 21: multipoolermanager.MultipoolerManager.ExpireBackups:output_type -> multipoolermanagerdata.ExpireBackupsResponse
+	22, // 22: multipoolermanager.MultipoolerManager.VerifyBackups:output_type -> multipoolermanagerdata.VerifyBackupsResponse
+	23, // 23: multipoolermanager.MultipoolerManager.ResignLeadership:output_type -> multipoolermanagerdata.ResignLeadershipResponse
+	24, // 24: multipoolermanager.MultipoolerManager.SetPostgresRestartsEnabled:output_type -> multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	25, // 25: multipoolermanager.MultipoolerManager.ReconcileFollowers:output_type -> multipoolermanagerdata.ReconcileFollowersResponse
+	26, // 26: multipoolermanager.MultipoolerManager.ReloadConfig:output_type -> multipoolermanagerdata.ReloadConfigResponse
+	27, // 27: multipoolermanager.MultipoolerManager.ManagerHealthStream:output_type -> multipoolermanagerdata.ManagerHealthStreamResponse
+	14, // [14:28] is the sub-list for method output_type
+	0,  // [0:14] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/go/pb/multipoolermanager/multipoolermanagerservice.pb.gw.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice.pb.gw.go
@@ -333,6 +333,33 @@ func local_request_MultipoolerManager_SetPostgresRestartsEnabled_0(ctx context.C
 	return msg, metadata, err
 }
 
+func request_MultipoolerManager_ReconcileFollowers_0(ctx context.Context, marshaler runtime.Marshaler, client MultipoolerManagerClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq multipoolermanagerdata.ReconcileFollowersRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ReconcileFollowers(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MultipoolerManager_ReconcileFollowers_0(ctx context.Context, marshaler runtime.Marshaler, server MultipoolerManagerServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq multipoolermanagerdata.ReconcileFollowersRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ReconcileFollowers(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_MultipoolerManager_ReloadConfig_0(ctx context.Context, marshaler runtime.Marshaler, client MultipoolerManagerClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq multipoolermanagerdata.ReloadConfigRequest
@@ -629,6 +656,26 @@ func RegisterMultipoolerManagerHandlerServer(ctx context.Context, mux *runtime.S
 		}
 		forward_MultipoolerManager_SetPostgresRestartsEnabled_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultipoolerManager_ReconcileFollowers_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/multipoolermanager.MultipoolerManager/ReconcileFollowers", runtime.WithHTTPPathPattern("/multipoolermanager.MultipoolerManager/ReconcileFollowers"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MultipoolerManager_ReconcileFollowers_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultipoolerManager_ReconcileFollowers_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_MultipoolerManager_ReloadConfig_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -883,6 +930,23 @@ func RegisterMultipoolerManagerHandlerClient(ctx context.Context, mux *runtime.S
 		}
 		forward_MultipoolerManager_SetPostgresRestartsEnabled_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultipoolerManager_ReconcileFollowers_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/multipoolermanager.MultipoolerManager/ReconcileFollowers", runtime.WithHTTPPathPattern("/multipoolermanager.MultipoolerManager/ReconcileFollowers"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MultipoolerManager_ReconcileFollowers_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultipoolerManager_ReconcileFollowers_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_MultipoolerManager_ReloadConfig_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -932,6 +996,7 @@ var (
 	pattern_MultipoolerManager_VerifyBackups_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultipoolerManager", "VerifyBackups"}, ""))
 	pattern_MultipoolerManager_ResignLeadership_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultipoolerManager", "ResignLeadership"}, ""))
 	pattern_MultipoolerManager_SetPostgresRestartsEnabled_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultipoolerManager", "SetPostgresRestartsEnabled"}, ""))
+	pattern_MultipoolerManager_ReconcileFollowers_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultipoolerManager", "ReconcileFollowers"}, ""))
 	pattern_MultipoolerManager_ReloadConfig_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultipoolerManager", "ReloadConfig"}, ""))
 	pattern_MultipoolerManager_ManagerHealthStream_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultipoolerManager", "ManagerHealthStream"}, ""))
 )
@@ -948,6 +1013,7 @@ var (
 	forward_MultipoolerManager_VerifyBackups_0              = runtime.ForwardResponseMessage
 	forward_MultipoolerManager_ResignLeadership_0           = runtime.ForwardResponseMessage
 	forward_MultipoolerManager_SetPostgresRestartsEnabled_0 = runtime.ForwardResponseMessage
+	forward_MultipoolerManager_ReconcileFollowers_0         = runtime.ForwardResponseMessage
 	forward_MultipoolerManager_ReloadConfig_0               = runtime.ForwardResponseMessage
 	forward_MultipoolerManager_ManagerHealthStream_0        = runtime.ForwardResponseStream
 )

--- a/go/pb/multipoolermanager/multipoolermanagerservice_grpc.pb.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice_grpc.pb.go
@@ -45,6 +45,7 @@ const (
 	MultipoolerManager_VerifyBackups_FullMethodName              = "/multipoolermanager.MultipoolerManager/VerifyBackups"
 	MultipoolerManager_ResignLeadership_FullMethodName           = "/multipoolermanager.MultipoolerManager/ResignLeadership"
 	MultipoolerManager_SetPostgresRestartsEnabled_FullMethodName = "/multipoolermanager.MultipoolerManager/SetPostgresRestartsEnabled"
+	MultipoolerManager_ReconcileFollowers_FullMethodName         = "/multipoolermanager.MultipoolerManager/ReconcileFollowers"
 	MultipoolerManager_ReloadConfig_FullMethodName               = "/multipoolermanager.MultipoolerManager/ReloadConfig"
 	MultipoolerManager_ManagerHealthStream_FullMethodName        = "/multipoolermanager.MultipoolerManager/ManagerHealthStream"
 )
@@ -92,6 +93,15 @@ type MultipoolerManagerClient interface {
 	// PostgreSQL instance. Used by tests and demos to prevent premature restarts during
 	// controlled failovers.
 	SetPostgresRestartsEnabled(ctx context.Context, in *multipoolermanagerdata.SetPostgresRestartsEnabledRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.SetPostgresRestartsEnabledResponse, error)
+	// ReconcileFollowers declares to the primary the full set of cohort-eligible
+	// follower members it should hold per-follower physical replication slots for.
+	// The primary creates any missing slot and drops managed slots for members no
+	// longer in the set. It is level-triggered and declarative: the orchestrator
+	// re-sends the set each cycle, so a missed event or a primary restart
+	// self-heals. It creates only the physical slots (so a late-joining standby
+	// can stream); it does NOT touch synchronized_standby_slots — a follower is
+	// added there only once it is streaming and caught up, via the cohort path.
+	ReconcileFollowers(ctx context.Context, in *multipoolermanagerdata.ReconcileFollowersRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.ReconcileFollowersResponse, error)
 	// ReloadConfig triggers a PostgreSQL configuration reload (SIGHUP via pgctld)
 	// on this multipooler's local PostgreSQL and confirms it took effect by
 	// waiting for pg_conf_load_time() to advance. The returned config_load_time
@@ -232,6 +242,16 @@ func (c *multipoolerManagerClient) SetPostgresRestartsEnabled(ctx context.Contex
 	return out, nil
 }
 
+func (c *multipoolerManagerClient) ReconcileFollowers(ctx context.Context, in *multipoolermanagerdata.ReconcileFollowersRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.ReconcileFollowersResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(multipoolermanagerdata.ReconcileFollowersResponse)
+	err := c.cc.Invoke(ctx, MultipoolerManager_ReconcileFollowers_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *multipoolerManagerClient) ReloadConfig(ctx context.Context, in *multipoolermanagerdata.ReloadConfigRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.ReloadConfigResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(multipoolermanagerdata.ReloadConfigResponse)
@@ -298,6 +318,15 @@ type MultipoolerManagerServer interface {
 	// PostgreSQL instance. Used by tests and demos to prevent premature restarts during
 	// controlled failovers.
 	SetPostgresRestartsEnabled(context.Context, *multipoolermanagerdata.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdata.SetPostgresRestartsEnabledResponse, error)
+	// ReconcileFollowers declares to the primary the full set of cohort-eligible
+	// follower members it should hold per-follower physical replication slots for.
+	// The primary creates any missing slot and drops managed slots for members no
+	// longer in the set. It is level-triggered and declarative: the orchestrator
+	// re-sends the set each cycle, so a missed event or a primary restart
+	// self-heals. It creates only the physical slots (so a late-joining standby
+	// can stream); it does NOT touch synchronized_standby_slots — a follower is
+	// added there only once it is streaming and caught up, via the cohort path.
+	ReconcileFollowers(context.Context, *multipoolermanagerdata.ReconcileFollowersRequest) (*multipoolermanagerdata.ReconcileFollowersResponse, error)
 	// ReloadConfig triggers a PostgreSQL configuration reload (SIGHUP via pgctld)
 	// on this multipooler's local PostgreSQL and confirms it took effect by
 	// waiting for pg_conf_load_time() to advance. The returned config_load_time
@@ -360,6 +389,9 @@ func (UnimplementedMultipoolerManagerServer) ResignLeadership(context.Context, *
 }
 func (UnimplementedMultipoolerManagerServer) SetPostgresRestartsEnabled(context.Context, *multipoolermanagerdata.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdata.SetPostgresRestartsEnabledResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SetPostgresRestartsEnabled not implemented")
+}
+func (UnimplementedMultipoolerManagerServer) ReconcileFollowers(context.Context, *multipoolermanagerdata.ReconcileFollowersRequest) (*multipoolermanagerdata.ReconcileFollowersResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReconcileFollowers not implemented")
 }
 func (UnimplementedMultipoolerManagerServer) ReloadConfig(context.Context, *multipoolermanagerdata.ReloadConfigRequest) (*multipoolermanagerdata.ReloadConfigResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ReloadConfig not implemented")
@@ -586,6 +618,24 @@ func _MultipoolerManager_SetPostgresRestartsEnabled_Handler(srv interface{}, ctx
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MultipoolerManager_ReconcileFollowers_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(multipoolermanagerdata.ReconcileFollowersRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MultipoolerManagerServer).ReconcileFollowers(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MultipoolerManager_ReconcileFollowers_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MultipoolerManagerServer).ReconcileFollowers(ctx, req.(*multipoolermanagerdata.ReconcileFollowersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _MultipoolerManager_ReloadConfig_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(multipoolermanagerdata.ReloadConfigRequest)
 	if err := dec(in); err != nil {
@@ -661,6 +711,10 @@ var MultipoolerManager_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SetPostgresRestartsEnabled",
 			Handler:    _MultipoolerManager_SetPostgresRestartsEnabled_Handler,
+		},
+		{
+			MethodName: "ReconcileFollowers",
+			Handler:    _MultipoolerManager_ReconcileFollowers_Handler,
 		},
 		{
 			MethodName: "ReloadConfig",

--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -516,7 +516,12 @@ type PrimaryConnInfo struct {
 	// Path to the libpq password file (passfile=) the standby uses to
 	// authenticate to the primary. Empty when the conninfo carries no passfile
 	// clause. Not a secret (it is a filesystem path, not the password itself).
-	Passfile      string `protobuf:"bytes,6,opt,name=passfile,proto3" json:"passfile,omitempty"`
+	Passfile string `protobuf:"bytes,6,opt,name=passfile,proto3" json:"passfile,omitempty"`
+	// Database name for the replication connection (dbname=). Required by the
+	// PostgreSQL 17 slot-sync worker, which opens an ordinary SQL connection to
+	// the primary to synchronize failover slots; ignored by physical streaming
+	// replication.
+	Dbname        string `protobuf:"bytes,7,opt,name=dbname,proto3" json:"dbname,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -589,6 +594,13 @@ func (x *PrimaryConnInfo) GetRaw() string {
 func (x *PrimaryConnInfo) GetPassfile() string {
 	if x != nil {
 		return x.Passfile
+	}
+	return ""
+}
+
+func (x *PrimaryConnInfo) GetDbname() string {
+	if x != nil {
+		return x.Dbname
 	}
 	return ""
 }
@@ -1227,8 +1239,17 @@ type Status struct {
 	// This is the combined check: process must exist AND respond to pg_isready.
 	// Use postgres_running to check only if the process exists.
 	PostgresReady bool `protobuf:"varint,14,opt,name=postgres_ready,json=postgresReady,proto3" json:"postgres_ready,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Failover logical replication slots on this node: failover_slots_ready is the
+	// number that are failover-ready (synced, not temporary, not invalidated) and
+	// failover_slots_total is how many exist. Populated only when slot-based
+	// replication is enabled; both zero otherwise. Multiorch uses
+	// failover_slots_ready as a tiebreaker among equally-WAL-advanced promotion
+	// candidates, so a failover prefers a node that keeps the most subscribers
+	// resumable.
+	FailoverSlotsReady int32 `protobuf:"varint,15,opt,name=failover_slots_ready,json=failoverSlotsReady,proto3" json:"failover_slots_ready,omitempty"`
+	FailoverSlotsTotal int32 `protobuf:"varint,16,opt,name=failover_slots_total,json=failoverSlotsTotal,proto3" json:"failover_slots_total,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *Status) Reset() {
@@ -1343,6 +1364,20 @@ func (x *Status) GetPostgresReady() bool {
 		return x.PostgresReady
 	}
 	return false
+}
+
+func (x *Status) GetFailoverSlotsReady() int32 {
+	if x != nil {
+		return x.FailoverSlotsReady
+	}
+	return 0
+}
+
+func (x *Status) GetFailoverSlotsTotal() int32 {
+	if x != nil {
+		return x.FailoverSlotsTotal
+	}
+	return 0
 }
 
 // Status gets unified status that works for both PRIMARY and REPLICA poolers
@@ -2735,6 +2770,100 @@ func (x *ResignLeadershipResponse) GetFlushLsn() string {
 	return ""
 }
 
+// ReconcileFollowersRequest notifies the primary of the current set of
+// cohort-eligible follower members so it can pre-create their per-follower
+// physical replication slots ahead of streaming.
+//
+// This is NOT a consensus message. It does not change the consensus rule or
+// cohort membership and carries no term/quorum semantics; it is purely a
+// level-triggered notification, decoupled from the Recruit / Promote /
+// UpdateConsensusRule path, that lets the current primary hold a slot ready
+// before a follower's WAL receiver attaches. It is a declaration of intent, not
+// a guarantee: the primary ensures a physical slot for each listed member and
+// drops managed slots for members not listed, best-effort (e.g. it cannot
+// create more slots than max_replication_slots allows).
+type ReconcileFollowersRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Followers     []*clustermetadata.ID  `protobuf:"bytes,1,rep,name=followers,proto3" json:"followers,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReconcileFollowersRequest) Reset() {
+	*x = ReconcileFollowersRequest{}
+	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReconcileFollowersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReconcileFollowersRequest) ProtoMessage() {}
+
+func (x *ReconcileFollowersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReconcileFollowersRequest.ProtoReflect.Descriptor instead.
+func (*ReconcileFollowersRequest) Descriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *ReconcileFollowersRequest) GetFollowers() []*clustermetadata.ID {
+	if x != nil {
+		return x.Followers
+	}
+	return nil
+}
+
+// ReconcileFollowersResponse is returned once the primary's per-follower physical
+// slots have been reconciled to the requested set. It carries no fields.
+type ReconcileFollowersResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReconcileFollowersResponse) Reset() {
+	*x = ReconcileFollowersResponse{}
+	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReconcileFollowersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReconcileFollowersResponse) ProtoMessage() {}
+
+func (x *ReconcileFollowersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReconcileFollowersResponse.ProtoReflect.Descriptor instead.
+func (*ReconcileFollowersResponse) Descriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{35}
+}
+
 // SetPostgresRestartsEnabledRequest enables or disables automatic PostgreSQL restarts
 // by the postgres monitor. When disabled, the monitor will still run and detect problems,
 // but will not automatically restart a stopped PostgreSQL instance.
@@ -2748,7 +2877,7 @@ type SetPostgresRestartsEnabledRequest struct {
 
 func (x *SetPostgresRestartsEnabledRequest) Reset() {
 	*x = SetPostgresRestartsEnabledRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2760,7 +2889,7 @@ func (x *SetPostgresRestartsEnabledRequest) String() string {
 func (*SetPostgresRestartsEnabledRequest) ProtoMessage() {}
 
 func (x *SetPostgresRestartsEnabledRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2773,7 +2902,7 @@ func (x *SetPostgresRestartsEnabledRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use SetPostgresRestartsEnabledRequest.ProtoReflect.Descriptor instead.
 func (*SetPostgresRestartsEnabledRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{34}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *SetPostgresRestartsEnabledRequest) GetEnabled() bool {
@@ -2793,7 +2922,7 @@ type SetPostgresRestartsEnabledResponse struct {
 
 func (x *SetPostgresRestartsEnabledResponse) Reset() {
 	*x = SetPostgresRestartsEnabledResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2805,7 +2934,7 @@ func (x *SetPostgresRestartsEnabledResponse) String() string {
 func (*SetPostgresRestartsEnabledResponse) ProtoMessage() {}
 
 func (x *SetPostgresRestartsEnabledResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2818,7 +2947,7 @@ func (x *SetPostgresRestartsEnabledResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use SetPostgresRestartsEnabledResponse.ProtoReflect.Descriptor instead.
 func (*SetPostgresRestartsEnabledResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{35}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{37}
 }
 
 // ReloadConfigRequest asks the multipooler to trigger a PostgreSQL
@@ -2845,7 +2974,7 @@ type ReloadConfigRequest struct {
 
 func (x *ReloadConfigRequest) Reset() {
 	*x = ReloadConfigRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2857,7 +2986,7 @@ func (x *ReloadConfigRequest) String() string {
 func (*ReloadConfigRequest) ProtoMessage() {}
 
 func (x *ReloadConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2870,7 +2999,7 @@ func (x *ReloadConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReloadConfigRequest.ProtoReflect.Descriptor instead.
 func (*ReloadConfigRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{36}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ReloadConfigRequest) GetExpectedSettings() map[string]string {
@@ -2913,7 +3042,7 @@ type ReloadConfigResponse struct {
 
 func (x *ReloadConfigResponse) Reset() {
 	*x = ReloadConfigResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2925,7 +3054,7 @@ func (x *ReloadConfigResponse) String() string {
 func (*ReloadConfigResponse) ProtoMessage() {}
 
 func (x *ReloadConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2938,7 +3067,7 @@ func (x *ReloadConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReloadConfigResponse.ProtoReflect.Descriptor instead.
 func (*ReloadConfigResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{37}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *ReloadConfigResponse) GetConfigLoadTime() *timestamppb.Timestamp {
@@ -2989,7 +3118,7 @@ type SettingMismatch struct {
 
 func (x *SettingMismatch) Reset() {
 	*x = SettingMismatch{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[38]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3001,7 +3130,7 @@ func (x *SettingMismatch) String() string {
 func (*SettingMismatch) ProtoMessage() {}
 
 func (x *SettingMismatch) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[38]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3014,7 +3143,7 @@ func (x *SettingMismatch) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SettingMismatch.ProtoReflect.Descriptor instead.
 func (*SettingMismatch) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{38}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *SettingMismatch) GetName() string {
@@ -3042,14 +3171,15 @@ var File_multipoolermanagerdata_proto protoreflect.FileDescriptor
 
 const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\n" +
-	"\x1cmultipoolermanagerdata.proto\x12\x16multipoolermanagerdata\x1a\x15clustermetadata.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa6\x01\n" +
+	"\x1cmultipoolermanagerdata.proto\x12\x16multipoolermanagerdata\x1a\x15clustermetadata.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xbe\x01\n" +
 	"\x0fPrimaryConnInfo\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
 	"\x04port\x18\x02 \x01(\x05R\x04port\x12\x12\n" +
 	"\x04user\x18\x03 \x01(\tR\x04user\x12)\n" +
 	"\x10application_name\x18\x04 \x01(\tR\x0fapplicationName\x12\x10\n" +
 	"\x03raw\x18\x05 \x01(\tR\x03raw\x12\x1a\n" +
-	"\bpassfile\x18\x06 \x01(\tR\bpassfile\"\x97\x06\n" +
+	"\bpassfile\x18\x06 \x01(\tR\bpassfile\x12\x16\n" +
+	"\x06dbname\x18\a \x01(\tR\x06dbname\"\x97\x06\n" +
 	"\x18StandbyReplicationStatus\x12&\n" +
 	"\x0flast_replay_lsn\x18\x01 \x01(\tR\rlastReplayLsn\x12(\n" +
 	"\x10last_receive_lsn\x18\x02 \x01(\tR\x0elastReceiveLsn\x12/\n" +
@@ -3088,7 +3218,7 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\x05ready\x18\x02 \x01(\bR\x05ready\x12D\n" +
 	"\x13connected_followers\x18\x03 \x03(\v2\x13.clustermetadata.IDR\x12connectedFollowers\x12s\n" +
 	"\x17sync_replication_config\x18\x04 \x01(\v2;.multipoolermanagerdata.SynchronousReplicationConfigurationR\x15syncReplicationConfig\x12&\n" +
-	"\x0fmax_wal_senders\x18\x05 \x01(\x05R\rmaxWalSenders\"\xd1\x05\n" +
+	"\x0fmax_wal_senders\x18\x05 \x01(\x05R\rmaxWalSenders\"\xb5\x06\n" +
 	"\x06Status\x12<\n" +
 	"\vpooler_type\x18\x01 \x01(\x0e2\x1b.clustermetadata.PoolerTypeR\n" +
 	"poolerType\x12L\n" +
@@ -3103,7 +3233,9 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	" \x01(\tR\ashardId\x12O\n" +
 	"\x0fpostgres_action\x18\v \x01(\x0e2&.multipoolermanagerdata.PostgresActionR\x0epostgresAction\x12S\n" +
 	"\x18postgres_action_duration\x18\f \x01(\v2\x19.google.protobuf.DurationR\x16postgresActionDuration\x12%\n" +
-	"\x0epostgres_ready\x18\x0e \x01(\bR\rpostgresReady\"\x0f\n" +
+	"\x0epostgres_ready\x18\x0e \x01(\bR\rpostgresReady\x120\n" +
+	"\x14failover_slots_ready\x18\x0f \x01(\x05R\x12failoverSlotsReady\x120\n" +
+	"\x14failover_slots_total\x18\x10 \x01(\x05R\x12failoverSlotsTotal\"\x0f\n" +
 	"\rStatusRequest\"\xeb\x01\n" +
 	"\x0eStatusResponse\x126\n" +
 	"\x06status\x18\x01 \x01(\v2\x1e.multipoolermanagerdata.StatusR\x06status\x12T\n" +
@@ -3194,7 +3326,10 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\bCOMPLETE\x10\x02\"\x19\n" +
 	"\x17ResignLeadershipRequest\"7\n" +
 	"\x18ResignLeadershipResponse\x12\x1b\n" +
-	"\tflush_lsn\x18\x01 \x01(\tR\bflushLsn\"=\n" +
+	"\tflush_lsn\x18\x01 \x01(\tR\bflushLsn\"N\n" +
+	"\x19ReconcileFollowersRequest\x121\n" +
+	"\tfollowers\x18\x01 \x03(\v2\x13.clustermetadata.IDR\tfollowers\"\x1c\n" +
+	"\x1aReconcileFollowersResponse\"=\n" +
 	"!SetPostgresRestartsEnabledRequest\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\"$\n" +
 	"\"SetPostgresRestartsEnabledResponse\"\xca\x01\n" +
@@ -3263,7 +3398,7 @@ func file_multipoolermanagerdata_proto_rawDescGZIP() []byte {
 }
 
 var file_multipoolermanagerdata_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
+var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 44)
 var file_multipoolermanagerdata_proto_goTypes = []any{
 	(PostgresStatus)(0),                         // 0: multipoolermanagerdata.PostgresStatus
 	(PostgresAction)(0),                         // 1: multipoolermanagerdata.PostgresAction
@@ -3307,82 +3442,85 @@ var file_multipoolermanagerdata_proto_goTypes = []any{
 	(*BackupMetadata)(nil),                      // 39: multipoolermanagerdata.BackupMetadata
 	(*ResignLeadershipRequest)(nil),             // 40: multipoolermanagerdata.ResignLeadershipRequest
 	(*ResignLeadershipResponse)(nil),            // 41: multipoolermanagerdata.ResignLeadershipResponse
-	(*SetPostgresRestartsEnabledRequest)(nil),   // 42: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	(*SetPostgresRestartsEnabledResponse)(nil),  // 43: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	(*ReloadConfigRequest)(nil),                 // 44: multipoolermanagerdata.ReloadConfigRequest
-	(*ReloadConfigResponse)(nil),                // 45: multipoolermanagerdata.ReloadConfigResponse
-	(*SettingMismatch)(nil),                     // 46: multipoolermanagerdata.SettingMismatch
-	nil,                                         // 47: multipoolermanagerdata.BackupRequest.OverridesEntry
-	nil,                                         // 48: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	nil,                                         // 49: multipoolermanagerdata.ReloadConfigRequest.ExpectedSettingsEntry
-	(*durationpb.Duration)(nil),                 // 50: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),               // 51: google.protobuf.Timestamp
-	(*clustermetadata.ID)(nil),                  // 52: clustermetadata.ID
-	(clustermetadata.PoolerType)(0),             // 53: clustermetadata.PoolerType
-	(*clustermetadata.AvailabilityStatus)(nil),  // 54: clustermetadata.AvailabilityStatus
-	(*clustermetadata.ConsensusStatus)(nil),     // 55: clustermetadata.ConsensusStatus
-	(*clustermetadata.RuleNumber)(nil),          // 56: clustermetadata.RuleNumber
-	(*clustermetadata.PoolerPosition)(nil),      // 57: clustermetadata.PoolerPosition
-	(clustermetadata.RoutingRole)(0),            // 58: clustermetadata.RoutingRole
+	(*ReconcileFollowersRequest)(nil),           // 42: multipoolermanagerdata.ReconcileFollowersRequest
+	(*ReconcileFollowersResponse)(nil),          // 43: multipoolermanagerdata.ReconcileFollowersResponse
+	(*SetPostgresRestartsEnabledRequest)(nil),   // 44: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
+	(*SetPostgresRestartsEnabledResponse)(nil),  // 45: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	(*ReloadConfigRequest)(nil),                 // 46: multipoolermanagerdata.ReloadConfigRequest
+	(*ReloadConfigResponse)(nil),                // 47: multipoolermanagerdata.ReloadConfigResponse
+	(*SettingMismatch)(nil),                     // 48: multipoolermanagerdata.SettingMismatch
+	nil,                                         // 49: multipoolermanagerdata.BackupRequest.OverridesEntry
+	nil,                                         // 50: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	nil,                                         // 51: multipoolermanagerdata.ReloadConfigRequest.ExpectedSettingsEntry
+	(*durationpb.Duration)(nil),                 // 52: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),               // 53: google.protobuf.Timestamp
+	(*clustermetadata.ID)(nil),                  // 54: clustermetadata.ID
+	(clustermetadata.PoolerType)(0),             // 55: clustermetadata.PoolerType
+	(*clustermetadata.AvailabilityStatus)(nil),  // 56: clustermetadata.AvailabilityStatus
+	(*clustermetadata.ConsensusStatus)(nil),     // 57: clustermetadata.ConsensusStatus
+	(*clustermetadata.RuleNumber)(nil),          // 58: clustermetadata.RuleNumber
+	(*clustermetadata.PoolerPosition)(nil),      // 59: clustermetadata.PoolerPosition
+	(clustermetadata.RoutingRole)(0),            // 60: clustermetadata.RoutingRole
 }
 var file_multipoolermanagerdata_proto_depIdxs = []int32{
-	50, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
+	52, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
 	8,  // 1: multipoolermanagerdata.StandbyReplicationStatus.primary_conn_info:type_name -> multipoolermanagerdata.PrimaryConnInfo
-	51, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
-	50, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
-	50, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
-	51, // 5: multipoolermanagerdata.StandbyReplicationStatus.last_receive_lsn_advance_time:type_name -> google.protobuf.Timestamp
-	50, // 6: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
+	53, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
+	52, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
+	52, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
+	53, // 5: multipoolermanagerdata.StandbyReplicationStatus.last_receive_lsn_advance_time:type_name -> google.protobuf.Timestamp
+	52, // 6: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
 	3,  // 7: multipoolermanagerdata.StopReplicationRequest.mode:type_name -> multipoolermanagerdata.ReplicationPauseMode
 	9,  // 8: multipoolermanagerdata.StopReplicationResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
 	6,  // 9: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
 	4,  // 10: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
-	52, // 11: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
-	52, // 12: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
+	54, // 11: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
+	54, // 12: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
 	16, // 13: multipoolermanagerdata.PrimaryStatus.sync_replication_config:type_name -> multipoolermanagerdata.SynchronousReplicationConfiguration
-	53, // 14: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
+	55, // 14: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
 	17, // 15: multipoolermanagerdata.Status.primary_status:type_name -> multipoolermanagerdata.PrimaryStatus
 	9,  // 16: multipoolermanagerdata.Status.replication_status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
 	0,  // 17: multipoolermanagerdata.Status.postgres_status:type_name -> multipoolermanagerdata.PostgresStatus
 	1,  // 18: multipoolermanagerdata.Status.postgres_action:type_name -> multipoolermanagerdata.PostgresAction
-	50, // 19: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
+	52, // 19: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
 	18, // 20: multipoolermanagerdata.StatusResponse.status:type_name -> multipoolermanagerdata.Status
-	54, // 21: multipoolermanagerdata.StatusResponse.availability_status:type_name -> clustermetadata.AvailabilityStatus
-	55, // 22: multipoolermanagerdata.StatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	56, // 21: multipoolermanagerdata.StatusResponse.availability_status:type_name -> clustermetadata.AvailabilityStatus
+	57, // 22: multipoolermanagerdata.StatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
 	22, // 23: multipoolermanagerdata.ManagerHealthStreamClientMessage.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartRequest
 	23, // 24: multipoolermanagerdata.ManagerHealthStreamClientMessage.poll:type_name -> multipoolermanagerdata.ManagerHealthStreamPollRequest
-	50, // 25: multipoolermanagerdata.ManagerHealthStreamStartRequest.snapshot_interval:type_name -> google.protobuf.Duration
-	50, // 26: multipoolermanagerdata.ManagerHealthStreamStartRequest.staleness_timeout:type_name -> google.protobuf.Duration
-	50, // 27: multipoolermanagerdata.ManagerHealthStreamStartResponse.snapshot_interval:type_name -> google.protobuf.Duration
-	50, // 28: multipoolermanagerdata.ManagerHealthStreamStartResponse.staleness_timeout:type_name -> google.protobuf.Duration
+	52, // 25: multipoolermanagerdata.ManagerHealthStreamStartRequest.snapshot_interval:type_name -> google.protobuf.Duration
+	52, // 26: multipoolermanagerdata.ManagerHealthStreamStartRequest.staleness_timeout:type_name -> google.protobuf.Duration
+	52, // 27: multipoolermanagerdata.ManagerHealthStreamStartResponse.snapshot_interval:type_name -> google.protobuf.Duration
+	52, // 28: multipoolermanagerdata.ManagerHealthStreamStartResponse.staleness_timeout:type_name -> google.protobuf.Duration
 	24, // 29: multipoolermanagerdata.ManagerHealthStreamResponse.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartResponse
 	26, // 30: multipoolermanagerdata.ManagerHealthStreamResponse.snapshot:type_name -> multipoolermanagerdata.ManagerHealthSnapshot
 	20, // 31: multipoolermanagerdata.ManagerHealthSnapshot.status:type_name -> multipoolermanagerdata.StatusResponse
-	50, // 32: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
+	52, // 32: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
 	2,  // 33: multipoolermanagerdata.ManagerHealthSnapshot.trigger:type_name -> multipoolermanagerdata.SnapshotTrigger
-	51, // 34: multipoolermanagerdata.ManagerHealthSnapshot.captured_at:type_name -> google.protobuf.Timestamp
+	53, // 34: multipoolermanagerdata.ManagerHealthSnapshot.captured_at:type_name -> google.protobuf.Timestamp
 	5,  // 35: multipoolermanagerdata.UpdateConsensusRuleRequest.operation:type_name -> multipoolermanagerdata.RuleOperation
-	52, // 36: multipoolermanagerdata.UpdateConsensusRuleRequest.standby_ids:type_name -> clustermetadata.ID
-	56, // 37: multipoolermanagerdata.UpdateConsensusRuleRequest.expected_outgoing_rule:type_name -> clustermetadata.RuleNumber
-	52, // 38: multipoolermanagerdata.UpdateConsensusRuleRequest.coordinator_id:type_name -> clustermetadata.ID
-	57, // 39: multipoolermanagerdata.UpdateConsensusRuleResponse.current_position:type_name -> clustermetadata.PoolerPosition
-	47, // 40: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
+	54, // 36: multipoolermanagerdata.UpdateConsensusRuleRequest.standby_ids:type_name -> clustermetadata.ID
+	58, // 37: multipoolermanagerdata.UpdateConsensusRuleRequest.expected_outgoing_rule:type_name -> clustermetadata.RuleNumber
+	54, // 38: multipoolermanagerdata.UpdateConsensusRuleRequest.coordinator_id:type_name -> clustermetadata.ID
+	59, // 39: multipoolermanagerdata.UpdateConsensusRuleResponse.current_position:type_name -> clustermetadata.PoolerPosition
+	49, // 40: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
 	39, // 41: multipoolermanagerdata.GetBackupsResponse.backups:type_name -> multipoolermanagerdata.BackupMetadata
 	39, // 42: multipoolermanagerdata.GetBackupByJobIdResponse.backup:type_name -> multipoolermanagerdata.BackupMetadata
-	48, // 43: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	50, // 44: multipoolermanagerdata.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
+	50, // 43: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	52, // 44: multipoolermanagerdata.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
 	7,  // 45: multipoolermanagerdata.BackupMetadata.status:type_name -> multipoolermanagerdata.BackupMetadata.Status
-	58, // 46: multipoolermanagerdata.BackupMetadata.routing_role:type_name -> clustermetadata.RoutingRole
-	51, // 47: multipoolermanagerdata.BackupMetadata.start_timestamp:type_name -> google.protobuf.Timestamp
-	51, // 48: multipoolermanagerdata.BackupMetadata.stop_timestamp:type_name -> google.protobuf.Timestamp
-	49, // 49: multipoolermanagerdata.ReloadConfigRequest.expected_settings:type_name -> multipoolermanagerdata.ReloadConfigRequest.ExpectedSettingsEntry
-	51, // 50: multipoolermanagerdata.ReloadConfigResponse.config_load_time:type_name -> google.protobuf.Timestamp
-	46, // 51: multipoolermanagerdata.ReloadConfigResponse.mismatches:type_name -> multipoolermanagerdata.SettingMismatch
-	52, // [52:52] is the sub-list for method output_type
-	52, // [52:52] is the sub-list for method input_type
-	52, // [52:52] is the sub-list for extension type_name
-	52, // [52:52] is the sub-list for extension extendee
-	0,  // [0:52] is the sub-list for field type_name
+	60, // 46: multipoolermanagerdata.BackupMetadata.routing_role:type_name -> clustermetadata.RoutingRole
+	53, // 47: multipoolermanagerdata.BackupMetadata.start_timestamp:type_name -> google.protobuf.Timestamp
+	53, // 48: multipoolermanagerdata.BackupMetadata.stop_timestamp:type_name -> google.protobuf.Timestamp
+	54, // 49: multipoolermanagerdata.ReconcileFollowersRequest.followers:type_name -> clustermetadata.ID
+	51, // 50: multipoolermanagerdata.ReloadConfigRequest.expected_settings:type_name -> multipoolermanagerdata.ReloadConfigRequest.ExpectedSettingsEntry
+	53, // 51: multipoolermanagerdata.ReloadConfigResponse.config_load_time:type_name -> google.protobuf.Timestamp
+	48, // 52: multipoolermanagerdata.ReloadConfigResponse.mismatches:type_name -> multipoolermanagerdata.SettingMismatch
+	53, // [53:53] is the sub-list for method output_type
+	53, // [53:53] is the sub-list for method input_type
+	53, // [53:53] is the sub-list for extension type_name
+	53, // [53:53] is the sub-list for extension extendee
+	0,  // [0:53] is the sub-list for field type_name
 }
 
 func init() { file_multipoolermanagerdata_proto_init() }
@@ -3404,7 +3542,7 @@ func file_multipoolermanagerdata_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_multipoolermanagerdata_proto_rawDesc), len(file_multipoolermanagerdata_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   42,
+			NumMessages:   44,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/services/multigateway/handler/handler.go
+++ b/go/services/multigateway/handler/handler.go
@@ -114,6 +114,13 @@ type MultigatewayHandler struct {
 	// new connection states target replicas so the planner routes queries there.
 	targetReplica bool
 
+	// slotBasedReplicationEnabled reports, read live, whether the
+	// slot-based-replication feature is on. When true the replication preamble
+	// admits a non-temporary logical slot registered for failover (otherwise
+	// every non-temporary slot is rejected). Dynamic so it tracks config
+	// reloads; nil reads as disabled. Set via SetSlotBasedReplicationEnabled.
+	slotBasedReplicationEnabled func() bool
+
 	// normalQueryLogSampleRate controls 1/N sampling for normal-path query
 	// logs. 0 disables sampling (handler level alone governs emission); 1
 	// emits every normal query; N>1 emits every Nth. Normal queries always
@@ -154,6 +161,20 @@ func (h *MultigatewayHandler) SetNormalQueryLogSampleRate(rate uint64) {
 // target replicas. Must be called before connections are accepted.
 func (h *MultigatewayHandler) SetTargetReplica(target bool) {
 	h.targetReplica = target
+}
+
+// SetSlotBasedReplicationEnabled wires the dynamic getter that gates admitting
+// non-temporary failover replication slots in the replication preamble. Must be
+// called before connections are accepted. A nil getter (the default) keeps the
+// feature off, rejecting every non-temporary slot as before.
+func (h *MultigatewayHandler) SetSlotBasedReplicationEnabled(enabled func() bool) {
+	h.slotBasedReplicationEnabled = enabled
+}
+
+// admitsFailoverSlots reports whether the replication preamble should admit a
+// non-temporary logical failover slot, reading the dynamic gate live.
+func (h *MultigatewayHandler) admitsFailoverSlots() bool {
+	return h.slotBasedReplicationEnabled != nil && h.slotBasedReplicationEnabled()
 }
 
 // SetQueryRegistry attaches a per-query-shape registry to the handler.

--- a/go/services/multigateway/handler/replication_preamble.go
+++ b/go/services/multigateway/handler/replication_preamble.go
@@ -15,7 +15,6 @@
 package handler
 
 import (
-	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -27,6 +26,7 @@ import (
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/common/sqltypes"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	multipoolerservice "github.com/multigres/multigres/go/pb/multipoolerservice"
 )
@@ -110,9 +110,9 @@ func parseNullTerminatedString(body []byte) (string, bool) {
 // machine for a case nothing in practice exercises. Anything other than
 // Query is rejected outright instead.
 func runReplicationPreamble(
-	ctx context.Context,
 	conn *server.Conn,
 	stream multipoolerservice.MultipoolerService_StreamReplicationClient,
+	admitFailoverSlots bool,
 ) (streaming bool, leftover []byte, err error) {
 	for {
 		// 1. Read one full frontend message off the still-attached client
@@ -155,14 +155,14 @@ func runReplicationPreamble(
 		// command, so this connection can reach that function same as any
 		// other), and reject either before the pooler/postgres ever see it.
 		if cmd, ok := parseNullTerminatedString(body); ok {
-			if rejectErr := nonTemporaryCreateReplicationSlotError(cmd); rejectErr != nil {
+			if rejectErr := nonTemporaryCreateReplicationSlotError(cmd, admitFailoverSlots); rejectErr != nil {
 				// The pooler/postgres never see the rejected command.
 				if werr := conn.WriteError(rejectErr); werr != nil {
 					return false, nil, werr
 				}
 				return false, nil, rejectErr
 			}
-			if rejectErr := nonTemporaryReplicationSlotSQLFuncError(cmd); rejectErr != nil {
+			if rejectErr := nonTemporaryReplicationSlotSQLFuncError(cmd, admitFailoverSlots); rejectErr != nil {
 				if werr := conn.WriteError(rejectErr); werr != nil {
 					return false, nil, werr
 				}
@@ -226,22 +226,33 @@ func runReplicationPreamble(
 // the extended query protocol isn't supported here.
 func unsupportedPreambleMessageError(msgType byte) error {
 	return mterrors.NewFeatureNotSupported(
-		fmt.Sprintf("message type %q is not supported on a replication connection before streaming begins: only the simple query protocol is supported here", string(msgType)))
+		fmt.Sprintf("message type %q is not supported on a replication connection before streaming begins: only the simple query protocol is supported here", string(msgType)),
+	)
 }
 
 // nonTemporaryCreateReplicationSlotError returns a rejection error if cmd is
 // a CREATE_REPLICATION_SLOT command that does not request a TEMPORARY slot,
-// or nil if cmd is anything else / already requests TEMPORARY. Multigres
-// cannot yet transition a replication slot's position across a primary
-// failover, so only ephemeral (client-lifetime) slots are safe.
+// or nil if cmd is anything else / already requests TEMPORARY. A non-temporary
+// slot could not previously be carried across a primary failover, so only
+// ephemeral (client-lifetime) slots were safe.
+//
+// When admitFailoverSlots is true (the slot-based-replication feature is on) a
+// non-temporary LOGICAL slot registered for failover is also admitted: such a
+// slot is synced to standbys and can be transitioned across a promotion. This
+// is exactly the command a real PostgreSQL 17 subscriber sends for
+// CREATE SUBSCRIPTION ... WITH (failover = true) — the FAILOVER option rides in
+// the CREATE_REPLICATION_SLOT command itself (verified in
+// go/test/endtoend/subscriptionwire), so no ALTER_REPLICATION_SLOT follow-up
+// needs to be tracked.
 //
 // No grammar exists in this codebase for the replication protocol's command
 // language (see go/common/parser/ast/replication.go — the AST nodes exist
 // but nothing constructs them), so this is deliberately a lightweight
 // tokenizer, not a parser: CREATE_REPLICATION_SLOT slot_name [TEMPORARY]
-// {PHYSICAL|LOGICAL ...} — TEMPORARY, if present, appears between the slot
-// name and the PHYSICAL/LOGICAL keyword, so stop scanning there.
-func nonTemporaryCreateReplicationSlotError(cmd string) error {
+// {PHYSICAL | LOGICAL output_plugin [ ( option [, ...] ) ]}. TEMPORARY, if
+// present, appears between the slot name and the PHYSICAL/LOGICAL keyword; the
+// FAILOVER option appears in the parenthesized list after the plugin.
+func nonTemporaryCreateReplicationSlotError(cmd string, admitFailoverSlots bool) error {
 	fields := strings.Fields(cmd)
 	if len(fields) == 0 || !strings.EqualFold(fields[0], "CREATE_REPLICATION_SLOT") {
 		return nil
@@ -250,16 +261,64 @@ func nonTemporaryCreateReplicationSlotError(cmd string) error {
 		return mterrors.NewNonTemporaryReplicationSlotError("CREATE_REPLICATION_SLOT", "TEMPORARY")
 	}
 	// fields[1] is the slot name — skip it, or a client naming its slot
-	// "temporary" would have that name misread as the keyword.
-	for _, f := range fields[2:] {
-		if strings.EqualFold(f, "TEMPORARY") {
+	// "temporary" would have that name misread as the keyword. TEMPORARY, if
+	// present, appears before the PHYSICAL/LOGICAL keyword.
+	kindIdx := -1
+	for i := 2; i < len(fields); i++ {
+		if strings.EqualFold(fields[i], "TEMPORARY") {
 			return nil
 		}
-		if strings.EqualFold(f, "PHYSICAL") || strings.EqualFold(f, "LOGICAL") {
+		if strings.EqualFold(fields[i], "PHYSICAL") || strings.EqualFold(fields[i], "LOGICAL") {
+			kindIdx = i
 			break
 		}
 	}
+	// Non-temporary. Admit only a LOGICAL failover slot, and only when the
+	// feature is enabled.
+	if admitFailoverSlots && kindIdx >= 0 && strings.EqualFold(fields[kindIdx], "LOGICAL") &&
+		createReplicationSlotHasFailover(fields[kindIdx+1:]) {
+		return nil
+	}
 	return mterrors.NewNonTemporaryReplicationSlotError("CREATE_REPLICATION_SLOT", "TEMPORARY")
+}
+
+// createReplicationSlotHasFailover reports whether the tokens following the
+// LOGICAL keyword of a CREATE_REPLICATION_SLOT command request failover. The
+// first token is the output plugin; its options follow in PostgreSQL 17's
+// parenthesized, comma-separated list — e.g. `pgoutput (FAILOVER, SNAPSHOT
+// 'nothing')`. Parentheses and commas are normalized to spaces so an option
+// glued to a paren or comma is still seen as its own token. A bare FAILOVER
+// means true; an explicit boolean value (FAILOVER false/off/no/0/...) is
+// interpreted with sqltypes.ParseBool, which mirrors PostgreSQL's own
+// parse_bool_with_len.
+//
+// It is conservative in the safe direction: it admits only when a FAILOVER
+// option is unambiguously present and not set false, so a parse it doesn't
+// understand rejects (never wrongly admits a non-failover, non-temporary slot).
+// The only false positive would be an output plugin literally named "failover",
+// which does not exist.
+func createReplicationSlotHasFailover(tokens []string) bool {
+	normalized := strings.Map(func(r rune) rune {
+		if r == '(' || r == ')' || r == ',' {
+			return ' '
+		}
+		return r
+	}, strings.Join(tokens, " "))
+	opts := strings.Fields(normalized)
+	for i, opt := range opts {
+		if strings.EqualFold(opt, "FAILOVER") {
+			// A bare FAILOVER means true; if an explicit boolean value follows,
+			// honor it. A following token that isn't a boolean (another option,
+			// or end of list) leaves FAILOVER at its bare "true".
+			if i+1 < len(opts) {
+				if v, ok := sqltypes.ParseBool(strings.Trim(opts[i+1], "'\"")); ok {
+					return v
+				}
+			}
+			return true
+		}
+	}
+	return false
 }
 
 // nonTemporaryReplicationSlotSQLFuncError returns a rejection error if cmd
@@ -270,6 +329,11 @@ func nonTemporaryCreateReplicationSlotError(cmd string) error {
 // START_REPLICATION, which nonTemporaryCreateReplicationSlotError already
 // handles above and which never parses as SQL).
 //
+// When admitFailoverSlots is true, a non-temporary logical slot created with
+// failover => true is also admitted, mirroring the command-form guard — for the
+// case where the slot is created by a plain `SELECT
+// pg_create_logical_replication_slot(...)` rather than the walsender command.
+//
 // This exists because postgres's walsender falls through to the normal SQL
 // executor for any query on a replication=database connection that isn't a
 // recognized replication command (exec_replication_command returning false
@@ -277,14 +341,21 @@ func nonTemporaryCreateReplicationSlotError(cmd string) error {
 // reaches the same function the planner already guards on ordinary
 // connections (go/services/multigateway/planner/unsafe_funccall.go), and
 // must be guarded here too.
-func nonTemporaryReplicationSlotSQLFuncError(cmd string) error {
+func nonTemporaryReplicationSlotSQLFuncError(cmd string, admitFailoverSlots bool) error {
 	// A parse error means cmd isn't SQL at all — most likely one of the
 	// replication-protocol commands nonTemporaryCreateReplicationSlotError
 	// already handled above. Nothing to check.
 	stmts, err := parser.ParseSQL(cmd)
 	if err == nil {
 		for _, stmt := range stmts {
-			if name, found := ast.FindNonTemporaryReplicationSlotCall(stmt); found {
+			var name string
+			var found bool
+			if admitFailoverSlots {
+				name, found = ast.FindNonTemporaryNonFailoverReplicationSlotCall(stmt)
+			} else {
+				name, found = ast.FindNonTemporaryReplicationSlotCall(stmt)
+			}
+			if found {
 				return mterrors.NewNonTemporaryReplicationSlotError(name, "temporary=true")
 			}
 		}

--- a/go/services/multigateway/handler/replication_preamble_test.go
+++ b/go/services/multigateway/handler/replication_preamble_test.go
@@ -200,7 +200,7 @@ func TestNonTemporaryCreateReplicationSlotError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := nonTemporaryCreateReplicationSlotError(tt.cmd)
+			err := nonTemporaryCreateReplicationSlotError(tt.cmd, false)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "requires TEMPORARY")
@@ -209,6 +209,131 @@ func TestNonTemporaryCreateReplicationSlotError(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestNonTemporaryCreateReplicationSlotError_Failover covers the command-form
+// guard once the slot-based-replication feature admits failover slots: a
+// non-temporary LOGICAL slot registered for failover is accepted, everything
+// else non-temporary is still rejected, and admitting is gated on the flag.
+func TestNonTemporaryCreateReplicationSlotError_Failover(t *testing.T) {
+	tests := []struct {
+		name          string
+		cmd           string
+		admitFailover bool
+		wantErr       bool
+	}{
+		// The exact command a real PostgreSQL 17 subscriber sends for
+		// CREATE SUBSCRIPTION ... WITH (failover = true); see
+		// go/test/endtoend/subscriptionwire.
+		{"real subscriber failover form admitted", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput (FAILOVER, SNAPSHOT 'nothing')", true, false},
+		{"bare FAILOVER admitted", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput (FAILOVER)", true, false},
+		{"FAILOVER glued to plugin admitted", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput(FAILOVER)", true, false},
+		{"TWO_PHASE before FAILOVER admitted", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput (TWO_PHASE, FAILOVER)", true, false},
+		{"failover rejected when feature disabled", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput (FAILOVER)", false, true},
+		{"non-failover logical rejected when enabled", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput", true, true},
+		{"physical rejected when enabled", "CREATE_REPLICATION_SLOT s1 PHYSICAL", true, true},
+		{"explicit FAILOVER false rejected when enabled", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput (FAILOVER 'false')", true, true},
+		{"explicit FAILOVER off rejected when enabled", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput (FAILOVER off)", true, true},
+		{"temporary still accepted when enabled", "CREATE_REPLICATION_SLOT s1 TEMPORARY LOGICAL pgoutput", true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := nonTemporaryCreateReplicationSlotError(tt.cmd, tt.admitFailover)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "requires TEMPORARY")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestNonTemporaryReplicationSlotSQLFuncError_Failover covers the SQL-function
+// guard (pg_create_logical_replication_slot on a replication connection) with
+// the failover argument, mirroring the command-form guard.
+func TestNonTemporaryReplicationSlotSQLFuncError_Failover(t *testing.T) {
+	tests := []struct {
+		name          string
+		cmd           string
+		admitFailover bool
+		wantErr       bool
+	}{
+		{"logical failover admitted when enabled", "SELECT pg_create_logical_replication_slot('s', 'pgoutput', false, false, true)", true, false},
+		{"logical failover rejected when disabled", "SELECT pg_create_logical_replication_slot('s', 'pgoutput', false, false, true)", false, true},
+		{"logical non-failover rejected when enabled", "SELECT pg_create_logical_replication_slot('s', 'pgoutput', false, false, false)", true, true},
+		{"logical defaulted (no failover arg) rejected when enabled", "SELECT pg_create_logical_replication_slot('s', 'pgoutput')", true, true},
+		{"logical temporary accepted when enabled", "SELECT pg_create_logical_replication_slot('s', 'pgoutput', true)", true, false},
+		{"physical rejected when enabled", "SELECT pg_create_physical_replication_slot('s')", true, true},
+		{"physical temporary accepted when enabled", "SELECT pg_create_physical_replication_slot('s', false, true)", true, false},
+		{"non-slot SQL passes through", "SELECT 1", true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := nonTemporaryReplicationSlotSQLFuncError(tt.cmd, tt.admitFailover)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestCreateReplicationSlotHasFailover exercises the option-list tokenizer that
+// backs the command-form guard. Token slices are what strings.Fields produces
+// for the text after the LOGICAL keyword.
+func TestCreateReplicationSlotHasFailover(t *testing.T) {
+	tests := []struct {
+		name   string
+		tokens []string
+		want   bool
+	}{
+		{"real subscriber form", []string{"pgoutput", "(FAILOVER,", "SNAPSHOT", "'nothing')"}, true},
+		{"bare failover", []string{"pgoutput", "(FAILOVER)"}, true},
+		{"glued to plugin", []string{"pgoutput(FAILOVER)"}, true},
+		{"failover true quoted", []string{"pgoutput", "(FAILOVER", "'true')"}, true},
+		{"two_phase then failover", []string{"pgoutput", "(TWO_PHASE,", "FAILOVER)"}, true},
+		{"failover false quoted", []string{"pgoutput", "(FAILOVER", "'false')"}, false},
+		{"failover off unquoted", []string{"pgoutput", "(FAILOVER", "off)"}, false},
+		{"no options", []string{"pgoutput"}, false},
+		{"other options only", []string{"pgoutput", "(TWO_PHASE,", "SNAPSHOT", "'use')"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, createReplicationSlotHasFailover(tt.tokens))
+		})
+	}
+}
+
+// TestRunReplicationPreamble_AdmitsFailoverSlotWhenEnabled drives a real
+// PG17-style failover CREATE_REPLICATION_SLOT through the preamble with the
+// feature on, and confirms it is forwarded to the pooler (not rejected) and
+// streaming begins.
+func TestRunReplicationPreamble_AdmitsFailoverSlotWhenEnabled(t *testing.T) {
+	var clientInput bytes.Buffer
+	writeQueryMessage(&clientInput, `CREATE_REPLICATION_SLOT "sub_orders" LOGICAL pgoutput (FAILOVER, SNAPSHOT 'nothing')`)
+	writeQueryMessage(&clientInput, "START_REPLICATION SLOT sub_orders LOGICAL 0/0")
+
+	createSlotResp := bytes.Join([][]byte{
+		frameMessage(protocol.MsgCommandComplete, []byte("CREATE_REPLICATION_SLOT\x00")),
+		frameMessage(protocol.MsgReadyForQuery, []byte{'I'}),
+	}, nil)
+	startReplResp := frameMessage(protocol.MsgCopyBothResponse, []byte{0, 0, 0})
+
+	stream := &scriptedReplStream{
+		ctx:       context.Background(),
+		responses: [][]byte{createSlotResp, startReplResp},
+	}
+	testConn := server.NewTestConn(&clientInput)
+
+	streaming, _, err := runReplicationPreamble(testConn.Conn, stream, true)
+	require.NoError(t, err)
+	assert.True(t, streaming)
+
+	// The failover CREATE_REPLICATION_SLOT was relayed to the pooler verbatim.
+	require.Len(t, stream.sentRaw, 2)
+	assert.Contains(t, string(stream.sentRaw[0]), "FAILOVER")
 }
 
 // TestRunReplicationPreamble_HappyPath drives IDENTIFY_SYSTEM ->
@@ -242,7 +367,7 @@ func TestRunReplicationPreamble_HappyPath(t *testing.T) {
 	}
 
 	testConn := server.NewTestConn(&clientInput)
-	streaming, leftover, err := runReplicationPreamble(context.Background(), testConn.Conn, stream)
+	streaming, leftover, err := runReplicationPreamble(testConn.Conn, stream, false)
 	require.NoError(t, err)
 	assert.True(t, streaming)
 	assert.Empty(t, leftover)
@@ -274,7 +399,7 @@ func TestRunReplicationPreamble_ReturnsLeftoverAfterCopyBothResponse(t *testing.
 	}
 
 	testConn := server.NewTestConn(&clientInput)
-	streaming, leftover, err := runReplicationPreamble(context.Background(), testConn.Conn, stream)
+	streaming, leftover, err := runReplicationPreamble(testConn.Conn, stream, false)
 	require.NoError(t, err)
 	assert.True(t, streaming)
 	assert.Equal(t, extra, leftover)
@@ -295,7 +420,7 @@ func TestRunReplicationPreamble_RejectsNonTemporarySlot(t *testing.T) {
 	stream := &scriptedReplStream{ctx: context.Background()}
 	testConn := server.NewTestConn(&clientInput)
 
-	streaming, leftover, err := runReplicationPreamble(context.Background(), testConn.Conn, stream)
+	streaming, leftover, err := runReplicationPreamble(testConn.Conn, stream, false)
 	require.Error(t, err)
 	assert.False(t, streaming)
 	assert.Nil(t, leftover)
@@ -339,7 +464,7 @@ func TestRunReplicationPreamble_RejectsSQLFunctionSlotCreation(t *testing.T) {
 			}
 			testConn := server.NewTestConn(&clientInput)
 
-			streaming, _, err := runReplicationPreamble(context.Background(), testConn.Conn, stream)
+			streaming, _, err := runReplicationPreamble(testConn.Conn, stream, false)
 			assert.False(t, streaming)
 			if !tt.wantErr {
 				require.NoError(t, err)
@@ -361,7 +486,7 @@ func TestRunReplicationPreamble_CleanEOF(t *testing.T) {
 	testConn := server.NewTestConn(&bytes.Buffer{})
 	stream := &scriptedReplStream{ctx: context.Background()}
 
-	streaming, leftover, err := runReplicationPreamble(context.Background(), testConn.Conn, stream)
+	streaming, leftover, err := runReplicationPreamble(testConn.Conn, stream, false)
 	require.NoError(t, err)
 	assert.False(t, streaming)
 	assert.Nil(t, leftover)
@@ -376,7 +501,7 @@ func TestRunReplicationPreamble_ClientTerminate(t *testing.T) {
 	stream := &scriptedReplStream{ctx: context.Background()}
 	testConn := server.NewTestConn(&clientInput)
 
-	streaming, leftover, err := runReplicationPreamble(context.Background(), testConn.Conn, stream)
+	streaming, leftover, err := runReplicationPreamble(testConn.Conn, stream, false)
 	require.NoError(t, err)
 	assert.False(t, streaming)
 	assert.Nil(t, leftover)
@@ -413,7 +538,7 @@ func TestRunReplicationPreamble_RejectsExtendedProtocol(t *testing.T) {
 			stream := &scriptedReplStream{ctx: context.Background()}
 			testConn := server.NewTestConn(&clientInput)
 
-			streaming, leftover, err := runReplicationPreamble(context.Background(), testConn.Conn, stream)
+			streaming, leftover, err := runReplicationPreamble(testConn.Conn, stream, false)
 			require.Error(t, err)
 			assert.False(t, streaming)
 			assert.Nil(t, leftover)

--- a/go/services/multigateway/handler/replication_stream.go
+++ b/go/services/multigateway/handler/replication_stream.go
@@ -73,7 +73,7 @@ func (h *MultigatewayHandler) HandleReplicationStream(ctx context.Context, conn 
 	// before the pooler/postgres ever see it. Runs on the still-attached
 	// client socket — any rejection error has already been surfaced to the
 	// client as an ErrorResponse inside the preamble.
-	streaming, leftover, err := runReplicationPreamble(ctx, conn, stream)
+	streaming, leftover, err := runReplicationPreamble(conn, stream, h.admitsFailoverSlots())
 	if err != nil {
 		return err
 	}

--- a/go/services/multigateway/init.go
+++ b/go/services/multigateway/init.go
@@ -65,6 +65,9 @@ type Multigateway struct {
 	pgTLSKeyFile viperutil.Value[string]
 	// pgRequireSSL rejects plaintext client connections; requires cert + key.
 	pgRequireSSL viperutil.Value[bool]
+	// slotBasedReplicationEnabled gates admitting non-temporary logical failover
+	// slots in the replication preamble (default off, dynamic/reloadable).
+	slotBasedReplicationEnabled viperutil.Value[bool]
 	// poolerGateway manages connections to poolers and owns the lifecycle
 	// of the underlying pooler cache (topology watch + per-pooler health
 	// streams + per-pooler connection riders).
@@ -211,6 +214,12 @@ func NewMultigateway() *Multigateway {
 			Dynamic:  false,
 			EnvVars:  []string{"MT_PG_REQUIRE_SSL"},
 		}),
+		slotBasedReplicationEnabled: viperutil.Configure(reg, "enable-slot-based-replication", viperutil.Options[bool]{
+			Default:  false,
+			FlagName: "enable-slot-based-replication",
+			Dynamic:  true,
+			EnvVars:  []string{"MT_ENABLE_SLOT_BASED_REPLICATION"},
+		}),
 		pgReplicaPort: viperutil.Configure(reg, "pg-replica-port", viperutil.Options[int]{
 			Default:  0,
 			FlagName: "pg-replica-port",
@@ -267,6 +276,7 @@ func (mg *Multigateway) RegisterFlags(fs *pflag.FlagSet) {
 	fs.String("pg-tls-cert-file", mg.pgTLSCertFile.Default(), "path to TLS certificate file for PostgreSQL SSL connections")
 	fs.String("pg-tls-key-file", mg.pgTLSKeyFile.Default(), "path to TLS private key file for PostgreSQL SSL connections")
 	fs.Bool("pg-require-ssl", mg.pgRequireSSL.Default(), "require TLS for all client PostgreSQL connections; multigateway fails to start if no cert/key is configured. CancelRequest still permitted over plaintext.")
+	fs.Bool("enable-slot-based-replication", mg.slotBasedReplicationEnabled.Default(), "admit non-temporary logical replication slots registered for failover (slot-based replication). Default off.")
 	fs.Int("pg-replica-port", mg.pgReplicaPort.Default(), "optional port for replica-reads connections; 0 disables the replica listener")
 	fs.Int("low-replication-lag-ms", mg.pgReplicaLowLagMs.Default(), "replicas at or below this lag (milliseconds) are preferred; 0 treats all replicas equally")
 	fs.Int("high-replication-lag-tolerance-ms", mg.pgReplicaHighLagToleranceMs.Default(), "absolute max lag (milliseconds) for replicas; 0 means no upper bound")
@@ -274,7 +284,8 @@ func (mg *Multigateway) RegisterFlags(fs *pflag.FlagSet) {
 	fs.Int("query-metrics-memory", mg.queryMetricsMemory.Default(), "memory budget (bytes) for per-query-shape metrics tracking; 0 disables per-query metrics and the registry RPC")
 	fs.Int("query-metrics-sql-max-bytes", mg.queryMetricsSQLMaxBytes.Default(), "maximum bytes of representative normalized SQL stored per tracked fingerprint")
 	fs.Uint64("query-log-sample-rate", mg.queryLogSampleRate.Default(), "1/N sampling rate for normal-path per-query logs. Normal queries log at DEBUG, so visibility also requires --log-level=debug. 0 disables sampling (level alone governs); 1 emits every query; N>1 emits every Nth.")
-	viperutil.BindFlags(fs,
+	viperutil.BindFlags(
+		fs,
 		mg.cell,
 		mg.serviceID,
 		mg.pgPort,
@@ -284,6 +295,7 @@ func (mg *Multigateway) RegisterFlags(fs *pflag.FlagSet) {
 		mg.pgTLSCertFile,
 		mg.pgTLSKeyFile,
 		mg.pgRequireSSL,
+		mg.slotBasedReplicationEnabled,
 		mg.pgReplicaPort,
 		mg.pgReplicaLowLagMs,
 		mg.pgReplicaHighLagToleranceMs,
@@ -417,7 +429,8 @@ func (mg *Multigateway) Init(ctx context.Context) error {
 	// retries with jitter until two racing gateways converge on different prefixes.
 	regCtx, regCancel := context.WithTimeout(context.TODO(), 10*time.Second)
 	defer regCancel()
-	mg.tr, err = toporeg.RegisterSynchronous(regCtx,
+	mg.tr, err = toporeg.RegisterSynchronous(
+		regCtx,
 		func(ctx context.Context) error {
 			if multigateway.PidPrefix == 0 {
 				prefix, err := mg.findUnusedPrefix(ctx)
@@ -462,6 +475,7 @@ func (mg *Multigateway) Init(ctx context.Context) error {
 	mg.pgHandler = handler.NewMultigatewayHandler(mg.executor, logger, mg.statementTimeout.Get())
 	mg.pgHandler.SetQueryRegistry(mg.queryRegistry)
 	mg.pgHandler.SetNormalQueryLogSampleRate(queryLogSampleRate)
+	mg.pgHandler.SetSlotBasedReplicationEnabled(mg.slotBasedReplicationEnabled.Get)
 
 	// Wire LISTEN/NOTIFY notification manager.
 	// Uses a lazy client getter that resolves the primary pooler connection
@@ -512,6 +526,7 @@ func (mg *Multigateway) Init(ctx context.Context) error {
 		replicaHandler.SetTargetReplica(true)
 		replicaHandler.SetQueryRegistry(mg.queryRegistry)
 		replicaHandler.SetNormalQueryLogSampleRate(queryLogSampleRate)
+		replicaHandler.SetSlotBasedReplicationEnabled(mg.slotBasedReplicationEnabled.Get)
 		replicaAddr := fmt.Sprintf("%s:%d", mg.pgBindAddress.Get(), replicaPort)
 		mg.pgReplicaListener, err = server.NewListener(server.ListenerConfig{
 			Address:               replicaAddr,
@@ -590,7 +605,8 @@ func (mg *Multigateway) Init(ctx context.Context) error {
 		}()
 	}
 
-	logger.InfoContext(ctx, "multigateway starting up",
+	logger.InfoContext(
+		ctx, "multigateway starting up",
 		"cell", mg.cell.Get(),
 		"service_id", mg.serviceID.Get(),
 		"http_port", mg.senv.GetHTTPPort(),

--- a/go/services/multiorch/consensus/leader_appointment_test.go
+++ b/go/services/multiorch/consensus/leader_appointment_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -432,4 +433,136 @@ func TestAppointLeader_TiebreaksByResignation(t *testing.T) {
 	resignedKey := topoclient.ComponentIDString(cohortIDs[0])
 	_, promotedResigned := fakeClient.PromoteRequests[resignedKey]
 	require.False(t, promotedResigned, "resigned primary should NOT be re-elected when a standby is available")
+}
+
+// TestAppointLeader_TiebreaksBySlotReadiness verifies that poolerHealthStateLess
+// prefers the candidate with more failover-ready logical slots when candidates
+// are otherwise tied (same WAL position, neither resigning). Promoting the
+// slot-ready node keeps subscribers resumable across the failover instead of
+// forcing a re-seed.
+func TestAppointLeader_TiebreaksBySlotReadiness(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	coordID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIORCH,
+		Cell:      "test-cell",
+		Name:      "test-coordinator",
+	}
+
+	fakeClient := rpcclient.NewFakeClient()
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+	defer ts.Close()
+
+	c := NewCoordinator(coordID, ts, fakeClient, logger)
+
+	cohortIDs := []*clustermetadatapb.ID{
+		{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "slot_empty"},
+		{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "slot_ready"},
+	}
+	outgoingRule := &clustermetadatapb.ShardRule{
+		RuleNumber:       &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
+		LeaderId:         cohortIDs[0],
+		CohortMembers:    cohortIDs,
+		DurabilityPolicy: topoclient.AtLeastN(2),
+	}
+
+	const flushLSN = "0/2000000"
+	slotEmpty := createMockNode(fakeClient, "slot_empty", 5, flushLSN, true, outgoingRule)
+	slotReady := createMockNode(fakeClient, "slot_ready", 5, flushLSN, true, outgoingRule)
+
+	// Neither node is resigning and both are at the same WAL position — the only
+	// difference is failover-slot readiness. slot_empty is listed first, so
+	// without the slot tiebreak it would win on stable ordering.
+	slotEmpty.Status.FailoverSlotsReady = 0
+	slotReady.Status.FailoverSlotsReady = 2
+
+	for i, mp := range []*multiorchdatapb.PoolerHealthState{slotEmpty, slotReady} {
+		id := cohortIDs[i]
+		mp.ConsensusStatus.Id = id
+		mp.ConsensusStatus.CurrentPosition = &clustermetadatapb.PoolerPosition{
+			Lsn:      flushLSN,
+			Position: &clustermetadatapb.RulePosition{Decision: outgoingRule},
+		}
+		fakeClient.RecruitResponses[topoclient.ComponentIDString(id)] = &consensusdatapb.RecruitResponse{
+			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+				Id: id,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{
+					Lsn:      flushLSN,
+					Position: &clustermetadatapb.RulePosition{Decision: outgoingRule},
+				},
+			},
+		}
+		require.NoError(t, ts.CreateMultipooler(ctx, mp.Multipooler))
+	}
+
+	cohort := []*multiorchdatapb.PoolerHealthState{slotEmpty, slotReady}
+	shardKey := &clustermetadatapb.ShardKey{Database: "postgres", TableGroup: "default", Shard: "0-inf"}
+
+	require.NoError(t, c.AppointLeader(ctx, shardKey, cohort, "test_slot_readiness_tiebreak"))
+
+	readyKey := topoclient.ComponentIDString(cohortIDs[1])
+	_, promoted := fakeClient.PromoteRequests[readyKey]
+	require.True(t, promoted, "the slot-ready node should be elected")
+
+	emptyKey := topoclient.ComponentIDString(cohortIDs[0])
+	_, promotedEmpty := fakeClient.PromoteRequests[emptyKey]
+	require.False(t, promotedEmpty, "the slot-empty node should NOT be elected when a slot-ready peer is available")
+}
+
+// TestPoolerHealthStateLess pins the comparator's ordering contract directly:
+// the leadership signal is the primary key (non-resigning before resigning) and
+// failover-slot readiness only breaks a tie between equal signals. The
+// end-to-end TiebreaksBy* tests each pin one dimension; this covers the
+// precedence between them and the fully-tied case.
+func TestPoolerHealthStateLess(t *testing.T) {
+	const (
+		active = clustermetadatapb.LeadershipSignal_LEADERSHIP_SIGNAL_ACTIVE
+		resign = clustermetadatapb.LeadershipSignal_LEADERSHIP_SIGNAL_REQUESTING_DEMOTION
+	)
+
+	// node builds a ConsensusStatus and its matching PoolerHealthState carrying
+	// the given leadership signal and failover-slot-ready count.
+	node := func(name string, signal clustermetadatapb.LeadershipSignal, slotsReady int32) (*clustermetadatapb.ConsensusStatus, *multiorchdatapb.PoolerHealthState) {
+		id := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: name}
+		cs := &clustermetadatapb.ConsensusStatus{Id: id}
+		h := &multiorchdatapb.PoolerHealthState{
+			AvailabilityStatus: &clustermetadatapb.AvailabilityStatus{
+				LeadershipStatus: &clustermetadatapb.LeadershipStatus{Signal: signal},
+			},
+			Status: &multipoolermanagerdatapb.Status{FailoverSlotsReady: slotsReady},
+		}
+		return cs, h
+	}
+	lessFor := func(aCS, bCS *clustermetadatapb.ConsensusStatus, aH, bH *multiorchdatapb.PoolerHealthState) func(a, b *clustermetadatapb.ConsensusStatus) bool {
+		return poolerHealthStateLess(map[string]*multiorchdatapb.PoolerHealthState{
+			topoclient.ClusterIDString(aCS.GetId()): aH,
+			topoclient.ClusterIDString(bCS.GetId()): bH,
+		})
+	}
+
+	t.Run("non-resigning sorts before resigning regardless of slot readiness", func(t *testing.T) {
+		// The resigning node is slot-ready and the active node is slot-empty:
+		// the signal must still dominate so the resign intent is honored.
+		a, aH := node("active_empty", active, 0)
+		b, bH := node("resign_ready", resign, 5)
+		less := lessFor(a, b, aH, bH)
+		assert.True(t, less(a, b), "active (slot-empty) must sort before resigning (slot-ready)")
+		assert.False(t, less(b, a))
+	})
+
+	t.Run("same signal: more failover-ready slots sorts first", func(t *testing.T) {
+		a, aH := node("ready2", active, 2)
+		b, bH := node("ready0", active, 0)
+		less := lessFor(a, b, aH, bH)
+		assert.True(t, less(a, b))
+		assert.False(t, less(b, a))
+	})
+
+	t.Run("fully tied is not less in either direction", func(t *testing.T) {
+		a, aH := node("t1", active, 1)
+		b, bH := node("t2", active, 1)
+		less := lessFor(a, b, aH, bH)
+		assert.False(t, less(a, b))
+		assert.False(t, less(b, a))
+	})
 }

--- a/go/services/multiorch/consensus/rule_change.go
+++ b/go/services/multiorch/consensus/rule_change.go
@@ -442,10 +442,24 @@ func poolerHealthStateLess(healthByID map[string]*multiorchdatapb.PoolerHealthSt
 		h := healthByID[topoclient.ClusterIDString(cs.GetId())]
 		return h.GetAvailabilityStatus().GetLeadershipStatus().GetSignal()
 	}
+	failoverSlotsReady := func(cs *clustermetadatapb.ConsensusStatus) int32 {
+		h := healthByID[topoclient.ClusterIDString(cs.GetId())]
+		return h.GetStatus().GetFailoverSlotsReady()
+	}
 	return func(a, b *clustermetadatapb.ConsensusStatus) bool {
 		sigA := leadershipSignal(a)
 		sigB := leadershipSignal(b)
-		return leadershipSignalPriority[sigA] < leadershipSignalPriority[sigB]
+		if leadershipSignalPriority[sigA] != leadershipSignalPriority[sigB] {
+			return leadershipSignalPriority[sigA] < leadershipSignalPriority[sigB]
+		}
+		// Slot-aware tiebreak among otherwise-equal candidates: prefer the one
+		// with more failover-ready logical slots so a promotion keeps the most
+		// subscribers resumable (see the durable slot-creation barrier). This
+		// only reorders candidates that already tied on WAL position (the
+		// EligibleLeaders set) and on leadership signal, so it never trades data
+		// safety or a resign intent for slot readiness. Zero when slot-based
+		// replication is off, leaving the ordering unchanged.
+		return failoverSlotsReady(a) > failoverSlotsReady(b)
 	}
 }
 

--- a/go/services/multiorch/recovery/actions/fix_replication.go
+++ b/go/services/multiorch/recovery/actions/fix_replication.go
@@ -143,7 +143,7 @@ func (a *FixReplicationAction) Execute(ctx context.Context, problem types.Proble
 	// Dispatch to the appropriate fix based on the problem
 	switch problem.Code {
 	case types.ProblemReplicaNotReplicating:
-		return a.fixNotReplicating(ctx, replica, leader, members.HighestKnownPosition)
+		return a.fixNotReplicating(ctx, replica, leader, members)
 
 	// TODO: Future problem codes to handle
 	// case types.ProblemReplicaWrongPrimary:
@@ -167,7 +167,7 @@ func (a *FixReplicationAction) fixNotReplicating(
 	ctx context.Context,
 	replica *store.Pooler,
 	leader *store.Pooler,
-	highestKnownPosition *clustermetadatapb.RulePosition,
+	members store.ShardMembers,
 ) (retErr error) {
 	a.logger.InfoContext(ctx, "fixing replication: not configured",
 		"replica", replica.Health().Multipooler.Id.Name,
@@ -187,6 +187,22 @@ func (a *FixReplicationAction) fixNotReplicating(
 		}
 	}()
 
+	// Backstop for the discovery-driven reconcile (§2.6): ensure the primary
+	// holds a physical replication slot for this replica before we point the
+	// replica at it, so the replica's WAL receiver START_REPLICATION SLOT
+	// mg_<self> cannot fail with "slot does not exist" and strand it (the very
+	// deadlock this reactive step exists to break if the proactive reconcile was
+	// missed). Declarative: we send the full cohort-eligible set, so no peer's
+	// slot is dropped. Best-effort — on error we log and proceed; SetPrimary and
+	// the pooler's own repair still run, and the proactive loop retries.
+	if _, err := a.rpcClient.ReconcileFollowers(ctx, leader.Health().Multipooler, &multipoolermanagerdatapb.ReconcileFollowersRequest{
+		Followers: store.CohortEligibleFollowerIDs(members),
+	}); err != nil {
+		a.logger.WarnContext(ctx, "fix replication: ensuring follower physical slot on primary failed; proceeding",
+			"replica", replica.Health().Multipooler.Id.Name,
+			"primary", leader.Health().Multipooler.Id.Name, "error", err)
+	}
+
 	// Configure primary_conninfo on the replica via SetPrimary. The rule is the
 	// shard's highest-known rule (authoritative — the leader may not yet know it
 	// holds that rule), the contact is the leader's topology address, and we
@@ -194,7 +210,7 @@ func (a *FixReplicationAction) fixNotReplicating(
 	// its pg_rewind until the leader has checkpointed onto its current timeline.
 	setPrimaryReq := &consensusdatapb.SetPrimaryRequest{
 		ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
-			Position:    highestKnownPosition,
+			Position:    members.HighestKnownPosition,
 			Primary:     topoclient.PoolerAddressFor(leader.Health().Multipooler),
 			RewindReady: commonconsensus.ReplicationPrimaryOrNil(leader.Health().GetConsensusStatus()).GetRewindReady(),
 		},

--- a/go/services/multiorch/recovery/actions/fix_replication_test.go
+++ b/go/services/multiorch/recovery/actions/fix_replication_test.go
@@ -17,6 +17,7 @@ package actions
 import (
 	"context"
 	"log/slog"
+	"slices"
 	"testing"
 	"time"
 
@@ -332,6 +333,16 @@ func TestFixReplicationAction_ExecuteSuccessNotReplicating(t *testing.T) {
 	// Verify SetPrimary was called on the replica, NOT SetPrimaryConnInfo.
 	assert.Contains(t, fakeClient.CallLog, "SetPrimary(multipooler-cell1-replica1)")
 	assert.NotContains(t, fakeClient.CallLog, "SetPrimaryConnInfo(multipooler-cell1-replica1)")
+
+	// Backstop (§2.6): the primary is told to ensure the follower's physical slot,
+	// and that ReconcileFollowers runs BEFORE SetPrimary points the replica at the
+	// primary — otherwise the replica's WAL receiver could START_REPLICATION on a
+	// slot that does not exist yet and strand itself.
+	assert.Contains(t, fakeClient.CallLog, "ReconcileFollowers(multipooler-cell1-primary)")
+	reconcileIdx := slices.Index(fakeClient.CallLog, "ReconcileFollowers(multipooler-cell1-primary)")
+	setPrimaryIdx := slices.Index(fakeClient.CallLog, "SetPrimary(multipooler-cell1-replica1)")
+	require.GreaterOrEqual(t, reconcileIdx, 0, "ReconcileFollowers must have been called")
+	require.Less(t, reconcileIdx, setPrimaryIdx, "ReconcileFollowers must run before SetPrimary")
 
 	// Verify the request carried the primary's contact info and known position.
 	setPrimaryReq := fakeClient.SetPrimaryRequests["multipooler-cell1-replica1"]

--- a/go/services/multiorch/recovery/leader_info_propagation.go
+++ b/go/services/multiorch/recovery/leader_info_propagation.go
@@ -27,6 +27,7 @@ import (
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
 	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	"github.com/multigres/multigres/go/services/multiorch/store"
 )
 
@@ -85,6 +86,17 @@ func (re *Engine) propagateLeaderInfoForShard(ctx context.Context, shardKey *clu
 	if leader == nil || members.HighestKnownPosition == nil {
 		return
 	}
+
+	// Ensure the primary holds a physical replication slot for every
+	// cohort-eligible follower BEFORE any follower is pointed at it via
+	// SetPrimary below. A late-joining standby cannot stream — and therefore
+	// cannot join the cohort, and therefore cannot get its slot via the
+	// cohort-add path — until its slot already exists on the primary; this
+	// discovery-driven, declarative reconcile breaks that ordering deadlock
+	// (§2.6). Idempotent and level-triggered, so a missed event or a primary
+	// restart self-heals on the next tick.
+	re.reconcileFollowerSlots(ctx, leader, store.CohortEligibleFollowerIDs(members))
+
 	leaderAddress := topoclient.PoolerAddressFor(leader.Health().GetMultipooler())
 	leaderRewindReady := commonconsensus.ReplicationPrimaryOrNil(leader.Health().GetConsensusStatus()).GetRewindReady()
 
@@ -104,6 +116,24 @@ func (re *Engine) propagateLeaderInfoForShard(ctx context.Context, shardKey *clu
 		}(pooler)
 	}
 	wg.Wait()
+}
+
+// reconcileFollowerSlots notifies the leader of the current cohort-eligible
+// follower set so it pre-creates their per-follower physical replication slots.
+// Best-effort: a failure is logged and retried on the next tick. No-op when the
+// set is empty (single-node shard, or nothing discovered yet).
+func (re *Engine) reconcileFollowerSlots(ctx context.Context, leader *store.Pooler, followerIDs []*clustermetadatapb.ID) {
+	if len(followerIDs) == 0 {
+		return
+	}
+	rpcCtx, cancel := context.WithTimeout(ctx, setPrimaryPropagationTimeout)
+	defer cancel()
+	if _, err := re.rpcClient.ReconcileFollowers(rpcCtx, leader.Health().GetMultipooler(), &multipoolermanagerdatapb.ReconcileFollowersRequest{
+		Followers: followerIDs,
+	}); err != nil {
+		re.logger.WarnContext(ctx, "leader-info propagation: ReconcileFollowers failed, will retry next tick",
+			"leader", leader.Health().GetMultipooler().GetId().GetName(), "error", err)
+	}
 }
 
 // shouldPropagateLeaderInfo reports whether a pooler needs a SetPrimary call

--- a/go/services/multiorch/recovery/leader_info_propagation_test.go
+++ b/go/services/multiorch/recovery/leader_info_propagation_test.go
@@ -152,6 +152,34 @@ func TestShouldPropagateLeaderInfo(t *testing.T) {
 // ReplicationPrimary, so a reconcile tick immediately after doesn't
 // needlessly re-send the same SetPrimary before the pooler's own streamed
 // health update reports it back (see shouldPropagateLeaderInfo).
+func TestReconcileFollowerSlots(t *testing.T) {
+	leader := store.NewPooler(&multiorchdatapb.PoolerHealthState{
+		Multipooler: &clustermetadatapb.Multipooler{
+			Id:   &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "p0"},
+			Type: clustermetadatapb.PoolerType_PRIMARY,
+		},
+		LastSeen: timestamppb.Now(),
+	}, nil)
+
+	t.Run("calls ReconcileFollowers on the leader when the set is non-empty", func(t *testing.T) {
+		fake := rpcclient.NewFakeClient()
+		re := &Engine{rpcClient: fake, logger: slog.Default()}
+		ids := []*clustermetadatapb.ID{
+			{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "s1"},
+			{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "s2"},
+		}
+		re.reconcileFollowerSlots(t.Context(), leader, ids)
+		require.Equal(t, []string{"ReconcileFollowers(multipooler-zone1-p0)"}, fake.GetCallLog())
+	})
+
+	t.Run("no-op when the eligible set is empty", func(t *testing.T) {
+		fake := rpcclient.NewFakeClient()
+		re := &Engine{rpcClient: fake, logger: slog.Default()}
+		re.reconcileFollowerSlots(t.Context(), leader, nil)
+		require.Empty(t, fake.GetCallLog(), "must not call ReconcileFollowers with an empty set")
+	})
+}
+
 func TestPropagateLeaderInfoToPooler_CachesSuccessfulSetPrimary(t *testing.T) {
 	fake := rpcclient.NewFakeClient()
 	re := &Engine{rpcClient: fake, logger: slog.Default()}

--- a/go/services/multiorch/store/cohort_eligible_followers_test.go
+++ b/go/services/multiorch/store/cohort_eligible_followers_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
+)
+
+func TestCohortEligibleFollowerIDs(t *testing.T) {
+	pooler := func(name string) *Pooler {
+		return NewPooler(&multiorchdatapb.PoolerHealthState{
+			Multipooler: &clustermetadatapb.Multipooler{
+				Id: &clustermetadatapb.ID{Cell: "zone1", Name: name},
+			},
+		}, nil)
+	}
+	names := func(ids []*clustermetadatapb.ID) []string {
+		out := make([]string, 0, len(ids))
+		for _, id := range ids {
+			out = append(out, id.GetName())
+		}
+		return out
+	}
+
+	leader := pooler("p0")
+	s1 := pooler("s1")
+	s2 := pooler("s2")
+
+	t.Run("every non-leader member is eligible", func(t *testing.T) {
+		members := ShardMembers{
+			Poolers: []*Pooler{leader, s1, s2},
+			Leader:  leader,
+		}
+		// The leader is identified from consensus (members.Leader) and excluded;
+		// every other member is a follower, regardless of topology role.
+		require.ElementsMatch(t, []string{"s1", "s2"}, names(CohortEligibleFollowerIDs(members)))
+	})
+
+	t.Run("a member is included even before it streams", func(t *testing.T) {
+		// A freshly discovered standby is not yet in the committed cohort / not
+		// yet streaming; it must still be eligible so its slot is pre-created (the
+		// whole point of the deadlock fix). Eligibility is membership, not role.
+		members := ShardMembers{Poolers: []*Pooler{leader, s1}, Leader: leader}
+		require.Equal(t, []string{"s1"}, names(CohortEligibleFollowerIDs(members)))
+	})
+
+	t.Run("single-node shard yields no followers", func(t *testing.T) {
+		members := ShardMembers{Poolers: []*Pooler{leader}, Leader: leader}
+		require.Empty(t, CohortEligibleFollowerIDs(members))
+	})
+}

--- a/go/services/multiorch/store/pooler_store.go
+++ b/go/services/multiorch/store/pooler_store.go
@@ -74,6 +74,31 @@ type ShardMembers struct {
 	Leader *Pooler
 }
 
+// CohortEligibleFollowerIDs returns the IDs of the shard's cohort-eligible
+// followers: every member that is not the leader. The leader is identified from
+// consensus state — FindShardMembers derives members.Leader from the highest
+// known shard rule — never from the topology Multipooler.Type, which multiorch
+// must not consult for identity. This mirrors the SetPrimary fan-out in
+// propagateLeaderInfoForShard, which likewise points every non-leader member at
+// the primary: each such member streams from the primary and therefore needs a
+// per-follower physical replication slot pre-created there (§2.6). Eligibility is
+// membership, not streaming state or role, so a freshly discovered standby is
+// included before it streams — breaking the bootstrap ordering deadlock where a
+// late-joining standby can never stream, so can never join the cohort, so never
+// gets its slot. Pure; call on the result of FindShardMembers (a nil
+// members.Leader yields every member, so callers gate on a known leader before
+// acting).
+func CohortEligibleFollowerIDs(members ShardMembers) []*clustermetadatapb.ID {
+	ids := make([]*clustermetadatapb.ID, 0, len(members.Poolers))
+	for _, pooler := range members.Poolers {
+		if pooler == members.Leader {
+			continue
+		}
+		ids = append(ids, pooler.Health().GetMultipooler().GetId())
+	}
+	return ids
+}
+
 // FindShardMembers identifies the shard's members, consensus position, and
 // leader's health.
 func FindShardMembers(cache *PoolerCache, shardKey *clustermetadatapb.ShardKey) ShardMembers {

--- a/go/services/multipooler/grpcmanagerservice/service.go
+++ b/go/services/multipooler/grpcmanagerservice/service.go
@@ -155,6 +155,17 @@ func (s *managerService) ResignLeadership(ctx context.Context, req *multipoolerm
 	return resp, nil
 }
 
+// ReconcileFollowers ensures the primary holds a per-follower physical replication
+// slot for each cohort-eligible follower in the request (creating missing slots,
+// dropping managed slots for members no longer listed). It is a declarative,
+// non-consensus notification the orchestrator sends off the cohort path.
+func (s *managerService) ReconcileFollowers(ctx context.Context, req *multipoolermanagerdatapb.ReconcileFollowersRequest) (*multipoolermanagerdatapb.ReconcileFollowersResponse, error) {
+	if err := s.manager.ReconcileFollowers(ctx, req.GetFollowers()); err != nil {
+		return nil, mterrors.ToGRPC(err)
+	}
+	return &multipoolermanagerdatapb.ReconcileFollowersResponse{}, nil
+}
+
 // SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts by the monitor
 func (s *managerService) SetPostgresRestartsEnabled(ctx context.Context, req *multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse, error) {
 	return s.manager.SetPostgresRestartsEnabled(ctx, req)

--- a/go/services/multipooler/init.go
+++ b/go/services/multipooler/init.go
@@ -97,6 +97,11 @@ type Multipooler struct {
 	backendVpidTrackingEnabled       viperutil.Value[bool]
 	postgresUnrecoverableTimeout     viperutil.Value[time.Duration]
 	postgresUnrecoverableMinAttempts viperutil.Value[int]
+	// slotBasedReplicationEnabled gates slot-based physical replication
+	// (per-follower physical slots, primary_slot_name, synchronized_standby_slots).
+	// Dynamic so it can be toggled at runtime as a rollout kill-switch; default
+	// false keeps the current slot-less behavior.
+	slotBasedReplicationEnabled viperutil.Value[bool]
 	// flagSet is saved at RegisterFlags time so resolvers can distinguish an
 	// explicitly-set-but-empty flag from an unset one (pflag.Flag.Changed),
 	// which viperutil.Get cannot.
@@ -223,6 +228,11 @@ func NewMultipooler(telemetry *telemetry.Telemetry) *Multipooler {
 			FlagName: "postgres-unrecoverable-min-attempts",
 			Dynamic:  false,
 		}),
+		slotBasedReplicationEnabled: viperutil.Configure(reg, "enable-slot-based-replication", viperutil.Options[bool]{
+			Default:  false,
+			FlagName: "enable-slot-based-replication",
+			Dynamic:  true,
+		}),
 		grpcServer:     servenv.NewGrpcServer(reg),
 		senv:           servenv.NewServEnvWithConfig(reg, servenv.NewLogger(reg, telemetry), viperutil.NewViperConfig(reg), telemetry),
 		telemetry:      telemetry,
@@ -264,6 +274,7 @@ func (mp *Multipooler) RegisterFlags(flags *pflag.FlagSet) {
 	flags.Bool("backend-vpid-tracking-enabled", mp.backendVpidTrackingEnabled.Default(), "Track active gateway virtual pid to PostgreSQL backend pid mappings in multigres.backend_vpid")
 	flags.Duration("postgres-unrecoverable-timeout", mp.postgresUnrecoverableTimeout.Default(), "How long postgres may continuously fail to start/rewind/restore before the pooler quarantines itself for replacement (e.g. 5m). 0 (default) disables it; enable only where an actor replaces quarantined nodes.")
 	flags.Int("postgres-unrecoverable-min-attempts", mp.postgresUnrecoverableMinAttempts.Default(), "Minimum consecutive failed postgres start/rewind/restore attempts required alongside --postgres-unrecoverable-timeout before quarantining. Must be >= 2 and < 10.")
+	flags.Bool("enable-slot-based-replication", mp.slotBasedReplicationEnabled.Default(), "Enable slot-based physical replication (per-follower physical replication slots, primary_slot_name, synchronized_standby_slots) for logical-slot failover. Dynamic (runtime-toggleable); default off keeps the slot-less posture.")
 
 	viperutil.BindFlags(
 		flags,
@@ -286,6 +297,7 @@ func (mp *Multipooler) RegisterFlags(flags *pflag.FlagSet) {
 		mp.backendVpidTrackingEnabled,
 		mp.postgresUnrecoverableTimeout,
 		mp.postgresUnrecoverableMinAttempts,
+		mp.slotBasedReplicationEnabled,
 	)
 	mp.flagSet = flags
 
@@ -447,6 +459,7 @@ func (mp *Multipooler) Init(startCtx context.Context) error {
 		ConsensusEnabled:             mp.grpcServer.CheckServiceMap("consensus", mp.senv),
 		ConnPoolConfig:               mp.connPoolConfig,
 		BackendVpidTrackingEnabled:   mp.backendVpidTrackingEnabled.Get(),
+		SlotBasedReplicationEnabled:  mp.slotBasedReplicationEnabled.Get,
 		// pgBackRest TLS certificate paths for connecting to primary's pgBackRest server
 		PgBackRestCertFile: mp.pgBackRestCertFile.Get(),
 		PgBackRestKeyFile:  mp.pgBackRestKeyFile.Get(),

--- a/go/services/multipooler/internal/connpoolmanager/interface.go
+++ b/go/services/multipooler/internal/connpoolmanager/interface.go
@@ -56,6 +56,9 @@ type PoolManager interface {
 	// PgUser returns the configured PostgreSQL user for system queries.
 	PgUser() string
 
+	// PgDatabase returns the configured PostgreSQL database for system queries.
+	PgDatabase() string
+
 	// PgPassword returns the resolved PostgreSQL password and an "ok" flag
 	// indicating whether a password source was successfully resolved at
 	// startup. !ok means ResolvePgPassword has not run successfully and

--- a/go/services/multipooler/internal/connpoolmanager/manager.go
+++ b/go/services/multipooler/internal/connpoolmanager/manager.go
@@ -94,9 +94,14 @@ const (
 //	regularConn, _ := mgr.GetRegularConn(ctx, user)
 //	reservedConn, _ := mgr.NewReservedConn(ctx, settings, user)
 type Manager struct {
-	config     *Config
-	logger     *slog.Logger      // Set by Open()
-	connConfig *ConnectionConfig // Stored for lazy pool creation
+	config *Config
+	logger *slog.Logger // Set by Open()
+
+	// connConfig holds the connection settings, stored once at Open and read
+	// lock-free elsewhere — PgDatabase (off the postgres-monitor loop) and
+	// buildClientConfig (on pool creation). An atomic pointer so those reads never
+	// race the Open write; nil until the first Open.
+	connConfig atomic.Pointer[ConnectionConfig]
 
 	ctx           context.Context          // Manager lifecycle context, used for lazy pool creation
 	adminPool     *admin.Pool              // Shared admin pool for kill operations
@@ -186,7 +191,7 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 	defer m.createMu.Unlock()
 
 	m.ctx = ctx
-	m.connConfig = connConfig
+	m.connConfig.Store(connConfig)
 	emptyPools := make(map[string]*UserPool)
 	m.userPoolsSnapshot.Store(&emptyPools)
 
@@ -277,16 +282,20 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 // this manager. They are honored only on TCP connections (libpq parity); the
 // client startup code skips SSLRequest when SocketFile is set.
 func (m *Manager) buildClientConfig(user, password string) *client.Config {
+	// Non-nil on every call: buildClientConfig runs only after Open has stored
+	// connConfig (the admin pool is built later in Open; user pools are built
+	// lazily thereafter).
+	cc := m.connConfig.Load()
 	return &client.Config{
-		SocketFile:     m.connConfig.SocketFile,
-		Host:           m.connConfig.Host,
-		Port:           m.connConfig.Port,
-		Database:       m.connConfig.Database,
+		SocketFile:     cc.SocketFile,
+		Host:           cc.Host,
+		Port:           cc.Port,
+		Database:       cc.Database,
 		User:           user,
 		Password:       password,
-		SSLMode:        m.connConfig.SSLMode,
-		SSLNegotiation: m.connConfig.SSLNegotiation,
-		TLSConfig:      m.connConfig.TLSConfig,
+		SSLMode:        cc.SSLMode,
+		SSLNegotiation: cc.SSLNegotiation,
+		TLSConfig:      cc.TLSConfig,
 		DialTimeout:    m.config.DialTimeout(),
 	}
 }
@@ -532,6 +541,16 @@ func (m *Manager) teardownLocked() {
 // PgUser returns the configured PostgreSQL user for system queries.
 func (m *Manager) PgUser() string {
 	return m.config.PgUser()
+}
+
+// PgDatabase returns the PostgreSQL database the pooler connects to, taken from
+// the connection config supplied at Open. Empty before Open.
+func (m *Manager) PgDatabase() string {
+	cc := m.connConfig.Load()
+	if cc == nil {
+		return ""
+	}
+	return cc.Database
 }
 
 // PgPassword returns the resolved PostgreSQL superuser password and an "ok"

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -224,6 +224,7 @@ func (m *stubPoolManager) Open(context.Context, *connpoolmanager.ConnectionConfi
 func (m *stubPoolManager) Close()                                                  {}
 func (m *stubPoolManager) CloseForReopen()                                         {}
 func (m *stubPoolManager) PgUser() string                                          { return "postgres" }
+func (m *stubPoolManager) PgDatabase() string                                      { return "postgres" }
 func (m *stubPoolManager) PgPassword() (string, bool)                              { return "", true }
 func (m *stubPoolManager) GetAdminConn(ctx context.Context) (admin.PooledConn, error) {
 	if m.adminErr != nil {

--- a/go/services/multipooler/internal/manager/config.go
+++ b/go/services/multipooler/internal/manager/config.go
@@ -36,6 +36,11 @@ type Config struct {
 	ConsensusEnabled             bool                    // Whether consensus gRPC service is enabled
 	ConnPoolConfig               *connpoolmanager.Config // Connection pool config (manager created in MultipoolerManager)
 	BackendVpidTrackingEnabled   bool                    // Whether to write active gateway-vpid/backend-pid mappings
+	// SlotBasedReplicationEnabled reads whether slot-based physical replication is
+	// enabled. It is a getter (not a bool) so the value is read live: the backing
+	// flag is dynamic and reloadable at runtime. Nil reads as disabled (see
+	// MultipoolerManager.slotBasedReplicationEnabled).
+	SlotBasedReplicationEnabled func() bool
 
 	// StandbyStuckDivergenceThreshold is how long a standby must stay unable to
 	// stream from its correctly-recorded leader before the monitor concludes its

--- a/go/services/multipooler/internal/manager/logical_slots.go
+++ b/go/services/multipooler/internal/manager/logical_slots.go
@@ -1,0 +1,556 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/timeouts"
+	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
+)
+
+// ============================================================================
+// Logical Replication Slots
+//
+// This file contains the low-level primitives for managing multigres-owned
+// logical replication slots used by the slot-failover machinery. They run as
+// admin SQL through the same superuser query path (pm.exec / pm.query) used by
+// pg_promote() and ALTER SYSTEM.
+//
+// These primitives are deliberately standalone: nothing in the lifecycle
+// (recruit / SetPrimary / promote / demote) calls them yet. Wiring them in is a
+// later step.
+// ============================================================================
+
+const (
+	// logicalSlotNamePrefix namespaces every multigres-managed replication
+	// slot. Client-created slots never carry it, so a multigres slot can never
+	// collide with one a user made by hand. Mirrors the "multigres"
+	// sidecar-schema convention; replication slot names cannot be
+	// schema-qualified, so the namespacing has to live in the name itself. We
+	// use a short prefix to leave more room for the sanitized pooler name and
+	// potentially avoid hitting PostgreSQL's 63-character slot-name limit,
+	// which would trigger using a hash. In summary, with a short prefix we will
+	// usually get a more readable slot name, and only fall back to a hash when
+	// the pooler name is long or contains characters that need sanitizing.
+	logicalSlotNamePrefix = "mg_"
+
+	// maxReplicationSlotNameLength is PostgreSQL's limit on a replication slot
+	// name (NAMEDATALEN - 1).
+	maxReplicationSlotNameLength = 63
+
+	// logicalSlotStateTimeout bounds the pg_replication_slots reads. These are
+	// cheap catalog lookups on the local instance.
+	logicalSlotStateTimeout = 500 * time.Millisecond
+
+	// logicalSlotWriteTimeout bounds slot creation and drop. Creating a logical
+	// slot has to reach a consistent decoding point, which can wait for a
+	// running-xacts / standby-snapshot record, so it gets a generous bound
+	// rather than the sub-second read timeout.
+	logicalSlotWriteTimeout = timeouts.RemoteOperationTimeout
+)
+
+// ErrLogicalSlotNotFound is returned by GetSlotState when pg_replication_slots
+// has no slot with the requested name.
+var ErrLogicalSlotNotFound = errors.New("logical replication slot not found")
+
+// LogicalSlotState is a projection of a single pg_replication_slots row for a
+// multigres-managed logical slot.
+type LogicalSlotState struct {
+	// The slot's name.
+	Name string
+
+	// RestartLSN is pg_replication_slots.restart_lsn (the oldest WAL the slot
+	// still needs), in pg_lsn text form, or nil when NULL (the slot has not yet
+	// reserved WAL). Kept as text — the codebase's LSN convention (e.g. the
+	// target_lsn RPC field) — so it round-trips straight back into a pg_lsn
+	// context without lossy parsing.
+	RestartLSN *string
+
+	// CatalogXmin is pg_replication_slots.catalog_xmin (the transaction id whose
+	// catalog rows the slot needs retained), or nil when NULL (e.g. a slot with
+	// no catalog hold). An xid is 32-bit, so int64 holds every value losslessly.
+	// Note that comparing two xids requires modular (wraparound-aware) logic,
+	// not a plain <, per the failover catalog-safety check.
+	CatalogXmin *int64
+
+	// InvalidationReason is pg_replication_slots.invalidation_reason, or nil when
+	// the slot has not been invalidated (the column is NULL).
+	InvalidationReason *string
+
+	// FailoverReady reports whether the slot can safely take over after a
+	// failover: it has been synced to this node, is not temporary, and has not
+	// been invalidated. Computed in SQL as
+	// (synced AND NOT temporary AND invalidation_reason IS NULL).
+	FailoverReady bool
+}
+
+// LogicalSlotName derives the deterministic, cluster-unique name of a
+// multigres-managed logical replication slot from a multipooler component name
+// (already cluster-unique). Pass the bare name — clustermetadata ID.Name — not
+// the "{cell}_{name}" application_name: the cell is not part of the slot name.
+// The result is prefixed with logicalSlotNamePrefix, lower-cased, restricted to
+// PostgreSQL's slot-name charset [a-z0-9_], and capped at
+// maxReplicationSlotNameLength.
+//
+// It returns an error if name contains an underscore. '_' is not a legal
+// character in a multipooler ID.Name — NewReplicaID rejects it because the
+// "{cell}_{name}" application_name uses '_' as its delimiter — so a name
+// carrying one is a violated identity invariant, not a value to sanitize.
+// Erroring here surfaces that bug instead of masking it behind a munged slot
+// name. (It also keeps the transform below collision-free: since '_' cannot
+// reach it, the only rewrite in the injective domain, '-'→'_', can never alias
+// onto a pre-existing '_'.)
+//
+// The transform is collision-free. On the expected input domain — a lower-case
+// [a-z0-9-] name — lower-casing is a no-op and the only rewrite is '-'→'_', so
+// distinct pooler names yield distinct slot names. Characters that are legal in
+// a name but not in a slot name (an upper-case letter that folds to lower case,
+// or a symbol such as '.') make the sanitizing map many-to-one; so does a
+// sanitized name that would exceed the length cap. In those cases a short
+// deterministic hash of the original name is appended (and the body truncated)
+// to keep the mapping collision-free.
+func LogicalSlotName(name string) (string, error) {
+	if strings.Contains(name, "_") {
+		return "", mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
+			"multipooler name %q contains an underscore, which is not a valid ID.Name character", name)
+	}
+
+	lowered := strings.ToLower(name)
+
+	// injective stays true only while every character is in the [a-z0-9-] domain
+	// on which the sanitizing map is one-to-one.
+	injective := name == lowered
+	var b strings.Builder
+	b.Grow(len(lowered))
+	for _, r := range lowered {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+			// A character outside [a-z0-9-] (e.g. '.'); rewriting it to '_' can
+			// alias distinct inputs, so fall back to the hash-disambiguated form
+			// below.
+			if r != '-' {
+				injective = false
+			}
+		}
+	}
+	sanitized := b.String()
+
+	candidate := logicalSlotNamePrefix + sanitized
+	if injective && len(candidate) <= maxReplicationSlotNameLength {
+		return candidate, nil
+	}
+
+	// Non-injective transform or over-length: append a short deterministic hash
+	// of the original name and truncate the sanitized body so the whole name
+	// fits within the length cap.
+	sum := sha256.Sum256([]byte(name))
+	suffix := "_" + hex.EncodeToString(sum[:4]) // '_' + 8 hex chars
+	budget := maxReplicationSlotNameLength - len(logicalSlotNamePrefix) - len(suffix)
+	if len(sanitized) > budget {
+		sanitized = sanitized[:budget]
+	}
+	return logicalSlotNamePrefix + sanitized + suffix, nil
+}
+
+// EnsureLogicalSlot creates the logical replication slot with the given name
+// using the given output plugin, requesting failover-slot behavior when
+// failover is true. It is idempotent: if a slot with that name already exists
+// it returns nil rather than raising duplicate_object.
+//
+// The multipooler is the sole manager of its own slots, so there is no
+// competing writer to race with between the existence check and the create.
+func (pm *MultipoolerManager) EnsureLogicalSlot(ctx context.Context, name, plugin string, failover bool) error {
+	exists, err := pm.LogicalSlotExists(ctx, name)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	execCtx, cancel := context.WithTimeout(ctx, logicalSlotWriteTimeout)
+	defer cancel()
+	// Bind the slot name and plugin as parameters rather than interpolating them
+	// into the statement. temporary=false and twophase=false; failover is
+	// caller-controlled (the PostgreSQL slot-sync flag that lets a standby
+	// maintain a copy of this slot).
+	if err := pm.execArgs(execCtx,
+		"SELECT pg_create_logical_replication_slot($1, $2, false, false, $3)",
+		name, plugin, failover); err != nil {
+		return mterrors.Wrap(err, "failed to create logical replication slot")
+	}
+	return nil
+}
+
+// DropLogicalSlot drops the replication slot named name. pg_drop_replication_slot
+// drops both logical and physical slots, so this also drops physical slots.
+func (pm *MultipoolerManager) DropLogicalSlot(ctx context.Context, name string) error {
+	execCtx, cancel := context.WithTimeout(ctx, logicalSlotWriteTimeout)
+	defer cancel()
+	// Bind the slot name as a parameter rather than interpolating it.
+	if err := pm.execArgs(execCtx, "SELECT pg_drop_replication_slot($1)", name); err != nil {
+		return mterrors.Wrap(err, "failed to drop replication slot")
+	}
+	return nil
+}
+
+// EnsurePhysicalSlot creates the physical replication slot named name. A standby
+// points its primary_slot_name at such a slot so the primary durably retains
+// WAL and the standby's hot_standby_feedback (catalog_xmin) across disconnects —
+// the durable hold the logical-slot failover machinery relies on. Idempotent:
+// returns nil if a slot with that name already exists (LogicalSlotExists is a
+// type-agnostic existence check on pg_replication_slots). Drop via
+// DropLogicalSlot, which drops physical slots too.
+func (pm *MultipoolerManager) EnsurePhysicalSlot(ctx context.Context, name string) error {
+	exists, err := pm.LogicalSlotExists(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		execCtx, cancel := context.WithTimeout(ctx, logicalSlotWriteTimeout)
+		defer cancel()
+		// immediately_reserve=true retains WAL from slot creation (before the standby
+		// attaches); temporary=false so the slot survives reconnects.
+		if err := pm.execArgs(execCtx,
+			"SELECT pg_create_physical_replication_slot($1, true, false)", name); err != nil {
+			return mterrors.Wrap(err, "failed to create physical replication slot")
+		}
+	}
+
+	return nil
+}
+
+// slotBasedReplicationEnabled reports whether the dynamic slot-based physical
+// replication gate is on. It reads the getter live (the backing flag is dynamic
+// and reloadable at runtime), so callers should invoke it at each decision point
+// rather than caching. A nil getter (e.g. tests that don't set it) reads as
+// disabled, preserving the slot-less default.
+func (pm *MultipoolerManager) slotBasedReplicationEnabled() bool {
+	if pm.config == nil || pm.config.SlotBasedReplicationEnabled == nil {
+		return false
+	}
+	return pm.config.SlotBasedReplicationEnabled()
+}
+
+// ensureFollowerPhysicalSlots creates a physical replication slot for each
+// follower in cohort (cohort minus this pooler) so their primary_slot_name
+// resolves and the primary durably retains WAL and catalog_xmin for them. Slot
+// names are derived from each follower's component name via LogicalSlotName. It
+// is a no-op unless slot-based replication is enabled, and idempotent per slot.
+// Intended to run on the node that is (about to be) primary.
+func (pm *MultipoolerManager) ensureFollowerPhysicalSlots(ctx context.Context, cohort []*clustermetadatapb.ID) error {
+	if !pm.slotBasedReplicationEnabled() {
+		return nil
+	}
+	selfName := pm.serviceID.GetName()
+	for _, member := range cohort {
+		if member.GetName() != selfName {
+			if slot, err := LogicalSlotName(member.GetName()); err != nil {
+				return mterrors.Wrapf(err, "compute physical slot name for follower %q", member.GetName())
+			} else if err := pm.EnsurePhysicalSlot(ctx, slot); err != nil {
+				return mterrors.Wrapf(err, "ensure physical slot %q for follower %q", slot, member.GetName())
+			}
+		}
+	}
+	return nil
+}
+
+// dropFollowerPhysicalSlots drops the physical replication slot backing each
+// member in ids (e.g. followers removed from the cohort) so a departed
+// follower's slot stops pinning WAL on the primary. Slot names are derived via
+// LogicalSlotName. Idempotent (skips slots that are not present); no-op unless
+// slot-based replication is enabled; skips this pooler.
+func (pm *MultipoolerManager) dropFollowerPhysicalSlots(ctx context.Context, ids []*clustermetadatapb.ID) error {
+	if !pm.slotBasedReplicationEnabled() {
+		return nil
+	}
+	selfName := pm.serviceID.GetName()
+	for _, member := range ids {
+		if member.GetName() != selfName {
+			if slot, err := LogicalSlotName(member.GetName()); err != nil {
+				return mterrors.Wrapf(err, "compute physical slot name for member %q", member.GetName())
+			} else if exists, err := pm.LogicalSlotExists(ctx, slot); err != nil {
+				return mterrors.Wrapf(err, "check physical slot %q for member %q", slot, member.GetName())
+			} else if exists {
+				if err := pm.DropLogicalSlot(ctx, slot); err != nil {
+					return mterrors.Wrapf(err, "drop physical slot %q for member %q", slot, member.GetName())
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// dropManagedPhysicalSlotsSQL drops every physical replication slot whose name
+// begins with $1 (the multigres slot-name prefix). The slot_type filter keeps
+// it from ever touching logical (failover) slots.
+const dropManagedPhysicalSlotsSQL = `
+SELECT pg_drop_replication_slot(slot_name)
+  FROM pg_replication_slots
+ WHERE slot_type = 'physical'
+   AND starts_with(slot_name, $1)`
+
+// dropManagedPhysicalSlots drops every multigres-managed physical replication
+// slot on this node (physical slots whose name carries the logicalSlotNamePrefix).
+// A node that is (becoming) a standby backs no followers, so any such slot it
+// still holds — as a demoted primary, or a former primary rejoining after a
+// crash — is obsolete and would otherwise pin WAL. It is safe to call once the
+// node's walsenders are gone (e.g. after a restart-as-standby), when the slots
+// are inactive and therefore droppable. No-op unless slot-based replication is
+// enabled; the slot_type filter guarantees logical (failover) slots are never
+// touched.
+func (pm *MultipoolerManager) dropManagedPhysicalSlots(ctx context.Context) error {
+	if !pm.slotBasedReplicationEnabled() {
+		return nil
+	}
+
+	execCtx, cancel := context.WithTimeout(ctx, logicalSlotWriteTimeout)
+	defer cancel()
+	if err := pm.execArgs(execCtx, dropManagedPhysicalSlotsSQL, logicalSlotNamePrefix); err != nil {
+		return mterrors.Wrap(err, "failed to drop managed physical replication slots")
+	}
+
+	return nil
+}
+
+// listManagedPhysicalSlotsSQL lists this node's managed physical replication
+// slots (name + active flag) so a reconcile can drop the ones no longer wanted.
+// Mirrors dropManagedPhysicalSlotsSQL's WHERE clause; the slot_type filter keeps
+// it from ever touching logical (failover) slots.
+const listManagedPhysicalSlotsSQL = `
+SELECT slot_name, active
+  FROM pg_replication_slots
+ WHERE slot_type = 'physical'
+   AND starts_with(slot_name, $1)`
+
+// ReconcileFollowers declaratively reconciles this (primary) node's per-follower
+// physical replication slots to exactly the set of followers in followerIDs: it
+// creates any slot that is missing and drops managed slots for members no longer
+// in the set. It is the level-triggered entry point the orchestrator calls off
+// the consensus path (see the ReconcileFollowers RPC) so a follower's slot exists
+// before its WAL receiver attaches — breaking the bootstrap ordering deadlock
+// where a late-joining standby can never stream (and thus never join the cohort,
+// and thus never get its slot). Idempotent; no-op unless slot-based replication
+// is enabled.
+//
+// It touches ONLY the physical slots. It deliberately does NOT update
+// synchronized_standby_slots: a follower is added there only once it is streaming
+// and caught up (the cohort path), because listing a not-yet-streaming follower
+// would stall logical decoding on the primary.
+func (pm *MultipoolerManager) ReconcileFollowers(ctx context.Context, followerIDs []*clustermetadatapb.ID) error {
+	if !pm.slotBasedReplicationEnabled() {
+		return nil
+	}
+
+	// Create-missing half: reuse the per-follower ensure.
+	if err := pm.ensureFollowerPhysicalSlots(ctx, followerIDs); err != nil {
+		return err
+	}
+
+	// Drop-departed half: any managed physical slot not in the desired set and
+	// not currently active (streaming). The active guard is defensive — a
+	// streaming follower momentarily absent from the set must never have its slot
+	// yanked out from under it; such a slot is left for a later reconcile or the
+	// cohort-remove path.
+	desiredNames, err := pm.followerPhysicalSlotNames(followerIDs)
+	if err != nil {
+		return err
+	}
+	desired := make(map[string]struct{}, len(desiredNames))
+	for _, name := range desiredNames {
+		desired[name] = struct{}{}
+	}
+
+	queryCtx, cancel := context.WithTimeout(ctx, logicalSlotStateTimeout)
+	defer cancel()
+	result, err := pm.queryArgs(queryCtx, listManagedPhysicalSlotsSQL, logicalSlotNamePrefix)
+	if err != nil {
+		return mterrors.Wrap(err, "failed to list managed physical replication slots")
+	}
+	for _, row := range result.Rows {
+		var (
+			name   string
+			active bool
+		)
+		if err := executor.ScanRow(row, &name, &active); err != nil {
+			return mterrors.Wrap(err, "failed to scan managed physical replication slot")
+		}
+		if _, keep := desired[name]; keep || active {
+			continue
+		}
+		if err := pm.DropLogicalSlot(ctx, name); err != nil {
+			return mterrors.Wrapf(err, "drop departed managed physical slot %q", name)
+		}
+		pm.logger.InfoContext(ctx, "dropped departed follower physical slot during reconcile", "slot", name)
+	}
+	return nil
+}
+
+// unreadyFailoverSlotsSQL counts, and names, this node's synced logical failover
+// slots that are NOT yet failover-ready (not synced, temporary, or invalidated).
+const unreadyFailoverSlotsSQL = `
+SELECT count(*), coalesce(string_agg(slot_name, ', '), '')
+  FROM pg_replication_slots
+ WHERE slot_type = 'logical'
+   AND failover
+   AND NOT (synced AND NOT temporary AND invalidation_reason IS NULL)`
+
+// unreadyFailoverSlots returns how many failover slots on this node are not yet
+// failover-ready, plus a comma-separated list of their names for logging.
+func (pm *MultipoolerManager) unreadyFailoverSlots(ctx context.Context) (int, string, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, logicalSlotStateTimeout)
+	defer cancel()
+	result, err := pm.query(queryCtx, unreadyFailoverSlotsSQL)
+	if err != nil {
+		return 0, "", mterrors.Wrap(err, "failed to query failover-slot readiness")
+	}
+	var count int64
+	var names string
+	if err := executor.ScanSingleRow(result, &count, &names); err != nil {
+		return 0, "", mterrors.Wrap(err, "failed to scan failover-slot readiness")
+	}
+	return int(count), names, nil
+}
+
+// logUnreadyFailoverSlots checks, once, whether any synced failover slot on this
+// node is not failover-ready, and logs those that are not. It is advisory and
+// never waits: durable slot creation guarantees a failover slot is synced and
+// persistent on the required standbys before its creation is acknowledged (see
+// docs/ha/decision-log/2026-08-17-failover-slot-readiness-before-promotion.md), so
+// the temporary/catching-up transient a wait would ride out cannot occur at
+// promotion. A slot that is still not ready here is in a terminal state —
+// invalidated, or synced=false because the sync machinery is broken (the
+// unreadyFailoverSlots query tests synced too) — that a wait could not recover.
+// Promotion must never be blocked, so this only logs. No-op unless slot-based
+// replication is enabled.
+func (pm *MultipoolerManager) logUnreadyFailoverSlots(ctx context.Context) {
+	if !pm.slotBasedReplicationEnabled() {
+		return
+	}
+
+	if count, names, err := pm.unreadyFailoverSlots(ctx); err != nil {
+		// Best-effort: a transient read error must not block promotion.
+		pm.logger.WarnContext(ctx, "failover-slot readiness check failed; proceeding with promotion", "error", err)
+		return
+	} else if count > 0 {
+		pm.logger.WarnContext(ctx, "failover slots are not failover-ready at promotion; proceeding anyway",
+			"unready_count", count, "unready_slots", names)
+	}
+}
+
+// failoverSlotReadinessSQL counts this node's logical failover slots: how many
+// are failover-ready, and how many exist in total.
+const failoverSlotReadinessSQL = `
+SELECT
+	count(*) FILTER (WHERE synced AND NOT temporary AND invalidation_reason IS NULL),
+	count(*)
+  FROM pg_replication_slots
+ WHERE slot_type = 'logical'
+   AND failover`
+
+// failoverSlotReadiness returns how many logical failover slots on this node are
+// failover-ready and how many exist in total. It feeds the health snapshot so
+// multiorch can prefer a slot-ready promotion candidate; a node with more
+// failover-ready slots keeps more subscribers resumable across a failover.
+func (pm *MultipoolerManager) failoverSlotReadiness(ctx context.Context) (ready int, total int, err error) {
+	queryCtx, cancel := context.WithTimeout(ctx, logicalSlotStateTimeout)
+	defer cancel()
+	result, err := pm.query(queryCtx, failoverSlotReadinessSQL)
+	if err != nil {
+		return 0, 0, mterrors.Wrap(err, "failed to query failover-slot readiness")
+	}
+	var readyCount, totalCount int64
+	if err := executor.ScanSingleRow(result, &readyCount, &totalCount); err != nil {
+		return 0, 0, mterrors.Wrap(err, "failed to scan failover-slot readiness")
+	}
+	return int(readyCount), int(totalCount), nil
+}
+
+const fetchLogicalSlotStateSQL = `SELECT
+	slot_name,
+	restart_lsn,
+	catalog_xmin,
+	invalidation_reason,
+	(synced AND NOT temporary AND invalidation_reason IS NULL) AS failover_ready
+FROM pg_replication_slots
+WHERE slot_name = $1`
+
+// GetSlotState reads the pg_replication_slots row for the slot named name.
+// It returns ErrLogicalSlotNotFound (wrapped) when no such slot exists.
+func (pm *MultipoolerManager) GetSlotState(ctx context.Context, name string) (*LogicalSlotState, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, logicalSlotStateTimeout)
+	defer cancel()
+	// Bind the slot name as a parameter rather than interpolating it.
+	result, err := pm.queryArgs(queryCtx, fetchLogicalSlotStateSQL, name)
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to read replication slot state")
+	}
+	if result.RowCount() == 0 {
+		return nil, mterrors.Wrapf(ErrLogicalSlotNotFound, "slot %q", name)
+	}
+
+	var (
+		slotName           string
+		restartLSN         *string
+		catalogXmin        *int64
+		invalidationReason *string
+		failoverReady      bool
+	)
+	if err := executor.ScanSingleRow(result, &slotName, &restartLSN, &catalogXmin, &invalidationReason, &failoverReady); err != nil {
+		return nil, mterrors.Wrap(err, "failed to scan replication slot state")
+	}
+
+	slotState := &LogicalSlotState{
+		Name:               slotName,
+		RestartLSN:         restartLSN,
+		CatalogXmin:        catalogXmin,
+		InvalidationReason: invalidationReason,
+		FailoverReady:      failoverReady,
+	}
+	return slotState, nil
+}
+
+// LogicalSlotExists reports whether a replication slot named name is present in
+// pg_replication_slots.
+func (pm *MultipoolerManager) LogicalSlotExists(ctx context.Context, name string) (bool, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, logicalSlotStateTimeout)
+	defer cancel()
+	// Bind the slot name as a parameter rather than interpolating it. SELECT
+	// EXISTS(...) returns exactly one boolean row and lets the planner stop at
+	// the first matching row; it's the existence-check idiom used elsewhere in
+	// this package (see querySchemaExists).
+	result, err := pm.queryArgs(queryCtx, "SELECT EXISTS(SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)", name)
+	if err != nil {
+		return false, mterrors.Wrap(err, "failed to check replication slot existence")
+	}
+	var exists bool
+	if err := executor.ScanSingleRow(result, &exists); err != nil {
+		return false, mterrors.Wrap(err, "failed to scan replication slot existence result")
+	}
+	return exists, nil
+}

--- a/go/services/multipooler/internal/manager/logical_slots_test.go
+++ b/go/services/multipooler/internal/manager/logical_slots_test.go
@@ -1,0 +1,738 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/constants"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/services/multipooler/internal/executor/mock"
+)
+
+// slotNameCharset matches a fully-sanitized multigres slot name: the fixed
+// prefix followed only by PostgreSQL's legal slot-name characters. Derived from
+// logicalSlotNamePrefix so it tracks the prefix rather than hard-coding it.
+var slotNameCharset = regexp.MustCompile(`^` + regexp.QuoteMeta(logicalSlotNamePrefix) + `[a-z0-9_]*$`)
+
+func TestLogicalSlotName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string // exact expected output; only set for the injective (hash-free) cases
+	}{
+		{
+			name:     "simple name",
+			input:    "replica1",
+			expected: logicalSlotNamePrefix + "replica1",
+		},
+		{
+			name:     "hyphens map to underscores",
+			input:    "replica-1",
+			expected: logicalSlotNamePrefix + "replica_1",
+		},
+		{
+			name:     "multiple hyphens",
+			input:    "us-east-1a-pooler",
+			expected: logicalSlotNamePrefix + "us_east_1a_pooler",
+		},
+		{
+			name:     "digits only",
+			input:    "001",
+			expected: logicalSlotNamePrefix + "001",
+		},
+		{
+			name:     "exactly at the length cap stays verbatim",
+			input:    strings.Repeat("a", maxReplicationSlotNameLength-len(logicalSlotNamePrefix)),
+			expected: logicalSlotNamePrefix + strings.Repeat("a", maxReplicationSlotNameLength-len(logicalSlotNamePrefix)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LogicalSlotName(tt.input)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected, got)
+			assert.True(t, strings.HasPrefix(got, logicalSlotNamePrefix), "must carry the multigres slot-name prefix")
+			assert.Regexp(t, slotNameCharset, got, "must be restricted to [a-z0-9_]")
+			assert.LessOrEqual(t, len(got), maxReplicationSlotNameLength, "must respect the length cap")
+		})
+	}
+}
+
+// TestLogicalSlotName_UnderscoreRejected verifies that an underscore in the name
+// — which NewReplicaID already forbids in an ID.Name — is reported as an error
+// rather than silently sanitized into a slot name.
+func TestLogicalSlotName_UnderscoreRejected(t *testing.T) {
+	for _, input := range []string{"a_b", "_leading", "trailing_", "us_east"} {
+		t.Run(input, func(t *testing.T) {
+			_, err := LogicalSlotName(input)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "underscore")
+		})
+	}
+}
+
+// TestLogicalSlotName_Sanitization covers inputs outside the expected
+// [a-z0-9-] domain: they must still produce a legal, capped name, and because
+// the sanitizing map is lossy for them, a disambiguating hash is appended.
+func TestLogicalSlotName_Sanitization(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "uppercase is folded", input: "Replica-1"},
+		{name: "mixed case", input: "PoolerABC"},
+		{name: "dot separator", input: "pooler.zone"},
+		{name: "over length", input: strings.Repeat("x", 80)},
+		{name: "over length with hyphens", input: strings.Repeat("a-", 40)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LogicalSlotName(tt.input)
+			require.NoError(t, err)
+
+			assert.True(t, strings.HasPrefix(got, logicalSlotNamePrefix), "must carry the multigres slot-name prefix")
+			assert.Regexp(t, slotNameCharset, got, "must be restricted to [a-z0-9_]")
+			assert.LessOrEqual(t, len(got), maxReplicationSlotNameLength, "must respect the length cap")
+
+			// The disambiguating suffix is "_" + 8 hex characters.
+			assert.Regexp(t, regexp.MustCompile(`_[0-9a-f]{8}$`), got, "lossy inputs get a hash suffix")
+
+			// Deterministic: same input always yields the same slot name.
+			again, err := LogicalSlotName(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, got, again)
+		})
+	}
+}
+
+// TestLogicalSlotName_CollisionFree checks that distinct pooler names — both
+// within the injective domain and across the lossy boundary — never map to the
+// same slot name.
+func TestLogicalSlotName_CollisionFree(t *testing.T) {
+	// verbatimBodyMax is the longest sanitized body that still fits under the
+	// length cap without a hash. Computed from the prefix so these cases stay
+	// meaningful regardless of its length.
+	verbatimBodyMax := maxReplicationSlotNameLength - len(logicalSlotNamePrefix)
+
+	inputs := []string{
+		// Injective domain.
+		"replica1",
+		"replica-1",
+		"replica2",
+		"us-east-1a",
+		"us-east-1b",
+		strings.Repeat("a", verbatimBodyMax),   // exactly fits verbatim
+		strings.Repeat("a", verbatimBodyMax+1), // one over -> hashed, body truncated
+		strings.Repeat("a", verbatimBodyMax+9), // far over -> hashed, same truncated body, different original
+		// Lossy inputs that share a sanitized body and would collide without the hash.
+		"abc",
+		"aBc",
+		"AbC",
+		"a-b",
+		"pooler.zone",
+		"pooler-zone",
+	}
+
+	seen := make(map[string]string, len(inputs))
+	for _, in := range inputs {
+		got, err := LogicalSlotName(in)
+		require.NoError(t, err)
+		if prev, dup := seen[got]; dup {
+			t.Fatalf("collision: %q and %q both map to %q", prev, in, got)
+		}
+		seen[got] = in
+	}
+}
+
+func TestEnsureLogicalSlot(t *testing.T) {
+	const (
+		slotName = "multigres_replica_1"
+		plugin   = "pgoutput"
+	)
+
+	t.Run("creates slot when absent", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{false}}))
+		m.AddQueryPatternOnce("pg_create_logical_replication_slot",
+			mock.MakeQueryResult([]string{"slot_name", "lsn"}, [][]any{{slotName, "0/1500000"}}))
+
+		require.NoError(t, pm.EnsureLogicalSlot(t.Context(), slotName, plugin, true))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("idempotent when slot already exists", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		// Only the existence check is registered. If EnsureLogicalSlot tried to
+		// create the slot, the mock would return a no-matching-pattern error.
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{true}}))
+
+		require.NoError(t, pm.EnsureLogicalSlot(t.Context(), slotName, plugin, true))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("propagates existence-check error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnceWithError("SELECT EXISTS", errors.New("boom"))
+
+		err := pm.EnsureLogicalSlot(t.Context(), slotName, plugin, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to check replication slot existence")
+	})
+
+	t.Run("propagates create error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{false}}))
+		m.AddQueryPatternOnceWithError("pg_create_logical_replication_slot", errors.New("boom"))
+
+		err := pm.EnsureLogicalSlot(t.Context(), slotName, plugin, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create logical replication slot")
+	})
+}
+
+func TestDropLogicalSlot(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("pg_drop_replication_slot", mock.MakeQueryResult(nil, nil))
+
+		require.NoError(t, pm.DropLogicalSlot(t.Context(), "multigres_replica_1"))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnceWithError("pg_drop_replication_slot", errors.New("boom"))
+
+		err := pm.DropLogicalSlot(t.Context(), "multigres_replica_1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to drop replication slot")
+	})
+}
+
+func TestGetSlotState(t *testing.T) {
+	const slotName = "multigres_replica_1"
+
+	stateColumns := []string{"slot_name", "restart_lsn", "catalog_xmin", "invalidation_reason", "failover_ready"}
+
+	t.Run("failover-ready slot", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("failover_ready",
+			mock.MakeQueryResult(stateColumns, [][]any{{slotName, "0/1518978", "12345", nil, true}}))
+
+		state, err := pm.GetSlotState(t.Context(), slotName)
+		require.NoError(t, err)
+		assert.Equal(t, slotName, state.Name)
+		require.NotNil(t, state.RestartLSN)
+		assert.Equal(t, "0/1518978", *state.RestartLSN)
+		require.NotNil(t, state.CatalogXmin)
+		assert.Equal(t, int64(12345), *state.CatalogXmin)
+		assert.Nil(t, state.InvalidationReason)
+		assert.True(t, state.FailoverReady)
+	})
+
+	t.Run("invalidated slot is not failover-ready", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("failover_ready",
+			mock.MakeQueryResult(stateColumns, [][]any{{slotName, "0/1518978", "12345", "wal_removed", false}}))
+
+		state, err := pm.GetSlotState(t.Context(), slotName)
+		require.NoError(t, err)
+		require.NotNil(t, state.InvalidationReason)
+		assert.Equal(t, "wal_removed", *state.InvalidationReason)
+		assert.False(t, state.FailoverReady)
+	})
+
+	t.Run("null restart_lsn and catalog_xmin", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("failover_ready",
+			mock.MakeQueryResult(stateColumns, [][]any{{slotName, nil, nil, nil, false}}))
+
+		state, err := pm.GetSlotState(t.Context(), slotName)
+		require.NoError(t, err)
+		assert.Nil(t, state.RestartLSN)
+		assert.Nil(t, state.CatalogXmin)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("failover_ready", mock.MakeQueryResult(stateColumns, nil))
+
+		_, err := pm.GetSlotState(t.Context(), slotName)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrLogicalSlotNotFound)
+	})
+
+	t.Run("propagates query error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnceWithError("failover_ready", errors.New("boom"))
+
+		_, err := pm.GetSlotState(t.Context(), slotName)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read replication slot state")
+	})
+}
+
+func TestLogicalSlotExists(t *testing.T) {
+	const slotName = "mg_replica_1"
+
+	t.Run("slot present", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{true}}))
+
+		exists, err := pm.LogicalSlotExists(t.Context(), slotName)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("slot absent", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{false}}))
+
+		exists, err := pm.LogicalSlotExists(t.Context(), slotName)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("propagates query error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnceWithError("SELECT EXISTS", errors.New("boom"))
+
+		_, err := pm.LogicalSlotExists(t.Context(), slotName)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to check replication slot existence")
+	})
+}
+
+// enableSlotBasedReplication flips the dynamic slot-based-replication gate on for
+// a test manager (the production flag is a dynamic viperutil value).
+func enableSlotBasedReplication(pm *MultipoolerManager) {
+	pm.config.SlotBasedReplicationEnabled = func() bool { return true }
+}
+
+// selfCohort is the harness pooler ("test-pooler") plus one follower. Helpers
+// must create/drop the follower's slot and skip self.
+func selfAndFollowerCohort() []*clustermetadatapb.ID {
+	return []*clustermetadatapb.ID{
+		{Cell: "test-cell", Name: "test-pooler"}, // self — must be skipped
+		{Cell: "test-cell", Name: "replica-a"},   // follower — slot mg_replica_a
+	}
+}
+
+func TestEnsurePhysicalSlot(t *testing.T) {
+	const slotName = "mg_replica_a"
+
+	t.Run("creates slot when absent", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{false}}))
+		m.AddQueryPatternOnce("pg_create_physical_replication_slot", mock.MakeQueryResult(nil, nil))
+
+		require.NoError(t, pm.EnsurePhysicalSlot(t.Context(), slotName))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("idempotent when slot already exists", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		// Only the existence check is registered; a create attempt would fail the mock.
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{true}}))
+
+		require.NoError(t, pm.EnsurePhysicalSlot(t.Context(), slotName))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("propagates create error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{false}}))
+		m.AddQueryPatternOnceWithError("pg_create_physical_replication_slot", errors.New("boom"))
+
+		err := pm.EnsurePhysicalSlot(t.Context(), slotName)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create physical replication slot")
+	})
+
+	t.Run("propagates existence-check error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnceWithError("SELECT EXISTS", errors.New("boom"))
+
+		err := pm.EnsurePhysicalSlot(t.Context(), slotName)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to check replication slot existence")
+	})
+}
+
+// TestSlotBasedReplicationEnabled covers the dynamic gate: a nil getter (default
+// test manager) reads as disabled, and the getter is read live.
+func TestSlotBasedReplicationEnabled(t *testing.T) {
+	pm, _ := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+	assert.False(t, pm.slotBasedReplicationEnabled(), "nil getter must read as disabled")
+
+	pm.config.SlotBasedReplicationEnabled = func() bool { return true }
+	assert.True(t, pm.slotBasedReplicationEnabled())
+
+	pm.config.SlotBasedReplicationEnabled = func() bool { return false }
+	assert.False(t, pm.slotBasedReplicationEnabled())
+}
+
+func TestEnsureFollowerPhysicalSlots(t *testing.T) {
+	t.Run("no-op when disabled", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		// Nothing registered: any query would fail the mock, proving no-op.
+		require.NoError(t, pm.ensureFollowerPhysicalSlots(t.Context(), selfAndFollowerCohort()))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("creates a slot per follower, skipping self", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		// Exactly one follower (self is skipped): one existence check + one create.
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{false}}))
+		m.AddQueryPatternOnce("pg_create_physical_replication_slot", mock.MakeQueryResult(nil, nil))
+
+		require.NoError(t, pm.ensureFollowerPhysicalSlots(t.Context(), selfAndFollowerCohort()))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+}
+
+func TestDropFollowerPhysicalSlots(t *testing.T) {
+	t.Run("no-op when disabled", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		require.NoError(t, pm.dropFollowerPhysicalSlots(t.Context(), selfAndFollowerCohort()))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("drops an existing follower slot, skipping self", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{true}}))
+		m.AddQueryPatternOnce("pg_drop_replication_slot", mock.MakeQueryResult(nil, nil))
+
+		require.NoError(t, pm.dropFollowerPhysicalSlots(t.Context(), selfAndFollowerCohort()))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("skips a follower whose slot is absent", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		// Existence check returns false, so no drop is attempted.
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{false}}))
+
+		require.NoError(t, pm.dropFollowerPhysicalSlots(t.Context(), selfAndFollowerCohort()))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("propagates existence-check error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		m.AddQueryPatternOnceWithError("SELECT EXISTS", errors.New("boom"))
+
+		err := pm.dropFollowerPhysicalSlots(t.Context(), selfAndFollowerCohort())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "check physical slot")
+	})
+
+	t.Run("propagates drop error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{true}}))
+		m.AddQueryPatternOnceWithError("pg_drop_replication_slot", errors.New("boom"))
+
+		err := pm.dropFollowerPhysicalSlots(t.Context(), selfAndFollowerCohort())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "drop physical slot")
+	})
+}
+
+func TestDropManagedPhysicalSlots(t *testing.T) {
+	t.Run("no-op when disabled", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		require.NoError(t, pm.dropManagedPhysicalSlots(t.Context()))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("drops managed physical slots when enabled", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		// starts_with is unique to the managed-physical-slot drop query.
+		m.AddQueryPatternOnce("starts_with", mock.MakeQueryResult(nil, nil))
+
+		require.NoError(t, pm.dropManagedPhysicalSlots(t.Context()))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("propagates exec error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		m.AddQueryPatternOnceWithError("starts_with", errors.New("boom"))
+
+		err := pm.dropManagedPhysicalSlots(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to drop managed physical replication slots")
+	})
+}
+
+func TestReconcileFollowers(t *testing.T) {
+	t.Run("no-op when disabled", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		// Nothing registered: any query would fail the mock, proving no-op.
+		require.NoError(t, pm.ReconcileFollowers(t.Context(), selfAndFollowerCohort()))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("creates the missing follower slot and drops only inactive departed managed slots", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		// Create-missing half: one follower (replica-a → mg_replica_a); self skipped.
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{false}}))
+		m.AddQueryPatternOnce("pg_create_physical_replication_slot", mock.MakeQueryResult(nil, nil))
+		// Drop-departed half: list managed physical slots. mg_replica_a is desired
+		// (keep); mg_departed is inactive and not desired (DROP); mg_streaming is
+		// active and not desired (KEEP — never yank an active/streaming slot).
+		m.AddQueryPatternOnce("slot_name, active", mock.MakeQueryResult(
+			[]string{"slot_name", "active"},
+			[][]any{{"mg_replica_a", true}, {"mg_departed", false}, {"mg_streaming", true}}))
+		// Exactly one drop is expected (mg_departed). A second drop would find no
+		// registered pattern and fail the mock, proving mg_streaming is not yanked;
+		// zero drops would leave this Once expectation unmet.
+		m.AddQueryPatternOnce("pg_drop_replication_slot", mock.MakeQueryResult(nil, nil))
+
+		require.NoError(t, pm.ReconcileFollowers(t.Context(), selfAndFollowerCohort()))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("propagates a create-missing error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		m.AddQueryPatternOnceWithError("SELECT EXISTS", errors.New("boom"))
+
+		err := pm.ReconcileFollowers(t.Context(), selfAndFollowerCohort())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ensure physical slot")
+	})
+
+	t.Run("propagates a list error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{false}}))
+		m.AddQueryPatternOnce("pg_create_physical_replication_slot", mock.MakeQueryResult(nil, nil))
+		m.AddQueryPatternOnceWithError("slot_name, active", errors.New("boom"))
+
+		err := pm.ReconcileFollowers(t.Context(), selfAndFollowerCohort())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to list managed physical replication slots")
+	})
+
+	t.Run("propagates a drop-departed error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		m.AddQueryPatternOnce("SELECT EXISTS", mock.MakeQueryResult([]string{"exists"}, [][]any{{false}}))
+		m.AddQueryPatternOnce("pg_create_physical_replication_slot", mock.MakeQueryResult(nil, nil))
+		// One managed slot, inactive and not desired, so a drop is attempted.
+		m.AddQueryPatternOnce("slot_name, active", mock.MakeQueryResult(
+			[]string{"slot_name", "active"}, [][]any{{"mg_departed", false}}))
+		m.AddQueryPatternOnceWithError("pg_drop_replication_slot", errors.New("boom"))
+
+		err := pm.ReconcileFollowers(t.Context(), selfAndFollowerCohort())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "drop departed managed physical slot")
+	})
+}
+
+func TestUnreadyFailoverSlots(t *testing.T) {
+	// string_agg is unique to the failover-readiness query.
+	const readyCols = "string_agg"
+
+	t.Run("all ready", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce(readyCols, mock.MakeQueryResult([]string{"count", "names"}, [][]any{{"0", ""}}))
+
+		count, names, err := pm.unreadyFailoverSlots(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, 0, count)
+		assert.Empty(t, names)
+	})
+
+	t.Run("some unready", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnce(readyCols, mock.MakeQueryResult([]string{"count", "names"}, [][]any{{"2", "mg_a, mg_b"}}))
+
+		count, names, err := pm.unreadyFailoverSlots(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, 2, count)
+		assert.Equal(t, "mg_a, mg_b", names)
+	})
+
+	t.Run("propagates query error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		m.AddQueryPatternOnceWithError(readyCols, errors.New("boom"))
+
+		_, _, err := pm.unreadyFailoverSlots(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to query failover-slot readiness")
+	})
+}
+
+func TestLogUnreadyFailoverSlots(t *testing.T) {
+	const readyCols = "string_agg"
+
+	t.Run("no-op when disabled", func(t *testing.T) {
+		pm, _ := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		// Flag off: returns immediately without querying (no mock expectation set).
+		pm.logUnreadyFailoverSlots(t.Context())
+	})
+
+	t.Run("checks once when all ready", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		m.AddQueryPatternOnce(readyCols, mock.MakeQueryResult([]string{"count", "names"}, [][]any{{"0", ""}}))
+
+		pm.logUnreadyFailoverSlots(t.Context())
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("checks once and proceeds when slots are unready", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		// A single check (no polling loop): one query, then it logs and returns.
+		m.AddQueryPatternOnce(readyCols, mock.MakeQueryResult([]string{"count", "names"}, [][]any{{"2", "mg_a, mg_b"}}))
+
+		pm.logUnreadyFailoverSlots(t.Context())
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("proceeds when the readiness check errors", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		m.AddQueryPatternOnceWithError(readyCols, errors.New("boom"))
+
+		pm.logUnreadyFailoverSlots(t.Context())
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+}
+
+func TestFailoverSlotReadiness(t *testing.T) {
+	pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+	// Two of three failover slots are failover-ready.
+	m.AddQueryPattern("slot_type = 'logical'", mock.MakeQueryResult([]string{"ready", "total"}, [][]any{{int64(2), int64(3)}}))
+
+	ready, total, err := pm.failoverSlotReadiness(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 2, ready)
+	assert.Equal(t, 3, total)
+}
+
+func TestFailoverSlotReadiness_Error(t *testing.T) {
+	pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+	m.AddQueryPatternOnceWithError("slot_type = 'logical'", errors.New("boom"))
+
+	_, _, err := pm.failoverSlotReadiness(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to query failover-slot readiness")
+}
+
+func TestApplyStandbySlotSettings(t *testing.T) {
+	t.Run("no-op when disabled", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		// Nothing registered: any query would fail the mock, proving no-op.
+		require.NoError(t, pm.applyStandbySlotSettings(t.Context()))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("applies the standby GUCs and reloads when enabled", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		m.AddQueryPatternOnce("ALTER SYSTEM SET primary_slot_name", mock.MakeQueryResult(nil, nil))
+		m.AddQueryPatternOnce("ALTER SYSTEM SET hot_standby_feedback", mock.MakeQueryResult(nil, nil))
+		m.AddQueryPatternOnce("ALTER SYSTEM SET sync_replication_slots", mock.MakeQueryResult(nil, nil))
+		expectReloadConfig(m)
+
+		require.NoError(t, pm.applyStandbySlotSettings(t.Context()))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("propagates an ALTER SYSTEM error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		m.AddQueryPatternOnceWithError("ALTER SYSTEM SET primary_slot_name", errors.New("boom"))
+
+		err := pm.applyStandbySlotSettings(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "primary_slot_name")
+	})
+}
+
+func TestSetSynchronizedStandbySlots(t *testing.T) {
+	t.Run("no-op when disabled", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		require.NoError(t, pm.setSynchronizedStandbySlots(t.Context(), selfAndFollowerCohort()))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("points the GUC at the follower slots and reloads", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		m.AddQueryPatternOnce("ALTER SYSTEM SET synchronized_standby_slots", mock.MakeQueryResult(nil, nil))
+		expectReloadConfig(m)
+
+		require.NoError(t, pm.setSynchronizedStandbySlots(t.Context(), selfAndFollowerCohort()))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("propagates an ALTER SYSTEM error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		m.AddQueryPatternOnceWithError("ALTER SYSTEM SET synchronized_standby_slots", errors.New("boom"))
+
+		err := pm.setSynchronizedStandbySlots(t.Context(), selfAndFollowerCohort())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "synchronized_standby_slots")
+	})
+}
+
+func TestResetSynchronizedStandbySlots(t *testing.T) {
+	t.Run("no-op when disabled", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		require.NoError(t, pm.resetSynchronizedStandbySlots(t.Context()))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("clears the GUC and reloads when enabled", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		m.AddQueryPatternOnce("ALTER SYSTEM SET synchronized_standby_slots", mock.MakeQueryResult(nil, nil))
+		expectReloadConfig(m)
+
+		require.NoError(t, pm.resetSynchronizedStandbySlots(t.Context()))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("propagates an ALTER SYSTEM error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		m.AddQueryPatternOnceWithError("ALTER SYSTEM SET synchronized_standby_slots", errors.New("boom"))
+
+		err := pm.resetSynchronizedStandbySlots(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "synchronized_standby_slots")
+	})
+}

--- a/go/services/multipooler/internal/manager/pg_config.go
+++ b/go/services/multipooler/internal/manager/pg_config.go
@@ -137,6 +137,12 @@ func parseSynchronousStandbyNames(value string) (*SyncStandbyConfig, error) {
 func buildPrimaryConnInfo(ci *multipoolermanagerdata.PrimaryConnInfo) string {
 	connInfo := fmt.Sprintf("host=%s port=%d user=%s application_name=%s",
 		ci.GetHost(), ci.GetPort(), ci.GetUser(), ci.GetApplicationName())
+	// dbname is required by the PostgreSQL 17 slot-sync worker, which opens an
+	// ordinary SQL connection to the primary to synchronize failover slots; it is
+	// ignored for physical streaming replication. Omitted when empty, like passfile.
+	if ci.GetDbname() != "" {
+		connInfo += " dbname=" + ci.GetDbname()
+	}
 	if ci.GetPassfile() != "" {
 		connInfo += " passfile=" + ci.GetPassfile()
 	}
@@ -194,6 +200,8 @@ func parseAndRedactPrimaryConnInfo(connInfoStr string) (*multipoolermanagerdata.
 			connInfo.ApplicationName = value
 		case "passfile":
 			connInfo.Passfile = value
+		case "dbname":
+			connInfo.Dbname = value
 		}
 	}
 

--- a/go/services/multipooler/internal/manager/pg_config_test.go
+++ b/go/services/multipooler/internal/manager/pg_config_test.go
@@ -457,6 +457,7 @@ func TestParseAndRedactPrimaryConnInfo(t *testing.T) {
 				Port:            5432,
 				User:            "postgres",
 				ApplicationName: "",
+				Dbname:          "mydb",
 				Raw:             "host=localhost port=5432 dbname=mydb user=postgres",
 			},
 		},
@@ -614,6 +615,7 @@ func TestParseAndRedactPrimaryConnInfo(t *testing.T) {
 				assert.Equal(t, tt.expected.Port, result.Port, "Port should match")
 				assert.Equal(t, tt.expected.User, result.User, "User should match")
 				assert.Equal(t, tt.expected.ApplicationName, result.ApplicationName, "ApplicationName should match")
+				assert.Equal(t, tt.expected.Dbname, result.Dbname, "Dbname should match")
 				assert.Equal(t, tt.expected.Raw, result.Raw, "Raw should match")
 			}
 		})
@@ -621,7 +623,7 @@ func TestParseAndRedactPrimaryConnInfo(t *testing.T) {
 }
 
 // TestBuildPrimaryConnInfo covers the single conninfo-string builder: field
-// rendering and the passfile-omitted-when-empty rule.
+// rendering and the dbname/passfile clauses (each omitted when empty).
 func TestBuildPrimaryConnInfo(t *testing.T) {
 	tests := []struct {
 		name string
@@ -635,9 +637,10 @@ func TestBuildPrimaryConnInfo(t *testing.T) {
 				Port:            5432,
 				User:            "postgres",
 				ApplicationName: "zone1_standby1",
+				Dbname:          "postgres",
 				Passfile:        "/var/lib/pgpass",
 			},
-			want: "host=primary.example.com port=5432 user=postgres application_name=zone1_standby1 passfile=/var/lib/pgpass",
+			want: "host=primary.example.com port=5432 user=postgres application_name=zone1_standby1 dbname=postgres passfile=/var/lib/pgpass",
 		},
 		{
 			name: "PassfileOmittedWhenEmpty",

--- a/go/services/multipooler/internal/manager/pg_replication.go
+++ b/go/services/multipooler/internal/manager/pg_replication.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -492,6 +493,122 @@ func (pm *MultipoolerManager) resetPrimaryConnInfo(ctx context.Context) error {
 	}
 
 	return pm.reloadPostgresConfig(ctx)
+}
+
+type postgresOption struct {
+	name  string
+	value string
+}
+
+// alterSystemSetOptions applies a list of ALTER SYSTEM SET commands. Each
+// option's value is quoted as a string literal, but its name is interpolated
+// verbatim — so name must be a trusted constant (a hardcoded GUC name), never
+// client-derived input.
+func (pm *MultipoolerManager) alterSystemSetOptions(ctx context.Context, options []postgresOption) error {
+	for _, opt := range options {
+		// Explicit cancel (not defer) so timeouts don't accumulate across the loop.
+		execCtx, execCancel := context.WithTimeout(ctx, timeouts.PostgresConfigTimeout)
+		sql := fmt.Sprintf("ALTER SYSTEM SET %s = %s", opt.name, ast.QuoteStringLiteral(opt.value))
+		err := pm.exec(execCtx, sql)
+		execCancel()
+		if err != nil {
+			return mterrors.Wrapf(err, "failed to set option %q", opt.name)
+		}
+	}
+	return nil
+}
+
+// applyStandbySlotSettings configures the standby-side GUCs for slot-based
+// physical replication when the flag is on: primary_slot_name (this node's own
+// deterministic slot, which its primary creates for it), hot_standby_feedback,
+// and sync_replication_slots. Applied via ALTER SYSTEM + reload; idempotent.
+// No-op when the flag is off, so the default stays slot-less streaming.
+func (pm *MultipoolerManager) applyStandbySlotSettings(ctx context.Context) error {
+	if !pm.slotBasedReplicationEnabled() {
+		return nil
+	}
+	slot, err := LogicalSlotName(pm.serviceID.GetName())
+	if err != nil {
+		return mterrors.Wrapf(err, "compute primary_slot_name for %q", pm.serviceID.GetName())
+	}
+
+	execCtx, execCancel := context.WithTimeout(ctx, timeouts.PostgresConfigTimeout)
+	defer execCancel()
+	// LogicalSlotName restricts the slot to [a-z0-9_]; quote it as a string
+	// literal regardless. hot_standby_feedback + sync_replication_slots are the
+	// standby half of native slot sync.
+	if err := pm.alterSystemSetOptions(ctx, []postgresOption{
+		{name: "primary_slot_name", value: slot},
+		{name: "hot_standby_feedback", value: "on"},
+		{name: "sync_replication_slots", value: "on"},
+	}); err != nil {
+		return err
+	}
+	return pm.reloadPostgresConfig(execCtx)
+}
+
+// followerPhysicalSlotNames returns the deterministic physical-slot names for
+// every follower in cohort (cohort minus this pooler), sorted so the derived
+// synchronized_standby_slots value is stable across calls.
+func (pm *MultipoolerManager) followerPhysicalSlotNames(cohort []*clustermetadatapb.ID) ([]string, error) {
+	selfName := pm.serviceID.GetName()
+	slots := make([]string, 0, len(cohort))
+	for _, member := range cohort {
+		if member.GetName() == selfName {
+			continue
+		}
+		slot, err := LogicalSlotName(member.GetName())
+		if err != nil {
+			return nil, mterrors.Wrapf(err, "compute physical slot name for follower %q", member.GetName())
+		}
+		slots = append(slots, slot)
+	}
+	sort.Strings(slots)
+	return slots, nil
+}
+
+// setSynchronizedStandbySlots points synchronized_standby_slots at the cohort's
+// follower physical slots so the primary's failover logical slots hold their
+// restart_lsn and catalog_xmin back to what those standbys have received.
+// Without it a standby's catalog horizon can outrun a freshly-created failover
+// slot, and the standby's slot-sync worker refuses to persist the synced slot
+// ("synchronization could lead to data loss"). An empty cohort clears it to ”
+// so logical decoding is not stalled when no follower slot exists yet. Applied
+// via ALTER SYSTEM + reload; no-op unless slot-based replication is enabled.
+func (pm *MultipoolerManager) setSynchronizedStandbySlots(ctx context.Context, cohort []*clustermetadatapb.ID) error {
+	if !pm.slotBasedReplicationEnabled() {
+		return nil
+	}
+	slots, err := pm.followerPhysicalSlotNames(cohort)
+	if err != nil {
+		return err
+	}
+	if err := pm.alterSystemSetOptions(ctx, []postgresOption{
+		{name: "synchronized_standby_slots", value: strings.Join(slots, ",")},
+	}); err != nil {
+		return err
+	}
+	execCtx, cancel := context.WithTimeout(ctx, timeouts.PostgresConfigTimeout)
+	defer cancel()
+	return pm.reloadPostgresConfig(execCtx)
+}
+
+// resetSynchronizedStandbySlots clears synchronized_standby_slots. A standby has
+// no followers; leaving a stale list would, on a later promotion, make the node
+// wait on physical slots that may no longer exist and stall logical decoding
+// (§2.3). No-op unless slot-based replication is enabled.
+func (pm *MultipoolerManager) resetSynchronizedStandbySlots(ctx context.Context) error {
+	if !pm.slotBasedReplicationEnabled() {
+		return nil
+	}
+	if err := pm.alterSystemSetOptions(ctx, []postgresOption{
+		{name: "synchronized_standby_slots", value: ""},
+	}); err != nil {
+		return err
+	}
+	execCtx, cancel := context.WithTimeout(ctx, timeouts.PostgresConfigTimeout)
+	defer cancel()
+	return pm.reloadPostgresConfig(execCtx)
 }
 
 // readRestoreCommand reads the currently configured restore_command, or ""

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -472,14 +472,19 @@ func (pm *MultipoolerManager) expectedPrimaryConnInfo(target *clustermetadatapb.
 // to follow the primary at (host, port) from the authoritative inputs: the
 // replication user (connPoolMgr.PgUser(), falling back to the default superuser
 // before the pool manager exists), this pooler's application_name
-// (servicePoolerID), and the pgpass path (pgpassFilePath(), the ONLY read of
+// (servicePoolerID), the database (connPoolMgr.PgDatabase(), the default postgres
+// database before the pool manager exists), and the pgpass path (pgpassFilePath(), the ONLY read of
 // pgpassPath). Both the write path (setPrimaryConnInfoLocked) and the drift
 // check assemble their value here, so there is one source of truth for what the
 // conninfo should contain.
 func (pm *MultipoolerManager) expectedPrimaryConnInfoAt(host string, port int32) *multipoolermanagerdatapb.PrimaryConnInfo {
 	user := constants.DefaultPostgresUser
+	dbname := constants.DefaultPostgresDatabase
 	if pm.connPoolMgr != nil {
 		user = pm.connPoolMgr.PgUser()
+		if db := pm.connPoolMgr.PgDatabase(); db != "" {
+			dbname = db
+		}
 	}
 	return &multipoolermanagerdatapb.PrimaryConnInfo{
 		Host:            host,
@@ -487,6 +492,7 @@ func (pm *MultipoolerManager) expectedPrimaryConnInfoAt(host string, port int32)
 		User:            user,
 		ApplicationName: pm.servicePoolerID.AppName(),
 		Passfile:        pm.pgpassFilePath(),
+		Dbname:          dbname,
 	}
 }
 
@@ -500,7 +506,7 @@ func connInfoPointsAt(actual *multipoolermanagerdatapb.PrimaryConnInfo, host str
 
 // connInfoDrifted reports whether the live primary_conninfo (actual) differs
 // from what this pooler should have (expected) in ANY managed field: host, port,
-// user, application_name, and passfile. This is the single comparison site — a
+// user, application_name, passfile, and dbname. This is the single comparison site — a
 // field added to the builder (buildPrimaryConnInfo) and to expectedPrimaryConnInfo
 // must be compared here too or the round-trip test fails.
 //
@@ -528,6 +534,11 @@ func connInfoDrifted(actual, expected *multipoolermanagerdatapb.PrimaryConnInfo)
 		return true
 	}
 	if expected.GetPassfile() != "" && actual.GetPassfile() != expected.GetPassfile() {
+		return true
+	}
+	// dbname uses the same "only flag drift we can fix" guard as passfile: an
+	// empty expected dbname means "nothing to reconcile toward yet".
+	if expected.GetDbname() != "" && actual.GetDbname() != expected.GetDbname() {
 		return true
 	}
 	return false

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -1800,7 +1800,7 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 				Primary:  mkAddress(recordedHost, recordedPort),
 			},
 			expectQuery:   true,
-			mockConnInfo:  "host=primary.example.com port=5432 user=" + expectedUser + " application_name=" + expectedApp,
+			mockConnInfo:  "host=primary.example.com port=5432 user=" + expectedUser + " application_name=" + expectedApp + " dbname=" + constants.DefaultPostgresDatabase,
 			matchPassfile: true,
 			want:          false,
 		},
@@ -1815,7 +1815,7 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 				Primary:  mkAddress(recordedHost, recordedPort),
 			},
 			expectQuery:  true,
-			mockConnInfo: "host=primary.example.com port=5432 user=" + expectedUser + " application_name=" + expectedApp,
+			mockConnInfo: "host=primary.example.com port=5432 user=" + expectedUser + " application_name=" + expectedApp + " dbname=" + constants.DefaultPostgresDatabase,
 			want:         true,
 		},
 		{
@@ -1827,7 +1827,7 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 				Primary:  mkAddress(recordedHost, recordedPort),
 			},
 			expectQuery:  true,
-			mockConnInfo: "host=primary.example.com port=5432 user=" + expectedUser + " application_name=" + expectedApp + " passfile=/stale/path/pgpass",
+			mockConnInfo: "host=primary.example.com port=5432 user=" + expectedUser + " application_name=" + expectedApp + " dbname=" + constants.DefaultPostgresDatabase + " passfile=/stale/path/pgpass",
 			want:         true,
 		},
 		{
@@ -1944,7 +1944,7 @@ func TestPrimaryConnInfoDiffersFromRecorded(t *testing.T) {
 
 // TestConnInfoDrifted is the single-comparison-site guard: it asserts drift is
 // detected for a mismatch in EVERY field the builder emits (host, port, user,
-// application_name, passfile) and NOT detected when every field matches. If a
+// application_name, passfile, dbname) and NOT detected when every field matches. If a
 // future field is added to buildPrimaryConnInfo / expectedPrimaryConnInfo but
 // not to connInfoDrifted, the "all match" round-trip stays green while the new
 // per-field case must be added here — forcing the field through the comparison.
@@ -1958,6 +1958,7 @@ func TestConnInfoDrifted(t *testing.T) {
 		User:            "postgres",
 		ApplicationName: "zone1_test-pooler",
 		Passfile:        "/var/lib/pgpass",
+		Dbname:          "postgres",
 	}
 
 	// clone returns a fresh copy of expected so each mutator starts from a
@@ -1969,6 +1970,7 @@ func TestConnInfoDrifted(t *testing.T) {
 			User:            expected.User,
 			ApplicationName: expected.ApplicationName,
 			Passfile:        expected.Passfile,
+			Dbname:          expected.Dbname,
 		}
 	}
 
@@ -2032,6 +2034,15 @@ func TestConnInfoDrifted(t *testing.T) {
 			}(),
 			want: true,
 		},
+		{
+			name: "DbnameDiffers",
+			actual: func() *multipoolermanagerdatapb.PrimaryConnInfo {
+				a := clone()
+				a.Dbname = "otherdb"
+				return a
+			}(),
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2044,7 +2055,7 @@ func TestConnInfoDrifted(t *testing.T) {
 	// per-field mismatch case above. This is a soft tripwire — if a new field is
 	// added to PrimaryConnInfo and the builder starts emitting it, add a case.
 	// (Raw is not builder-emitted; it is the parser's redacted round-trip copy.)
-	const managedFieldCases = 5 // host, port, user, application_name, passfile
+	const managedFieldCases = 6 // host, port, user, application_name, passfile, dbname
 	mismatchCases := 0
 	for _, tt := range tests {
 		if tt.want && tt.actual != nil {
@@ -2067,6 +2078,20 @@ func TestConnInfoDrifted(t *testing.T) {
 		noPassfile := clone()
 		noPassfile.Passfile = ""
 		assert.False(t, connInfoDrifted(noPassfile, exp))
+	})
+
+	// The dbname comparison is asymmetric for the same reason: an empty expected
+	// dbname means "nothing to reconcile toward yet", so any actual dbname is
+	// tolerated.
+	t.Run("UnknownExpectedDbnameToleratesAny", func(t *testing.T) {
+		exp := clone()
+		exp.Dbname = ""
+		withDbname := clone()
+		withDbname.Dbname = "whatever"
+		assert.False(t, connInfoDrifted(withDbname, exp))
+		noDbname := clone()
+		noDbname.Dbname = ""
+		assert.False(t, connInfoDrifted(noDbname, exp))
 	})
 }
 

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -564,27 +564,52 @@ func (pm *MultipoolerManager) promoteLocked(ctx context.Context, req *consensusd
 	if reason == "" {
 		reason = "promote"
 	}
+
+	promotionHook := func(hookCtx context.Context) error {
+		if err := pm.consensusMgr.ClearResignedLeaderAtTerm(ctx); err != nil {
+			return mterrors.Wrap(err, "failed to clear resigned primary term")
+		}
+		// Slot-based replication (flag-gated): create a physical replication
+		// slot for each follower BEFORE pg_promote, while this node is still a
+		// standby, so a slot failure fails the promotion cleanly rather than
+		// leaving a promoted-but-unrecorded node. No-op when the flag is off.
+		cohortMembers := proposedRule.GetCohortMembers()
+		if err := pm.ensureFollowerPhysicalSlots(hookCtx, cohortMembers); err != nil {
+			return err
+		}
+		// Hold the failover logical slots back to the followers' physical slots so
+		// a standby cannot outrun a slot's catalog_xmin and block slot-sync. Set
+		// before pg_promote so it is in effect the moment this node is primary.
+		if err := pm.setSynchronizedStandbySlots(hookCtx, cohortMembers); err != nil {
+			return err
+		}
+		// Log any synced failover slots that are not failover-ready before
+		// pg_promote. Durable slot creation guarantees a failover slot is synced and
+		// persistent on the required standbys before its creation is acknowledged, so
+		// a slot that is not ready here is in a terminal state a wait could not fix.
+		// Advisory only — never blocks failover.
+		pm.logUnreadyFailoverSlots(hookCtx)
+		return pm.promoteStandbyToPrimary(hookCtx, state, proposal.GetProposedTransition())
+	}
+
 	ruleUpdate := consensus.NewRuleUpdate(
 		revokedBelowTerm,
 		proposedRule.GetCoordinatorId(),
 		"promotion",
 		reason,
-		proposedRule.GetCreationTime().AsTime()).
+		proposedRule.GetCreationTime().AsTime(),
+	).
 		WithLeader(pm.serviceID).
 		WithCohort(proposedRule.GetCohortMembers()).
 		WithDurabilityPolicy(proposedRule.GetDurabilityPolicy()).
 		WithAcceptedMembers(req.GetAcceptedNodeIds()).
 		WithWALPosition(beforeStatus.GetCurrentPosition().GetLsn()).
-		WithPromotionHook(func(hookCtx context.Context) error {
-			if err := pm.consensusMgr.ClearResignedLeaderAtTerm(ctx); err != nil {
-				return mterrors.Wrap(err, "failed to clear resigned primary term")
-			}
-			return pm.promoteStandbyToPrimary(hookCtx, state, proposal.GetProposedTransition())
-		}).
+		WithPromotionHook(promotionHook).
 		// CAS catches drift across the whole Recruit-to-Promote window.
 		WithPreviousRule(
 			revocation.GetOutgoingRule().GetCoordinatorTerm(),
-			revocation.GetOutgoingRule().GetLeaderSubterm())
+			revocation.GetOutgoingRule().GetLeaderSubterm(),
+		)
 	if req.GetProposal().GetSkipOutgoingQuorum() {
 		ruleUpdate.WithSkipOutgoingQuorum()
 	}
@@ -599,7 +624,8 @@ func (pm *MultipoolerManager) promoteLocked(ctx context.Context, req *consensusd
 	// monitor can resign (if postgres never left recovery) or reconcile
 	// serving state (if it did) — either way, orch's next recovery cycle can
 	// finish or supersede this term instead of it going undetected.
-	if err := pm.consensusMgr.RecordTermPrimary(ctx,
+	if err := pm.consensusMgr.RecordTermPrimary(
+		ctx,
 		commonconsensus.ReplicationPrimaryFromProposal(proposal, false),
 	); err != nil {
 		pm.logger.ErrorContext(ctx, "failed to record replication primary before promote", "error", err)
@@ -899,6 +925,22 @@ func (pm *MultipoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 			true /* stopReplicationBefore */, true /* startReplicationAfter */); err != nil {
 			return nil, err
 		}
+	}
+
+	// Slot-based replication (flag-gated): this node is now a standby of the
+	// leader. Drop any physical slots it still holds as a former primary (covers a
+	// stale-primary rejoin), then point primary_slot_name at its own deterministic
+	// slot (created on the primary during promotion / cohort-add) and enable the
+	// standby-side feedback and slot-sync GUCs. Best-effort — on failure the
+	// standby simply streams slot-less, as it does today.
+	if err := pm.dropManagedPhysicalSlots(ctx); err != nil {
+		pm.logger.WarnContext(ctx, "failed to drop stale managed physical slots (non-fatal)", "error", err)
+	}
+	if err := pm.resetSynchronizedStandbySlots(ctx); err != nil {
+		pm.logger.WarnContext(ctx, "failed to clear synchronized_standby_slots (non-fatal)", "error", err)
+	}
+	if err := pm.applyStandbySlotSettings(ctx); err != nil {
+		pm.logger.WarnContext(ctx, "failed to apply standby slot settings (non-fatal)", "error", err)
 	}
 
 	// Ensure topology reflects REPLICA. This matters when postgres has

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -337,6 +337,19 @@ func (pm *MultipoolerManager) Status(ctx context.Context) (*multipoolermanagerda
 	walPosition, _ := pm.getWALPosition(ctx)
 	poolerStatus.WalPosition = walPosition
 
+	// Failover-slot readiness feeds multiorch's slot-aware leader appointment.
+	// Only meaningful with slot-based replication on; best-effort — a read
+	// failure (e.g. postgres unreachable) leaves the counts zero, which safely
+	// deprioritizes this node as a promotion target rather than failing Status.
+	if pm.slotBasedReplicationEnabled() {
+		if ready, total, err := pm.failoverSlotReadiness(ctx); err != nil {
+			pm.logger.WarnContext(ctx, "failed to read failover-slot readiness for status", "error", err)
+		} else {
+			poolerStatus.FailoverSlotsReady = int32(ready)
+			poolerStatus.FailoverSlotsTotal = int32(total)
+		}
+	}
+
 	resp := &multipoolermanagerdatapb.StatusResponse{
 		Status: poolerStatus,
 	}
@@ -540,6 +553,31 @@ func (pm *MultipoolerManager) UpdateConsensusRule(ctx context.Context, operation
 	newPos, err := pm.DoUpdateRule(ctx, standbyUpdate)
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to record replication config history")
+	}
+
+	// Slot-based replication (flag-gated): keep the per-follower physical slots in
+	// step with the committed cohort change. Best-effort — the rule is already
+	// committed, so a slot hiccup must not fail the cohort update; a later
+	// lifecycle event reconciles. ADD creates the new follower's slot so its
+	// primary_slot_name resolves once multiorch re-issues SetPrimary; REMOVE drops
+	// the departed follower's slot so it stops pinning WAL.
+	switch operation {
+	case multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_ADD:
+		if err := pm.ensureFollowerPhysicalSlots(ctx, standbyIDs); err != nil {
+			pm.logger.WarnContext(ctx, "failed to create physical slots for added cohort members (non-fatal)", "error", err)
+		}
+	case multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_REMOVE:
+		if err := pm.dropFollowerPhysicalSlots(ctx, standbyIDs); err != nil {
+			pm.logger.WarnContext(ctx, "failed to drop physical slots for removed cohort members (non-fatal)", "error", err)
+		}
+	}
+	// Recompute synchronized_standby_slots from the full committed cohort so the
+	// hold tracks the current follower set after an add or remove.
+	if operation == multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_ADD ||
+		operation == multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_REMOVE {
+		if err := pm.setSynchronizedStandbySlots(ctx, updatedStandbyIDs); err != nil {
+			pm.logger.WarnContext(ctx, "failed to update synchronized_standby_slots after cohort change (non-fatal)", "error", err)
+		}
 	}
 
 	pm.logger.InfoContext(ctx, "UpdateConsensusRule completed successfully", //nolint:sloglint // message intentionally starts with an operation name or proper noun
@@ -783,6 +821,14 @@ func (pm *MultipoolerManager) demoteToStandbyLocked(ctx context.Context, consens
 	// in most cases. The coordinator still uses pg_rewind for nodes that diverged.
 	if err := pm.restartPostgresAsStandby(ctx, state); err != nil {
 		return err
+	}
+
+	// Slot-based replication (flag-gated): the restart terminated this node's
+	// walsenders, so its former follower physical slots are now inactive and
+	// obsolete. Drop them so they don't pin WAL on a node that no longer backs
+	// any followers. Best-effort — a later demote / the monitor can retry.
+	if err := pm.dropManagedPhysicalSlots(ctx); err != nil {
+		pm.logger.WarnContext(ctx, "failed to drop managed physical slots after demote (non-fatal)", "error", err)
 	}
 
 	// Mark the WAL as rewind-suspect: this node was just demoted, so the next

--- a/go/test/endtoend/multiorch/slot_late_join_test.go
+++ b/go/test/endtoend/multiorch/slot_late_join_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiorch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestSlotBasedReplicationLateStandbyJoins is the regression test for the
+// bootstrap slot-creation deadlock (§2.6). It reproduces the exact case the
+// deadlock hits — a standby that joins AFTER the primary was promoted — with
+// slot-based replication enabled, and asserts the late standby still joins the
+// cohort.
+//
+// With the flag on, a standby sets primary_slot_name = mg_<self> and its WAL
+// receiver cannot stream until that physical slot exists on the primary. Before
+// the fix, the primary only created a follower's slot at the promotion hook (for
+// the committed cohort) or COHORT_ADD (which itself requires the standby to
+// already be streaming). A late-joining standby therefore deadlocked: it could
+// not stream, so it was never admitted to the cohort, so its slot was never
+// created. The discovery-driven ReconcileFollowers reconcile creates the slot as
+// soon as multiorch discovers the standby — ahead of streaming — so it can
+// stream and be admitted. Without the fix, the final waitForCohortMembership
+// times out.
+func TestSlotBasedReplicationLateStandbyJoins(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end late-standby-join test (short mode)")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("Skipping end-to-end late-standby-join test (no postgres binaries)")
+	}
+
+	// Start with one primary + one standby, slot-based replication on.
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2),
+		shardsetup.WithMultiorchCount(1),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+		shardsetup.WithDurabilityPolicy("AT_LEAST_2"),
+		shardsetup.WithMultipoolerExtraArgs("--enable-slot-based-replication=true"),
+	)
+	defer cleanup()
+
+	setup.StartMultiorchs(t.Context(), t)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioInitialSettle)
+	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
+	require.NotEmpty(t, setup.PrimaryName, "initial primary must be elected")
+
+	initial := make([]string, 0, 2)
+	for name := range setup.Multipoolers {
+		initial = append(initial, name)
+	}
+	require.Len(t, initial, 2, "expected one primary + one standby to start")
+	waitForCohortMembership(t, setup, initial, 60*time.Second)
+	t.Logf("Initial cohort established: primary=%s, members=%v", setup.PrimaryName, initial)
+
+	// Add a standby AFTER the primary is established (the deadlock case). Late
+	// poolers created via CreateMultipoolerInstance do not inherit the setup-wide
+	// extra args, so set the flag explicitly.
+	const lateName = "late-standby"
+	inst := setup.CreateMultipoolerInstance(t, lateName, utils.GetFreePort(t), utils.GetFreePort(t), utils.GetFreePort(t))
+	inst.Multipooler.ExtraArgs = append(inst.Multipooler.ExtraArgs, "--enable-slot-based-replication=true")
+
+	ctx := t.Context()
+	require.NoError(t, inst.Pgctld.Start(ctx, t), "failed to start pgctld for %s", lateName)
+	require.NoError(t, inst.Multipooler.Start(ctx, t), "failed to start multipooler for %s", lateName)
+	shardsetup.WaitForManagerReady(t, inst.Multipooler)
+	t.Logf("Late standby %s started after promotion; awaiting cohort admission", lateName)
+
+	// The regression assertion: the late standby must join the cohort. Before the
+	// §2.6 fix this deadlocks and the wait times out.
+	expected := append(append([]string{}, initial...), lateName)
+	waitForCohortMembership(t, setup, expected, 90*time.Second)
+	t.Logf("Late standby joined the cohort without a manual slot workaround: %v", expected)
+}

--- a/go/test/endtoend/multiorch/slot_sync_test.go
+++ b/go/test/endtoend/multiorch/slot_sync_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiorch
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestSlotSyncPropagatesFailoverSlot verifies the slot-based physical-replication
+// machinery end to end against real PostgreSQL: with
+// --enable-slot-based-replication on, a failover logical slot created on the
+// primary is copied to the standby by PostgreSQL's native slot-sync worker and
+// becomes failover-ready there (synced, not temporary, not invalidated).
+//
+// This is the foundation the durable slot-creation barrier (multipooler) and
+// slot-aware leader appointment (multiorch) build on: both assume that with the
+// flag on, a failover slot actually propagates and persists on standbys. It
+// exercises the full flag-gated path — the primary's per-follower physical slot,
+// the standby's primary_slot_name + hot_standby_feedback + sync_replication_slots
+// — without the gateway or the barrier in the way, so a failure here localizes to
+// the machinery rather than the barrier logic layered on top.
+func TestSlotSyncPropagatesFailoverSlot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end slot-sync test (short mode)")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("Skipping end-to-end slot-sync test (no postgres binaries)")
+	}
+
+	// Primary + one standby, synchronous durability, slot-based replication on so
+	// the primary creates the follower's physical slot and the standby enables
+	// primary_slot_name + hot_standby_feedback + sync_replication_slots.
+	setup, cleanup := shardsetup.NewIsolated(
+		t,
+		shardsetup.WithMultipoolerCount(2),
+		shardsetup.WithoutInitialization(),
+		shardsetup.WithDurabilityPolicy("AT_LEAST_2"),
+		shardsetup.WithMultipoolerExtraArgs("--enable-slot-based-replication=true"),
+	)
+	defer cleanup()
+
+	// Start multiorch to bootstrap: elect a primary, recruit the standby, and
+	// configure sync replication and (with the flag on) the slot machinery.
+	watchTargets := []string{"postgres/default/0-inf"}
+	config := &shardsetup.SetupConfig{CellName: setup.CellName}
+	mo, moCleanup := setup.CreateMultiorchInstance(t, "test-multiorch", watchTargets, config)
+	require.NoError(t, mo.Start(t.Context(), t), "should start multiorch")
+	t.Cleanup(moCleanup)
+
+	primaryName := waitForShardReady(t, setup, 1, 60*time.Second)
+	require.NotEmpty(t, primaryName, "multiorch should bootstrap the shard")
+
+	primary := setup.Multipoolers[primaryName]
+	var standby *shardsetup.MultipoolerInstance
+	var standbyName string
+	for name, inst := range setup.Multipoolers {
+		if name != primaryName {
+			standby, standbyName = inst, name
+			break
+		}
+	}
+	require.NotNil(t, standby, "expected a standby distinct from the primary")
+
+	// Create a failover logical slot on the primary. A failover subscription uses
+	// pgoutput; here we use test_decoding so the test can act as a self-contained
+	// consumer via pg_logical_slot_get_changes. Slot-sync is plugin-agnostic, so
+	// this exercises the same machinery a pgoutput subscription relies on. A small
+	// table gives the consumer real changes to decode.
+	primaryDB := connectToPostgres(t, filepath.Join(primary.Pgctld.PoolerDir, "pg_sockets"), primary.Pgctld.PgPort)
+	defer primaryDB.Close()
+
+	const slot = "mg_e2e_failover"
+	execCtx := utils.WithTimeout(t, 10*time.Second)
+	_, err := primaryDB.ExecContext(execCtx,
+		"SELECT pg_create_logical_replication_slot($1, 'test_decoding', false, false, true)", slot)
+	require.NoError(t, err, "create failover logical slot on primary %s", primaryName)
+	_, err = primaryDB.ExecContext(execCtx, "CREATE TABLE IF NOT EXISTS mg_e2e_probe (id bigint)")
+	require.NoError(t, err, "create probe table on primary %s", primaryName)
+
+	// The native slot-sync worker on the standby copies the slot and, once the
+	// standby has caught up, persists it — at which point it is failover-ready.
+	//
+	// A never-consumed slot keeps its catalog_xmin frozen at creation while the
+	// standby's catalog horizon creeps forward, and slot-sync refuses to persist a
+	// slot whose catalog_xmin is behind the standby. So the test behaves like a
+	// normal consumer: each iteration it writes a row and drains the slot with
+	// pg_logical_slot_get_changes, which advances the slot's catalog_xmin over the
+	// changes it actually received — the way a real subscriber does, and unlike
+	// pg_replication_slot_advance, which would skip past undelivered changes. That
+	// naturally overtakes the standby's horizon, and slot-sync then persists the
+	// slot. Once synced, the standby's own slot holds catalog_xmin and it stays
+	// failover-ready.
+	standbyDB := connectToPostgres(t, filepath.Join(standby.Pgctld.PoolerDir, "pg_sockets"), standby.Pgctld.PgPort)
+	defer standbyDB.Close()
+
+	require.Eventually(t, func() bool {
+		pctx := utils.WithTimeout(t, 5*time.Second)
+		if _, err := primaryDB.ExecContext(pctx, "INSERT INTO mg_e2e_probe VALUES (1)"); err != nil {
+			return false
+		}
+		if _, err := primaryDB.ExecContext(pctx,
+			"SELECT count(*) FROM pg_logical_slot_get_changes($1, NULL, NULL)", slot); err != nil {
+			return false
+		}
+
+		var ready bool
+		qctx := utils.WithTimeout(t, 5*time.Second)
+		if err := standbyDB.QueryRowContext(qctx,
+			`SELECT synced AND NOT temporary AND invalidation_reason IS NULL
+			   FROM pg_replication_slots WHERE slot_name = $1`, slot).Scan(&ready); err != nil {
+			// sql.ErrNoRows until the slot has synced across; keep polling.
+			return false
+		}
+		return ready
+	}, 30*time.Second, 1*time.Second,
+		"failover slot %q should become failover-ready on standby %s via native slot-sync", slot, standbyName)
+}

--- a/go/test/endtoend/subscriptionwire/subscription_wire_test.go
+++ b/go/test/endtoend/subscriptionwire/subscription_wire_test.go
@@ -1,0 +1,322 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package subscriptionwire verifies, against real PostgreSQL, exactly how a
+// logical-replication subscriber puts `failover = true` on the wire when it
+// creates its slot. The multigateway's replication preamble guard (which admits
+// a persistent slot only when it is registered for failover) depends on this:
+// if the subscriber carries FAILOVER inside the CREATE_REPLICATION_SLOT command
+// then the command-form guard can admit it at creation time; if instead the
+// subscriber creates a plain slot and enables failover afterward via
+// ALTER_REPLICATION_SLOT, the guard would reject the CREATE and needs to
+// understand the create+alter pair. This test settles that empirically rather
+// than by assumption, and fails loudly if a future PostgreSQL changes it.
+package subscriptionwire
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/utils"
+	"github.com/multigres/multigres/go/tools/executil"
+)
+
+const (
+	// subscriptionName is also the default slot name PostgreSQL uses for the
+	// subscription's main (non-temporary) slot.
+	subscriptionName = "sub_orders"
+	publicationName  = "orders_pub"
+	pgSuperuser      = "postgres"
+)
+
+// TestCreateSubscriptionFailoverWireBehavior stands up a real publisher and
+// subscriber, runs CREATE SUBSCRIPTION ... WITH (failover = true), and inspects
+// the publisher's logged replication commands to confirm the subscriber sends
+// FAILOVER inside CREATE_REPLICATION_SLOT (not via a later ALTER_REPLICATION_SLOT).
+func TestCreateSubscriptionFailoverWireBehavior(t *testing.T) {
+	skipUnlessPostgres17(t)
+
+	ctx := utils.WithTimeout(t, 90*time.Second)
+
+	// Publisher: wal_level=logical for logical decoding, and
+	// log_replication_commands=on so every replication-protocol command it
+	// receives is written verbatim to the server log — our observation point.
+	publisher := startPostgres(t, ctx, "publisher",
+		"wal_level = logical",
+		"log_replication_commands = on",
+		"max_wal_senders = 10",
+		"max_replication_slots = 10",
+	)
+	// Subscriber is an ordinary primary; wal_level=logical is harmless and keeps
+	// the two configs uniform.
+	subscriber := startPostgres(t, ctx, "subscriber",
+		"wal_level = logical",
+	)
+
+	// Matching table on both sides; publication on the publisher.
+	pubConn := connect(t, ctx, publisher.port)
+	defer pubConn.Close(ctx)
+	mustExec(t, ctx, pubConn, `CREATE TABLE orders (id int PRIMARY KEY, note text)`)
+	mustExec(t, ctx, pubConn, `CREATE PUBLICATION `+publicationName+` FOR TABLE orders`)
+
+	subConn := connect(t, ctx, subscriber.port)
+	defer subConn.Close(ctx)
+	mustExec(t, ctx, subConn, `CREATE TABLE orders (id int PRIMARY KEY, note text)`)
+
+	// The subject under test. create_slot defaults to true, so this command
+	// itself connects to the publisher and creates the subscription's main slot
+	// before returning — the CREATE_REPLICATION_SLOT we want to observe.
+	conninfo := fmt.Sprintf("host=localhost port=%d user=%s dbname=postgres", publisher.port, pgSuperuser)
+	mustExec(t, ctx, subConn, fmt.Sprintf(
+		`CREATE SUBSCRIPTION %s CONNECTION '%s' PUBLICATION %s WITH (failover = true, copy_data = true)`,
+		subscriptionName, conninfo, publicationName))
+
+	// The main slot exists on the publisher once CREATE SUBSCRIPTION returns;
+	// poll to be robust against any lag, then read its recorded state.
+	temporary, failover := waitForSlot(t, ctx, pubConn, subscriptionName)
+	assert.False(t, temporary, "the subscription's main slot must be persistent (non-temporary)")
+	assert.True(t, failover, "WITH (failover = true) must produce a failover slot on the publisher")
+
+	// Read the publisher's log and extract the replication commands it received.
+	cmds := receivedReplicationCommands(t, publisher.logPath)
+	require.NotEmpty(t, cmds, "publisher should have logged replication commands (is log_replication_commands on?)")
+	t.Logf("publisher received %d replication command(s):", len(cmds))
+	for i, c := range cmds {
+		t.Logf("  [%d] %s", i, c)
+	}
+
+	// Find the CREATE_REPLICATION_SLOT for the subscription's main slot (the
+	// non-temporary one; tablesync workers create separate TEMPORARY slots).
+	var mainCreate string
+	for _, c := range cmds {
+		u := strings.ToUpper(c)
+		if strings.Contains(u, "CREATE_REPLICATION_SLOT") &&
+			strings.Contains(c, subscriptionName) &&
+			!strings.Contains(u, "TEMPORARY") {
+			mainCreate = c
+			break
+		}
+	}
+	require.NotEmpty(t, mainCreate,
+		"expected a non-temporary CREATE_REPLICATION_SLOT for %q among the received commands", subscriptionName)
+
+	// The claim the gateway guard relies on: FAILOVER rides inside the
+	// CREATE_REPLICATION_SLOT command, so it can be admitted at creation time.
+	assert.Contains(t, strings.ToUpper(mainCreate), "FAILOVER",
+		"CREATE_REPLICATION_SLOT for the failover subscription must carry FAILOVER; "+
+			"if this fails, the subscriber sets failover some other way (e.g. ALTER_REPLICATION_SLOT) "+
+			"and the preamble guard must account for that")
+
+	// Informational: report whether an ALTER_REPLICATION_SLOT also appeared, so
+	// a change in mechanism is visible in the test output even when the assert
+	// above still holds.
+	for _, c := range cmds {
+		if strings.Contains(strings.ToUpper(c), "ALTER_REPLICATION_SLOT") {
+			t.Logf("note: publisher also received an ALTER_REPLICATION_SLOT: %s", c)
+		}
+	}
+}
+
+// TestTemporaryFailoverSlotRejected pins PostgreSQL's own rejection of the
+// contradictory temporary + failover combination: a temporary slot is dropped
+// when its session ends, so it can never be a failover target. The multigateway
+// preamble deliberately does not special-case this — it admits any TEMPORARY
+// slot and lets PostgreSQL enforce the contradiction — so this guards the
+// assumption that PostgreSQL still rejects it, asserting the exact error message
+// PostgreSQL returns.
+func TestTemporaryFailoverSlotRejected(t *testing.T) {
+	skipUnlessPostgres17(t)
+
+	ctx := utils.WithTimeout(t, 60*time.Second)
+
+	pg := startPostgres(t, ctx, "pg", "wal_level = logical")
+	conn := connect(t, ctx, pg.port)
+	defer conn.Close(ctx)
+
+	// temporary => true together with failover => true.
+	_, err := conn.Exec(ctx,
+		`SELECT pg_create_logical_replication_slot('t_tempfail', 'pgoutput', true, false, true)`)
+	require.Error(t, err)
+
+	var pgErr *pgconn.PgError
+	require.ErrorAs(t, err, &pgErr)
+	assert.Equal(t, "cannot enable failover for a temporary replication slot", pgErr.Message)
+}
+
+// skipUnlessPostgres17 skips the test unless PostgreSQL 17+ binaries are on PATH.
+func skipUnlessPostgres17(t *testing.T) {
+	t.Helper()
+	if !utils.HasPostgreSQLBinaries() {
+		t.Skip("PostgreSQL binaries (initdb/postgres/pg_ctl/pg_isready) not on PATH")
+	}
+	if major := postgresMajorVersion(t); major < 17 {
+		t.Skipf("logical-slot failover needs PostgreSQL 17+, found major version %d", major)
+	}
+}
+
+// pgInstance is a running standalone PostgreSQL instance under a temp datadir.
+type pgInstance struct {
+	dir     string
+	port    int
+	logPath string
+}
+
+// startPostgres initdb's a fresh cluster, applies extraConf, starts it with
+// pg_ctl (server log redirected to a file), and registers cleanup that stops it.
+func startPostgres(t *testing.T, ctx context.Context, name string, extraConf ...string) *pgInstance {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	dataDir := filepath.Join(dir, "data")
+	logPath := filepath.Join(dir, "postgres.log")
+	port := utils.GetFreePort(t)
+
+	// Pin the locale/encoding so initdb does not depend on the caller's LANG /
+	// LC_* environment (unset in some test/CI shells, which makes initdb fail
+	// with "invalid locale settings").
+	run(t, ctx, "initdb", "-D", dataDir, "-U", pgSuperuser, "-A", "trust",
+		"--no-instructions", "--locale=C", "--encoding=UTF8")
+
+	conf := append([]string{
+		fmt.Sprintf("port = %d", port),
+		"listen_addresses = 'localhost'",
+		// Disable the Unix socket: everything here connects over TCP, and a
+		// temp-dir socket path easily exceeds the ~103-char sun_path limit on
+		// macOS, which would keep the server from starting.
+		"unix_socket_directories = ''",
+		"fsync = off",
+		"full_page_writes = off",
+	}, extraConf...)
+	appendFile(t, filepath.Join(dataDir, "postgresql.conf"), strings.Join(conf, "\n")+"\n")
+
+	startCmd := executil.Command(ctx, "pg_ctl", "-D", dataDir, "-l", logPath, "-w", "-t", "60", "start").
+		AddEnv("LC_ALL=C", "LANG=C")
+	if out, err := startCmd.CombinedOutput(); err != nil {
+		serverLog, _ := os.ReadFile(logPath)
+		t.Fatalf("pg_ctl start failed: %v\n%s\n--- server log ---\n%s", err, out, serverLog)
+	}
+	t.Cleanup(func() {
+		// Best-effort immediate stop; the temp dir is removed by t.TempDir.
+		stop := executil.Command(context.Background(), "pg_ctl", "-D", dataDir, "-m", "immediate", "-w", "-t", "30", "stop").
+			AddEnv("LC_ALL=C", "LANG=C")
+		_ = stop.Run()
+	})
+
+	inst := &pgInstance{dir: dir, port: port, logPath: logPath}
+	// Prove it accepts connections before returning.
+	conn := connect(t, ctx, port)
+	_ = conn.Close(ctx)
+	return inst
+}
+
+func connect(t *testing.T, ctx context.Context, port int) *pgx.Conn {
+	t.Helper()
+	connStr := fmt.Sprintf("postgres://%s@localhost:%d/postgres?sslmode=disable", pgSuperuser, port)
+	conn, err := pgx.Connect(ctx, connStr)
+	require.NoError(t, err, "connect to postgres on port %d", port)
+	return conn
+}
+
+func mustExec(t *testing.T, ctx context.Context, conn *pgx.Conn, sql string) {
+	t.Helper()
+	_, err := conn.Exec(ctx, sql)
+	require.NoError(t, err, "exec: %s", sql)
+}
+
+// waitForSlot polls pg_replication_slots until the named slot exists, returning
+// its temporary and failover flags.
+func waitForSlot(t *testing.T, ctx context.Context, conn *pgx.Conn, slot string) (temporary, failover bool) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		err := conn.QueryRow(ctx,
+			`SELECT temporary, failover FROM pg_replication_slots WHERE slot_name = $1`, slot).
+			Scan(&temporary, &failover)
+		if err == nil {
+			return temporary, failover
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			require.NoError(t, err, "query pg_replication_slots")
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("slot %q did not appear on the publisher within the timeout", slot)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// receivedReplicationCommands extracts the command text of every
+// "received replication command: <cmd>" line from a publisher log.
+func receivedReplicationCommands(t *testing.T, logPath string) []string {
+	t.Helper()
+	data, err := os.ReadFile(logPath)
+	require.NoError(t, err, "read publisher log %s", logPath)
+	const marker = "received replication command: "
+	var cmds []string
+	for line := range strings.SplitSeq(string(data), "\n") {
+		if _, after, ok := strings.Cut(line, marker); ok {
+			cmds = append(cmds, strings.TrimSpace(after))
+		}
+	}
+	return cmds
+}
+
+func postgresMajorVersion(t *testing.T) int {
+	t.Helper()
+	out, err := executil.Command(context.Background(), "postgres", "--version").
+		AddEnv("LC_ALL=C", "LANG=C").Output()
+	require.NoError(t, err, "postgres --version")
+	// e.g. "postgres (PostgreSQL) 17.10 (Homebrew)"
+	for f := range strings.FieldsSeq(string(out)) {
+		if maj, _, ok := strings.Cut(f, "."); ok {
+			if n, err := strconv.Atoi(maj); err == nil {
+				return n
+			}
+		}
+	}
+	t.Fatalf("could not parse postgres version from %q", string(out))
+	return 0
+}
+
+func run(t *testing.T, ctx context.Context, name string, args ...string) {
+	t.Helper()
+	// AddEnv pins LC_ALL/LANG so initdb and the postmaster get a valid locale
+	// even when the test shell leaves them unset (macOS postgres refuses to
+	// start otherwise: "postmaster became multithreaded during startup").
+	cmd := executil.Command(ctx, name, args...).AddEnv("LC_ALL=C", "LANG=C")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%s %s failed: %v\n%s", name, strings.Join(args, " "), err, out)
+	}
+}
+
+func appendFile(t *testing.T, path, content string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	require.NoError(t, err, "open %s", path)
+	defer func() { require.NoError(t, f.Close()) }()
+	_, err = f.WriteString(content)
+	require.NoError(t, err, "append to %s", path)
+}

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -43,6 +43,12 @@ message PrimaryConnInfo {
   // authenticate to the primary. Empty when the conninfo carries no passfile
   // clause. Not a secret (it is a filesystem path, not the password itself).
   string passfile = 6;
+
+  // Database name for the replication connection (dbname=). Required by the
+  // PostgreSQL 17 slot-sync worker, which opens an ordinary SQL connection to
+  // the primary to synchronize failover slots; ignored by physical streaming
+  // replication.
+  string dbname = 7;
 }
 
 // StandbyReplicationStatus PostgreSQL replication status information
@@ -226,6 +232,16 @@ message Status {
   // This is the combined check: process must exist AND respond to pg_isready.
   // Use postgres_running to check only if the process exists.
   bool postgres_ready = 14;
+
+  // Failover logical replication slots on this node: failover_slots_ready is the
+  // number that are failover-ready (synced, not temporary, not invalidated) and
+  // failover_slots_total is how many exist. Populated only when slot-based
+  // replication is enabled; both zero otherwise. Multiorch uses
+  // failover_slots_ready as a tiebreaker among equally-WAL-advanced promotion
+  // candidates, so a failover prefers a node that keeps the most subscribers
+  // resumable.
+  int32 failover_slots_ready = 15;
+  int32 failover_slots_total = 16;
 }
 
 // PostgresStatus is the observed state of the PostgreSQL server process.
@@ -408,7 +424,7 @@ enum RuleOperation {
   RULE_OPERATION_UNSPECIFIED = 0;
 
   // Cohort-membership changes: add or remove a synchronous standby.
-  RULE_OPERATION_COHORT_ADD = 1;
+  RULE_OPERATION_COHORT_ADD    = 1;
   RULE_OPERATION_COHORT_REMOVE = 2;
 
   // ADVANCE makes no cohort change: it re-writes the current rule with the same
@@ -553,10 +569,10 @@ message VerifyBackupsResponse {
 // BackupMetadata contains metadata about a backup
 message BackupMetadata {
   string table_group = 1;
-  string shard = 2;
-  Status status = 3;
-  string backup_id = 4;
-  string stop_lsn = 5; // Stop (final checkpoint) LSN for this backup, from pgbackrest info backup[].lsn.stop
+  string shard       = 2;
+  Status status      = 3;
+  string backup_id   = 4;
+  string stop_lsn    = 5; // Stop (final checkpoint) LSN for this backup, from pgbackrest info backup[].lsn.stop
 
   // Job ID annotation if present (for cross-process tracking)
   string job_id = 6;
@@ -576,7 +592,7 @@ message BackupMetadata {
   // When the backup started/stopped, parsed from pgbackrest info's
   // backup[].timestamp.{start,stop}. Unset if unknown.
   google.protobuf.Timestamp start_timestamp = 11;
-  google.protobuf.Timestamp stop_timestamp = 12;
+  google.protobuf.Timestamp stop_timestamp  = 12;
 
   // Start LSN for this backup, from pgbackrest info backup[].lsn.start. Empty if unknown.
   string start_lsn = 13;
@@ -587,9 +603,9 @@ message BackupMetadata {
 
   // Status represents the state of a backup
   enum Status {
-    UNKNOWN = 0;
+    UNKNOWN    = 0;
     INCOMPLETE = 1;
-    COMPLETE = 2;
+    COMPLETE   = 2;
     // TODO: add VALID/INVALID states
   }
 }
@@ -608,6 +624,27 @@ message ResignLeadershipResponse {
   // writes. Callers should wait for standbys to reach this LSN before triggering
   // a new election, ensuring no data loss.
   string flush_lsn = 1;
+}
+
+// ReconcileFollowersRequest notifies the primary of the current set of
+// cohort-eligible follower members so it can pre-create their per-follower
+// physical replication slots ahead of streaming.
+//
+// This is NOT a consensus message. It does not change the consensus rule or
+// cohort membership and carries no term/quorum semantics; it is purely a
+// level-triggered notification, decoupled from the Recruit / Promote /
+// UpdateConsensusRule path, that lets the current primary hold a slot ready
+// before a follower's WAL receiver attaches. It is a declaration of intent, not
+// a guarantee: the primary ensures a physical slot for each listed member and
+// drops managed slots for members not listed, best-effort (e.g. it cannot
+// create more slots than max_replication_slots allows).
+message ReconcileFollowersRequest {
+  repeated clustermetadata.ID followers = 1;
+}
+
+// ReconcileFollowersResponse is returned once the primary's per-follower physical
+// slots have been reconciled to the requested set. It carries no fields.
+message ReconcileFollowersResponse {
 }
 
 // =============================================================================

--- a/proto/multipoolermanagerservice.proto
+++ b/proto/multipoolermanagerservice.proto
@@ -96,6 +96,17 @@ service MultipoolerManager {
   rpc SetPostgresRestartsEnabled(multipoolermanagerdata.SetPostgresRestartsEnabledRequest)
       returns (multipoolermanagerdata.SetPostgresRestartsEnabledResponse);
 
+  // ReconcileFollowers declares to the primary the full set of cohort-eligible
+  // follower members it should hold per-follower physical replication slots for.
+  // The primary creates any missing slot and drops managed slots for members no
+  // longer in the set. It is level-triggered and declarative: the orchestrator
+  // re-sends the set each cycle, so a missed event or a primary restart
+  // self-heals. It creates only the physical slots (so a late-joining standby
+  // can stream); it does NOT touch synchronized_standby_slots — a follower is
+  // added there only once it is streaming and caught up, via the cohort path.
+  rpc ReconcileFollowers(multipoolermanagerdata.ReconcileFollowersRequest)
+      returns (multipoolermanagerdata.ReconcileFollowersResponse);
+
   //
   // PostgreSQL Configuration Reload
   //

--- a/web/multiadmin/lib/api/generated/multipoolermanagerdata_pb.ts
+++ b/web/multiadmin/lib/api/generated/multipoolermanagerdata_pb.ts
@@ -380,6 +380,16 @@ export class PrimaryConnInfo extends Message<PrimaryConnInfo> {
    */
   passfile = "";
 
+  /**
+   * Database name for the replication connection (dbname=). Required by the
+   * PostgreSQL 17 slot-sync worker, which opens an ordinary SQL connection to
+   * the primary to synchronize failover slots; ignored by physical streaming
+   * replication.
+   *
+   * @generated from field: string dbname = 7;
+   */
+  dbname = "";
+
   constructor(data?: PartialMessage<PrimaryConnInfo>) {
     super();
     proto3.util.initPartial(data, this);
@@ -394,6 +404,7 @@ export class PrimaryConnInfo extends Message<PrimaryConnInfo> {
     { no: 4, name: "application_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 5, name: "raw", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 6, name: "passfile", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 7, name: "dbname", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): PrimaryConnInfo {
@@ -1044,6 +1055,24 @@ export class Status extends Message<Status> {
    */
   postgresReady = false;
 
+  /**
+   * Failover logical replication slots on this node: failover_slots_ready is the
+   * number that are failover-ready (synced, not temporary, not invalidated) and
+   * failover_slots_total is how many exist. Populated only when slot-based
+   * replication is enabled; both zero otherwise. Multiorch uses
+   * failover_slots_ready as a tiebreaker among equally-WAL-advanced promotion
+   * candidates, so a failover prefers a node that keeps the most subscribers
+   * resumable.
+   *
+   * @generated from field: int32 failover_slots_ready = 15;
+   */
+  failoverSlotsReady = 0;
+
+  /**
+   * @generated from field: int32 failover_slots_total = 16;
+   */
+  failoverSlotsTotal = 0;
+
   constructor(data?: PartialMessage<Status>) {
     super();
     proto3.util.initPartial(data, this);
@@ -1064,6 +1093,8 @@ export class Status extends Message<Status> {
     { no: 11, name: "postgres_action", kind: "enum", T: proto3.getEnumType(PostgresAction) },
     { no: 12, name: "postgres_action_duration", kind: "message", T: Duration },
     { no: 14, name: "postgres_ready", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 15, name: "failover_slots_ready", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 16, name: "failover_slots_total", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Status {
@@ -2305,6 +2336,90 @@ export class ResignLeadershipResponse extends Message<ResignLeadershipResponse> 
 
   static equals(a: ResignLeadershipResponse | PlainMessage<ResignLeadershipResponse> | undefined, b: ResignLeadershipResponse | PlainMessage<ResignLeadershipResponse> | undefined): boolean {
     return proto3.util.equals(ResignLeadershipResponse, a, b);
+  }
+}
+
+/**
+ * ReconcileFollowersRequest notifies the primary of the current set of
+ * cohort-eligible follower members so it can pre-create their per-follower
+ * physical replication slots ahead of streaming.
+ *
+ * This is NOT a consensus message. It does not change the consensus rule or
+ * cohort membership and carries no term/quorum semantics; it is purely a
+ * level-triggered notification, decoupled from the Recruit / Promote /
+ * UpdateConsensusRule path, that lets the current primary hold a slot ready
+ * before a follower's WAL receiver attaches. It is a declaration of intent, not
+ * a guarantee: the primary ensures a physical slot for each listed member and
+ * drops managed slots for members not listed, best-effort (e.g. it cannot
+ * create more slots than max_replication_slots allows).
+ *
+ * @generated from message multipoolermanagerdata.ReconcileFollowersRequest
+ */
+export class ReconcileFollowersRequest extends Message<ReconcileFollowersRequest> {
+  /**
+   * @generated from field: repeated clustermetadata.ID followers = 1;
+   */
+  followers: ID[] = [];
+
+  constructor(data?: PartialMessage<ReconcileFollowersRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "multipoolermanagerdata.ReconcileFollowersRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "followers", kind: "message", T: ID, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ReconcileFollowersRequest {
+    return new ReconcileFollowersRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ReconcileFollowersRequest {
+    return new ReconcileFollowersRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ReconcileFollowersRequest {
+    return new ReconcileFollowersRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ReconcileFollowersRequest | PlainMessage<ReconcileFollowersRequest> | undefined, b: ReconcileFollowersRequest | PlainMessage<ReconcileFollowersRequest> | undefined): boolean {
+    return proto3.util.equals(ReconcileFollowersRequest, a, b);
+  }
+}
+
+/**
+ * ReconcileFollowersResponse is returned once the primary's per-follower physical
+ * slots have been reconciled to the requested set. It carries no fields.
+ *
+ * @generated from message multipoolermanagerdata.ReconcileFollowersResponse
+ */
+export class ReconcileFollowersResponse extends Message<ReconcileFollowersResponse> {
+  constructor(data?: PartialMessage<ReconcileFollowersResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "multipoolermanagerdata.ReconcileFollowersResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ReconcileFollowersResponse {
+    return new ReconcileFollowersResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ReconcileFollowersResponse {
+    return new ReconcileFollowersResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ReconcileFollowersResponse {
+    return new ReconcileFollowersResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ReconcileFollowersResponse | PlainMessage<ReconcileFollowersResponse> | undefined, b: ReconcileFollowersResponse | PlainMessage<ReconcileFollowersResponse> | undefined): boolean {
+    return proto3.util.equals(ReconcileFollowersResponse, a, b);
   }
 }
 


### PR DESCRIPTION
Closes MUL-482

## Summary

Today Multigres only allows **temporary** logical replication slots: the Multigateway rejects any non-temporary `CREATE_REPLICATION_SLOT` because a persistent slot cannot survive a primary failover — slot state is not in the WAL stream, so a promoted standby never has it — and a mid-stream failover simply tears the tunnel down. A logical subscriber therefore cannot continue across a promotion; it has to drop and recreate its subscription and re-`COPY` every table.

This PR makes a persistent logical replication slot survive a primary failover using PostgreSQL 17's native slot-sync, so a subscriber can resume on the new primary instead of re-seeding. Everything is behind a dynamic feature flag (`--enable-slot-based-replication`, default off), so the branch is inert until an operator opts in.

## How it works

- **Multipooler** — logical-slot primitives (`EnsureLogicalSlot` / `DropLogicalSlot` / `GetSlotState` / `LogicalSlotName`); slot-based physical replication (per-follower physical slots, `primary_slot_name`, `hot_standby_feedback`, `sync_replication_slots`, `wal_level = logical`, and a `dbname` in `primary_conninfo`) maintained across the promote / demote / add-standby / remove-standby paths; `synchronized_standby_slots` on the primary; and failover-slot readiness that is **logged, not gated** at promotion (a fresh slot's `catalog_xmin` does not advance until a consumer consumes, so a not-ready slot is expected — gating would hang, and readiness can never be reached once the source primary is gone).
- **Multigateway** — the replication preamble now admits a non-temporary LOGICAL slot registered for failover — both the walsender `CREATE_REPLICATION_SLOT ... (FAILOVER)` command and the `pg_create_logical_replication_slot(..., failover => true)` SQL form — while every other non-temporary slot stays rejected.
- **Multiorch** — leader appointment is slot-aware: failover-slot readiness (reported in the health stream) breaks ties among WAL-equal candidates. WAL position always wins, so this never trades data safety for slot readiness.
- **Failover model** — client-driven: the consumer reconnects and resumes from its own durably-tracked LSN, which the slot synced to the new primary can still serve; a failover before a freshly created slot has synced degrades to a safe client-driven re-seed. There is deliberately **no** creation-time durability barrier (an ack-hold was prototyped and removed — it cannot deliver durable-before-ack because a fresh slot's `catalog_xmin` only advances once the client consumes, which the held ack would block).

## Message sequence charts

The consumer always connects to the **Multigateway**, which relays the logical stream to the current leader's Multipooler/PostgreSQL and, on a leader change, routes the reconnect to the new primary. Physical replication and slot-sync happen PostgreSQL-to-PostgreSQL between the poolers, below the gateway.

### 1. Happy path — subscribe and stream, slots synced to the standbys

A persistent failover slot is created **once** on the primary. The consumer streams through the gateway, and PostgreSQL 17's slot-sync workers on each standby independently copy that slot (clamped to the standby's own replay LSN) so every standby can serve a resume after a future promotion.

```mermaid
sequenceDiagram
    participant C as Consumer
    participant G as Multigateway
    participant P as Primary
    participant S1 as Standby 1
    participant S2 as Standby 2

    C->>G: CREATE_REPLICATION_SLOT sub LOGICAL (FAILOVER)
    G->>P: relay to the current leader
    Note over P: create persistent logical slot sub, failover=true
    P-->>G: slot created at consistent_point
    G-->>C: slot created
    C->>G: START_REPLICATION SLOT sub LOGICAL at lsn
    G->>P: relay START_REPLICATION
    P-->>G: XLogData, decoded WAL
    G-->>C: XLogData, relayed with LSN-aware tap
    C->>G: StandbyStatusUpdate flushed=lsn
    G->>P: relay StandbyStatusUpdate
    Note over P: advance confirmed_flush_lsn and catalog_xmin
    P-->>S1: stream WAL via physical slot mg_s1
    P-->>S2: stream WAL via physical slot mg_s2
    S1->>P: slot-sync worker reads failover slots
    Note over S1: create synced copy of sub, clamped to replay LSN
    S2->>P: slot-sync worker reads failover slots
    Note over S2: create synced copy of sub, clamped to replay LSN
    Note over S1,S2: synced copies become failover_ready as catalog_xmin advances
```

### 2. Failover while the consumer is streaming — disconnect and reconnect

A mid-stream primary failure drops the gateway's upstream, and the consumer's connection with it. Multiorch promotes the standby whose synced slot is failover-ready and re-bases the other standby onto it. The consumer reconnects to the gateway, which routes it to the new primary, and resumes from its own durably-tracked LSN — the synced slot is already present and retained there, so there is no re-`COPY`.

```mermaid
sequenceDiagram
    participant C as Consumer
    participant O as Multiorch
    participant G as Multigateway
    participant P as Primary
    participant S1 as Standby 1
    participant S2 as Standby 2

    C-->>G: streaming sub
    G-->>P: relay stream, XLogData and StandbyStatusUpdate
    Note over P,S2: sub is synced and failover_ready on S1 and S2
    Note over P: old primary fails
    P-xG: upstream stream drops
    G-xC: consumer connection drops
    O->>S1: promote, WAL-highest and failover-ready
    Note over S1: new primary, sub present and retained
    O->>S2: SetPrimary S1
    S2-->>S1: re-base and stream WAL
    C->>G: reconnect START_REPLICATION SLOT sub LOGICAL at confirmed_lsn
    G->>S1: route to the new leader
    S1-->>G: resume from confirmed_lsn, no re-COPY
    G-->>C: stream resumes
```

### 3. Standby added after the primary — keeping the slot-based path from stranding a late joiner

This deadlock is one the slot-based path *introduces*, not a pre-existing bug — so this MSC shows how the PR avoids it rather than fixing something older. With slot-based replication on, a standby streams through a per-follower physical slot and cannot start until that slot exists on the primary. The natural ordering — create a follower's slot only at the promotion hook (for the already-committed cohort), or via a `COHORT_ADD` that itself requires the standby to already be streaming — would deadlock a standby that joins after promotion: it cannot stream, so it is never admitted to the cohort, so its slot is never created. To keep the feature from stranding late joiners, the discovery-driven `ReconcileFollowers` RPC has the primary pre-create the slot the moment Multiorch sees the standby, ahead of streaming. (Surfaced in kind testing; see §2.6 of the design doc.)

```mermaid
sequenceDiagram
    participant C as Consumer
    participant O as Multiorch
    participant G as Multigateway
    participant P as Primary
    participant S1 as Standby 1
    participant S2 as Standby 2

    Note over C,P: initial cohort P and S1, physical slot mg_s1 exists
    C->>G: START_REPLICATION SLOT sub LOGICAL
    G->>P: relay to the current leader
    S2->>O: starts and reports health, REPLICA and not yet streaming
    O->>P: ReconcileFollowers followers=S1,S2
    Note over O,P: not a consensus message, level-triggered notification
    Note over P: create missing physical slot mg_s2 ahead of streaming
    O->>S2: SetPrimary P
    Note over S2: set primary_slot_name to mg_s2
    S2-->>P: stream WAL via mg_s2 and catch up
    S2->>O: now streaming, admitted to the cohort
    Note over S2: slot-sync then creates a synced copy of sub
    Note over P,S2: without ReconcileFollowers mg_s2 never exists and S2 deadlocks
```

## Design doc

`docs/ha/logical_slot_failover_design.md` covers the PostgreSQL background, the Multigateway/Multipooler machinery, the correctness invariants, the scenarios where data can actually be lost (§4.4.1), the bootstrap slot-creation deadlock the slot-based path introduces and how `ReconcileFollowers` avoids it (§2.6), and why the creation-time barrier was rejected (§4.4). A fully-DIY Patroni-model alternative is recorded in Appendix A.

## Testing

- Unit tests across the touched packages (Multipooler manager, Multigateway handler, Multiorch consensus, `rpcclient`, `parser/ast`).
- End-to-end: slot-sync propagation of a failover slot to a standby (driving a real consumer so `catalog_xmin` advances the slot to `failover_ready`); a subscription-wire test verifying the FAILOVER option rides in the `CREATE_REPLICATION_SLOT` a PostgreSQL 17 subscriber sends; and a regression test (`TestSlotBasedReplicationLateStandbyJoins`) that adds a standby after promotion and asserts it joins the cohort — reproducing the deadlock the slot-based path would otherwise hit (§2.6) and proving `ReconcileFollowers` avoids it.
