### PR TITLE
fix(pgctld): stop child reaper from stealing subprocess exit status

### DIFF
--- a/go/cmd/pgctld/command/crash_recovery.go
+++ b/go/cmd/pgctld/command/crash_recovery.go
@@ -102,6 +102,20 @@ func (s *PgCtldService) runCrashRecoveryInDir(
 	r *retry.Retry,
 ) error {
 	logger := s.logger
+	dataDir := s.pgConfig.PostgresDataDir
+
+	// Never disturb a live postmaster. The standby.signal removal below opens a
+	// window in which the file is absent; a postmaster that is running — or still
+	// mid-startup after a Start whose success was misreported — can observe that
+	// absence and finish recovery as a primary on a timeline it must not claim.
+	// Callers gate this path on a stopped node; this is the last-line guard for
+	// the residual race where a postmaster appears between that check and here.
+	// A running node needs no crash recovery, so skipping is also the correct no-op.
+	if isPostgreSQLRunning(dataDir) {
+		logger.InfoContext(ctx, "skipping crash recovery: postgres is running", "data_dir", dataDir)
+		return nil
+	}
+
 	signalPath := s.standbySignalPath()
 	if _, err := os.Stat(signalPath); err == nil {
 		logger.InfoContext(ctx, "temporarily removing standby.signal for single-user crash recovery",

--- a/go/cmd/pgctld/command/crash_recovery_test.go
+++ b/go/cmd/pgctld/command/crash_recovery_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -270,4 +271,34 @@ func TestRunCrashRecoveryInDir_RemoveFailureSkipsRecovery(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to remove standby.signal")
 	assert.False(t, called, "recovery must not run when standby.signal could not be removed")
+}
+
+// TestRunCrashRecoveryInDir_SkipsWhenPostgresRunning verifies the guard that
+// crash recovery never disturbs a live postmaster: it must not touch
+// standby.signal and must not run recovery. A live postmaster is simulated by a
+// postmaster.pid pointing at this test process (which is, by definition, running).
+func TestRunCrashRecoveryInDir_SkipsWhenPostgresRunning(t *testing.T) {
+	dir := t.TempDir()
+	s := testPgCtldService(dir)
+	signalPath, err1 := s.createStandbySignal()
+	require.NoError(t, err1)
+
+	// postmaster.pid's first line is the PID; point it at ourselves so
+	// isPostgreSQLRunning sees a live process.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "postmaster.pid"),
+		[]byte(strconv.Itoa(os.Getpid())+"\n"),
+		0o644,
+	))
+
+	called := false
+	runner := func(ctx context.Context) ([]byte, error) {
+		called = true
+		return []byte("recovery complete"), nil
+	}
+
+	err := s.runCrashRecoveryInDir(context.Background(), runner, fastRetry())
+	require.NoError(t, err)
+	assert.False(t, called, "recovery must not run against a live postmaster")
+	assert.True(t, fileExists(t, signalPath), "standby.signal must be left untouched while postgres is running")
 }

--- a/go/cmd/pgctld/command/reaper.go
+++ b/go/cmd/pgctld/command/reaper.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"log/slog"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+// childReaper reaps PostgreSQL postmaster processes that pgctld starts.
+//
+// When pgctld runs as PID 1 (container init), `pg_ctl start -W` forks the
+// postmaster and exits, so the postmaster is reparented to pgctld and must be
+// wait()ed on or it lingers as a zombie.
+//
+// The reaper waits ONLY on the specific PIDs it has been told to track via
+// TrackPID — it never calls Wait4(-1). A blanket Wait4(-1) reaper races every
+// other subprocess pgctld runs through os/exec (pg_ctl, initdb, pg_rewind,
+// pg_isready, psql, postgres --single, ...): both the reaper and os/exec's own
+// Wait call wait4 on the same child, and whichever wins consumes the exit
+// status. When the reaper wins, os/exec's Wait sees ECHILD ("waitid: no child
+// processes") and reports a failure for a command that actually succeeded.
+//
+// That false failure is exactly what wedged a production cluster: a
+// `pg_ctl start` that had in fact succeeded was reported as failed, a redundant
+// Start RPC then treated the node as needing crash recovery, deleted
+// standby.signal, and single-user crash-recovered a still-live postmaster into a
+// second read-write server on the primary's timeline — an unrecoverable split
+// (pg_rewind reports "no rewind required" for same-timeline peers).
+//
+// Tracking exact PIDs keeps the reaper from ever touching an os/exec-owned
+// child, so os/exec always observes the true exit status.
+type childReaper struct {
+	logger *slog.Logger
+
+	mu      sync.Mutex
+	tracked map[int]struct{}
+
+	sigCh chan os.Signal
+}
+
+// newChildReaper creates a childReaper. Call Run in a goroutine to start reaping.
+func newChildReaper(logger *slog.Logger) *childReaper {
+	return &childReaper{
+		logger:  logger,
+		tracked: make(map[int]struct{}),
+		sigCh:   make(chan os.Signal, 1),
+	}
+}
+
+// TrackPID registers a postmaster PID for reaping and attempts an immediate reap so
+// a postmaster that has already exited does not linger until the next SIGCHLD.
+//
+// Safe to call on a nil receiver (the reaper is only created under PID 1), with a
+// non-positive PID, or repeatedly with the same PID — all are no-ops.
+func (r *childReaper) TrackPID(pid int) {
+	if r == nil || pid <= 0 {
+		return
+	}
+	r.mu.Lock()
+	r.tracked[pid] = struct{}{}
+	r.mu.Unlock()
+
+	// Reap immediately in case the postmaster already exited between the caller
+	// obtaining its PID and this call. SIGCHLD is not queued, so its death signal
+	// may have already fired (and found nothing tracked) and will not fire again;
+	// without this the zombie would linger until an unrelated child's SIGCHLD
+	// happens to wake the run loop. In the common case (still running) this is a
+	// cheap WNOHANG no-op.
+	r.Reap()
+}
+
+// Run installs the SIGCHLD handler and reaps tracked children on each signal. It
+// runs until sigCh is closed, i.e. for the process lifetime in production.
+func (r *childReaper) Run() {
+	signal.Notify(r.sigCh, syscall.SIGCHLD)
+	for range r.sigCh {
+		r.Reap()
+	}
+}
+
+// Reap does a non-blocking wait on every tracked PID, dropping those that have
+// exited or are no longer our children.
+func (r *childReaper) Reap() {
+	r.mu.Lock()
+	pids := make([]int, 0, len(r.tracked))
+	for pid := range r.tracked {
+		pids = append(pids, pid)
+	}
+	r.mu.Unlock()
+
+	for _, pid := range pids {
+		var status syscall.WaitStatus
+		wpid, err := syscall.Wait4(pid, &status, syscall.WNOHANG, nil)
+		if wpid == pid || err == syscall.ECHILD {
+			r.UntrackPID(pid)
+		} else if err != nil {
+			r.logger.Warn("failed to reap tracked postmaster process", "pid", pid, "error", err)
+		}
+	}
+}
+
+func (r *childReaper) UntrackPID(pid int) {
+	r.mu.Lock()
+	delete(r.tracked, pid)
+	r.mu.Unlock()
+}
+
+// Stop detaches the SIGCHLD handler and ends the run loop. signal.Stop is called
+// before close so the signal package cannot send on the closed channel.
+func (r *childReaper) Stop() {
+	signal.Stop(r.sigCh)
+	close(r.sigCh)
+}

--- a/go/cmd/pgctld/command/reaper_test.go
+++ b/go/cmd/pgctld/command/reaper_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"context"
+	"log/slog"
+	"os/exec"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/tools/executil"
+)
+
+func quietReaper() *childReaper {
+	return newChildReaper(slog.New(slog.DiscardHandler))
+}
+
+func (r *childReaper) isTracked(pid int) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok := r.tracked[pid]
+	return ok
+}
+
+// TestChildReaper_ReapsTrackedChild verifies the reaper wait()s on a tracked,
+// un-waited child once it exits — exactly the postmaster case, where pgctld is
+// the reparented parent and nothing else calls wait().
+func TestChildReaper_ReapsTrackedChild(t *testing.T) {
+	r := quietReaper()
+
+	// Start a short-lived child and deliberately never call cmd.Wait(), so the
+	// reaper is the only thing that can reap it (as with the reparented postmaster).
+	cmd := exec.Command("sleep", "0.3")
+	require.NoError(t, cmd.Start())
+	pid := cmd.Process.Pid
+
+	// Track attempts an immediate reap; the child is still running, so it stays tracked.
+	r.TrackPID(pid)
+	require.True(t, r.isTracked(pid))
+
+	// After the child exits, reaping drops it from the tracked set.
+	require.Eventually(t, func() bool {
+		r.Reap()
+		return !r.isTracked(pid)
+	}, 5*time.Second, 20*time.Millisecond)
+
+	// The child has genuinely been reaped: it is no longer waitable.
+	_, err := syscall.Wait4(pid, nil, syscall.WNOHANG, nil)
+	require.ErrorIs(t, err, syscall.ECHILD)
+}
+
+// TestChildReaper_IgnoresUntrackedPID verifies the reaper leaves a running child
+// it was never told about completely alone.
+func TestChildReaper_IgnoresUntrackedPID(t *testing.T) {
+	r := quietReaper()
+
+	// Use executil.Cmd so cleanup can Stop() it: Stop reaps via the command's own
+	// Wait(), whereas signalling a bare *os.Process would leave an unreaped zombie
+	// that a liveness poll never sees exit.
+	cmd := executil.Command(context.Background(), "sleep", "5")
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_, _ = cmd.Stop(context.Background())
+	})
+
+	// Reaping with nothing tracked must not touch the running child.
+	r.Reap()
+	require.False(t, r.isTracked(cmd.Process.Pid))
+
+	// The child is still alive and still ours to wait on.
+	require.NoError(t, cmd.Process.Signal(syscall.Signal(0)))
+}
+
+// TestChildReaper_DoesNotStealOsExecChildren is the regression guard for the
+// exit-status theft. With the running reaper installed (SIGCHLD handler active),
+// many concurrent os/exec children that Wait() for themselves must all observe their true exit
+// status. The old Wait4(-1) reaper raced these waits and intermittently made
+// Run() fail with "waitid: no child processes"; tracking exact PIDs cannot.
+func TestChildReaper_DoesNotStealOsExecChildren(t *testing.T) {
+	r := quietReaper()
+	go r.Run()
+	t.Cleanup(r.Stop)
+
+	// Let the SIGCHLD handler install before spawning children.
+	time.Sleep(50 * time.Millisecond)
+
+	var wg sync.WaitGroup
+	for range 40 {
+		wg.Go(func() {
+			for range 5 {
+				// A trivial, fast command that os/exec both starts and waits on.
+				assert.NoError(t, exec.Command("true").Run())
+			}
+		})
+	}
+	wg.Wait()
+}

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -21,7 +21,6 @@ import (
 	"log/slog"
 	"math"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -127,19 +126,6 @@ func (s *PgCtldServerCmd) runServer(cmd *cobra.Command, args []string) error {
 	// Get the configured logger
 	logger := s.senv.GetLogger()
 
-	// Start reaping orphaned children to prevent zombie processes.
-	// Only start when running as PID 1 (container init process). pg_ctl with -W
-	// forks a child that gets reparented to PID 1 on exit; without this reaper
-	// those children become zombies.
-	//
-	// When pgctld is NOT PID 1 (tests, CI, systemd), orphaned children are
-	// reparented to the system init — not pgctld — so the reaper is unnecessary.
-	// Starting it anyway races with cmd.Wait() in RPC handlers (initdb, pg_rewind)
-	// causing "waitid: no child processes" errors.
-	if os.Getpid() == 1 {
-		go reapOrphanedChildren(logger)
-	}
-
 	// Create and register our service
 	poolerDir := s.pgCtlCmd.GetPoolerDir()
 	pgbackrestPort := s.pgbackrestPort.Get()
@@ -187,6 +173,17 @@ func (s *PgCtldServerCmd) runServer(cmd *cobra.Command, args []string) error {
 			"http_port", s.senv.GetHTTPPort(),
 		)
 
+		// Start reaping the postmaster to prevent a zombie. Only needed when
+		// pgctld is PID 1 (container init): `pg_ctl start -W` forks the postmaster
+		// and exits, so it is reparented to pgctld and must be wait()ed on. When
+		// pgctld is NOT PID 1 (tests, CI, systemd) orphans reparent to the system
+		// init instead, so no reaper is needed. See childReaper for why it tracks
+		// exact PIDs rather than using Wait4(-1).
+		if os.Getpid() == 1 {
+			pgctldService.reaper = newChildReaper(logger)
+			go pgctldService.reaper.Run()
+		}
+
 		// Start pgBackRest management
 		pgctldService.StartPgBackRestManagement()
 
@@ -202,31 +199,6 @@ func (s *PgCtldServerCmd) runServer(cmd *cobra.Command, args []string) error {
 	})
 
 	return s.senv.RunDefault(s.grpcServer)
-}
-
-// reapOrphanedChildren handles SIGCHLD signals to reap zombie processes.
-// This is necessary because pg_ctl with -W flag creates child processes that get
-// reparented to pgctld (when running as PID 1 in a container). Without this reaper,
-// these child processes remain in defunct (zombie) state after exit.
-//
-// The function runs in a goroutine and continuously waits for SIGCHLD signals,
-// then reaps all available zombie children using Wait4 with WNOHANG.
-func reapOrphanedChildren(logger *slog.Logger) {
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGCHLD)
-
-	for range sigCh {
-		// Reap all zombie children
-		for {
-			var status syscall.WaitStatus
-			pid, err := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
-			if err != nil || pid <= 0 {
-				// No more children to reap
-				break
-			}
-			logger.Debug("reaped orphaned child process", "pid", pid, "status", status)
-		}
-	}
 }
 
 // PgCtldServiceConfig holds the PostgreSQL instance identity and initialization
@@ -272,6 +244,9 @@ type PgCtldService struct {
 	statusMu         sync.RWMutex
 	restartCount     int32
 	metrics          *Metrics
+
+	// reaper reaps the postmaster when pgctld runs as PID 1. Nil otherwise.
+	reaper *childReaper
 }
 
 // pgbackrestServerConfigPath returns the path to the pgbackrest server config file.
@@ -624,7 +599,15 @@ func (s *PgCtldService) Start(ctx context.Context, req *pb.StartRequest) (*pb.St
 	// is instead crash-recovered by the postmaster on the normal start below and
 	// does not set it.
 	var crashRecoveryRan bool
-	if req.GetAllowCrashRecovery() {
+	if req.GetAllowCrashRecovery() && isPostgreSQLRunning(s.pgConfig.PostgresDataDir) {
+		// Never crash-recover a running postmaster: runCrashRecovery removes
+		// standby.signal for single-user recovery, and doing that to a postmaster
+		// that is up — or still starting after a Start whose success was misreported
+		// — can bring it up read-write on a timeline it must not claim. A Start
+		// against an already-running node is an idempotent no-op via
+		// StartPostgreSQLWithResult below.
+		s.logger.InfoContext(ctx, "skipping crash recovery before start: postgres is already running")
+	} else if req.GetAllowCrashRecovery() {
 		needed, nErr := s.crashRecoveryNeeded(ctx)
 		if nErr != nil {
 			s.logger.WarnContext(ctx, "could not determine clean-shutdown state before start (continuing)", "error", nErr)
@@ -658,6 +641,9 @@ func (s *PgCtldService) Start(ctx context.Context, req *pb.StartRequest) (*pb.St
 	if err != nil {
 		return nil, fmt.Errorf("failed to start PostgreSQL: %w", err)
 	}
+
+	// Reap this postmaster when it exits (no-op unless pgctld is PID 1).
+	s.reaper.TrackPID(result.PID)
 
 	pid, err := intToInt32(result.PID)
 	if err != nil {
@@ -705,6 +691,9 @@ func (s *PgCtldService) Restart(ctx context.Context, req *pb.RestartRequest) (*p
 	if err != nil {
 		return nil, fmt.Errorf("failed to restart PostgreSQL: %w", err)
 	}
+
+	// Reap the restarted postmaster when it exits (no-op unless pgctld is PID 1).
+	s.reaper.TrackPID(result.PID)
 
 	pid, err := intToInt32(result.PID)
 	if err != nil {


### PR DESCRIPTION
## Summary

After the change that stopped pgctld from cancelling `pg_rewind`, a production cluster ran much longer but eventually wedged with two writers on the same timeline — an unrecoverable split, because `pg_rewind` reports "no rewind required" for same-timeline peers. The trigger was pgctld's SIGCHLD reaper.

pgctld runs a reaper (only under PID 1, container init) to reap the postmaster, which `pg_ctl start -W` forks and then leaves reparented to pgctld. That reaper reaped with `Wait4(-1)`, which races os/exec's own `Wait` for every other subprocess pgctld runs (`pg_ctl`, `initdb`, `pg_rewind`, `pg_isready`, `psql`, `postgres --single`). Both waiters call `wait4` on the same child; whichever wins consumes the exit status. When the reaper won, os/exec's `Wait` saw `ECHILD` ("waitid: no child processes") and reported a failure for a command that had actually succeeded.

That false failure is what wedged the cluster: a `pg_ctl start` that in fact succeeded was reported as failed, so a redundant `Start` RPC treated the node as needing crash recovery, removed `standby.signal`, and single-user crash-recovered a still-live postmaster into a second read-write server on the primary's timeline.

## Before

```mermaid
sequenceDiagram
    autonumber
    participant O as multiorch
    participant P as pgctld (PID 1)
    participant C as pg_ctl
    participant R as SIGCHLD reaper
    participant M as postmaster

    O->>P: Start (allow_crash_recovery)
    P->>C: exec pg_ctl start -W  (cmd.Run → Wait)
    C->>M: fork postmaster, then exit
    Note over M,P: postmaster reparented to pgctld (PID 1)
    R-->>C: Wait4(-1) reaps pg_ctl's status first  (RACE)
    Note over P: cmd.Wait() → ECHILD "waitid: no child processes"
    P-->>O: Start FAILED  (but postgres is actually up)
    O->>P: Start (retry)
    Note over P: not cleanly stopped + standby.signal present
    P->>M: remove standby.signal, run single-user recovery
    Note over M: mid-startup postmaster comes up READ-WRITE on the<br/>old timeline → two writers on one TLI (pg_rewind can't fix)
```

## After

The reaper now waits only on the specific postmaster PIDs registered after a successful `Start`/`Restart`, and never calls `Wait4(-1)` — so it can never touch an os/exec-owned child, and os/exec always observes the true exit status.

```mermaid
sequenceDiagram
    autonumber
    participant O as multiorch
    participant P as pgctld (PID 1)
    participant C as pg_ctl
    participant R as childReaper
    participant M as postmaster

    O->>P: Start (allow_crash_recovery)
    P->>C: exec pg_ctl start -W  (cmd.Run → Wait)
    C->>M: fork postmaster, then exit
    Note over M,P: postmaster reparented to pgctld (PID 1)
    Note over R: reaper waits only on tracked postmaster PIDs, never Wait4(-1)
    C-->>P: cmd.Wait() returns pg_ctl's true exit status
    P->>R: TrackPID(postmaster)
    P-->>O: Start OK
    O->>P: Start (retry / duplicate)
    Note over P: guard 2 — postmaster already running → skip crash recovery
    Note over P: guard 3 — never remove standby.signal while a postmaster is live
```

## Changes

- **Root fix** (`reaper.go`): replace the `Wait4(-1)` SIGCHLD reaper with a `childReaper` that tracks exact postmaster PIDs and reaps only those. It still runs only under PID 1, and is now started from `OnRun` alongside the other background workers.
- **Defense in depth — guard 2** (`server.go`): a `Start` with `allow_crash_recovery` skips the crash-recovery branch when a postmaster is already running. A duplicate `Start` against a live node is an idempotent no-op instead of a destructive recovery.
- **Defense in depth — guard 3** (`crash_recovery.go`): `runCrashRecovery` refuses to remove `standby.signal` while a postmaster is live, closing the residual race where a postmaster appears between guard 2's check and the removal. The transient absence of `standby.signal` is what let a mid-startup postmaster finish recovery as a primary.

Each of the three cuts a different link in the chain, so any one of them alone breaks the cascade.

## Testing

- New `reaper_test.go`, including `TestChildReaper_DoesNotStealOsExecChildren` — a regression guard that runs many concurrent os/exec children with the reaper active. It fails intermittently against the old `Wait4(-1)` reaper and passes deterministically with the scoped reaper.
- New `TestRunCrashRecoveryInDir_SkipsWhenPostgresRunning` covering guard 3.
- `go test ./go/cmd/pgctld/command` passes with `-race`; `golangci-lint` clean.

## Follow-up

A timeline/consensus-term backstop (refuse to come up read-write on an already-claimed timeline) is the deeper invariant but a larger change; tracked separately rather than folded in here.

Fixes MUL-1370
