### PR TITLE
test(pgregress): accept stats visibility-lag divergence under pooling

### DIFF
--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/stats.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/stats.patch
@@ -4,8 +4,44 @@
 # statistics differ. Backend-selection-sensitive counters are normalized by the
 # pg_regress verifier; SQL still runs through multigateway rather than directly
 # against PostgreSQL.
+#
+# The trunc_stats_test*/tenk2 hunks record cumulative-stats VISIBILITY lag, not
+# wrong accounting: since PG 15 each backend holds pending stats and flushes
+# them at idle, throttled to once per second, and pg_stat_force_next_flush()
+# only arms the one backend that executes it. Under pooling the explicit
+# transactions run on reserved backends and the enable_bitmapscan=off indexscan
+# runs on a different settings-bucket backend, so their pending counters are
+# still unflushed (idle in the pool, inside the throttle window) when the test
+# reads pg_stat_user_tables moments later; they arrive ~1s after the assertions
+# have run. The per-transaction truncate/subxact semantics themselves are
+# correct because each transaction is pinned to a single backend. A future fix
+# is fanning pg_stat_force_next_flush() out to idle pooled backends.
 --- a
 +++ b
+@@ -116,10 +116,10 @@
+ relname | n_tup_ins | n_tup_upd | n_tup_del | n_live_tup | n_dead_tup
+ -------------------+-----------+-----------+-----------+------------+------------
+ trunc_stats_test | 3 | 0 | 0 | 0 | 0
+-trunc_stats_test1 | 4 | 2 | 1 | 1 | 0
+-trunc_stats_test2 | 1 | 0 | 0 | 1 | 0
+-trunc_stats_test3 | 4 | 0 | 0 | 2 | 2
+-trunc_stats_test4 | 2 | 0 | 0 | 0 | 2
++trunc_stats_test1 | 3 | 2 | 1 | 2 | 3
++trunc_stats_test2 | 0 | 0 | 0 | 0 | 0
++trunc_stats_test3 | 0 | 0 | 0 | 0 | 0
++trunc_stats_test4 | 0 | 0 | 0 | 0 | 0
+ (5 rows)
+ 
+ SELECT st.seq_scan >= pr.seq_scan + 1,
+@@ -130,7 +130,7 @@
+ WHERE st.relname='tenk2' AND cl.relname='tenk2';
+ ?column? | ?column? | ?column? | ?column?
+ ----------+----------+----------+----------
+-t | t | t | t
++t | t | f | f
+ (1 row)
+ 
+ SELECT st.heap_blks_read + st.heap_blks_hit >= pr.heap_blks + cl.relpages,
 @@ -252,13 +252,13 @@
  SELECT funcname, calls FROM pg_stat_user_functions WHERE funcid = :stats_test_func1_oid;
  funcname | calls


### PR DESCRIPTION
## Summary

The `stats` regression test has been a persistent residual failure in the nightly compatibility runs (two hunks beyond the existing `stats.patch`). This records them as accepted divergences, with the mechanism documented in the patch header.

## Root cause

Both hunks are cumulative-stats **visibility lag**, not wrong accounting:

- Since PG 15, each backend accumulates pending stats and flushes them to shared memory at idle, throttled to once per second; `pg_stat_force_next_flush()` only arms the flush flag **in the backend that executes it**.
- The test's explicit `BEGIN … TRUNCATE … COMMIT/ROLLBACK` transactions run on reserved backends, and the `enable_bitmapscan=off` indexscan runs on a different settings-bucket backend. When the test calls `pg_stat_force_next_flush()` and immediately reads `pg_stat_user_tables`, those backends are idle in the pool with their counters still unflushed — they arrive ~1s after the assertions have already run.
- The per-transaction truncate/subxact stats semantics are computed **correctly** (each transaction is pinned to a single backend); only the read-after-write timing diverges. PgBouncer behaves identically. This matches the class of divergence `stats.patch` already accepts ("assumes one physical backend per psql session").

## Why a patch (and not a product change)

The diff is deterministic — byte-identical across the last two scheduled CI runs (32442932057, 32686056557) — so the patch holds. A future product fix that would make the upstream expectations pass for real is fanning `pg_stat_force_next_flush()` out to idle pooled backends; that is noted in the patch header.

## Verification

The two new hunks are net-zero line deltas, merged ahead of the existing hunks (whose offsets are unchanged). Verified mechanically with the harness's own pipeline: reconstructed the CI run's actual output (stock REL_17_6 `expected/stats.out` → old patch → CI residual diff) and ran `suiteutil.VerifyPatch` against the merged patch — applies cleanly and matches byte-for-byte.

Not touched here: the remaining residual failures have their own tracks — `brin*`/`explain`/`partition_prune` are addressed by #1352 and #1302.