### PR TITLE
fix(multiorch): make cohort-reconcile's CAS match its safety check

### DIFF
--- a/go/services/multiorch/recovery/actions/alert_only.go
+++ b/go/services/multiorch/recovery/actions/alert_only.go
@@ -41,7 +41,8 @@ func NewAlertOnlyAction(logger *slog.Logger) *AlertOnlyAction {
 
 // Execute records the problem for human attention and returns nil. It never
 // mutates cluster state.
-func (a *AlertOnlyAction) Execute(ctx context.Context, problem types.Problem) error {
+func (a *AlertOnlyAction) Execute(ctx context.Context, rechecked types.RecheckedProblem) error {
+	problem := rechecked.Problem
 	a.logger.WarnContext(ctx, "non-actionable problem detected; human intervention required",
 		"problem_code", problem.Code,
 		"database", problem.ShardKey.GetDatabase(),

--- a/go/services/multiorch/recovery/actions/alert_only_test.go
+++ b/go/services/multiorch/recovery/actions/alert_only_test.go
@@ -33,7 +33,7 @@ func TestAlertOnlyAction(t *testing.T) {
 	}
 
 	// Execute is a no-op: it records the problem and never errors or mutates state.
-	require.NoError(t, a.Execute(t.Context(), problem))
+	require.NoError(t, a.Execute(t.Context(), types.RecheckedProblem{Problem: problem}))
 
 	require.Equal(t, "AlertOnly", a.Metadata().Name)
 	require.False(t, a.RequiresHealthyLeader())

--- a/go/services/multiorch/recovery/actions/appoint_leader.go
+++ b/go/services/multiorch/recovery/actions/appoint_leader.go
@@ -70,7 +70,8 @@ func NewAppointLeaderAction(
 }
 
 // Execute performs leader appointment by running the coordinator's consensus protocol
-func (a *AppointLeaderAction) Execute(ctx context.Context, problem types.Problem) error {
+func (a *AppointLeaderAction) Execute(ctx context.Context, rechecked types.RecheckedProblem) error {
+	problem := rechecked.Problem
 	a.logger.InfoContext(ctx, "executing appoint leader action",
 		"shard_key", commontypes.FormatShardKey(problem.ShardKey))
 

--- a/go/services/multiorch/recovery/actions/demote_stale_leader.go
+++ b/go/services/multiorch/recovery/actions/demote_stale_leader.go
@@ -104,7 +104,8 @@ func (a *DemoteStaleLeaderAction) GracePeriod() *types.GracePeriodConfig {
 // Execute demotes the stale leader using SetPrimary with the correct leader's rule.
 // This is safer than Recruit because we use the correct leader's existing rule rather than
 // minting a new term, so both leaders end up agreeing on the same term and rule.
-func (a *DemoteStaleLeaderAction) Execute(ctx context.Context, problem types.Problem) (retErr error) {
+func (a *DemoteStaleLeaderAction) Execute(ctx context.Context, rechecked types.RecheckedProblem) (retErr error) {
+	problem := rechecked.Problem
 	poolerIDStr := topoclient.ComponentIDString(problem.PoolerID)
 
 	a.logger.InfoContext(ctx, "executing demote stale leader action",

--- a/go/services/multiorch/recovery/actions/demote_stale_leader_test.go
+++ b/go/services/multiorch/recovery/actions/demote_stale_leader_test.go
@@ -137,7 +137,7 @@ func TestDemoteStaleLeaderAction_Execute(t *testing.T) {
 		},
 		PoolerID: staleLeaderID,
 	}
-	require.NoError(t, action.Execute(ctx, problem))
+	require.NoError(t, action.Execute(ctx, types.RecheckedProblem{Problem: problem}))
 
 	assert.Contains(t, fakeClient.CallLog, "SetPrimary(multipooler-cell1-stale-leader)")
 	assert.NotContains(t, fakeClient.CallLog, "DemoteStalePrimary(multipooler-cell1-stale-leader)")
@@ -184,11 +184,11 @@ func TestDemoteStaleLeaderAction_ExecuteNoCorrectLeader(t *testing.T) {
 	cfg := config.NewTestConfig()
 	action := NewDemoteStaleLeaderAction(cfg, fakeClient, poolerStore, ts, slog.Default())
 
-	err := action.Execute(ctx, types.Problem{
+	err := action.Execute(ctx, types.RecheckedProblem{Problem: types.Problem{
 		Code:     types.ProblemStaleLeader,
 		ShardKey: shardKey,
 		PoolerID: staleLeaderID,
-	})
+	}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no consensus leader known")
 	assert.Empty(t, fakeClient.CallLog, "no RPC should be issued when there is no leader to demote toward")
@@ -232,11 +232,11 @@ func TestDemoteStaleLeaderAction_ExecuteRewindsTowardRuleNamedLeader(t *testing.
 	}, nil))
 
 	action := NewDemoteStaleLeaderAction(config.NewTestConfig(), fakeClient, ps, ts, slog.Default())
-	require.NoError(t, action.Execute(ctx, types.Problem{
+	require.NoError(t, action.Execute(ctx, types.RecheckedProblem{Problem: types.Problem{
 		Code:     types.ProblemStaleLeader,
 		ShardKey: shardKey,
 		PoolerID: staleID,
-	}))
+	}}))
 
 	assert.Contains(t, fakeClient.CallLog, "SetPrimary(multipooler-cell1-stale-leader)")
 	req := fakeClient.SetPrimaryRequests["multipooler-cell1-stale-leader"]
@@ -268,11 +268,11 @@ func TestDemoteStaleLeaderAction_ExecuteNoOpWhenNodeIsCurrentLeader(t *testing.T
 	}, nil))
 
 	action := NewDemoteStaleLeaderAction(config.NewTestConfig(), fakeClient, ps, ts, slog.Default())
-	require.NoError(t, action.Execute(ctx, types.Problem{
+	require.NoError(t, action.Execute(ctx, types.RecheckedProblem{Problem: types.Problem{
 		Code:     types.ProblemStaleLeader,
 		ShardKey: shardKey,
 		PoolerID: nodeID,
-	}))
+	}}))
 
 	assert.Empty(t, fakeClient.CallLog,
 		"no SetPrimary RPC when the flagged node is actually the current consensus leader")

--- a/go/services/multiorch/recovery/actions/fix_replication.go
+++ b/go/services/multiorch/recovery/actions/fix_replication.go
@@ -105,7 +105,8 @@ func NewFixReplicationAction(
 }
 
 // Execute performs replication fix for a replica that is not replicating.
-func (a *FixReplicationAction) Execute(ctx context.Context, problem types.Problem) error {
+func (a *FixReplicationAction) Execute(ctx context.Context, rechecked types.RecheckedProblem) error {
+	problem := rechecked.Problem
 	a.logger.InfoContext(ctx, "executing fix replication action",
 		"shard_key", problem.ShardKey.String(),
 		"pooler", problem.PoolerID.Name,

--- a/go/services/multiorch/recovery/actions/fix_replication_test.go
+++ b/go/services/multiorch/recovery/actions/fix_replication_test.go
@@ -105,7 +105,7 @@ func TestFixReplicationAction_ExecuteReplicaNotFound(t *testing.T) {
 		},
 	}
 
-	err := action.Execute(ctx, problem)
+	err := action.Execute(ctx, types.RecheckedProblem{Problem: problem})
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to find affected replica")
@@ -149,7 +149,7 @@ func TestFixReplicationAction_ExecuteNoPrimary(t *testing.T) {
 		PoolerID: replicaID,
 	}
 
-	err := action.Execute(ctx, problem)
+	err := action.Execute(ctx, types.RecheckedProblem{Problem: problem})
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no consensus leader known")
@@ -226,7 +226,7 @@ func TestFixReplicationAction_ExecuteUnsupportedProblemCode(t *testing.T) {
 		PoolerID: replicaID,
 	}
 
-	err := action.Execute(ctx, problem)
+	err := action.Execute(ctx, types.RecheckedProblem{Problem: problem})
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported problem code")
@@ -326,7 +326,7 @@ func TestFixReplicationAction_ExecuteSuccessNotReplicating(t *testing.T) {
 		PoolerID: replicaID,
 	}
 
-	err := action.Execute(ctx, problem)
+	err := action.Execute(ctx, types.RecheckedProblem{Problem: problem})
 	require.NoError(t, err)
 
 	// Verify SetPrimary was called on the replica, NOT SetPrimaryConnInfo.
@@ -430,7 +430,7 @@ func TestFixReplicationAction_ExecuteAlreadyConfigured(t *testing.T) {
 		PoolerID: replicaID,
 	}
 
-	err := action.Execute(ctx, problem)
+	err := action.Execute(ctx, types.RecheckedProblem{Problem: problem})
 
 	// Should succeed without calling SetPrimaryConnInfo (already configured)
 	require.NoError(t, err)
@@ -554,7 +554,7 @@ func TestFixReplicationAction_ExecuteStreamingNullLsn(t *testing.T) {
 		PoolerID: replicaID,
 	}
 
-	err := action.Execute(ctx, problem)
+	err := action.Execute(ctx, types.RecheckedProblem{Problem: problem})
 
 	// The null-LSN guard treats the first poll as not-yet-replicating, so
 	// Execute proceeds to call SetPrimary (fixNotReplicating path).
@@ -735,7 +735,7 @@ func TestFixReplicationAction_ExecuteRetryWhenConnInfoSetButNotStreaming(t *test
 		PoolerID: replicaID,
 	}
 
-	err := action.Execute(ctx, problem)
+	err := action.Execute(ctx, types.RecheckedProblem{Problem: problem})
 
 	// Should succeed: the fix was re-run despite primary_conninfo being set
 	require.NoError(t, err)
@@ -877,7 +877,7 @@ func TestFixReplicationAction_FailsWhenReplicationDoesNotStart(t *testing.T) {
 		PoolerID: replicaID,
 	}
 
-	err := action.Execute(ctx, problem)
+	err := action.Execute(ctx, types.RecheckedProblem{Problem: problem})
 
 	// SetPrimary configured the replica but the WAL receiver never reached
 	// "streaming", so verifyReplicationStarted fails and the action returns an

--- a/go/services/multiorch/recovery/actions/reconcile_cohort.go
+++ b/go/services/multiorch/recovery/actions/reconcile_cohort.go
@@ -75,8 +75,20 @@ func NewReconcileCohortAction(
 	}
 }
 
-// Execute applies the cohort change on the shard leader.
-func (a *ReconcileCohortAction) Execute(ctx context.Context, problem types.Problem) error {
+// Execute applies the cohort change on the shard leader. rechecked.HighestKnownRule
+// is the exact position the engine's recheck just re-verified this problem
+// against (recovery_loop.go's recheckProblem re-runs
+// CohortMismatchAnalyzer.Analyze against it). Because that analyzer only
+// emits ProblemCohortMemberIneligible when IsCohortMemberRemovalSafe already
+// holds for this same rule — a pure, deterministic function of (rule,
+// targetID) — a REMOVE problem surviving the recheck already proves removal
+// is safe against the rule; Execute does not re-verify it. CAS-ing on the
+// same rule (ExpectedOutgoingRule below) rather than a fresh, independent
+// store read means the mutation can't apply against any rule other than the
+// one just proven safe.
+func (a *ReconcileCohortAction) Execute(ctx context.Context, rechecked types.RecheckedProblem) error {
+	problem := rechecked.Problem
+	rule := rechecked.HighestKnownRule
 	a.logger.InfoContext(ctx, "executing reconcile cohort action",
 		"shard_key", problem.ShardKey.String(),
 		"pooler", problem.PoolerID.Name,
@@ -93,9 +105,28 @@ func (a *ReconcileCohortAction) Execute(ctx context.Context, problem types.Probl
 			"unsupported problem code for reconcile cohort: %s", problem.Code)
 	}
 
+	if rule == nil {
+		return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
+			"no consensus rule known for shard %s", problem.ShardKey)
+	}
+	// A cohort change is leader-led: it's meaningless to compute one from an
+	// outstanding, not-yet-decided proposal (no cohort is settled to add to
+	// or remove from yet). Require a decided rule rather than relying on
+	// LeaderWritesProgressing below to reject this incidentally.
+	//
+	// TODO: allow non-promotion rule changes to ride along with an
+	// outstanding proposal via propagation, instead of always waiting for
+	// decision.
+	if !commonconsensus.IsRuleDecided(rule) {
+		return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
+			"shard %s has an undecided rule proposal; cohort reconciliation requires a decided rule", problem.ShardKey)
+	}
+	decidedRule := rule.GetDecision()
+
 	// For ADD we need the pooler to be live in the cache (the cohort grows
-	// only if we have a healthy replica). For REMOVE the pooler may already
-	// be gone from the cache (the whole point of "cohort member is no longer
+	// only if we have a healthy replica) and we use it afterward to clear the
+	// joining member's archive. For REMOVE the pooler may already be gone
+	// from the cache (the whole point of "cohort member is no longer
 	// tracked"), so we operate on the problem's raw ID directly.
 	var targetID *clustermetadatapb.ID
 	var target *store.Pooler
@@ -110,16 +141,16 @@ func (a *ReconcileCohortAction) Execute(ctx context.Context, problem types.Probl
 		targetID = problem.PoolerID
 	}
 
-	members := store.FindShardMembers(a.poolerStore, problem.ShardKey)
-	leader := members.Leader
-	if leader == nil || members.HighestKnownPosition == nil {
-		return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
-			"no consensus leader known for shard %s", problem.ShardKey)
+	// The leader named by rule may not be the pooler we happen to have
+	// freshest connectivity/liveness data for — look it up by the ID the
+	// rule itself names, rather than independently re-deriving "the leader"
+	// from the cache the way the rule's own content already settles.
+	leader, err := store.FindPoolerByID(a.poolerStore, decidedRule.GetLeaderId())
+	if err != nil {
+		return mterrors.Wrap(err, "failed to find leader named by consensus rule")
 	}
-	// TODO: allow non-promotion rule changes to do propagation. Until then,
-	// LeaderWritesProgressing's decided-rule check below is what keeps this
-	// from firing against an outstanding proposal.
-	if !store.LeaderWritesProgressing(leader, members.HighestKnownPosition, time.Now(), store.DefaultLeaderWriteFreshness) {
+
+	if !store.LeaderWritesProgressing(leader, rule, time.Now(), store.DefaultLeaderWriteFreshness) {
 		return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
 			"leader for shard %s does not look able to commit writes right now", problem.ShardKey)
 	}
@@ -134,7 +165,7 @@ func (a *ReconcileCohortAction) Execute(ctx context.Context, problem types.Probl
 	req := &multipoolermanagerdatapb.UpdateConsensusRuleRequest{
 		Operation:            op,
 		StandbyIds:           []*clustermetadatapb.ID{targetID},
-		ExpectedOutgoingRule: members.HighestKnownPosition.GetDecision().GetRuleNumber(),
+		ExpectedOutgoingRule: rule.GetDecision().GetRuleNumber(),
 	}
 
 	if _, err := a.rpcClient.UpdateConsensusRule(ctx, leader.Health().Multipooler, req); err != nil {

--- a/go/services/multiorch/recovery/actions/reconcile_cohort_test.go
+++ b/go/services/multiorch/recovery/actions/reconcile_cohort_test.go
@@ -50,6 +50,15 @@ func TestReconcileCohortAction_Execute(t *testing.T) {
 	replicaID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "replica1"}
 	shardKey := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: "default", Shard: "0"}
 
+	// rule is the highest known consensus position setupStore's primary
+	// publishes. Tests pass it as RecheckedProblem.HighestKnownRule to stand
+	// in for what the engine's recheck would have supplied — Execute no
+	// longer derives it from the store itself.
+	rule := &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
+		RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 3, LeaderSubterm: 7},
+		LeaderId:   primaryID,
+	}}
+
 	setupStore := func(t *testing.T, fakeClient *rpcclient.FakeClient) (*store.PoolerCache, func()) {
 		t.Helper()
 		ts, _ := memorytopo.NewServerAndFactory(ctx, "cell1")
@@ -65,14 +74,9 @@ func TestReconcileCohortAction_Execute(t *testing.T) {
 			LastSeen: timestamppb.Now(),
 			Status:   &multipoolermanagerdatapb.Status{PostgresStatus: multipoolermanagerdatapb.PostgresStatus_POSTGRES_STATUS_PRIMARY},
 			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
-				Id:             primaryID,
-				TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 3},
-				CurrentPosition: &clustermetadatapb.PoolerPosition{
-					Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
-						RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 3, LeaderSubterm: 7},
-						LeaderId:   primaryID,
-					}},
-				},
+				Id:              primaryID,
+				TermRevocation:  &clustermetadatapb.TermRevocation{RevokedBelowTerm: 3},
+				CurrentPosition: &clustermetadatapb.PoolerPosition{Position: rule},
 			},
 		}, nil))
 		store.SeedCache(t, ps, store.NewPooler(&multiorchdatapb.PoolerHealthState{
@@ -104,11 +108,11 @@ func TestReconcileCohortAction_Execute(t *testing.T) {
 		defer cleanup()
 
 		action := NewReconcileCohortAction(nil, fakeClient, ps, nil, slog.Default())
-		err := action.Execute(ctx, types.Problem{
+		err := action.Execute(ctx, types.RecheckedProblem{Problem: types.Problem{
 			Code:     types.ProblemPoolerNotInCohort,
 			ShardKey: shardKey,
 			PoolerID: replicaID,
-		})
+		}, HighestKnownRule: rule})
 
 		require.NoError(t, err)
 		assert.Contains(t, fakeClient.CallLog, "UpdateConsensusRule(multipooler-cell1-primary)")
@@ -134,6 +138,12 @@ func TestReconcileCohortAction_Execute(t *testing.T) {
 	})
 
 	t.Run("ProblemCohortMemberIneligible issues UpdateConsensusRule with REMOVE", func(t *testing.T) {
+		// Removal safety (durability-policy quorum survival) is enforced by
+		// CohortMismatchAnalyzer before this problem is ever produced — see
+		// cohort_mismatch_analyzer_test.go — and re-verified by construction
+		// via the RecheckedProblem the engine passes in (Execute trusts it
+		// rather than re-deriving safety here). This test only exercises the
+		// REMOVE plumbing itself.
 		fakeClient := &rpcclient.FakeClient{
 			StatusResponses: map[topoclient.ComponentID]*rpcclient.ResponseWithDelay[*multipoolermanagerdatapb.StatusResponse]{
 				"multipooler-cell1-primary": {Response: &multipoolermanagerdatapb.StatusResponse{
@@ -149,11 +159,11 @@ func TestReconcileCohortAction_Execute(t *testing.T) {
 		defer cleanup()
 
 		action := NewReconcileCohortAction(nil, fakeClient, ps, nil, slog.Default())
-		err := action.Execute(ctx, types.Problem{
+		err := action.Execute(ctx, types.RecheckedProblem{Problem: types.Problem{
 			Code:     types.ProblemCohortMemberIneligible,
 			ShardKey: shardKey,
 			PoolerID: replicaID,
-		})
+		}, HighestKnownRule: rule})
 
 		require.NoError(t, err)
 		assert.Contains(t, fakeClient.CallLog, "UpdateConsensusRule(multipooler-cell1-primary)")
@@ -170,44 +180,35 @@ func TestReconcileCohortAction_Execute(t *testing.T) {
 		// No poolers added to the store — FindPoolerByID will fail.
 
 		action := NewReconcileCohortAction(nil, fakeClient, ps, nil, slog.Default())
-		err := action.Execute(ctx, types.Problem{
+		err := action.Execute(ctx, types.RecheckedProblem{Problem: types.Problem{
 			Code:     types.ProblemPoolerNotInCohort,
 			ShardKey: shardKey,
 			PoolerID: replicaID,
-		})
+		}, HighestKnownRule: rule})
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "find target pooler")
 		assert.NotContains(t, fakeClient.CallLog, "UpdateConsensusRule(multipooler-cell1-primary)")
 	})
 
-	t.Run("returns error when no consensus leader is known for the shard", func(t *testing.T) {
+	t.Run("returns error when no consensus rule is known for the shard", func(t *testing.T) {
+		// HighestKnownRule is nil — the engine's recheck found no rule for the
+		// shard (e.g. no poolers ever reported one). Execute trusts that
+		// verdict directly rather than re-deriving it from the store.
 		fakeClient := &rpcclient.FakeClient{}
 		ts, _ := memorytopo.NewServerAndFactory(ctx, "cell1")
 		defer ts.Close()
 		ps := store.NewTestCache(t)
-		// Add only the target replica; the shard search uses the
-		// (database, table_group, shard) tuple, so an unrelated shard tuple
-		// finds no poolers and therefore no leader.
-		store.SeedCache(t, ps, store.NewPooler(&multiorchdatapb.PoolerHealthState{
-			Multipooler: &clustermetadatapb.Multipooler{
-				Id:       replicaID,
-				ShardKey: shardKey,
-				Type:     clustermetadatapb.PoolerType_REPLICA,
-			},
-		}, nil))
 
 		action := NewReconcileCohortAction(nil, fakeClient, ps, nil, slog.Default())
-		err := action.Execute(ctx, types.Problem{
-			Code: types.ProblemPoolerNotInCohort,
-			ShardKey: &clustermetadatapb.ShardKey{
-				Database: "otherdb", TableGroup: "default", Shard: "0",
-			},
+		err := action.Execute(ctx, types.RecheckedProblem{Problem: types.Problem{
+			Code:     types.ProblemPoolerNotInCohort,
+			ShardKey: shardKey,
 			PoolerID: replicaID,
-		})
+		}})
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no consensus leader known")
+		assert.Contains(t, err.Error(), "no consensus rule known")
 	})
 
 	t.Run("rejects when the leader does not look able to commit writes", func(t *testing.T) {
@@ -226,18 +227,9 @@ func TestReconcileCohortAction_Execute(t *testing.T) {
 				Hostname: "primary.example.com",
 				PortMap:  map[string]int32{"postgres": 5432},
 			},
-			LastSeen: timestamppb.New(time.Now().Add(-time.Hour)),
-			Status:   &multipoolermanagerdatapb.Status{PostgresStatus: multipoolermanagerdatapb.PostgresStatus_POSTGRES_STATUS_PRIMARY},
-			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
-				Id:             primaryID,
-				TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 3},
-				CurrentPosition: &clustermetadatapb.PoolerPosition{
-					Position: &clustermetadatapb.RulePosition{Decision: &clustermetadatapb.ShardRule{
-						RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 3, LeaderSubterm: 7},
-						LeaderId:   primaryID,
-					}},
-				},
-			},
+			LastSeen:        timestamppb.New(time.Now().Add(-time.Hour)),
+			Status:          &multipoolermanagerdatapb.Status{PostgresStatus: multipoolermanagerdatapb.PostgresStatus_POSTGRES_STATUS_PRIMARY},
+			ConsensusStatus: &clustermetadatapb.ConsensusStatus{Id: primaryID, TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 3}, CurrentPosition: &clustermetadatapb.PoolerPosition{Position: rule}},
 		}, nil))
 		store.SeedCache(t, ps, store.NewPooler(&multiorchdatapb.PoolerHealthState{
 			Multipooler: &clustermetadatapb.Multipooler{
@@ -248,11 +240,11 @@ func TestReconcileCohortAction_Execute(t *testing.T) {
 		}, nil))
 
 		action := NewReconcileCohortAction(nil, fakeClient, ps, nil, slog.Default())
-		err := action.Execute(ctx, types.Problem{
+		err := action.Execute(ctx, types.RecheckedProblem{Problem: types.Problem{
 			Code:     types.ProblemPoolerNotInCohort,
 			ShardKey: shardKey,
 			PoolerID: replicaID,
-		})
+		}, HighestKnownRule: rule})
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not look able to commit writes right now")
@@ -273,76 +265,43 @@ func TestReconcileCohortAction_Execute(t *testing.T) {
 		defer cleanup()
 
 		action := NewReconcileCohortAction(nil, fakeClient, ps, nil, slog.Default())
-		err := action.Execute(ctx, types.Problem{
+		err := action.Execute(ctx, types.RecheckedProblem{Problem: types.Problem{
 			Code:     types.ProblemPoolerNotInCohort,
 			ShardKey: shardKey,
 			PoolerID: replicaID,
-		})
+		}, HighestKnownRule: rule})
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "UpdateConsensusRule failed")
 		assert.Contains(t, fakeClient.CallLog, "UpdateConsensusRule(multipooler-cell1-primary)")
 	})
 
-	t.Run("rejects when the leader's highest known position has an undecided proposal", func(t *testing.T) {
-		// Propagation isn't supported yet: the cohort must not be updated
-		// against an outgoing rule that isn't decided. LeaderWritesProgressing
-		// enforces this (via IsRuleDecided) alongside the leader-health checks.
-		// Seed the cache directly (bypassing setupStore's decided-only primary)
-		// with a proposal beyond the decision.
-		ts, _ := memorytopo.NewServerAndFactory(ctx, "cell1")
-		defer ts.Close()
-		ps := store.NewTestCache(t)
-		store.SeedCache(t, ps, store.NewPooler(&multiorchdatapb.PoolerHealthState{
-			Multipooler: &clustermetadatapb.Multipooler{
-				Id:       primaryID,
-				ShardKey: shardKey,
-				Type:     clustermetadatapb.PoolerType_PRIMARY,
-				Hostname: "primary.example.com",
-				PortMap:  map[string]int32{"postgres": 5432},
+	t.Run("rejects when the highest known rule has an undecided proposal", func(t *testing.T) {
+		// Propagation isn't supported yet: a cohort change is leader-led and
+		// meaningless against an outstanding, not-yet-decided proposal.
+		undecided := &clustermetadatapb.RulePosition{
+			Decision: &clustermetadatapb.ShardRule{
+				RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 3, LeaderSubterm: 7},
+				LeaderId:   primaryID,
 			},
-			// Otherwise healthy (fresh, genuinely primary) so the undecided
-			// proposal below is what LeaderWritesProgressing actually rejects on.
-			LastSeen: timestamppb.Now(),
-			Status:   &multipoolermanagerdatapb.Status{PostgresStatus: multipoolermanagerdatapb.PostgresStatus_POSTGRES_STATUS_PRIMARY},
-			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
-				Id:             primaryID,
-				TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 3},
-				CurrentPosition: &clustermetadatapb.PoolerPosition{
-					Position: &clustermetadatapb.RulePosition{
-						Decision: &clustermetadatapb.ShardRule{
-							RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 3, LeaderSubterm: 7},
-							LeaderId:   primaryID,
-						},
-						Proposal: &clustermetadatapb.ShardRule{
-							RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 3, LeaderSubterm: 8},
-							LeaderId:   primaryID,
-						},
-					},
-				},
+			Proposal: &clustermetadatapb.ShardRule{
+				RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 3, LeaderSubterm: 8},
+				LeaderId:   primaryID,
 			},
-		}, nil))
-		store.SeedCache(t, ps, store.NewPooler(&multiorchdatapb.PoolerHealthState{
-			Multipooler: &clustermetadatapb.Multipooler{
-				Id:       replicaID,
-				ShardKey: shardKey,
-				Type:     clustermetadatapb.PoolerType_REPLICA,
-			},
-			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
-				TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 3},
-			},
-		}, nil))
-
+		}
 		fakeClient := &rpcclient.FakeClient{}
+		ps, cleanup := setupStore(t, fakeClient)
+		defer cleanup()
+
 		action := NewReconcileCohortAction(nil, fakeClient, ps, nil, slog.Default())
-		err := action.Execute(ctx, types.Problem{
+		err := action.Execute(ctx, types.RecheckedProblem{Problem: types.Problem{
 			Code:     types.ProblemPoolerNotInCohort,
 			ShardKey: shardKey,
 			PoolerID: replicaID,
-		})
+		}, HighestKnownRule: undecided})
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "does not look able to commit writes right now")
+		assert.Contains(t, err.Error(), "undecided rule proposal")
 		assert.Empty(t, fakeClient.CallLog, "no RPC should be dispatched")
 	})
 
@@ -359,11 +318,11 @@ func TestReconcileCohortAction_Execute(t *testing.T) {
 		defer cleanup()
 
 		action := NewReconcileCohortAction(nil, fakeClient, ps, nil, slog.Default())
-		err := action.Execute(ctx, types.Problem{
+		err := action.Execute(ctx, types.RecheckedProblem{Problem: types.Problem{
 			Code:     types.ProblemReplicaNotReplicating,
 			ShardKey: shardKey,
 			PoolerID: replicaID,
-		})
+		}, HighestKnownRule: rule})
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported problem code")

--- a/go/services/multiorch/recovery/actions/reconnect_recruit_abandoned.go
+++ b/go/services/multiorch/recovery/actions/reconnect_recruit_abandoned.go
@@ -70,7 +70,8 @@ func NewReconnectRecruitAbandonedAction(
 }
 
 // Execute advances the leader's rule and reconnects the stranded follower.
-func (a *ReconnectRecruitAbandonedAction) Execute(ctx context.Context, problem types.Problem) error {
+func (a *ReconnectRecruitAbandonedAction) Execute(ctx context.Context, rechecked types.RecheckedProblem) error {
+	problem := rechecked.Problem
 	a.logger.InfoContext(ctx, "executing reconnect recruit-abandoned action",
 		"shard_key", problem.ShardKey.String(),
 		"pooler", problem.PoolerID.Name,

--- a/go/services/multiorch/recovery/actions/reconnect_recruit_abandoned_test.go
+++ b/go/services/multiorch/recovery/actions/reconnect_recruit_abandoned_test.go
@@ -94,7 +94,7 @@ func TestReconnectRecruitAbandonedAction(t *testing.T) {
 
 		action := NewReconnectRecruitAbandonedAction(config.NewTestConfig(), fake, seed(t, leaderCurrentPosition(1)), slog.Default())
 
-		require.NoError(t, action.Execute(ctx, problem))
+		require.NoError(t, action.Execute(ctx, types.RecheckedProblem{Problem: problem}))
 		assert.Contains(t, fake.CallLog, "UpdateConsensusRule(multipooler-cell1-primary)",
 			"must advance the rule on the leader")
 		assert.Contains(t, fake.CallLog, "SetPrimary(multipooler-cell1-replica1)",
@@ -111,7 +111,7 @@ func TestReconnectRecruitAbandonedAction(t *testing.T) {
 		// follower's revocation, so no advance is needed — just reconnect.
 		action := NewReconnectRecruitAbandonedAction(config.NewTestConfig(), fake, seed(t, leaderCurrentPosition(2)), slog.Default())
 
-		require.NoError(t, action.Execute(ctx, problem))
+		require.NoError(t, action.Execute(ctx, types.RecheckedProblem{Problem: problem}))
 		assert.NotContains(t, fake.CallLog, "UpdateConsensusRule(multipooler-cell1-primary)",
 			"must not advance when the rule already outranks the revocation")
 		assert.Contains(t, fake.CallLog, "SetPrimary(multipooler-cell1-replica1)",
@@ -135,7 +135,7 @@ func TestReconnectRecruitAbandonedAction(t *testing.T) {
 		}}
 		action := NewReconnectRecruitAbandonedAction(config.NewTestConfig(), fake, seed(t, undecided), slog.Default())
 
-		err := action.Execute(ctx, problem)
+		err := action.Execute(ctx, types.RecheckedProblem{Problem: problem})
 		require.Error(t, err)
 		assert.Equal(t, mtrpcpb.Code_FAILED_PRECONDITION, mterrors.Code(err))
 		assert.Contains(t, err.Error(), "undecided proposal")
@@ -152,7 +152,7 @@ func TestReconnectRecruitAbandonedAction(t *testing.T) {
 		}
 		action := NewReconnectRecruitAbandonedAction(config.NewTestConfig(), fake, seed(t, leaderCurrentPosition(1)), slog.Default())
 
-		err := action.Execute(ctx, problem)
+		err := action.Execute(ctx, types.RecheckedProblem{Problem: problem})
 		require.Error(t, err)
 		assert.Equal(t, mtrpcpb.Code_INTERNAL, mterrors.Code(err))
 		assert.Contains(t, err.Error(), "still short of the follower's revocation")
@@ -167,7 +167,7 @@ func TestReconnectRecruitAbandonedAction(t *testing.T) {
 
 		action := NewReconnectRecruitAbandonedAction(config.NewTestConfig(), fake, seed(t, leaderCurrentPosition(1)), slog.Default())
 
-		err := action.Execute(ctx, problem)
+		err := action.Execute(ctx, types.RecheckedProblem{Problem: problem})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "leader-led rule advance failed")
 		assert.Contains(t, err.Error(), "rpc boom")
@@ -181,7 +181,7 @@ func TestReconnectRecruitAbandonedAction(t *testing.T) {
 		// to the failing SetPrimary.
 		action := NewReconnectRecruitAbandonedAction(config.NewTestConfig(), fake, seed(t, leaderCurrentPosition(2)), slog.Default())
 
-		err := action.Execute(ctx, problem)
+		err := action.Execute(ctx, types.RecheckedProblem{Problem: problem})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "SetPrimary to reconnect stranded follower failed")
 		assert.Contains(t, err.Error(), "rpc boom")

--- a/go/services/multiorch/recovery/actions/shard_init_action.go
+++ b/go/services/multiorch/recovery/actions/shard_init_action.go
@@ -75,7 +75,8 @@ func NewShardInitAction(
 }
 
 // Execute performs the initial cohort establishment for a bootstrapped shard.
-func (a *ShardInitAction) Execute(ctx context.Context, problem types.Problem) error {
+func (a *ShardInitAction) Execute(ctx context.Context, rechecked types.RecheckedProblem) error {
+	problem := rechecked.Problem
 	a.logger.InfoContext(ctx, "executing shard init action",
 		"database", problem.ShardKey.Database,
 		"tablegroup", problem.ShardKey.TableGroup,

--- a/go/services/multiorch/recovery/actions/shard_init_action_test.go
+++ b/go/services/multiorch/recovery/actions/shard_init_action_test.go
@@ -249,7 +249,7 @@ func TestShardInitAction_Execute_NoInitializedPoolers(t *testing.T) {
 	store.SeedCache(t, ps, makePoolerState("cell1", "p1", "testdb", "default", "0", false, nil))
 
 	action := newTestAction(t, nil, ps, nil)
-	err := action.Execute(t.Context(), types.Problem{ShardKey: testShardInitShardKey})
+	err := action.Execute(t.Context(), types.RecheckedProblem{Problem: types.Problem{ShardKey: testShardInitShardKey}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no initialized poolers found for shard")
 }
@@ -263,7 +263,7 @@ func TestShardInitAction_Execute_CohortAlreadyEstablished(t *testing.T) {
 
 	coord := &mockCoordinator{}
 	action := newTestAction(t, coord, ps, nil)
-	err := action.Execute(t.Context(), types.Problem{ShardKey: testShardInitShardKey})
+	err := action.Execute(t.Context(), types.RecheckedProblem{Problem: types.Problem{ShardKey: testShardInitShardKey}})
 
 	require.NoError(t, err)
 	assert.Empty(t, coord.appointedCohort, "AppointInitialLeader must not be called when cohort is already established")
@@ -275,7 +275,7 @@ func TestShardInitAction_Execute_GetBootstrapPolicyError(t *testing.T) {
 
 	coord := &mockCoordinator{bootstrapPolicyErr: errors.New("etcd unreachable")}
 	action := newTestAction(t, coord, ps, nil)
-	err := action.Execute(t.Context(), types.Problem{ShardKey: testShardInitShardKey})
+	err := action.Execute(t.Context(), types.RecheckedProblem{Problem: types.Problem{ShardKey: testShardInitShardKey}})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load durability policy")
@@ -289,7 +289,7 @@ func TestShardInitAction_Execute_InsufficientInitializedPoolers(t *testing.T) {
 
 	coord := &mockCoordinator{bootstrapPolicy: topoclient.AtLeastN(2)}
 	action := newTestAction(t, coord, ps, nil)
-	err := action.Execute(t.Context(), types.Problem{ShardKey: testShardInitShardKey})
+	err := action.Execute(t.Context(), types.RecheckedProblem{Problem: types.Problem{ShardKey: testShardInitShardKey}})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "insufficient initialized poolers")
@@ -305,7 +305,7 @@ func TestShardInitAction_Execute_Success(t *testing.T) {
 	ts := memorytopo.NewServer(t.Context(), "cell1")
 	action := newTestAction(t, coord, ps, ts)
 
-	err := action.Execute(t.Context(), types.Problem{ShardKey: testShardInitShardKey})
+	err := action.Execute(t.Context(), types.RecheckedProblem{Problem: types.Problem{ShardKey: testShardInitShardKey}})
 	require.NoError(t, err)
 
 	require.Len(t, coord.appointedCohort, 2)
@@ -340,7 +340,7 @@ func TestShardInitAction_Execute_ClaimAfterCrash(t *testing.T) {
 	require.True(t, won)
 
 	action := newTestAction(t, coord, ps, ts)
-	err = action.Execute(t.Context(), types.Problem{ShardKey: testShardInitShardKey})
+	err = action.Execute(t.Context(), types.RecheckedProblem{Problem: types.Problem{ShardKey: testShardInitShardKey}})
 	require.NoError(t, err)
 
 	// The appointed cohort should use the etcd-committed names, not the pooler store names.
@@ -369,7 +369,7 @@ func TestShardInitAction_Execute_ClaimLostToDifferentCoordinator(t *testing.T) {
 	require.True(t, won)
 
 	action := newTestAction(t, coord, ps, ts)
-	err = action.Execute(t.Context(), types.Problem{ShardKey: testShardInitShardKey})
+	err = action.Execute(t.Context(), types.RecheckedProblem{Problem: types.Problem{ShardKey: testShardInitShardKey}})
 
 	require.NoError(t, err)
 	assert.Empty(t, coord.appointedCohort, "AppointInitialLeader must not be called when another coordinator owns the claim")
@@ -386,7 +386,7 @@ func TestShardInitAction_Execute_AppointInitialLeaderError(t *testing.T) {
 	}
 	action := newTestAction(t, coord, ps, memorytopo.NewServer(t.Context(), "cell1"))
 
-	err := action.Execute(t.Context(), types.Problem{ShardKey: testShardInitShardKey})
+	err := action.Execute(t.Context(), types.RecheckedProblem{Problem: types.Problem{ShardKey: testShardInitShardKey}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to appoint initial leader")
 	assert.Contains(t, err.Error(), "consensus failed")

--- a/go/services/multiorch/recovery/analysis/cohort_mismatch_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/cohort_mismatch_analyzer.go
@@ -92,7 +92,14 @@ func (a *CohortMismatchAnalyzer) Analyze(sa *ShardAnalysis) ([]types.Problem, er
 		// Removal candidates: current cohort members signaling INELIGIBLE.
 		if _, inCohort := cohortIDs[key]; inCohort {
 			seen[key] = struct{}{}
-			if types.PoolerIsCohortIneligible(pa.Health().GetAvailabilityStatus()) {
+			// Unlike a tombstoned member, an INELIGIBLE one is still an
+			// active cohort voter until removed — gate on
+			// IsCohortMemberRemovalSafe the same way the missing-from-cache
+			// case below does, so removal doesn't leave the shard unable to
+			// survive a subsequent leader failure. Deferred every cycle
+			// until another member makes it safe.
+			if types.PoolerIsCohortIneligible(pa.Health().GetAvailabilityStatus()) &&
+				commonconsensus.IsCohortMemberRemovalSafe(undecidedRule, id) {
 				problems = append(problems, types.Problem{
 					Code:           types.ProblemCohortMemberIneligible,
 					CheckName:      "CohortMismatch",

--- a/go/services/multiorch/recovery/analysis/cohort_mismatch_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/cohort_mismatch_analyzer.go
@@ -105,6 +105,16 @@ func (a *CohortMismatchAnalyzer) Analyze(sa *ShardAnalysis) ([]types.Problem, er
 			// an "ineligible" member for quorum in a genuine emergency
 			// (design not yet built) — without it, removing this gate risks
 			// stranding the shard on the next real leader failure.
+			//
+			// This check isn't capped to one removal per cycle the way the
+			// missing-from-cache path below is: multiple INELIGIBLE members
+			// each get their own problem, all checked against the same
+			// current rule. ReconcileCohortAction trusts this verdict as-is
+			// (it CASes on the same rule the engine's recheck re-verified
+			// this problem against, rather than re-deriving safety itself),
+			// and UpdateConsensusRule's compare-and-swap means only one
+			// removal lands per cycle regardless — the rest fail the CAS and
+			// retry next cycle against the now-changed cohort.
 			if types.PoolerIsCohortIneligible(pa.Health().GetAvailabilityStatus()) &&
 				commonconsensus.IsCohortMemberRemovalSafe(undecidedRule, id) {
 				problems = append(problems, types.Problem{

--- a/go/services/multiorch/recovery/analysis/cohort_mismatch_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/cohort_mismatch_analyzer.go
@@ -98,6 +98,13 @@ func (a *CohortMismatchAnalyzer) Analyze(sa *ShardAnalysis) ([]types.Problem, er
 			// case below does, so removal doesn't leave the shard unable to
 			// survive a subsequent leader failure. Deferred every cycle
 			// until another member makes it safe.
+			//
+			// A permanently-broken INELIGIBLE member can therefore never be
+			// removed from a standard 3-node AT_LEAST_N(2) shard. Intentional
+			// for now: relaxing this needs a fallback that can still recruit
+			// an "ineligible" member for quorum in a genuine emergency
+			// (design not yet built) — without it, removing this gate risks
+			// stranding the shard on the next real leader failure.
 			if types.PoolerIsCohortIneligible(pa.Health().GetAvailabilityStatus()) &&
 				commonconsensus.IsCohortMemberRemovalSafe(undecidedRule, id) {
 				problems = append(problems, types.Problem{

--- a/go/services/multiorch/recovery/analysis/cohort_mismatch_analyzer_test.go
+++ b/go/services/multiorch/recovery/analysis/cohort_mismatch_analyzer_test.go
@@ -106,6 +106,49 @@ func TestCohortMismatchAnalyzer_Analyze(t *testing.T) {
 		}
 	}
 
+	// missingMemberShard builds a ShardAnalysis where the cohort lists every
+	// id in cohortIDs, but only the analyses argument actually shows up in
+	// Analyses — i.e. ids in cohortIDs but absent from analyses are
+	// "missing from the cache" from the analyzer's perspective. tombstones,
+	// if any, are recorded as cache tombstones so the analyzer can tell the
+	// difference between "known SHUTDOWN" and "merely missing."
+	missingMemberShard := func(
+		policy *clustermetadatapb.DurabilityPolicy,
+		cohortIDs []*clustermetadatapb.ID,
+		tombstones []*clustermetadatapb.ID,
+		analyses ...*store.Pooler,
+	) *ShardAnalysis {
+		leader := leaderRider()
+		full := append([]*store.Pooler{leader}, analyses...)
+		tombSet := make(map[topoclient.ComponentID]struct{}, len(tombstones))
+		for _, id := range tombstones {
+			tombSet[topoclient.ComponentIDString(id)] = struct{}{}
+		}
+		return &ShardAnalysis{
+			ShardKey: shardKey,
+			HighestPosition: &clustermetadatapb.RulePosition{
+				Decision: &clustermetadatapb.ShardRule{
+					RuleNumber:       &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
+					LeaderId:         primaryID,
+					CohortMembers:    cohortIDs,
+					DurabilityPolicy: policy,
+				},
+			},
+			Now:          time.Now(),
+			Policy:       DefaultAvailabilityPolicy(),
+			Leader:       leader,
+			Analyses:     full,
+			TombstoneIDs: tombSet,
+		}
+	}
+
+	atLeastN := func(n int32) *clustermetadatapb.DurabilityPolicy {
+		return &clustermetadatapb.DurabilityPolicy{
+			QuorumType:    clustermetadatapb.QuorumType_QUORUM_TYPE_AT_LEAST_N,
+			RequiredCount: n,
+		}
+	}
+
 	t.Run("detects healthy replica missing from cohort", func(t *testing.T) {
 		// Cohort = {} — replica A is replicating, eligible by default, and absent.
 		sa := healthyShard(nil, healthyReplicaPA(replicaA, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_UNKNOWN))
@@ -151,9 +194,19 @@ func TestCohortMismatchAnalyzer_Analyze(t *testing.T) {
 	})
 
 	t.Run("detects cohort member signaling INELIGIBLE", func(t *testing.T) {
-		sa := healthyShard(
-			[]*clustermetadatapb.ID{replicaA},
+		// 5-member cohort under N=2 so removing A (INELIGIBLE) and losing the
+		// leader still leaves a recruitable quorum — the removal safety gate
+		// must pass for this REMOVE to be proposed at all.
+		extraReplica1 := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "replica-c"}
+		extraReplica2 := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "replica-d"}
+		sa := missingMemberShard(
+			atLeastN(2),
+			[]*clustermetadatapb.ID{primaryID, replicaA, replicaB, extraReplica1, extraReplica2},
+			nil,
 			healthyReplicaPA(replicaA, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE),
+			healthyReplicaPA(replicaB, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE),
+			healthyReplicaPA(extraReplica1, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE),
+			healthyReplicaPA(extraReplica2, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE),
 		)
 		problems, err := analyzer.Analyze(sa)
 		require.NoError(t, err)
@@ -267,10 +320,18 @@ func TestCohortMismatchAnalyzer_Analyze(t *testing.T) {
 	})
 
 	t.Run("emits both add and remove problems together", func(t *testing.T) {
-		sa := healthyShard(
-			[]*clustermetadatapb.ID{replicaA}, // A is in cohort, B is not
+		// 4-member cohort under N=2 (A is in cohort, B is not) so removing A
+		// and losing the leader still leaves a recruitable quorum.
+		extraReplica1 := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "replica-c"}
+		extraReplica2 := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "replica-d"}
+		sa := missingMemberShard(
+			atLeastN(2),
+			[]*clustermetadatapb.ID{primaryID, replicaA, extraReplica1, extraReplica2},
+			nil,
 			healthyReplicaPA(replicaA, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE),
 			healthyReplicaPA(replicaB, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE),
+			healthyReplicaPA(extraReplica1, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE),
+			healthyReplicaPA(extraReplica2, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE),
 		)
 		problems, err := analyzer.Analyze(sa)
 		require.NoError(t, err)
@@ -339,49 +400,6 @@ func TestCohortMismatchAnalyzer_Analyze(t *testing.T) {
 	// for cohort members the cache no longer tracks (tombstones from
 	// LIFECYCLE_SHUTDOWN, and untombstoned absences). They cover the
 	// confidence tiers the analyzer applies before proposing a problem.
-
-	// missingMemberShard builds a ShardAnalysis where the cohort lists every
-	// id in cohortIDs, but only the analyses argument actually shows up in
-	// Analyses — i.e. ids in cohortIDs but absent from analyses are
-	// "missing from the cache" from the analyzer's perspective. tombstones,
-	// if any, are recorded as cache tombstones so the analyzer can tell the
-	// difference between "known SHUTDOWN" and "merely missing."
-	missingMemberShard := func(
-		policy *clustermetadatapb.DurabilityPolicy,
-		cohortIDs []*clustermetadatapb.ID,
-		tombstones []*clustermetadatapb.ID,
-		analyses ...*store.Pooler,
-	) *ShardAnalysis {
-		leader := leaderRider()
-		full := append([]*store.Pooler{leader}, analyses...)
-		tombSet := make(map[topoclient.ComponentID]struct{}, len(tombstones))
-		for _, id := range tombstones {
-			tombSet[topoclient.ComponentIDString(id)] = struct{}{}
-		}
-		return &ShardAnalysis{
-			ShardKey: shardKey,
-			HighestPosition: &clustermetadatapb.RulePosition{
-				Decision: &clustermetadatapb.ShardRule{
-					RuleNumber:       &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
-					LeaderId:         primaryID,
-					CohortMembers:    cohortIDs,
-					DurabilityPolicy: policy,
-				},
-			},
-			Now:          time.Now(),
-			Policy:       DefaultAvailabilityPolicy(),
-			Leader:       leader,
-			Analyses:     full,
-			TombstoneIDs: tombSet,
-		}
-	}
-
-	atLeastN := func(n int32) *clustermetadatapb.DurabilityPolicy {
-		return &clustermetadatapb.DurabilityPolicy{
-			QuorumType:    clustermetadatapb.QuorumType_QUORUM_TYPE_AT_LEAST_N,
-			RequiredCount: n,
-		}
-	}
 
 	t.Run("tombstoned cohort member triggers unconditional REMOVE", func(t *testing.T) {
 		// Cohort = {primary, replicaA, replicaB}. replicaA is a tombstone

--- a/go/services/multiorch/recovery/recovery_grace_period_test.go
+++ b/go/services/multiorch/recovery/recovery_grace_period_test.go
@@ -33,7 +33,7 @@ type mockActionWithGracePeriod struct {
 	gracePeriod *types.GracePeriodConfig
 }
 
-func (m *mockActionWithGracePeriod) Execute(ctx context.Context, problem types.Problem) error {
+func (m *mockActionWithGracePeriod) Execute(ctx context.Context, rechecked types.RecheckedProblem) error {
 	return nil
 }
 

--- a/go/services/multiorch/recovery/recovery_loop.go
+++ b/go/services/multiorch/recovery/recovery_loop.go
@@ -267,7 +267,7 @@ func (re *Engine) attemptRecovery(ctx context.Context, problem types.Problem) {
 	}
 
 	// Force re-poll to validate the problem still exists
-	stillExists, err := re.recheckProblem(ctx, problem)
+	rechecked, err := re.recheckProblem(ctx, problem)
 	if err != nil {
 		span.SetAttributes(attribute.String("result", "recheck_failed"))
 		re.logger.WarnContext(ctx, "failed to validate problem, skipping recovery",
@@ -277,7 +277,7 @@ func (re *Engine) attemptRecovery(ctx context.Context, problem types.Problem) {
 		)
 		return
 	}
-	if !stillExists {
+	if rechecked == nil {
 		span.SetAttributes(attribute.String("result", "problem_resolved"))
 		re.logger.DebugContext(ctx, "problem no longer exists after re-poll, skipping recovery",
 			"problem_code", problem.Code,
@@ -292,7 +292,7 @@ func (re *Engine) attemptRecovery(ctx context.Context, problem types.Problem) {
 
 	startTime := time.Now()
 
-	err = problem.RecoveryAction.Execute(ctx, problem)
+	err = problem.RecoveryAction.Execute(ctx, *rechecked)
 	durationMs := float64(time.Since(startTime).Milliseconds())
 
 	if err != nil {
@@ -322,8 +322,14 @@ func (re *Engine) attemptRecovery(ctx context.Context, problem types.Problem) {
 // streams, so no explicit force-poll is needed. We simply re-generate the
 // shard analysis from the current store and re-run the analyzer.
 //
-// Returns (stillExists bool, error).
-func (re *Engine) recheckProblem(ctx context.Context, problem types.Problem) (bool, error) {
+// Returns nil (with a nil error) if the problem is no longer detected — the
+// caller should skip recovery. Otherwise returns the redetected problem
+// bundled with the shard's highest known consensus position as of this
+// recheck (the same snapshot the analyzer just re-verified it against), so
+// Execute anchors its CAS on exactly what was just judged safe rather than
+// re-deriving the rule itself and risking a second, independently-read
+// snapshot that could in principle disagree.
+func (re *Engine) recheckProblem(ctx context.Context, problem types.Problem) (*types.RecheckedProblem, error) {
 	entityID := problem.EntityID()
 
 	re.logger.DebugContext(ctx, "validating problem still exists",
@@ -338,8 +344,9 @@ func (re *Engine) recheckProblem(ctx context.Context, problem types.Problem) (bo
 	generator := analysis.NewAnalysisGenerator(re.poolerCache, re.makePolicyLookup(ctx))
 	shardAnalysis, err := generator.GenerateShardAnalysis(problem.ShardKey)
 	if err != nil {
-		return false, fmt.Errorf("failed to generate analysis after re-poll: %w", err)
+		return nil, fmt.Errorf("failed to generate analysis after re-poll: %w", err)
 	}
+	rule := shardAnalysis.HighestPosition
 
 	// Re-run the analyzer that originally detected this problem
 	analyzers := analysis.DefaultAnalyzers(re.actionFactory)
@@ -350,7 +357,7 @@ func (re *Engine) recheckProblem(ctx context.Context, problem types.Problem) (bo
 				re.metrics.errorsTotal.Add(ctx, "analyzer",
 					attribute.String("analyzer", string(analyzer.Name())),
 				)
-				return false, fmt.Errorf("analyzer %s failed during recheck: %w", analyzer.Name(), err)
+				return nil, fmt.Errorf("analyzer %s failed during recheck: %w", analyzer.Name(), err)
 			}
 
 			// Check if the same problem is still detected.
@@ -365,7 +372,7 @@ func (re *Engine) recheckProblem(ctx context.Context, problem types.Problem) (bo
 						"entity_id", entityID,
 						"problem_code", problem.Code,
 					)
-					return true, nil
+					return &types.RecheckedProblem{Problem: p, HighestKnownRule: rule}, nil
 				}
 			}
 
@@ -374,11 +381,11 @@ func (re *Engine) recheckProblem(ctx context.Context, problem types.Problem) (bo
 				"entity_id", entityID,
 				"problem_code", problem.Code,
 			)
-			return false, nil
+			return nil, nil
 		}
 	}
 
-	return false, fmt.Errorf("analyzer %s not found", problem.CheckName)
+	return nil, fmt.Errorf("analyzer %s not found", problem.CheckName)
 }
 
 // makePolicyLookup returns a closure that fetches the bootstrap durability policy

--- a/go/services/multiorch/recovery/recovery_loop_test.go
+++ b/go/services/multiorch/recovery/recovery_loop_test.go
@@ -95,7 +95,7 @@ type trackingRecoveryAction struct {
 	executionOrderMu *sync.Mutex
 }
 
-func (t *trackingRecoveryAction) Execute(ctx context.Context, problem types.Problem) error {
+func (t *trackingRecoveryAction) Execute(ctx context.Context, rechecked types.RecheckedProblem) error {
 	t.executionOrderMu.Lock()
 	*t.executionOrder = append(*t.executionOrder, t.label)
 	t.executionOrderMu.Unlock()
@@ -131,9 +131,9 @@ type mockRecoveryAction struct {
 	gracePeriod *types.GracePeriodConfig
 }
 
-func (m *mockRecoveryAction) Execute(ctx context.Context, problem types.Problem) error {
+func (m *mockRecoveryAction) Execute(ctx context.Context, rechecked types.RecheckedProblem) error {
 	if m.executeFn != nil {
-		return m.executeFn(ctx, problem)
+		return m.executeFn(ctx, rechecked.Problem)
 	}
 	m.executed.Store(true)
 	return m.executeErr
@@ -360,10 +360,10 @@ func TestRecheckProblem_PoolerNotFound(t *testing.T) {
 		Priority:  types.PriorityEmergency,
 	}
 
-	stillExists, err := engine.recheckProblem(t.Context(), problem)
+	rechecked, err := engine.recheckProblem(t.Context(), problem)
 
 	require.Error(t, err, "should return error when shard not found")
-	assert.False(t, stillExists)
+	assert.Nil(t, rechecked)
 	assert.Contains(t, err.Error(), "shard not found")
 }
 

--- a/go/services/multiorch/recovery/types/types.go
+++ b/go/services/multiorch/recovery/types/types.go
@@ -207,10 +207,26 @@ type GracePeriodConfig struct {
 	MaxJitter time.Duration
 }
 
+// RecheckedProblem pairs a Problem with the exact consensus rule the engine's
+// pre-execution recheck just re-verified it against (the same ShardAnalysis
+// that redetected the problem — see recovery_loop.go's recheckProblem). The
+// two are bundled deliberately: an action performing a CAS-anchored mutation
+// must judge safety and anchor its CAS on the same rule, or the two could
+// silently disagree. Passing them as independent parameters would let a
+// caller pass a mismatched pair and still compile; this makes that
+// structurally impossible — the only way to obtain one is from a successful
+// recheck. HighestKnownRule is nil if no rule was known for the shard at
+// recheck time; actions that don't mutate the consensus rule can ignore it.
+type RecheckedProblem struct {
+	Problem
+	HighestKnownRule *clustermetadatapb.RulePosition
+}
+
 // RecoveryAction is a function that fixes a problem.
 type RecoveryAction interface {
-	// Execute performs the recovery.
-	Execute(ctx context.Context, problem Problem) error
+	// Execute performs the recovery against the problem and rule the
+	// engine's pre-execution recheck just reconfirmed together.
+	Execute(ctx context.Context, rechecked RecheckedProblem) error
 
 	// Metadata returns info about this recovery.
 	Metadata() RecoveryMetadata


### PR DESCRIPTION
ReconcileCohortAction independently re-derived "the current rule" for both its removal-safety check and its `UpdateConsensusRule` CAS — a second read that could disagree with what the engine's pre-execution recheck already verified.

- Bundles the redetected problem and its verified rule into one `RecheckedProblem` value threaded through `RecoveryAction.Execute`, so a mismatched pair is a compile error.
- Drops the now-redundant safety re-check (the analyzer already proves it against that exact rule).
- Makes rejection of an undecided/in-flight rule proposal explicit instead of an incidental side effect of the leader-liveness check.
