### PR TITLE
feat(topo): add free-form metadata to cell records

### DIFF
--- a/go/common/topoclient/cell_test.go
+++ b/go/common/topoclient/cell_test.go
@@ -54,6 +54,58 @@ func TestCellCRUDOperations(t *testing.T) {
 			},
 		},
 		{
+			name: "Create and Get Cell with metadata",
+			test: func(t *testing.T, ts topoclient.Store) {
+				cl := &clustermetadatapb.Cell{
+					ServerAddresses: []string{"server1:2181"},
+					Root:            "/topo",
+					Metadata:        `{"zoneId":"use1-az1"}`,
+				}
+				err := ts.CreateCell(ctx, cell, cl)
+				require.NoError(t, err)
+
+				retrieved, err := ts.GetCell(ctx, cell)
+				require.NoError(t, err)
+				require.Equal(t, `{"zoneId":"use1-az1"}`, retrieved.Metadata)
+
+				cl2 := &clustermetadatapb.Cell{
+					ServerAddresses: []string{"server2:2181"},
+					Root:            "/topo",
+					Metadata:        "not json",
+				}
+				err = ts.CreateCell(ctx, cell2, cl2)
+				require.NoError(t, err)
+
+				retrieved2, err := ts.GetCell(ctx, cell2)
+				require.NoError(t, err)
+				require.Equal(t, "not json", retrieved2.Metadata)
+			},
+		},
+		{
+			name: "Update Cell metadata",
+			test: func(t *testing.T, ts topoclient.Store) {
+				cl := &clustermetadatapb.Cell{
+					ServerAddresses: []string{"server1:2181"},
+					Root:            "/topo",
+					Metadata:        `{"zoneId":"use1-az1"}`,
+				}
+				err := ts.CreateCell(ctx, cell, cl)
+				require.NoError(t, err)
+
+				err = ts.UpdateCellFields(ctx, cell, func(cl *clustermetadatapb.Cell) error {
+					cl.Metadata = `{"zoneId":"use1-az2"}`
+					return nil
+				})
+				require.NoError(t, err)
+
+				retrieved, err := ts.GetCell(ctx, cell)
+				require.NoError(t, err)
+				require.Equal(t, `{"zoneId":"use1-az2"}`, retrieved.Metadata)
+				require.Equal(t, []string{"server1:2181"}, retrieved.ServerAddresses)
+				require.Equal(t, "/topo", retrieved.Root)
+			},
+		},
+		{
 			name: "Get nonexistent Cell",
 			test: func(t *testing.T, ts topoclient.Store) {
 				_, err := ts.GetCell(ctx, "nonexistent")

--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -636,7 +636,10 @@ type Cell struct {
 	ServerAddresses []string `protobuf:"bytes,2,rep,name=server_addresses,json=serverAddresses,proto3" json:"server_addresses,omitempty"`
 	// root is the namespace or directory path within the topology service
 	// where this cell's metadata is stored. Used only when connecting to server_addresses.
-	Root          string `protobuf:"bytes,3,opt,name=root,proto3" json:"root,omitempty"`
+	Root string `protobuf:"bytes,3,opt,name=root,proto3" json:"root,omitempty"`
+	// metadata is an opaque document describing this cell, supplied by whatever
+	// deployed it: an operator, a provisioning tool, or a human.
+	Metadata      string `protobuf:"bytes,4,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -688,6 +691,13 @@ func (x *Cell) GetServerAddresses() []string {
 func (x *Cell) GetRoot() string {
 	if x != nil {
 		return x.Root
+	}
+	return ""
+}
+
+func (x *Cell) GetMetadata() string {
+	if x != nil {
+		return x.Metadata
 	}
 	return ""
 }
@@ -2924,11 +2934,12 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\x10GlobalTopoConfig\x12&\n" +
 	"\x0eimplementation\x18\x01 \x01(\tR\x0eimplementation\x12)\n" +
 	"\x10server_addresses\x18\x02 \x03(\tR\x0fserverAddresses\x12\x12\n" +
-	"\x04root\x18\x03 \x01(\tR\x04root\"Y\n" +
+	"\x04root\x18\x03 \x01(\tR\x04root\"u\n" +
 	"\x04Cell\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12)\n" +
 	"\x10server_addresses\x18\x02 \x03(\tR\x0fserverAddresses\x12\x12\n" +
-	"\x04root\x18\x03 \x01(\tR\x04root\"\xe1\x01\n" +
+	"\x04root\x18\x03 \x01(\tR\x04root\x12\x1a\n" +
+	"\bmetadata\x18\x04 \x01(\tR\bmetadata\"\xe1\x01\n" +
 	"\bDatabase\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12H\n" +
 	"\x0fbackup_location\x18\x02 \x01(\v2\x1f.clustermetadata.BackupLocationR\x0ebackupLocation\x12\x14\n" +

--- a/go/services/multiadmin/server_test.go
+++ b/go/services/multiadmin/server_test.go
@@ -79,6 +79,7 @@ func TestMultiadminServerGetCell(t *testing.T) {
 			Name:            "testcell",
 			ServerAddresses: []string{"localhost:2379"},
 			Root:            "/multigres/testcell",
+			Metadata:        `{"zoneId":"use1-az1"}`,
 		}
 
 		err := ts.CreateCell(ctx, "testcell", testCell)
@@ -94,6 +95,7 @@ func TestMultiadminServerGetCell(t *testing.T) {
 		assert.Equal(t, "testcell", resp.Cell.Name)
 		assert.Equal(t, []string{"localhost:2379"}, resp.Cell.ServerAddresses)
 		assert.Equal(t, "/multigres/testcell", resp.Cell.Root)
+		assert.Equal(t, `{"zoneId":"use1-az1"}`, resp.Cell.Metadata)
 	})
 }
 

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -57,6 +57,10 @@ message Cell {
   // root is the namespace or directory path within the topology service
   // where this cell's metadata is stored. Used only when connecting to server_addresses.
   string root = 3;
+
+  // metadata is an opaque document describing this cell, supplied by whatever
+  // deployed it: an operator, a provisioning tool, or a human.
+  string metadata = 4;
 }
 
 message Database {

--- a/web/multiadmin/lib/api/generated/clustermetadata_pb.ts
+++ b/web/multiadmin/lib/api/generated/clustermetadata_pb.ts
@@ -455,6 +455,14 @@ export class Cell extends Message<Cell> {
    */
   root = "";
 
+  /**
+   * metadata is an opaque document describing this cell, supplied by whatever
+   * deployed it: an operator, a provisioning tool, or a human.
+   *
+   * @generated from field: string metadata = 4;
+   */
+  metadata = "";
+
   constructor(data?: PartialMessage<Cell>) {
     super();
     proto3.util.initPartial(data, this);
@@ -466,6 +474,7 @@ export class Cell extends Message<Cell> {
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "server_addresses", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
     { no: 3, name: "root", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "metadata", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Cell {


### PR DESCRIPTION
Add an opaque metadata field to the Cell record, returned as-is by multiadmin's GET /api/v1/cells/{name}. This is never parsed by Multigres itself.

The purpose is to allow admins/operators to store information e.g. which AZ ID a specific cell is assigned to, since this is not something that can be retrieved from multiadmin atm.

Before:

```json
{
    "cell": {
        "name": "cell-1",
        "serverAddresses": [
            "mgc-ziwyfscpszokuhlowsjb-global-topo.ha-project-ziwyfscpszokuhlowsjb.svc:2379"
        ],
        "root": "/multigres/ha-project-ziwyfscpszokuhlowsjb/mgc-ziwyfscpszokuhlowsjb/global"
    }
}
```

After:

```json
{
    "cell": {
        "name": "cell-1",
        "serverAddresses": [
            "mgc-ziwyfscpszokuhlowsjb-global-topo.ha-project-ziwyfscpszokuhlowsjb.svc:2379"
        ],
        "root": "/multigres/ha-project-ziwyfscpszokuhlowsjb/mgc-ziwyfscpszokuhlowsjb/global",
        "metadata": "{\"zoneId\":\"apse1-az2\"}"
    }
}
```

Part of MUL-1371.