### PR TITLE
fix(multipooler): re-resign on failed promote; avoid sync-commit stall on rule-CAS read

### DIFF
--- a/go/services/multipooler/internal/executor/admin_query.go
+++ b/go/services/multipooler/internal/executor/admin_query.go
@@ -16,8 +16,10 @@ package executor
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/multigres/multigres/go/common/sqltypes"
+	"github.com/multigres/multigres/go/services/multipooler/internal/pools/admin"
 )
 
 // The QueryAdmin* methods are the InternalQueryService access path for the
@@ -52,4 +54,57 @@ func (e *Executor) QueryAdminArgs(ctx context.Context, sql string, args ...any) 
 // QueryAdminMultiStatement implements InternalQueryService on the admin pool.
 func (e *Executor) QueryAdminMultiStatement(ctx context.Context, queryStr string) error {
 	return runMultiStatement(ctx, e.borrowAdmin, queryStr)
+}
+
+// BeginAdmin implements InternalQueryService on the admin pool.
+func (e *Executor) BeginAdmin(ctx context.Context) (InternalTx, error) {
+	pooled, err := e.poolManager.GetAdminConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	conn := adminTxConn{conn: pooled.Conn}
+	if _, err := conn.Query(ctx, "BEGIN"); err != nil {
+		pooled.Recycle()
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	return &genericTx{
+		conn: conn,
+		// admin.Conn's own no-retry query methods already close the
+		// connection on a genuine connection failure (see QueryNoRetry's doc
+		// comment), so Recycle here always sees an accurate IsClosed() and
+		// does the right thing either way — no separate error-vs-clean
+		// release path is needed, unlike the reserved pool's ReleaseReason.
+		onRelease: func(_ txOutcome, _ error) {
+			pooled.Recycle()
+		},
+	}, nil
+}
+
+// adminTxConn adapts *admin.Conn to the txConn interface shared with the
+// regular pool's transactions (see genericTx). admin.Conn has no native
+// transaction-lifecycle methods, so Commit/Rollback are sent as literal
+// statements — always via the no-retry query path, never
+// QueryWithRetry/QueryArgsWithRetry, which are only safe for stateless calls
+// (see their doc comments for why: a silent reconnect mid-transaction would
+// lose it without any error to signal that).
+type adminTxConn struct {
+	conn *admin.Conn
+}
+
+func (c adminTxConn) Query(ctx context.Context, sql string) ([]*sqltypes.Result, error) {
+	return c.conn.QueryNoRetry(ctx, sql)
+}
+
+func (c adminTxConn) QueryArgs(ctx context.Context, sql string, args ...any) ([]*sqltypes.Result, error) {
+	return c.conn.QueryArgsNoRetry(ctx, sql, args...)
+}
+
+func (c adminTxConn) Commit(ctx context.Context) error {
+	_, err := c.conn.QueryNoRetry(ctx, "COMMIT")
+	return err
+}
+
+func (c adminTxConn) Rollback(ctx context.Context) error {
+	_, err := c.conn.QueryNoRetry(ctx, "ROLLBACK")
+	return err
 }

--- a/go/services/multipooler/internal/executor/admin_query.go
+++ b/go/services/multipooler/internal/executor/admin_query.go
@@ -16,10 +16,8 @@ package executor
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/multigres/multigres/go/common/sqltypes"
-	"github.com/multigres/multigres/go/services/multipooler/internal/pools/admin"
 )
 
 // The QueryAdmin* methods are the InternalQueryService access path for the
@@ -56,55 +54,28 @@ func (e *Executor) QueryAdminMultiStatement(ctx context.Context, queryStr string
 	return runMultiStatement(ctx, e.borrowAdmin, queryStr)
 }
 
-// BeginAdmin implements InternalQueryService on the admin pool.
+// BeginAdmin implements InternalQueryService on the admin pool. The returned
+// transaction runs on an admin.TxConn, which has no retry methods at all —
+// see its doc comment for why that matters mid-transaction.
 func (e *Executor) BeginAdmin(ctx context.Context) (InternalTx, error) {
 	pooled, err := e.poolManager.GetAdminConn(ctx)
 	if err != nil {
 		return nil, err
 	}
-	conn := adminTxConn{conn: pooled.Conn}
-	if _, err := conn.Query(ctx, "BEGIN"); err != nil {
+	txConn, err := pooled.Conn.BeginTx(ctx)
+	if err != nil {
 		pooled.Recycle()
-		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+		return nil, err
 	}
 	return &genericTx{
-		conn: conn,
-		// admin.Conn's own no-retry query methods already close the
-		// connection on a genuine connection failure (see QueryNoRetry's doc
-		// comment), so Recycle here always sees an accurate IsClosed() and
-		// does the right thing either way — no separate error-vs-clean
-		// release path is needed, unlike the reserved pool's ReleaseReason.
+		conn: txConn,
+		// admin.TxConn's query methods already close the connection on a
+		// genuine connection failure, so Recycle here always sees an
+		// accurate IsClosed() and does the right thing either way — no
+		// separate error-vs-clean release path is needed, unlike the
+		// reserved pool's ReleaseReason.
 		onRelease: func(_ txOutcome, _ error) {
 			pooled.Recycle()
 		},
 	}, nil
-}
-
-// adminTxConn adapts *admin.Conn to the txConn interface shared with the
-// regular pool's transactions (see genericTx). admin.Conn has no native
-// transaction-lifecycle methods, so Commit/Rollback are sent as literal
-// statements — always via the no-retry query path, never
-// QueryWithRetry/QueryArgsWithRetry, which are only safe for stateless calls
-// (see their doc comments for why: a silent reconnect mid-transaction would
-// lose it without any error to signal that).
-type adminTxConn struct {
-	conn *admin.Conn
-}
-
-func (c adminTxConn) Query(ctx context.Context, sql string) ([]*sqltypes.Result, error) {
-	return c.conn.QueryNoRetry(ctx, sql)
-}
-
-func (c adminTxConn) QueryArgs(ctx context.Context, sql string, args ...any) ([]*sqltypes.Result, error) {
-	return c.conn.QueryArgsNoRetry(ctx, sql, args...)
-}
-
-func (c adminTxConn) Commit(ctx context.Context) error {
-	_, err := c.conn.QueryNoRetry(ctx, "COMMIT")
-	return err
-}
-
-func (c adminTxConn) Rollback(ctx context.Context) error {
-	_, err := c.conn.QueryNoRetry(ctx, "ROLLBACK")
-	return err
 }

--- a/go/services/multipooler/internal/executor/internal_query.go
+++ b/go/services/multipooler/internal/executor/internal_query.go
@@ -278,10 +278,8 @@ func (e *Executor) Begin(ctx context.Context) (InternalTx, error) {
 }
 
 // txConn is the subset of a transaction-capable connection genericTx needs.
-// *reserved.Conn (the regular pool's reserved connection, used by Begin)
-// satisfies it natively; admin-pool connections are adapted via adminTxConn
-// (used by BeginAdmin), since admin.Conn has no native transaction-lifecycle
-// methods of its own.
+// *reserved.Conn (the regular pool's reserved connection, used by Begin) and
+// *admin.TxConn (used by BeginAdmin) both satisfy it natively.
 type txConn interface {
 	Query(ctx context.Context, sql string) ([]*sqltypes.Result, error)
 	QueryArgs(ctx context.Context, sql string, args ...any) ([]*sqltypes.Result, error)

--- a/go/services/multipooler/internal/executor/internal_query.go
+++ b/go/services/multipooler/internal/executor/internal_query.go
@@ -93,6 +93,9 @@ type InternalQueryService interface {
 	//	}
 	//	return tx.Commit(ctx)
 	Begin(ctx context.Context) (InternalTx, error)
+
+	// BeginAdmin is Begin on the admin pool.
+	BeginAdmin(ctx context.Context) (InternalTx, error)
 }
 
 // InternalTx is a handle to an in-progress transaction held on a reserved
@@ -119,8 +122,8 @@ type InternalTx interface {
 	Rollback(ctx context.Context) error
 }
 
-// Compile-time check that internalTx implements InternalTx.
-var _ InternalTx = (*internalTx)(nil)
+// Compile-time check that genericTx implements InternalTx.
+var _ InternalTx = (*genericTx)(nil)
 
 // Compile-time check that Executor implements InternalQueryService.
 var _ InternalQueryService = (*Executor)(nil)
@@ -256,22 +259,63 @@ func (e *Executor) Begin(ctx context.Context) (InternalTx, error) {
 		return nil, fmt.Errorf("failed to begin transaction: %w", err)
 	}
 
-	return &internalTx{conn: reservedConn}, nil
+	return &genericTx{
+		conn: reservedConn,
+		onRelease: func(outcome txOutcome, err error) {
+			switch {
+			case err != nil:
+				// The op itself failed: the connection's state is no longer
+				// known to be clean, so release it as an error (which taints
+				// it) rather than recycling.
+				reservedConn.Release(reserved.ReleaseError, nil)
+			case outcome == txCommitted:
+				reservedConn.Release(reserved.ReleaseCommit, nil)
+			default:
+				reservedConn.Release(reserved.ReleaseRollback, nil)
+			}
+		},
+	}, nil
 }
 
-// internalTx is the Executor's implementation of InternalTx. It owns a reserved
-// connection for the duration of a transaction.
-type internalTx struct {
-	// conn is the reserved connection carrying the open transaction.
-	conn *reserved.Conn
+// txConn is the subset of a transaction-capable connection genericTx needs.
+// *reserved.Conn (the regular pool's reserved connection, used by Begin)
+// satisfies it natively; admin-pool connections are adapted via adminTxConn
+// (used by BeginAdmin), since admin.Conn has no native transaction-lifecycle
+// methods of its own.
+type txConn interface {
+	Query(ctx context.Context, sql string) ([]*sqltypes.Result, error)
+	QueryArgs(ctx context.Context, sql string, args ...any) ([]*sqltypes.Result, error)
+	Commit(ctx context.Context) error
+	Rollback(ctx context.Context) error
+}
 
-	// finished is set once the transaction has been committed or rolled back and
-	// the connection released. Further queries on a finished tx are rejected.
+// txOutcome names which end of the transaction genericTx reached, passed to
+// onRelease alongside any error.
+type txOutcome int
+
+const (
+	txCommitted txOutcome = iota
+	txRolledBack
+)
+
+// genericTx is the shared InternalTx implementation for both Begin (regular
+// pool) and BeginAdmin (admin pool), so the two don't grow independent,
+// driftable copies of this logic. onRelease is called exactly once, after
+// Commit or Rollback resolves, naming which one ran and whether it errored,
+// so each pool can apply its own release semantics (reserved.Conn's
+// ReleaseCommit/ReleaseRollback/ReleaseError bookkeeping vs. the admin pool's
+// plain recycle).
+type genericTx struct {
+	conn      txConn
+	onRelease func(outcome txOutcome, err error)
+
+	// finished is set once the transaction has been committed or rolled back.
+	// Further queries on a finished tx are rejected.
 	finished bool
 }
 
 // Query implements InternalTx.
-func (tx *internalTx) Query(ctx context.Context, queryStr string) (*sqltypes.Result, error) {
+func (tx *genericTx) Query(ctx context.Context, queryStr string) (*sqltypes.Result, error) {
 	if tx.finished {
 		return nil, errTxFinished
 	}
@@ -290,7 +334,7 @@ func (tx *internalTx) Query(ctx context.Context, queryStr string) (*sqltypes.Res
 }
 
 // QueryArgs implements InternalTx.
-func (tx *internalTx) QueryArgs(ctx context.Context, sql string, args ...any) (*sqltypes.Result, error) {
+func (tx *genericTx) QueryArgs(ctx context.Context, sql string, args ...any) (*sqltypes.Result, error) {
 	if tx.finished {
 		return nil, errTxFinished
 	}
@@ -309,7 +353,7 @@ func (tx *internalTx) QueryArgs(ctx context.Context, sql string, args ...any) (*
 }
 
 // Commit implements InternalTx.
-func (tx *internalTx) Commit(ctx context.Context) error {
+func (tx *genericTx) Commit(ctx context.Context) error {
 	if tx.finished {
 		return errTxFinished
 	}
@@ -318,19 +362,17 @@ func (tx *internalTx) Commit(ctx context.Context) error {
 		IncludeQueryText: true,
 	})
 
-	if err := tx.conn.Commit(ctx); err != nil {
-		// COMMIT failed: the connection's state is no longer known to be clean,
-		// so release it as an error (which taints it) rather than recycling.
-		tx.conn.Release(reserved.ReleaseError, nil)
+	err := tx.conn.Commit(ctx)
+	tx.onRelease(txCommitted, err)
+	if err != nil {
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
-	tx.conn.Release(reserved.ReleaseCommit, nil)
 	return nil
 }
 
 // Rollback implements InternalTx. It is a no-op once the transaction is
 // finished, so callers can defer it unconditionally alongside Commit.
-func (tx *internalTx) Rollback(ctx context.Context) error {
+func (tx *genericTx) Rollback(ctx context.Context) error {
 	if tx.finished {
 		return nil
 	}
@@ -339,10 +381,10 @@ func (tx *internalTx) Rollback(ctx context.Context) error {
 		IncludeQueryText: true,
 	})
 
-	if err := tx.conn.Rollback(ctx); err != nil {
-		tx.conn.Release(reserved.ReleaseError, nil)
+	err := tx.conn.Rollback(ctx)
+	tx.onRelease(txRolledBack, err)
+	if err != nil {
 		return fmt.Errorf("failed to rollback transaction: %w", err)
 	}
-	tx.conn.Release(reserved.ReleaseRollback, nil)
 	return nil
 }

--- a/go/services/multipooler/internal/executor/internal_query.go
+++ b/go/services/multipooler/internal/executor/internal_query.go
@@ -297,12 +297,9 @@ const (
 )
 
 // genericTx is the shared InternalTx implementation for both Begin (regular
-// pool) and BeginAdmin (admin pool), so the two don't grow independent,
-// driftable copies of this logic. onRelease is called exactly once, after
-// Commit or Rollback resolves, naming which one ran and whether it errored,
-// so each pool can apply its own release semantics (reserved.Conn's
-// ReleaseCommit/ReleaseRollback/ReleaseError bookkeeping vs. the admin pool's
-// plain recycle).
+// pool) and BeginAdmin (admin pool). onRelease is called exactly once, after
+// Commit or Rollback resolves, so each pool can apply its own release
+// semantics.
 type genericTx struct {
 	conn      txConn
 	onRelease func(outcome txOutcome, err error)

--- a/go/services/multipooler/internal/executor/mock/mock_querier.go
+++ b/go/services/multipooler/internal/executor/mock/mock_querier.go
@@ -230,6 +230,12 @@ func (m *QueryService) Begin(ctx context.Context) (executor.InternalTx, error) {
 	return &mockTx{m: m}, nil
 }
 
+// BeginAdmin implements executor.InternalQueryService. The mock has no
+// separate admin pool, so this behaves identically to Begin.
+func (m *QueryService) BeginAdmin(ctx context.Context) (executor.InternalTx, error) {
+	return m.Begin(ctx)
+}
+
 // queryIfMatched runs queryStr through the matcher only if a pattern matches it,
 // returning any configured error. Unmatched control statements succeed silently.
 func (m *QueryService) queryIfMatched(ctx context.Context, queryStr string) error {

--- a/go/services/multipooler/internal/manager/consensus/rule_store.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store.go
@@ -31,6 +31,7 @@ import (
 	"github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/eventlog"
 	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/common/timeouts"
 	"github.com/multigres/multigres/go/common/topoclient"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
@@ -464,11 +465,7 @@ var errRuleConflict = errors.New("rule conflict: current rule version changed si
 //
 // The caller is responsible for adding an appropriate context timeout.
 func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clustermetadatapb.PoolerPosition, error) {
-	suffix := ""
-	if forUpdate {
-		suffix = " FOR UPDATE NOWAIT"
-	}
-	result, err := rs.queryService.QueryAdminArgs(ctx, `
+	query := `
 		SELECT decision_coordinator_term, decision_leader_subterm, leader_id, coordinator_id, cohort_members,
 		       durability_policy_name, durability_quorum_type, durability_required_count,
 		       created_at,
@@ -482,7 +479,21 @@ func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clus
 		         ELSE pg_current_wal_lsn()
 		       END::text AS current_lsn
 		FROM multigres.current_rule
-		WHERE shard_id = $1`+suffix, []byte("0"))
+		WHERE shard_id = $1`
+
+	var result *sqltypes.Result
+	var err error
+	if forUpdate {
+		// FOR UPDATE NOWAIT's only job here is to fail immediately if some
+		// other session is mid-write on the row (a tripwire against a
+		// concurrent writer bypassing the action lock, e.g. raw SQL); the
+		// lock doesn't need to persist past that check, so wrapInRollback
+		// keeps it from ever waiting on synchronous_commit the way the
+		// caller's actual rule write correctly does.
+		result, err = rs.wrapInRollback(ctx, query+" FOR UPDATE NOWAIT", []byte("0"))
+	} else {
+		result, err = rs.queryService.QueryAdminArgs(ctx, query, []byte("0"))
+	}
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to read current_rule")
 	}
@@ -525,6 +536,23 @@ func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clus
 		return nil, mterrors.Wrap(err, "failed to parse current_rule")
 	}
 	return pos, nil
+}
+
+// wrapInRollback runs query in its own transaction and always rolls back
+// rather than commits, so the query's implicit write (if any) never waits on
+// synchronous_commit — only COMMIT does, ROLLBACK never does, regardless of
+// the GUC. Useful for a statement whose WAL-logged side effect doesn't need
+// to persist or be replicated, such as SELECT ... FOR UPDATE NOWAIT: the row
+// lock it takes exists only to fail fast on a concurrent writer, not to
+// outlive this call.
+func (rs *ruleStore) wrapInRollback(ctx context.Context, query string, args ...any) (*sqltypes.Result, error) {
+	tx, err := rs.queryService.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	return tx.QueryArgs(ctx, query, args...)
 }
 
 // ObservePosition reads the current rule and WAL LSN from postgres and returns

--- a/go/services/multipooler/internal/manager/consensus/rule_store.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store.go
@@ -548,6 +548,12 @@ func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clus
 // deferred Rollback below always runs regardless of how the query failed.
 //
 // Uses BeginAdmin, not Begin: this touches the locked-down multigres schema.
+//
+// Untested: the synchronous_commit stall this avoids only reproduces against
+// real postgres with synchronous_standby_names set to an unreachable
+// standby, which the existing rule_store_pg_test.go harness doesn't yet set
+// up. The NOWAIT-fails-fast behavior is covered by
+// TestRuleStorePG_*_FailsWhenRuleIsLocked; the stall-avoidance itself isn't.
 func (rs *ruleStore) wrapInRollback(ctx context.Context, query string, args ...any) (*sqltypes.Result, error) {
 	tx, err := rs.queryService.BeginAdmin(ctx)
 	if err != nil {

--- a/go/services/multipooler/internal/manager/consensus/rule_store.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store.go
@@ -484,12 +484,12 @@ func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clus
 	var result *sqltypes.Result
 	var err error
 	if forUpdate {
-		// FOR UPDATE NOWAIT's only job here is to fail immediately if some
-		// other session is mid-write on the row (a tripwire against a
-		// concurrent writer bypassing the action lock, e.g. raw SQL); the
-		// lock doesn't need to persist past that check, so wrapInRollback
-		// keeps it from ever waiting on synchronous_commit the way the
-		// caller's actual rule write correctly does.
+		// FOR UPDATE NOWAIT is load-bearing, not just a raw-SQL tripwire: it's
+		// how callers prove a prior action-lock holder's write transaction has
+		// actually ended on postgres, even if that holder's own context timed
+		// out first (see WithPriorRuleWritesDrained). wrapInRollback keeps
+		// this check from paying for synchronous_commit it doesn't need — see
+		// its doc comment.
 		result, err = rs.wrapInRollback(ctx, query+" FOR UPDATE NOWAIT", []byte("0"))
 	} else {
 		result, err = rs.queryService.QueryAdminArgs(ctx, query, []byte("0"))
@@ -545,8 +545,20 @@ func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clus
 // to persist or be replicated, such as SELECT ... FOR UPDATE NOWAIT: the row
 // lock it takes exists only to fail fast on a concurrent writer, not to
 // outlive this call.
+//
+// An explicit transaction was chosen over a single "BEGIN; ...; ROLLBACK;"
+// string: a NOWAIT lock conflict — the expected, common case here, not an
+// edge case — aborts the transaction and skips every remaining statement in
+// a multi-statement message, including its own trailing ROLLBACK, leaving
+// the connection idle-in-a-failed-transaction for whoever borrows it next.
+// The deferred Rollback below always runs regardless of how the query
+// failed. A stored procedure was also considered; it would need a
+// schema-migration mechanism this codebase doesn't otherwise have, to
+// deploy the same behavior.
+//
+// Uses BeginAdmin, not Begin: this touches the locked-down multigres schema.
 func (rs *ruleStore) wrapInRollback(ctx context.Context, query string, args ...any) (*sqltypes.Result, error) {
-	tx, err := rs.queryService.Begin(ctx)
+	tx, err := rs.queryService.BeginAdmin(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/go/services/multipooler/internal/manager/consensus/rule_store.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store.go
@@ -484,12 +484,10 @@ func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clus
 	var result *sqltypes.Result
 	var err error
 	if forUpdate {
-		// FOR UPDATE NOWAIT is load-bearing, not just a raw-SQL tripwire: it's
-		// how callers prove a prior action-lock holder's write transaction has
-		// actually ended on postgres, even if that holder's own context timed
-		// out first (see WithPriorRuleWritesDrained). wrapInRollback keeps
-		// this check from paying for synchronous_commit it doesn't need — see
-		// its doc comment.
+		// Load-bearing, not just a raw-SQL tripwire: proves a prior
+		// action-lock holder's write transaction has actually ended on
+		// postgres, even after that holder's own context timed out (see
+		// WithPriorRuleWritesDrained).
 		result, err = rs.wrapInRollback(ctx, query+" FOR UPDATE NOWAIT", []byte("0"))
 	} else {
 		result, err = rs.queryService.QueryAdminArgs(ctx, query, []byte("0"))
@@ -538,23 +536,16 @@ func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clus
 	return pos, nil
 }
 
-// wrapInRollback runs query in its own transaction and always rolls back
-// rather than commits, so the query's implicit write (if any) never waits on
-// synchronous_commit — only COMMIT does, ROLLBACK never does, regardless of
-// the GUC. Useful for a statement whose WAL-logged side effect doesn't need
-// to persist or be replicated, such as SELECT ... FOR UPDATE NOWAIT: the row
-// lock it takes exists only to fail fast on a concurrent writer, not to
-// outlive this call.
+// wrapInRollback runs query in its own transaction and always rolls back, so
+// its implicit write (if any) never waits on synchronous_commit — only
+// COMMIT does. Useful for a statement whose WAL-logged side effect doesn't
+// need to persist, like SELECT ... FOR UPDATE NOWAIT.
 //
-// An explicit transaction was chosen over a single "BEGIN; ...; ROLLBACK;"
-// string: a NOWAIT lock conflict — the expected, common case here, not an
-// edge case — aborts the transaction and skips every remaining statement in
-// a multi-statement message, including its own trailing ROLLBACK, leaving
-// the connection idle-in-a-failed-transaction for whoever borrows it next.
-// The deferred Rollback below always runs regardless of how the query
-// failed. A stored procedure was also considered; it would need a
-// schema-migration mechanism this codebase doesn't otherwise have, to
-// deploy the same behavior.
+// Uses an explicit transaction rather than a "BEGIN; ...; ROLLBACK;" string:
+// a NOWAIT lock conflict is the expected case here, and it would abort the
+// transaction and skip the remaining statements — including the trailing
+// ROLLBACK — leaving the connection idle-in-a-failed-transaction. The
+// deferred Rollback below always runs regardless of how the query failed.
 //
 // Uses BeginAdmin, not Begin: this touches the locked-down multigres schema.
 func (rs *ruleStore) wrapInRollback(ctx context.Context, query string, args ...any) (*sqltypes.Result, error) {

--- a/go/services/multipooler/internal/manager/consensus/rule_store_pg_test.go
+++ b/go/services/multipooler/internal/manager/consensus/rule_store_pg_test.go
@@ -133,6 +133,11 @@ func (s *connQueryService) Begin(ctx context.Context) (executor.InternalTx, erro
 	return &connTx{conn: s.conn}, nil
 }
 
+// BeginAdmin runs on the same test connection as Begin — see the admin-variant note above.
+func (s *connQueryService) BeginAdmin(ctx context.Context) (executor.InternalTx, error) {
+	return s.Begin(ctx)
+}
+
 // connTx implements executor.InternalTx over a single *client.Conn for tests.
 type connTx struct {
 	conn     *client.Conn

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -592,14 +592,11 @@ func (pm *MultipoolerManager) promoteLocked(ctx context.Context, req *consensusd
 		return pm.promoteStandbyToPrimary(hookCtx, state, proposal.GetProposedTransition())
 	}
 
-	// Re-establish resignation on any failure from here on, regardless of
-	// cause. The promotion hook above clears it optimistically before the
-	// promotion is confirmed (to shrink the window where other coordinators
-	// still see this node as needing replacement and pile on with competing
-	// Recruit calls); if the promotion then fails for any reason, that leaves
-	// this node silently fallen through the cracks — no longer signaling
-	// resignation, but also never actually promoted. Recruit already proved
-	// this node needs replacing, so a failed promote must not lose that.
+	// The hook above clears resignation optimistically before promotion is
+	// confirmed, to shrink the window where other coordinators still see this
+	// node as needing replacement. If promotion then fails, re-establish it
+	// here — otherwise this node is stuck silently unpromoted and no longer
+	// signaling for replacement either.
 	defer func() {
 		if err != nil {
 			if resignErr := pm.consensusMgr.SetResignedLeaderAtTerm(ctx, beforeStatus.GetCurrentPosition().GetPosition()); resignErr != nil {

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -477,7 +477,7 @@ func (pm *MultipoolerManager) Promote(ctx context.Context, req *consensusdatapb.
 	return resp, err
 }
 
-func (pm *MultipoolerManager) promoteLocked(ctx context.Context, req *consensusdatapb.PromoteRequest) (*consensusdatapb.PromoteResponse, error) {
+func (pm *MultipoolerManager) promoteLocked(ctx context.Context, req *consensusdatapb.PromoteRequest) (resp *consensusdatapb.PromoteResponse, err error) {
 	proposal := req.GetProposal()
 	revocation := proposal.GetTermRevocation()
 	proposalLeader := proposal.GetProposalLeader()
@@ -591,6 +591,22 @@ func (pm *MultipoolerManager) promoteLocked(ctx context.Context, req *consensusd
 		pm.logUnreadyFailoverSlots(hookCtx)
 		return pm.promoteStandbyToPrimary(hookCtx, state, proposal.GetProposedTransition())
 	}
+
+	// Re-establish resignation on any failure from here on, regardless of
+	// cause. The promotion hook above clears it optimistically before the
+	// promotion is confirmed (to shrink the window where other coordinators
+	// still see this node as needing replacement and pile on with competing
+	// Recruit calls); if the promotion then fails for any reason, that leaves
+	// this node silently fallen through the cracks — no longer signaling
+	// resignation, but also never actually promoted. Recruit already proved
+	// this node needs replacing, so a failed promote must not lose that.
+	defer func() {
+		if err != nil {
+			if resignErr := pm.consensusMgr.SetResignedLeaderAtTerm(ctx, beforeStatus.GetCurrentPosition().GetPosition()); resignErr != nil {
+				pm.logger.ErrorContext(ctx, "failed to re-set resigned primary term after failed promote", "error", resignErr)
+			}
+		}
+	}()
 
 	ruleUpdate := consensus.NewRuleUpdate(
 		revokedBelowTerm,

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -1030,18 +1030,45 @@ func TestPromote(t *testing.T) {
 			// rather than mark the promotion successful — the rule write is
 			// the durability gate, and a failure here means the new primary
 			// hasn't satisfied sync replication.
+			//
+			// This also exercises the promotionHook clearing resignation
+			// before the failure: postCheck confirms resignation is
+			// re-established rather than lost (see rpc_consensus.go's defer
+			// in promoteLocked). Uses a custom revocation at outgoing term 3
+			// (rather than the shared recruitedTerm/makeLeaderReq, both fixed
+			// at outgoing term 0) so beforeStatus's decided position is
+			// non-zero: term 0 is indistinguishable from "not resigned" (see
+			// ConsensusManager.LeadershipStatus), so a term-0 baseline would
+			// pass this check without actually exercising it.
 			name:        "UpdateRuleFails",
 			initialTerm: recruitedTerm,
 			ruleStore: &fakeRuleStore{
-				pos:                makeRulePosition(0),
+				pos:                makeRulePosition(3),
 				updateErrAfterHook: errors.New("rule store offline"),
 			},
-			req: makeLeaderReq(),
+			req: &consensusdatapb.PromoteRequest{
+				Proposal: &consensusdatapb.CoordinatorProposal{
+					TermRevocation: &clustermetadatapb.TermRevocation{
+						RevokedBelowTerm:       7,
+						AcceptedCoordinatorId:  coordinatorA,
+						CoordinatorInitiatedAt: recruitTS,
+						OutgoingRule:           &clustermetadatapb.RuleNumber{CoordinatorTerm: 3},
+					},
+					ProposalLeader:     &clustermetadatapb.PoolerAddress{Id: selfID, Host: "pg-primary.internal", PostgresPort: 5432},
+					ProposedTransition: &clustermetadatapb.RulePosition{Proposal: validProposedRule},
+				},
+			},
 			setupMocks: func(m *mock.QueryService) {
 				expectLeaderPromoteMocks(m)
 			},
 			expectError:       true,
 			expectErrContains: "promote failed: could not write rule",
+			postCheck: func(t *testing.T, pm *MultipoolerManager, rs *fakeRuleStore) {
+				status := pm.consensusMgr.LeadershipStatus()
+				require.NotNil(t, status, "resignation must be re-set after a failed promote")
+				assert.Equal(t, int64(3), status.LeaderTerm)
+				assert.Equal(t, clustermetadatapb.LeadershipSignal_LEADERSHIP_SIGNAL_REQUESTING_DEMOTION, status.Signal)
+			},
 		},
 	}
 
@@ -1074,9 +1101,9 @@ func TestPromote(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, resp)
 				require.NotNil(t, resp.ConsensusStatus)
-				if tt.postCheck != nil {
-					tt.postCheck(t, pm, tt.ruleStore)
-				}
+			}
+			if tt.postCheck != nil {
+				tt.postCheck(t, pm, tt.ruleStore)
 			}
 
 			require.Eventually(t, func() bool {

--- a/go/services/multipooler/internal/pools/admin/admin_conn.go
+++ b/go/services/multipooler/internal/pools/admin/admin_conn.go
@@ -287,16 +287,20 @@ func (c *Conn) queryWithRetry(ctx context.Context, sql string) ([]*sqltypes.Resu
 	panic("unreachable")
 }
 
-// QueryNoRetry and QueryArgsNoRetry run a single query attempt with no retry
-// or reconnection on error. Use these instead of QueryWithRetry/
-// QueryArgsWithRetry once a transaction has begun (BEGIN already sent): those
-// retry by silently reconnecting on a connection error, which would start a
-// fresh session that never ran BEGIN, silently losing the transaction. An
-// ordinary SQL error (e.g. a NOWAIT lock conflict) leaves the now-aborted
-// transaction on this same connection for the caller's Rollback to clean up,
-// same as any transaction; only a genuine connection failure closes the
-// connection, so it's never returned to the pool in an unknown state.
-func (c *Conn) QueryNoRetry(ctx context.Context, sql string) ([]*sqltypes.Result, error) {
+// queryNoRetry and queryArgsNoRetry run a single query attempt with no retry
+// or reconnection on error. Used by TxConn once a transaction has begun
+// (BEGIN already sent): QueryWithRetry/QueryArgsWithRetry retry by silently
+// reconnecting on a connection error, which would start a fresh session that
+// never ran BEGIN, silently losing the transaction. An ordinary SQL error
+// (e.g. a NOWAIT lock conflict) leaves the now-aborted transaction on this
+// same connection for the caller's Rollback to clean up, same as any
+// transaction; only a genuine connection failure closes the connection, so
+// it's never returned to the pool in an unknown state.
+//
+// Unexported: TxConn is the only supported way to run a transaction on an
+// admin connection, so there is no reason for a caller outside this package
+// to reach for these directly.
+func (c *Conn) queryNoRetry(ctx context.Context, sql string) ([]*sqltypes.Result, error) {
 	results, err := execQueryWithContextCancel(ctx, c.conn, func() ([]*sqltypes.Result, error) {
 		return c.conn.Query(ctx, sql)
 	})
@@ -306,8 +310,8 @@ func (c *Conn) QueryNoRetry(ctx context.Context, sql string) ([]*sqltypes.Result
 	return results, err
 }
 
-// QueryArgsNoRetry is QueryNoRetry for a parameterized query.
-func (c *Conn) QueryArgsNoRetry(ctx context.Context, sql string, args ...any) ([]*sqltypes.Result, error) {
+// queryArgsNoRetry is queryNoRetry for a parameterized query.
+func (c *Conn) queryArgsNoRetry(ctx context.Context, sql string, args ...any) ([]*sqltypes.Result, error) {
 	results, err := execQueryWithContextCancel(ctx, c.conn, func() ([]*sqltypes.Result, error) {
 		return c.conn.QueryArgs(ctx, sql, args...)
 	})
@@ -315,6 +319,46 @@ func (c *Conn) QueryArgsNoRetry(ctx context.Context, sql string, args ...any) ([
 		c.conn.Close()
 	}
 	return results, err
+}
+
+// TxConn is an admin Conn that has started an explicit transaction. It
+// exposes only single-attempt query methods — no retry variant exists on it
+// at all — mirroring how the regular pool's reserved.Conn separates
+// transactional connections from the retry-capable stateless ones, so a
+// caller mid-transaction cannot reach for the wrong method by mistake.
+type TxConn struct {
+	conn *Conn
+}
+
+// BeginTx sends BEGIN on c and returns a TxConn for running the rest of the
+// transaction. c must not be used directly again until the transaction ends.
+func (c *Conn) BeginTx(ctx context.Context) (*TxConn, error) {
+	if _, err := c.queryNoRetry(ctx, "BEGIN"); err != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	return &TxConn{conn: c}, nil
+}
+
+// Query runs sql as a single no-retry attempt.
+func (tc *TxConn) Query(ctx context.Context, sql string) ([]*sqltypes.Result, error) {
+	return tc.conn.queryNoRetry(ctx, sql)
+}
+
+// QueryArgs is Query for a parameterized query.
+func (tc *TxConn) QueryArgs(ctx context.Context, sql string, args ...any) ([]*sqltypes.Result, error) {
+	return tc.conn.queryArgsNoRetry(ctx, sql, args...)
+}
+
+// Commit sends COMMIT.
+func (tc *TxConn) Commit(ctx context.Context) error {
+	_, err := tc.conn.queryNoRetry(ctx, "COMMIT")
+	return err
+}
+
+// Rollback sends ROLLBACK.
+func (tc *TxConn) Rollback(ctx context.Context) error {
+	_, err := tc.conn.queryNoRetry(ctx, "ROLLBACK")
+	return err
 }
 
 // execQueryWithContextCancel executes a query operation in a goroutine so that

--- a/go/services/multipooler/internal/pools/admin/admin_conn.go
+++ b/go/services/multipooler/internal/pools/admin/admin_conn.go
@@ -288,18 +288,10 @@ func (c *Conn) queryWithRetry(ctx context.Context, sql string) ([]*sqltypes.Resu
 }
 
 // queryNoRetry and queryArgsNoRetry run a single query attempt with no retry
-// or reconnection on error. Used by TxConn once a transaction has begun
-// (BEGIN already sent): QueryWithRetry/QueryArgsWithRetry retry by silently
-// reconnecting on a connection error, which would start a fresh session that
-// never ran BEGIN, silently losing the transaction. An ordinary SQL error
-// (e.g. a NOWAIT lock conflict) leaves the now-aborted transaction on this
-// same connection for the caller's Rollback to clean up, same as any
-// transaction; only a genuine connection failure closes the connection, so
-// it's never returned to the pool in an unknown state.
-//
-// Unexported: TxConn is the only supported way to run a transaction on an
-// admin connection, so there is no reason for a caller outside this package
-// to reach for these directly.
+// or reconnection. Used by TxConn once BEGIN has been sent: the WithRetry
+// variants reconnect silently on a connection error, which would start a
+// fresh session that never ran BEGIN, losing the transaction. Unexported —
+// TxConn is the only supported way to run a transaction here.
 func (c *Conn) queryNoRetry(ctx context.Context, sql string) ([]*sqltypes.Result, error) {
 	results, err := execQueryWithContextCancel(ctx, c.conn, func() ([]*sqltypes.Result, error) {
 		return c.conn.Query(ctx, sql)

--- a/go/services/multipooler/internal/pools/admin/admin_conn.go
+++ b/go/services/multipooler/internal/pools/admin/admin_conn.go
@@ -287,6 +287,36 @@ func (c *Conn) queryWithRetry(ctx context.Context, sql string) ([]*sqltypes.Resu
 	panic("unreachable")
 }
 
+// QueryNoRetry and QueryArgsNoRetry run a single query attempt with no retry
+// or reconnection on error. Use these instead of QueryWithRetry/
+// QueryArgsWithRetry once a transaction has begun (BEGIN already sent): those
+// retry by silently reconnecting on a connection error, which would start a
+// fresh session that never ran BEGIN, silently losing the transaction. An
+// ordinary SQL error (e.g. a NOWAIT lock conflict) leaves the now-aborted
+// transaction on this same connection for the caller's Rollback to clean up,
+// same as any transaction; only a genuine connection failure closes the
+// connection, so it's never returned to the pool in an unknown state.
+func (c *Conn) QueryNoRetry(ctx context.Context, sql string) ([]*sqltypes.Result, error) {
+	results, err := execQueryWithContextCancel(ctx, c.conn, func() ([]*sqltypes.Result, error) {
+		return c.conn.Query(ctx, sql)
+	})
+	if err != nil && mterrors.IsConnectionDead(err) {
+		c.conn.Close()
+	}
+	return results, err
+}
+
+// QueryArgsNoRetry is QueryNoRetry for a parameterized query.
+func (c *Conn) QueryArgsNoRetry(ctx context.Context, sql string, args ...any) ([]*sqltypes.Result, error) {
+	results, err := execQueryWithContextCancel(ctx, c.conn, func() ([]*sqltypes.Result, error) {
+		return c.conn.QueryArgs(ctx, sql, args...)
+	})
+	if err != nil && mterrors.IsConnectionDead(err) {
+		c.conn.Close()
+	}
+	return results, err
+}
+
 // execQueryWithContextCancel executes a query operation in a goroutine so that
 // context cancellation can interrupt a blocking network read.
 //


### PR DESCRIPTION
- Re-resign as leader if `Promote` fails after the promotion hook already cleared it — previously left the node stuck, neither leader nor signaling for replacement.
- `readCurrentRule`'s `FOR UPDATE NOWAIT` precheck ran under implicit auto-commit, so its row lock could stall on `synchronous_commit`. Fixed via `BeginAdmin` + explicit rollback (only `COMMIT` waits, never `ROLLBACK`).
- Added `BeginAdmin` (admin-pool transactions), sharing implementation with the existing `Begin` via a new `genericTx`/`txConn` abstraction.
- Split `admin.Conn`'s retry-capable stateless methods from its no-retry transactional path (`TxConn`), so the two can't be mixed up on one type.