### PR TITLE
feat(multiadmin): add only_reachable filter to GetGateways

### DIFF
--- a/go/pb/multiadmin/multiadminservice.pb.go
+++ b/go/pb/multiadmin/multiadminservice.pb.go
@@ -552,7 +552,10 @@ func (x *GetDatabaseNamesResponse) GetNames() []string {
 type GetGatewaysRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// cells is a comma-separated list of cell names to filter by (optional)
-	Cells         []string `protobuf:"bytes,1,rep,name=cells,proto3" json:"cells,omitempty"`
+	Cells []string `protobuf:"bytes,1,rep,name=cells,proto3" json:"cells,omitempty"`
+	// only_reachable drops gateways whose grpc address does not accept a TCP
+	// connection, filtering out stale registrations left by dead pods.
+	OnlyReachable bool `protobuf:"varint,2,opt,name=only_reachable,json=onlyReachable,proto3" json:"only_reachable,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -592,6 +595,13 @@ func (x *GetGatewaysRequest) GetCells() []string {
 		return x.Cells
 	}
 	return nil
+}
+
+func (x *GetGatewaysRequest) GetOnlyReachable() bool {
+	if x != nil {
+		return x.OnlyReachable
+	}
+	return false
 }
 
 // GetGatewaysResponse contains the filtered gateways
@@ -2463,9 +2473,10 @@ const file_multiadminservice_proto_rawDesc = "" +
 	"\x05names\x18\x01 \x03(\tR\x05names\"\x19\n" +
 	"\x17GetDatabaseNamesRequest\"0\n" +
 	"\x18GetDatabaseNamesResponse\x12\x14\n" +
-	"\x05names\x18\x01 \x03(\tR\x05names\"*\n" +
+	"\x05names\x18\x01 \x03(\tR\x05names\"Q\n" +
 	"\x12GetGatewaysRequest\x12\x14\n" +
-	"\x05cells\x18\x01 \x03(\tR\x05cells\"P\n" +
+	"\x05cells\x18\x01 \x03(\tR\x05cells\x12%\n" +
+	"\x0eonly_reachable\x18\x02 \x01(\bR\ronlyReachable\"P\n" +
 	"\x13GetGatewaysResponse\x129\n" +
 	"\bgateways\x18\x01 \x03(\v2\x1d.clustermetadata.MultigatewayR\bgateways\"[\n" +
 	"\x11GetPoolersRequest\x12\x14\n" +

--- a/go/services/multiadmin/server.go
+++ b/go/services/multiadmin/server.go
@@ -22,6 +22,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
+	"strconv"
+	"sync"
+	"time"
 
 	"github.com/multigres/multigres/go/common/rpcclient"
 	"github.com/multigres/multigres/go/common/topoclient"
@@ -223,6 +227,10 @@ func (s *MultiadminServer) GetGateways(ctx context.Context, req *multiadminpb.Ge
 		}
 	}
 
+	if req.OnlyReachable {
+		allGateways = filterReachableGateways(allGateways)
+	}
+
 	response := &multiadminpb.GetGatewaysResponse{
 		Gateways: allGateways,
 	}
@@ -235,6 +243,44 @@ func (s *MultiadminServer) GetGateways(ctx context.Context, req *multiadminpb.Ge
 
 	s.logger.DebugContext(ctx, "GetGateways request completed successfully", "count", len(allGateways)) //nolint:sloglint // message intentionally starts with an operation name or proper noun
 	return response, nil
+}
+
+// gatewayProbeTimeout bounds each reachability probe. Var so tests can shrink it.
+var gatewayProbeTimeout = 1 * time.Second
+
+// filterReachableGateways drops gateways whose grpc address does not accept a
+// TCP connection within gatewayProbeTimeout. Probes run concurrently, so the
+// caller waits at most ~one timeout regardless of gateway count.
+// ponytail: request-time probe to hide stale registrations from dead pods;
+// delete once lease-backed registration (MUL-1311) makes records self-expire.
+func filterReachableGateways(gateways []*clustermetadatapb.Multigateway) []*clustermetadatapb.Multigateway {
+	alive := make([]bool, len(gateways))
+	var wg sync.WaitGroup
+	for i, gw := range gateways {
+		grpcPort, ok := gw.PortMap["grpc"]
+		if !ok {
+			continue // no grpc port registered: cannot probe, treat as stale
+		}
+		wg.Add(1)
+		go func(i int, addr string) {
+			defer wg.Done()
+			conn, err := net.DialTimeout("tcp", addr, gatewayProbeTimeout)
+			if err != nil {
+				return
+			}
+			conn.Close()
+			alive[i] = true
+		}(i, net.JoinHostPort(gw.Hostname, strconv.Itoa(int(grpcPort))))
+	}
+	wg.Wait()
+
+	reachable := make([]*clustermetadatapb.Multigateway, 0, len(gateways))
+	for i, gw := range gateways {
+		if alive[i] {
+			reachable = append(reachable, gw)
+		}
+	}
+	return reachable
 }
 
 // GetPoolers retrieves poolers filtered by cells and/or database

--- a/go/services/multiadmin/server.go
+++ b/go/services/multiadmin/server.go
@@ -251,8 +251,8 @@ var gatewayProbeTimeout = 1 * time.Second
 // filterReachableGateways drops gateways whose grpc address does not accept a
 // TCP connection within gatewayProbeTimeout. Probes run concurrently, so the
 // caller waits at most ~one timeout regardless of gateway count.
-// ponytail: request-time probe to hide stale registrations from dead pods;
-// delete once lease-backed registration (MUL-1311) makes records self-expire.
+// TODO(MUL-1311): request-time probe to hide stale registrations from dead
+// pods; delete once lease-backed registration makes records self-expire.
 func filterReachableGateways(gateways []*clustermetadatapb.Multigateway) []*clustermetadatapb.Multigateway {
 	alive := make([]bool, len(gateways))
 	var wg sync.WaitGroup

--- a/go/services/multiadmin/server_test.go
+++ b/go/services/multiadmin/server_test.go
@@ -17,6 +17,7 @@ package multiadmin
 import (
 	"errors"
 	"log/slog"
+	"net"
 	"os"
 	"testing"
 
@@ -312,6 +313,49 @@ func TestMultiadminServerGetGatewaysMultiCell(t *testing.T) {
 		assert.Len(t, resp.Gateways, 3) // Should get results from existing cells only
 		assert.Contains(t, err.Error(), "partial results returned due to errors in 1 cell(s)")
 		assert.Contains(t, err.Error(), "failed to get gateways for cell nonexistent")
+	})
+}
+
+func TestMultiadminServerGetGatewaysOnlyReachable(t *testing.T) {
+	ctx := t.Context()
+	ts := memorytopo.NewServer(ctx, "cell1")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	server := NewMultiadminServer(ts, logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	// Live gateway: its grpc port has a real TCP listener.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+	livePort := int32(listener.Addr().(*net.TCPAddr).Port)
+
+	// Stale gateway: listener closed immediately, so the port refuses connections.
+	staleListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	stalePort := int32(staleListener.Addr().(*net.TCPAddr).Port)
+	require.NoError(t, staleListener.Close())
+
+	liveGW := topoclient.NewMultigateway("live", "cell1", "127.0.0.1")
+	liveGW.PortMap["grpc"] = livePort
+	require.NoError(t, ts.CreateMultigateway(ctx, liveGW))
+
+	staleGW := topoclient.NewMultigateway("stale", "cell1", "127.0.0.1")
+	staleGW.PortMap["grpc"] = stalePort
+	require.NoError(t, ts.CreateMultigateway(ctx, staleGW))
+
+	noPortGW := topoclient.NewMultigateway("noport", "cell1", "127.0.0.1")
+	require.NoError(t, ts.CreateMultigateway(ctx, noPortGW))
+
+	t.Run("without filter returns all registrations", func(t *testing.T) {
+		resp, err := server.GetGateways(ctx, &multiadminpb.GetGatewaysRequest{})
+		require.NoError(t, err)
+		assert.Len(t, resp.Gateways, 3)
+	})
+
+	t.Run("only_reachable drops stale and unprobeable gateways", func(t *testing.T) {
+		resp, err := server.GetGateways(ctx, &multiadminpb.GetGatewaysRequest{OnlyReachable: true})
+		require.NoError(t, err)
+		require.Len(t, resp.Gateways, 1)
+		assert.Equal(t, "live", resp.Gateways[0].Id.Name)
 	})
 }
 

--- a/proto/multiadminservice.proto
+++ b/proto/multiadminservice.proto
@@ -216,6 +216,9 @@ message GetDatabaseNamesResponse {
 message GetGatewaysRequest {
   // cells is a comma-separated list of cell names to filter by (optional)
   repeated string cells = 1;
+  // only_reachable drops gateways whose grpc address does not accept a TCP
+  // connection, filtering out stale registrations left by dead pods.
+  bool only_reachable = 2;
 }
 
 // GetGatewaysResponse contains the filtered gateways

--- a/web/multiadmin/lib/api/generated/multiadminservice_pb.ts
+++ b/web/multiadmin/lib/api/generated/multiadminservice_pb.ts
@@ -446,6 +446,14 @@ export class GetGatewaysRequest extends Message<GetGatewaysRequest> {
    */
   cells: string[] = [];
 
+  /**
+   * only_reachable drops gateways whose grpc address does not accept a TCP
+   * connection, filtering out stale registrations left by dead pods.
+   *
+   * @generated from field: bool only_reachable = 2;
+   */
+  onlyReachable = false;
+
   constructor(data?: PartialMessage<GetGatewaysRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -455,6 +463,7 @@ export class GetGatewaysRequest extends Message<GetGatewaysRequest> {
   static readonly typeName = "multiadmin.GetGatewaysRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "cells", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+    { no: 2, name: "only_reachable", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetGatewaysRequest {


### PR DESCRIPTION
## Problem

After gateway pod churn, gateway topo records left behind by dead pods have no liveness signal, so `GET /api/v1/gateways` returns stale registrations alongside live gateways (multiple records per cell sharing a replicaset hash with different pod suffixes). The UI cannot filter them, and its gateway count reflects every registered entry.

Fixes MUL-1368.

## Change

Adds an `only_reachable` flag to `GetGatewaysRequest` (`GET /api/v1/gateways?onlyReachable=true`). When set, multiadmin probes each gateway's `hostname:port_map["grpc"]` with a concurrent 1s TCP dial and drops non-responders. Records without a grpc port cannot be probed and are treated as stale.

- Response shape is unchanged — existing clients are unaffected.
- Probes run concurrently, so the request waits at most ~one probe timeout regardless of gateway count.
- Regenerated Go pb and web TS client, so the UI can pass the flag directly.

## Scope note

This is an interim, UI-facing filter. The root cause (no lease on gateway records + best-effort unregister) is addressed by lease-backed registration in MUL-1311 (#1376); the probing here is marked for deletion once records self-expire. Filtering the response also does nothing for the other stale-record side effects (held PID prefixes, cancel routing) — those are only fixed by MUL-1311.

## Testing

- New unit test `TestMultiadminServerGetGatewaysOnlyReachable`: live listener kept, refused port dropped, missing grpc port dropped, unfiltered behavior unchanged.
- `go build ./go/...` and full multiadmin package tests pass.