### PR TITLE
fix(multipooler): drop orphaned failover slots on demote/rejoin

### DIFF
--- a/docs/ha/logical_slot_failover_design.md
+++ b/docs/ha/logical_slot_failover_design.md
@@ -391,13 +391,26 @@ changes apply to any member of the cohort.
 - Repoint `primary_conninfo` at the new primary, keeping the static user / `dbname` / application_name.
 - Drop the physical replication slots it held for its former followers. They have no consumer now and would
   otherwise pin WAL indefinitely.
+- Drop the logical failover slots it still owns as _un-synced originals_ (`synced = false`). While this node was
+  primary it held the writable originals of the failover slots; a standby, by contrast, is only supposed to hold
+  the _synced copies_ that its slot-sync worker maintains (`synced = true`). If the un-synced originals are left
+  in place, slot-sync cannot create the synced copy — a slot of that name already exists — so the original never
+  advances: its `restart_lsn` freezes and Postgres eventually invalidates it (`rows_removed`). An invalidated
+  slot makes this node an unusable failover target for that slot, so after a couple of leader rotations the
+  cohort runs out of failover-ready targets. Dropping the un-synced originals lets slot-sync recreate them as
+  proper synced copies. This is safe precisely because it runs only as the node becomes a standby — the live
+  originals live on the current primary, which never takes this path.
 - `RESET synchronized_standby_slots`. Primary does not have any followers. The option does not make a difference
   for the standby since it is not consulted for standbys, but if the standby is promoted, the list would be
   wrong.
 
-> **NOTE:** These same steps apply when a _former primary rejoins after a crash_. It never ran a graceful
-> demotion, so it comes back still holding physical slots for its old followers and a stale
-> `synchronized_standby_slots`; both must be cleaned as it rejoins as a standby.
+> **NOTE:** These same steps apply when a _former primary rejoins after a crash_ — or after a failover in which
+> it did not diverge and so was **not** rewound (it simply repoints at the new primary and streams). It never ran
+> a graceful demotion, so it comes back still holding physical slots for its old followers, the un-synced logical
+> failover originals it created while primary, and a stale `synchronized_standby_slots`; all three must be cleaned
+> as it rejoins as a standby. The no-rewind case is the important one: a rewind would have discarded the stale
+> originals as a side effect, but a clean repoint leaves them behind, which is exactly when the invalidation trap
+> above bites.
 
 ### 2.4 Changes needed for when a server is added as a new standby to the cohort
 

--- a/go/services/multipooler/internal/manager/logical_slots.go
+++ b/go/services/multipooler/internal/manager/logical_slots.go
@@ -338,6 +338,53 @@ func (pm *MultipoolerManager) dropManagedPhysicalSlots(ctx context.Context) erro
 	return nil
 }
 
+// dropOrphanedFailoverSlotsSQL drops every logical failover slot this node still
+// owns as an un-synced original (synced = false) while it is (becoming) a
+// standby. On a standby a genuine failover slot is a copy the slot-sync worker
+// maintains from the primary (synced = true); an un-synced failover slot here is
+// the leftover original this node created back when it was primary. The
+// NOT active guard skips a slot a consumer is still attached to (dropping an
+// active slot errors and would abort the whole statement).
+const dropOrphanedFailoverSlotsSQL = `
+SELECT pg_drop_replication_slot(slot_name)
+  FROM pg_replication_slots
+ WHERE slot_type = 'logical'
+   AND failover
+   AND NOT synced
+   AND NOT active`
+
+// dropOrphanedFailoverSlots drops the logical failover slots this node still owns
+// as un-synced originals. It is the logical-slot counterpart of
+// dropManagedPhysicalSlots, called on the same demote / rejoin transitions.
+//
+// The problem it fixes: a former primary that rejoins as a standby (e.g. after a
+// failover, with no divergence and thus no rewind) keeps the original failover
+// slots it created while primary. Those originals carry synced = false. The
+// standby's slot-sync worker cannot create the proper synced copy because a slot
+// of that name already exists, so the stale original never advances — its
+// restart_lsn freezes, and postgres eventually invalidates it (rows_removed).
+// An invalidated slot makes this node an unusable failover target for that slot,
+// so after a couple of leader rotations the cohort runs out of failover-ready
+// targets. Dropping the un-synced originals lets slot-sync recreate them as
+// proper synced copies.
+//
+// Safe because this runs only when the node is (becoming) a standby, where it
+// owns no live originals — the live originals live on the current primary, which
+// never takes this path. No-op unless slot-based replication is enabled.
+func (pm *MultipoolerManager) dropOrphanedFailoverSlots(ctx context.Context) error {
+	if !pm.slotBasedReplicationEnabled() {
+		return nil
+	}
+
+	execCtx, cancel := context.WithTimeout(ctx, logicalSlotWriteTimeout)
+	defer cancel()
+	if err := pm.execArgs(execCtx, dropOrphanedFailoverSlotsSQL); err != nil {
+		return mterrors.Wrap(err, "failed to drop orphaned logical failover slots")
+	}
+
+	return nil
+}
+
 // listManagedPhysicalSlotsSQL lists this node's managed physical replication
 // slots (name + active flag) so a reconcile can drop the ones no longer wanted.
 // Mirrors dropManagedPhysicalSlotsSQL's WHERE clause; the slot_type filter keeps

--- a/go/services/multipooler/internal/manager/logical_slots_test.go
+++ b/go/services/multipooler/internal/manager/logical_slots_test.go
@@ -491,6 +491,35 @@ func TestDropManagedPhysicalSlots(t *testing.T) {
 	})
 }
 
+func TestDropOrphanedFailoverSlots(t *testing.T) {
+	t.Run("no-op when disabled", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		// Nothing registered: any query would fail the mock, proving no-op.
+		require.NoError(t, pm.dropOrphanedFailoverSlots(t.Context()))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("drops orphaned logical failover slots when enabled", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		// "synced" is unique to the orphaned-failover-slot drop query.
+		m.AddQueryPatternOnce("synced", mock.MakeQueryResult(nil, nil))
+
+		require.NoError(t, pm.dropOrphanedFailoverSlots(t.Context()))
+		assert.NoError(t, m.ExpectationsWereMet())
+	})
+
+	t.Run("propagates exec error", func(t *testing.T) {
+		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)
+		enableSlotBasedReplication(pm)
+		m.AddQueryPatternOnceWithError("synced", errors.New("boom"))
+
+		err := pm.dropOrphanedFailoverSlots(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to drop orphaned logical failover slots")
+	})
+}
+
 func TestReconcileFollowers(t *testing.T) {
 	t.Run("no-op when disabled", func(t *testing.T) {
 		pm, m := newTestManagerWithMock(t, constants.DefaultTableGroup, constants.DefaultShard)

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -936,6 +936,14 @@ func (pm *MultipoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 	if err := pm.dropManagedPhysicalSlots(ctx); err != nil {
 		pm.logger.WarnContext(ctx, "failed to drop stale managed physical slots (non-fatal)", "error", err)
 	}
+	// Also drop any logical failover slots this node still owns as un-synced
+	// originals from when it was primary. Left in place they collide with the
+	// synced copy slot-sync would create, freeze, and invalidate — making this
+	// node an unusable failover target. Dropping them lets slot-sync recreate
+	// proper synced copies.
+	if err := pm.dropOrphanedFailoverSlots(ctx); err != nil {
+		pm.logger.WarnContext(ctx, "failed to drop orphaned logical failover slots (non-fatal)", "error", err)
+	}
 	if err := pm.resetSynchronizedStandbySlots(ctx); err != nil {
 		pm.logger.WarnContext(ctx, "failed to clear synchronized_standby_slots (non-fatal)", "error", err)
 	}

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -830,6 +830,13 @@ func (pm *MultipoolerManager) demoteToStandbyLocked(ctx context.Context, consens
 	if err := pm.dropManagedPhysicalSlots(ctx); err != nil {
 		pm.logger.WarnContext(ctx, "failed to drop managed physical slots after demote (non-fatal)", "error", err)
 	}
+	// Likewise drop any logical failover slots this node still owns as un-synced
+	// originals from when it was primary: slot-sync cannot replace a same-named
+	// original, so it would freeze and invalidate, disqualifying this node as a
+	// failover target. Dropping them lets slot-sync recreate synced copies.
+	if err := pm.dropOrphanedFailoverSlots(ctx); err != nil {
+		pm.logger.WarnContext(ctx, "failed to drop orphaned logical failover slots after demote (non-fatal)", "error", err)
+	}
 
 	// Mark the WAL as rewind-suspect: this node was just demoted, so the next
 	// restart-as-standby (the monitor's demote path or its divergence-rewind

--- a/go/services/multipooler/internal/manager/rpc_set_primary_test.go
+++ b/go/services/multipooler/internal/manager/rpc_set_primary_test.go
@@ -373,6 +373,58 @@ func TestSetPrimary_StandbyAppliesNewPrimary(t *testing.T) {
 	assert.Equal(t, "primary-host", recorded.GetHost())
 }
 
+// TestSetPrimary_StandbyAppliesNewPrimary_SlotCleanupNonFatal verifies that, with
+// slot-based replication enabled, a failure while dropping this node's orphaned
+// logical failover slots on the standby-update path is non-fatal: SetPrimary still
+// succeeds and records the new primary. It exercises the error branch of the
+// dropOrphanedFailoverSlots call in setPrimaryLocked (the drop is best-effort — a
+// former primary that keeps its un-synced originals just streams without them,
+// and the monitor/next demote retries).
+func TestSetPrimary_StandbyAppliesNewPrimary_SlotCleanupNonFatal(t *testing.T) {
+	mockQueryService := mock.NewQueryService()
+
+	// Same standby-update flow as TestSetPrimary_StandbyAppliesNewPrimary, but with
+	// pg_is_in_recovery as a repeatable pattern (slot-based replication adds calls).
+	mockQueryService.AddQueryPattern("SELECT pg_is_in_recovery",
+		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
+	mockQueryService.AddQueryPatternOnce("SELECT pg_wal_replay_pause",
+		mock.MakeQueryResult(nil, nil))
+	mockQueryService.AddQueryPattern("^SELECT pg_last_wal_replay_lsn",
+		mock.MakeQueryResult([]string{"replay_lsn", "is_paused"}, [][]any{{"0/100", true}}))
+	mockQueryService.AddQueryPattern("ALTER SYSTEM SET primary_conninfo",
+		mock.MakeQueryResult(nil, nil))
+	expectReloadConfig(mockQueryService)
+	mockQueryService.AddQueryPattern("^SELECT 1$", mock.MakeQueryResult(nil, nil))
+	mockQueryService.AddQueryPatternOnce("SELECT pg_wal_replay_resume",
+		mock.MakeQueryResult(nil, nil))
+
+	// Slot-based replication on. dropManagedPhysicalSlots (starts_with) succeeds;
+	// dropOrphanedFailoverSlots (the "synced" query) fails. The remaining standby
+	// slot-GUC calls are unregistered and error harmlessly — all four calls in the
+	// slot block are best-effort, so SetPrimary must still succeed.
+	mockQueryService.AddQueryPattern("starts_with", mock.MakeQueryResult(nil, nil))
+	mockQueryService.AddQueryPatternWithError("synced", errors.New("boom dropping orphaned failover slots"))
+
+	pm, _ := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(3)})
+	enableSlotBasedReplication(pm)
+
+	leader := newLeaderAddress("new-primary", "primary-host", 5432)
+	req := &consensusdatapb.SetPrimaryRequest{
+		ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
+			Position:    &clustermetadatapb.RulePosition{Decision: ruleAtTermForLeader(leader, 10)},
+			Primary:     leader,
+			RewindReady: true,
+		},
+	}
+	resp, err := pm.SetPrimary(t.Context(), req)
+	require.NoError(t, err, "a failed orphaned-slot drop must be non-fatal")
+	require.NotNil(t, resp)
+
+	recorded := pm.consensusMgr.GetReplicationPrimary().GetPrimary()
+	require.NotNil(t, recorded, "primary should still be recorded despite the slot-drop failure")
+	assert.Equal(t, "new-primary", recorded.GetId().GetName())
+}
+
 // TestSetPrimary_StalePrimaryDemotes verifies the stale-primary branch end to end:
 // when the receiver is acting as primary (pg_is_in_recovery=false) and the
 // supplied position is higher, SetPrimary must drive a full demote — pg_rewind,


### PR DESCRIPTION
## Situation

Logical replication slot failover (#1394) synchronizes a subscriber's failover slot to standbys so a logical consumer can resume after a leader change. That machinery assumes a standby only ever holds *synced copies* of a failover slot (`synced = true`), maintained by its slot-sync worker.

## Problem

A former primary that rejoins as a standby **without a rewind** — the no-divergence, sync-replication case — keeps the failover slots it created while it was primary. Those originals carry `synced = false`. On the rejoined standby, the slot-sync worker cannot create the proper synced copy because a slot of that name already exists, so the stale original never advances: its `restart_lsn` freezes and PostgreSQL eventually invalidates it (`rows_removed`). An invalidated slot disqualifies the node as a failover target, so after a couple of leader rotations the cohort runs out of failover-ready targets.

This only bites under *repeated* failover. A single failover works, because it only needs the promoted node's slot — whose `synced` flag flips to `false` correctly on promotion — and the broken orphan left on the rejoined node is never required to be a target.

## Fix

Drop the node's own un-synced failover slots on the same demote / rejoin transitions that already drop stale physical slots (`setPrimaryLocked` and the emergency-demote path). Slot-sync then recreates them as proper synced copies.

- New `dropOrphanedFailoverSlots`: drops slots matching `slot_type = 'logical' AND failover AND NOT synced AND NOT active`. The `NOT active` guard skips a slot a consumer is still attached to; the `NOT synced` filter guarantees only this node's leftover originals are touched, never a legitimate synced copy. No-op unless slot-based replication is enabled.
- Wired in beside `dropManagedPhysicalSlots` at both demote/rejoin call sites.
- §2.3 of the design doc now documents the logical-slot cleanup and calls out the no-rewind case as the one where the trap bites.

## Flow comparison (before / after)

The two charts are identical up to the rejoin; the "after" chart is the "before" chart with one step added — dropping the stale `synced=false` slot on the demote/rejoin transition — which unblocks slot-sync.

Before (the bug):

```mermaid
sequenceDiagram
    participant C as Client (ETL)
    participant P as pooler-1
    participant SS as slot-sync on pooler-1
    participant B as pooler-2
    Note over P: pooler-1 is PRIMARY
    C->>P: CREATE_REPLICATION_SLOT etl (FAILOVER)
    Note over P: slot etl — synced=false (original)
    P-->>B: slot-sync copies etl to standby
    Note over B: slot etl — synced=true (copy)
    Note over P: pooler-1 KILLED
    Note over B: promoted — etl becomes writable original (synced=false)
    C->>B: reconnect, resume consuming etl (no data lost)
    Note over P: pooler-1 REJOINS as standby (no divergence so NO rewind)
    Note over P: still holds its OLD etl — synced=false (stale original)
    SS->>P: try to sync etl from pooler-2
    Note over SS,P: BLOCKED — a slot named etl already exists and is not synced
    Note over P: etl never advances — restart_lsn frozen, then INVALIDATED (rows_removed)
    Note over P: pooler-1 is no longer a failover-ready target for etl
```

After (this PR):

```mermaid
sequenceDiagram
    participant C as Client (ETL)
    participant P as pooler-1
    participant SS as slot-sync on pooler-1
    participant B as pooler-2
    Note over P: pooler-1 is PRIMARY
    C->>P: CREATE_REPLICATION_SLOT etl (FAILOVER)
    Note over P: slot etl — synced=false (original)
    P-->>B: slot-sync copies etl to standby
    Note over B: slot etl — synced=true (copy)
    Note over P: pooler-1 KILLED
    Note over B: promoted — etl becomes writable original (synced=false)
    C->>B: reconnect, resume consuming etl (no data lost)
    Note over P: pooler-1 REJOINS as standby (no divergence so NO rewind)
    Note over P: demote/rejoin drops its own synced=false failover slots — stale etl DROPPED
    SS->>P: sync etl from pooler-2
    Note over P: slot etl recreated — synced=true (copy)
    Note over P: etl advances, becomes failover_ready again
```

## Why it's safe

It runs only when a node is (re)becoming a standby, where it owns no live originals — the live originals live on the current primary, which never takes either path.

## Testing

- New unit test `TestDropOrphanedFailoverSlots` (no-op-when-disabled / drops-when-enabled / propagates-error), mirroring the sibling physical-slot test.

## Manual 10× failover test — verdict: PASS, no data loss

Validated end to end on a local kind Multigres cluster (1 primary + 2 standbys, slot-based replication enabled) with a Supabase ETL consumer (the pgoutput/`FAILOVER` client from supabase/etl#991), deleting the primary 10 times in a row under continuous writes:

- A background writer inserts a row every 0.1 s, started *before* the replication slot is created, so the run also exercises slot setup and teardown under load.
- Before each failover the harness waits for the slot to be `failover_ready` on both standbys, then deletes the primary; after each failover the pipeline must resume.

Verdict: **PASS.** Across all 10 failovers the pipeline resumed every time and no data was lost — final reconciliation `source = destination = 1383` rows. Every rejoined former-primary returned to `failover_ready` immediately (the readiness wait cleared after 1 check on failovers 2–10). Before this fix the same loop degraded after ~2 rotations because rejoined nodes never became failover-ready again — exactly the gap this PR closes.
