### PR TITLE
fix(multipooler): run control-plane queries on the admin pool

### DIFF
--- a/go/services/multipooler/internal/executor/admin_query.go
+++ b/go/services/multipooler/internal/executor/admin_query.go
@@ -20,15 +20,11 @@ import (
 	"github.com/multigres/multigres/go/common/sqltypes"
 )
 
-// The QueryAdmin* methods are the InternalQueryService access path for the
-// locked-down multigres sidecar schema. They share the run* helpers with the
-// regular Query* methods and differ only in the borrower: they run on the admin
-// pool, which authenticates as the true PostgreSQL superuser. The multigres
-// schema is created and owned by that superuser and is not reachable by customer
-// roles through their per-user regular pool (they get only USAGE on the schema
-// and SELECT on multigres.backend_vpid), so any internal read/write of a
-// multigres.* table must go through these methods or it would fail once the
-// regular pool's role is not the schema owner.
+// The QueryAdmin* methods are the InternalQueryService access path for recovery
+// probes that must bypass saturated user pools and for the locked-down multigres
+// sidecar schema. They share the run* helpers with the regular Query* methods and
+// differ only in the borrower: they run on the admin pool, which authenticates
+// as the true PostgreSQL superuser.
 
 // borrowAdmin borrows a connection from the admin (true-superuser) pool.
 func (e *Executor) borrowAdmin(ctx context.Context) (pooledQueryConn, func(), error) {

--- a/go/services/multipooler/internal/executor/internal_query.go
+++ b/go/services/multipooler/internal/executor/internal_query.go
@@ -33,16 +33,15 @@ var errTxFinished = errors.New("transaction already finished")
 // pools:
 //
 //   - Query / QueryArgs / QueryMultiStatement / Begin run on the regular pool (as
-//     the configured PgUser). Use for pure system queries — pg_is_in_recovery(),
-//     ALTER SYSTEM, WAL LSN reads, SELECT 1 — so the small admin pool is not
-//     exhausted by high-volume polling.
+//     the configured PgUser). Use for routine internal work that may safely share
+//     capacity with user traffic.
 //   - QueryAdmin / QueryAdminArgs / QueryAdminMultiStatement run on the admin
-//     (true-superuser) pool. Use for every read/write of the locked-down multigres
-//     sidecar schema, which is owned by the true superuser and which customer
-//     roles on the regular pool cannot reach.
+//     (true-superuser) pool. Use for control-plane recovery probes that must run
+//     when the regular pool is saturated, and for the locked-down multigres
+//     sidecar schema, which customer roles on the regular pool cannot reach.
 //
-// Choosing the pool at the call site (by method name) keeps "this touches the
-// locked-down schema" visible where the query is written.
+// Choosing the pool at the call site keeps the required isolation visible where
+// the query is written.
 type InternalQueryService interface {
 	// Query executes a query on the regular pool and returns the result.
 	Query(ctx context.Context, query string) (*sqltypes.Result, error)
@@ -60,7 +59,7 @@ type InternalQueryService interface {
 	QueryMultiStatement(ctx context.Context, query string) error
 
 	// QueryAdmin executes a query on the admin (true-superuser) pool and returns
-	// the single result. Use for reads/writes of the multigres sidecar schema.
+	// the single result. Use for recovery probes and the multigres sidecar schema.
 	QueryAdmin(ctx context.Context, query string) (*sqltypes.Result, error)
 
 	// QueryAdminArgs is QueryAdmin with arguments; it accepts the same Go argument
@@ -141,8 +140,8 @@ type pooledQueryConn interface {
 type connBorrower func(ctx context.Context) (conn pooledQueryConn, release func(), err error)
 
 // borrowRegular borrows a connection from the per-user regular pool as the
-// configured PgUser. We use the regular pool for system queries rather than the
-// admin pool so as not to exhaust the small admin pool.
+// configured PgUser. Routine internal work uses this path so it does not exhaust
+// the small admin pool reserved for control-plane operations.
 func (e *Executor) borrowRegular(ctx context.Context) (pooledQueryConn, func(), error) {
 	conn, err := e.poolManager.GetRegularConn(ctx, e.poolManager.PgUser(), nil, nil)
 	if err != nil {

--- a/go/services/multipooler/internal/executor/internal_query.go
+++ b/go/services/multipooler/internal/executor/internal_query.go
@@ -33,12 +33,15 @@ var errTxFinished = errors.New("transaction already finished")
 // pools:
 //
 //   - Query / QueryArgs / QueryMultiStatement / Begin run on the regular pool (as
-//     the configured PgUser). Use for routine internal work that may safely share
-//     capacity with user traffic.
+//     the configured PgUser). Use only for internal work that may safely share
+//     capacity — and queue behind — user traffic.
 //   - QueryAdmin / QueryAdminArgs / QueryAdminMultiStatement run on the admin
-//     (true-superuser) pool. Use for control-plane recovery probes that must run
-//     when the regular pool is saturated, and for the locked-down multigres
-//     sidecar schema, which customer roles on the regular pool cannot reach.
+//     (true-superuser) pool. Use for all control-plane work: recovery probes,
+//     replication and consensus control, promotion, and the locked-down
+//     multigres sidecar schema. Control-plane queries must never starve on a
+//     saturated regular pool — that is exactly the failover moment they exist
+//     for — so everything the manager, consensus, and heartbeat components run
+//     goes through these methods.
 //
 // Choosing the pool at the call site keeps the required isolation visible where
 // the query is written.

--- a/go/services/multipooler/internal/executor/mock/mock_querier.go
+++ b/go/services/multipooler/internal/executor/mock/mock_querier.go
@@ -29,9 +29,10 @@ import (
 
 // QueryService is a mock implementation of executor.InternalQueryService for testing.
 type QueryService struct {
-	mu       sync.Mutex
-	patterns []queryPattern
-	beginErr error
+	mu           sync.Mutex
+	patterns     []queryPattern
+	beginErr     error
+	adminQueries int
 }
 
 type queryPattern struct {
@@ -185,20 +186,35 @@ func (m *QueryService) QueryArgs(ctx context.Context, queryStr string, args ...a
 	return m.Query(ctx, queryStr)
 }
 
+// AdminQueryCount returns the number of QueryAdmin* calls.
+func (m *QueryService) AdminQueryCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.adminQueries
+}
+
+func (m *QueryService) recordAdminQuery() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.adminQueries++
+}
+
 // QueryAdmin implements executor.InternalQueryService.
-// The mock records admin-pool queries through the same pattern matcher as Query;
-// tests assert on the query string regardless of which pool it targets.
+// The mock records admin-pool queries through the same pattern matcher as Query.
 func (m *QueryService) QueryAdmin(ctx context.Context, queryStr string) (*sqltypes.Result, error) {
+	m.recordAdminQuery()
 	return m.Query(ctx, queryStr)
 }
 
 // QueryAdminArgs implements executor.InternalQueryService (delegates to Query).
 func (m *QueryService) QueryAdminArgs(ctx context.Context, queryStr string, args ...any) (*sqltypes.Result, error) {
+	m.recordAdminQuery()
 	return m.Query(ctx, queryStr)
 }
 
 // QueryAdminMultiStatement implements executor.InternalQueryService (delegates to Query).
 func (m *QueryService) QueryAdminMultiStatement(ctx context.Context, queryStr string) error {
+	m.recordAdminQuery()
 	_, err := m.Query(ctx, queryStr)
 	return err
 }

--- a/go/services/multipooler/internal/manager/consensus/sync_standby_manager.go
+++ b/go/services/multipooler/internal/manager/consensus/sync_standby_manager.go
@@ -79,7 +79,7 @@ func NewSyncStandbyManager(logger *slog.Logger, qs executor.InternalQueryService
 }
 
 func (s *postgresqlSyncStandbyManager) exec(ctx context.Context, sql string) error {
-	_, err := s.qs.Query(ctx, sql)
+	_, err := s.qs.QueryAdmin(ctx, sql)
 	return err
 }
 
@@ -190,7 +190,7 @@ func (s *postgresqlSyncStandbyManager) NeedsApply(ctx context.Context, pc common
 	// Query postgres for the live GUC values.
 	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	result, err := s.qs.Query(queryCtx, "SELECT current_setting('synchronous_commit'), current_setting('synchronous_standby_names')")
+	result, err := s.qs.QueryAdmin(queryCtx, "SELECT current_setting('synchronous_commit'), current_setting('synchronous_standby_names')")
 	if err != nil {
 		// Fall back to cache: unreachable postgres means we can't detect drift,
 		// but the cache is trustworthy since we own all writes to these GUCs.
@@ -290,7 +290,7 @@ func (s *postgresqlSyncStandbyManager) Clear(ctx context.Context) error {
 	// to proceed without standby acknowledgment, violating durability guarantees.
 	checkCtx, checkCancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer checkCancel()
-	result, err := s.qs.Query(checkCtx, "SELECT pg_is_in_recovery()")
+	result, err := s.qs.QueryAdmin(checkCtx, "SELECT pg_is_in_recovery()")
 	if err != nil {
 		return fmt.Errorf("clear: could not verify recovery mode: %w", err)
 	}

--- a/go/services/multipooler/internal/manager/consensus/sync_standby_names.go
+++ b/go/services/multipooler/internal/manager/consensus/sync_standby_names.go
@@ -168,7 +168,7 @@ func ReloadPostgresConfig(ctx context.Context, logger *slog.Logger, qs executor.
 	logger.InfoContext(ctx, "reloading Postgres configuration")
 	reloadCtx, reloadCancel := context.WithTimeout(ctx, timeouts.PostgresConfigTimeout)
 	defer reloadCancel()
-	if _, err := qs.Query(reloadCtx, "SELECT pg_reload_conf()"); err != nil {
+	if _, err := qs.QueryAdmin(reloadCtx, "SELECT pg_reload_conf()"); err != nil {
 		logger.ErrorContext(ctx, "failed to reload configuration", "error", err)
 		return mterrors.Wrap(err, "failed to reload PostgreSQL configuration")
 	}
@@ -228,7 +228,7 @@ func WaitForConfigReload(ctx context.Context, qs executor.InternalQueryService, 
 // +05:30) that the text-timestamp scanner does not parse. The epoch is an
 // absolute instant, safe to compare across callers and sessions.
 func readConfLoadTime(ctx context.Context, qs executor.InternalQueryService) (time.Time, error) {
-	result, err := qs.Query(ctx, "SELECT extract(epoch from pg_conf_load_time())")
+	result, err := qs.QueryAdmin(ctx, "SELECT extract(epoch from pg_conf_load_time())")
 	if err != nil {
 		return time.Time{}, mterrors.Wrap(err, "failed to read pg_conf_load_time")
 	}

--- a/go/services/multipooler/internal/manager/logical_slots.go
+++ b/go/services/multipooler/internal/manager/logical_slots.go
@@ -198,7 +198,7 @@ func (pm *MultipoolerManager) EnsureLogicalSlot(ctx context.Context, name, plugi
 	// into the statement. temporary=false and twophase=false; failover is
 	// caller-controlled (the PostgreSQL slot-sync flag that lets a standby
 	// maintain a copy of this slot).
-	if err := pm.execArgs(execCtx,
+	if err := pm.adminExecArgs(execCtx,
 		"SELECT pg_create_logical_replication_slot($1, $2, false, false, $3)",
 		name, plugin, failover); err != nil {
 		return mterrors.Wrap(err, "failed to create logical replication slot")
@@ -212,7 +212,7 @@ func (pm *MultipoolerManager) DropLogicalSlot(ctx context.Context, name string) 
 	execCtx, cancel := context.WithTimeout(ctx, logicalSlotWriteTimeout)
 	defer cancel()
 	// Bind the slot name as a parameter rather than interpolating it.
-	if err := pm.execArgs(execCtx, "SELECT pg_drop_replication_slot($1)", name); err != nil {
+	if err := pm.adminExecArgs(execCtx, "SELECT pg_drop_replication_slot($1)", name); err != nil {
 		return mterrors.Wrap(err, "failed to drop replication slot")
 	}
 	return nil
@@ -236,7 +236,7 @@ func (pm *MultipoolerManager) EnsurePhysicalSlot(ctx context.Context, name strin
 		defer cancel()
 		// immediately_reserve=true retains WAL from slot creation (before the standby
 		// attaches); temporary=false so the slot survives reconnects.
-		if err := pm.execArgs(execCtx,
+		if err := pm.adminExecArgs(execCtx,
 			"SELECT pg_create_physical_replication_slot($1, true, false)", name); err != nil {
 			return mterrors.Wrap(err, "failed to create physical replication slot")
 		}
@@ -331,7 +331,7 @@ func (pm *MultipoolerManager) dropManagedPhysicalSlots(ctx context.Context) erro
 
 	execCtx, cancel := context.WithTimeout(ctx, logicalSlotWriteTimeout)
 	defer cancel()
-	if err := pm.execArgs(execCtx, dropManagedPhysicalSlotsSQL, logicalSlotNamePrefix); err != nil {
+	if err := pm.adminExecArgs(execCtx, dropManagedPhysicalSlotsSQL, logicalSlotNamePrefix); err != nil {
 		return mterrors.Wrap(err, "failed to drop managed physical replication slots")
 	}
 
@@ -388,7 +388,7 @@ func (pm *MultipoolerManager) ReconcileFollowers(ctx context.Context, followerID
 
 	queryCtx, cancel := context.WithTimeout(ctx, logicalSlotStateTimeout)
 	defer cancel()
-	result, err := pm.queryArgs(queryCtx, listManagedPhysicalSlotsSQL, logicalSlotNamePrefix)
+	result, err := pm.adminQueryArgs(queryCtx, listManagedPhysicalSlotsSQL, logicalSlotNamePrefix)
 	if err != nil {
 		return mterrors.Wrap(err, "failed to list managed physical replication slots")
 	}
@@ -425,7 +425,7 @@ SELECT count(*), coalesce(string_agg(slot_name, ', '), '')
 func (pm *MultipoolerManager) unreadyFailoverSlots(ctx context.Context) (int, string, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, logicalSlotStateTimeout)
 	defer cancel()
-	result, err := pm.query(queryCtx, unreadyFailoverSlotsSQL)
+	result, err := pm.adminQuery(queryCtx, unreadyFailoverSlotsSQL)
 	if err != nil {
 		return 0, "", mterrors.Wrap(err, "failed to query failover-slot readiness")
 	}
@@ -480,7 +480,7 @@ SELECT
 func (pm *MultipoolerManager) failoverSlotReadiness(ctx context.Context) (ready int, total int, err error) {
 	queryCtx, cancel := context.WithTimeout(ctx, logicalSlotStateTimeout)
 	defer cancel()
-	result, err := pm.query(queryCtx, failoverSlotReadinessSQL)
+	result, err := pm.adminQuery(queryCtx, failoverSlotReadinessSQL)
 	if err != nil {
 		return 0, 0, mterrors.Wrap(err, "failed to query failover-slot readiness")
 	}
@@ -506,7 +506,7 @@ func (pm *MultipoolerManager) GetSlotState(ctx context.Context, name string) (*L
 	queryCtx, cancel := context.WithTimeout(ctx, logicalSlotStateTimeout)
 	defer cancel()
 	// Bind the slot name as a parameter rather than interpolating it.
-	result, err := pm.queryArgs(queryCtx, fetchLogicalSlotStateSQL, name)
+	result, err := pm.adminQueryArgs(queryCtx, fetchLogicalSlotStateSQL, name)
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to read replication slot state")
 	}
@@ -544,7 +544,7 @@ func (pm *MultipoolerManager) LogicalSlotExists(ctx context.Context, name string
 	// EXISTS(...) returns exactly one boolean row and lets the planner stop at
 	// the first matching row; it's the existence-check idiom used elsewhere in
 	// this package (see querySchemaExists).
-	result, err := pm.queryArgs(queryCtx, "SELECT EXISTS(SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)", name)
+	result, err := pm.adminQueryArgs(queryCtx, "SELECT EXISTS(SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)", name)
 	if err != nil {
 		return false, mterrors.Wrap(err, "failed to check replication slot existence")
 	}

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -482,43 +482,11 @@ func (pm *MultipoolerManager) DoUpdateRule(ctx context.Context, update *consensu
 	return pm.consensusMgr.Rules().UpdateRule(ruleWriteCtx, update)
 }
 
-// query executes a query using the internal query service and returns the result.
-// This is a convenience method for internal manager operations.
-func (pm *MultipoolerManager) query(ctx context.Context, sql string) (*sqltypes.Result, error) {
-	queryService := pm.internalQueryService()
-	if queryService == nil {
-		return nil, errors.New("internal query service not available")
-	}
-	return queryService.Query(ctx, sql)
-}
-
-// exec executes a command that doesn't return rows.
-// This is a convenience method for internal manager operations.
-func (pm *MultipoolerManager) exec(ctx context.Context, sql string) error {
-	_, err := pm.query(ctx, sql)
-	return err
-}
-
-// queryArgs executes a parameterized query using the internal query service and returns the result.
-// This is a convenience method for internal manager operations that helps prevent SQL injection.
-func (pm *MultipoolerManager) queryArgs(ctx context.Context, sql string, args ...any) (*sqltypes.Result, error) {
-	queryService := pm.internalQueryService()
-	if queryService == nil {
-		return nil, errors.New("internal query service not available")
-	}
-	return queryService.QueryArgs(ctx, sql, args...)
-}
-
-// execArgs executes a parameterized command that doesn't return rows.
-// This is a convenience method for internal manager operations that helps prevent SQL injection.
-func (pm *MultipoolerManager) execArgs(ctx context.Context, sql string, args ...any) error {
-	_, err := pm.queryArgs(ctx, sql, args...)
-	return err
-}
-
 // adminQuery executes a query on the admin (true-superuser) pool via the
-// InternalQueryService's QueryAdmin method. Use for recovery probes that must
-// bypass saturated user pools and for the multigres sidecar schema.
+// InternalQueryService's QueryAdmin method. Every manager query is
+// control-plane work (recovery probes, replication and consensus control,
+// promotion, sidecar schema), which must not queue behind saturated user
+// pools — so these admin-pool helpers are the only query path the manager has.
 func (pm *MultipoolerManager) adminQuery(ctx context.Context, sql string) (*sqltypes.Result, error) {
 	queryService := pm.internalQueryService()
 	if queryService == nil {
@@ -528,14 +496,14 @@ func (pm *MultipoolerManager) adminQuery(ctx context.Context, sql string) (*sqlt
 }
 
 // adminExec executes a command that doesn't return rows on the admin
-// (true-superuser) pool. Use for multigres sidecar schema DDL/DML.
+// (true-superuser) pool.
 func (pm *MultipoolerManager) adminExec(ctx context.Context, sql string) error {
 	_, err := pm.adminQuery(ctx, sql)
 	return err
 }
 
 // adminQueryArgs executes a parameterized query on the admin (true-superuser)
-// pool and returns the result. Use for reads/writes of the multigres sidecar schema.
+// pool and returns the result. Parameterization helps prevent SQL injection.
 func (pm *MultipoolerManager) adminQueryArgs(ctx context.Context, sql string, args ...any) (*sqltypes.Result, error) {
 	queryService := pm.internalQueryService()
 	if queryService == nil {
@@ -544,8 +512,8 @@ func (pm *MultipoolerManager) adminQueryArgs(ctx context.Context, sql string, ar
 	return queryService.QueryAdminArgs(ctx, sql, args...)
 }
 
-// adminExecArgs executes a parameterized command that doesn't return rows on the
-// admin (true-superuser) pool. Use for multigres sidecar schema DDL/DML.
+// adminExecArgs executes a parameterized command that doesn't return rows on
+// the admin (true-superuser) pool.
 func (pm *MultipoolerManager) adminExecArgs(ctx context.Context, sql string, args ...any) error {
 	_, err := pm.adminQueryArgs(ctx, sql, args...)
 	return err
@@ -1289,7 +1257,7 @@ func (pm *MultipoolerManager) getActiveWriteConnections(ctx context.Context) ([]
 		  AND query NOT ILIKE 'ROLLBACK%'
 		  AND query != '<IDLE>'`
 
-	result, err := pm.query(ctx, sql)
+	result, err := pm.adminQuery(ctx, sql)
 	if err != nil {
 		return nil, err
 	}
@@ -1327,7 +1295,7 @@ func (pm *MultipoolerManager) terminateWriteConnections(ctx context.Context) (in
 
 	// Terminate each write connection
 	for _, pid := range pids {
-		if err := pm.execArgs(ctx, "SELECT pg_terminate_backend($1)", pid); err != nil {
+		if err := pm.adminExecArgs(ctx, "SELECT pg_terminate_backend($1)", pid); err != nil {
 			pm.logger.WarnContext(ctx, "failed to terminate write connection", "pid", pid, "error", err)
 		}
 	}
@@ -1446,7 +1414,7 @@ func (pm *MultipoolerManager) promoteStandbyToPrimary(ctx context.Context, state
 		pm.broadcastHealth()
 	}()
 
-	if err := pm.exec(ctx, "SELECT pg_promote()"); err != nil {
+	if err := pm.adminExec(ctx, "SELECT pg_promote()"); err != nil {
 		pm.logger.ErrorContext(ctx, "failed to call pg_promote()", "error", err)
 		return mterrors.Wrap(err, "failed to promote standby")
 	}
@@ -1476,7 +1444,7 @@ func (pm *MultipoolerManager) promoteStandbyToPrimary(ctx context.Context, state
 	// it observes the completed checkpoint.
 	checkpointCtx := pm.ctx
 	go func() {
-		if err := pm.exec(checkpointCtx, "CHECKPOINT"); err != nil {
+		if err := pm.adminExec(checkpointCtx, "CHECKPOINT"); err != nil {
 			pm.logger.WarnContext(checkpointCtx, "async post-promotion checkpoint failed; rewind-readiness will be delayed until Postgres's own checkpoint completes", "error", err)
 			return
 		}
@@ -1561,7 +1529,7 @@ func (pm *MultipoolerManager) dropUnloggedTablesAfterPromotion(ctx context.Conte
 		  AND c.relkind = 'r'
 		  AND n.nspname NOT IN ('pg_catalog', 'information_schema')`
 
-	result, err := pm.query(ctx, listSQL)
+	result, err := pm.adminQuery(ctx, listSQL)
 	if err != nil {
 		pm.logger.WarnContext(ctx, "failed to list unlogged tables after promotion; skipping drop", "error", err)
 		return
@@ -1581,7 +1549,7 @@ func (pm *MultipoolerManager) dropUnloggedTablesAfterPromotion(ctx context.Conte
 		if name == "multigres.backend_vpid" {
 			continue
 		}
-		if err := pm.exec(ctx, "DROP TABLE "+name); err != nil {
+		if err := pm.adminExec(ctx, "DROP TABLE "+name); err != nil {
 			pm.logger.WarnContext(ctx, "best-effort drop of unlogged table after promotion failed; table left empty",
 				"table", name, "error", err)
 			continue

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -517,8 +517,8 @@ func (pm *MultipoolerManager) execArgs(ctx context.Context, sql string, args ...
 }
 
 // adminQuery executes a query on the admin (true-superuser) pool via the
-// InternalQueryService's QueryAdmin method and returns the result. Use for
-// reads/writes of the multigres sidecar schema.
+// InternalQueryService's QueryAdmin method. Use for recovery probes that must
+// bypass saturated user pools and for the multigres sidecar schema.
 func (pm *MultipoolerManager) adminQuery(ctx context.Context, sql string) (*sqltypes.Result, error) {
 	queryService := pm.internalQueryService()
 	if queryService == nil {

--- a/go/services/multipooler/internal/manager/pg_replication.go
+++ b/go/services/multipooler/internal/manager/pg_replication.go
@@ -97,7 +97,7 @@ func (pm *MultipoolerManager) archiverStats(ctx context.Context) (backupengine.A
 		COALESCE(EXTRACT(EPOCH FROM last_failed_time)::bigint, 0)   AS last_failed,
 		failed_count
 	FROM pg_stat_archiver`
-	result, err := pm.query(queryCtx, sql)
+	result, err := pm.adminQuery(queryCtx, sql)
 	if err != nil {
 		return backupengine.ArchiverStats{}, mterrors.Wrap(err, "failed to query pg_stat_archiver")
 	}
@@ -131,7 +131,7 @@ func (pm *MultipoolerManager) backupSettings(ctx context.Context) (backupengine.
 		COALESCE(current_setting('archive_mode', true), '')    AS archive_mode,
 		COALESCE(current_setting('restore_command', true), '') AS restore_command,
 		COALESCE(split_part(current_setting('server_version', true), ' ', 1), '') AS server_version`
-	result, err := pm.query(queryCtx, sql)
+	result, err := pm.adminQuery(queryCtx, sql)
 	if err != nil {
 		return backupengine.PGSettings{}, mterrors.Wrap(err, "failed to query backup settings")
 	}
@@ -152,7 +152,7 @@ func (pm *MultipoolerManager) backupSettings(ctx context.Context) (backupengine.
 func (pm *MultipoolerManager) getPrimaryLSN(ctx context.Context) (string, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	result, err := pm.query(queryCtx, "SELECT pg_current_wal_lsn()::text")
+	result, err := pm.adminQuery(queryCtx, "SELECT pg_current_wal_lsn()::text")
 	if err != nil {
 		return "", mterrors.Wrap(err, "failed to get current WAL LSN")
 	}
@@ -222,7 +222,7 @@ func (pm *MultipoolerManager) querySchemaExists(ctx context.Context) (bool, erro
 	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
 	sql := "SELECT EXISTS(SELECT 1 FROM information_schema.schemata WHERE schema_name = 'multigres')"
-	result, err := pm.query(queryCtx, sql)
+	result, err := pm.adminQuery(queryCtx, sql)
 	if err != nil {
 		return false, mterrors.Wrap(err, "failed to check schema exists")
 	}
@@ -237,7 +237,7 @@ func (pm *MultipoolerManager) querySchemaExists(ctx context.Context) (bool, erro
 func (pm *MultipoolerManager) checkLSNReached(ctx context.Context, targetLsn string) (bool, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	result, err := pm.queryArgs(queryCtx, "SELECT pg_last_wal_replay_lsn() >= $1::pg_lsn", targetLsn)
+	result, err := pm.adminQueryArgs(queryCtx, "SELECT pg_last_wal_replay_lsn() >= $1::pg_lsn", targetLsn)
 	if err != nil {
 		return false, mterrors.Wrap(err, "failed to check if replay LSN reached target")
 	}
@@ -276,7 +276,7 @@ SELECT	pg_last_wal_replay_lsn(),
 func (pm *MultipoolerManager) queryReplicationStatus(ctx context.Context) (*multipoolermanagerdatapb.StandbyReplicationStatus, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	result, err := pm.query(queryCtx, sqlGetReplicationStatus)
+	result, err := pm.adminQuery(queryCtx, sqlGetReplicationStatus)
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to query replication status")
 	}
@@ -471,7 +471,7 @@ func (pm *MultipoolerManager) setPrimaryConnInfo(ctx context.Context, connInfo s
 	execCtx, execCancel := context.WithTimeout(ctx, timeouts.PostgresConfigTimeout)
 	defer execCancel()
 	sql := "ALTER SYSTEM SET primary_conninfo = " + ast.QuoteStringLiteral(connInfo)
-	if err := pm.exec(execCtx, sql); err != nil {
+	if err := pm.adminExec(execCtx, sql); err != nil {
 		pm.logger.ErrorContext(ctx, "failed to set primary_conninfo", "error", err)
 		return mterrors.Wrap(err, "failed to set primary_conninfo")
 	}
@@ -487,7 +487,7 @@ func (pm *MultipoolerManager) resetPrimaryConnInfo(ctx context.Context) error {
 
 	execCtx, execCancel := context.WithTimeout(ctx, timeouts.PostgresConfigTimeout)
 	defer execCancel()
-	if err := pm.exec(execCtx, "ALTER SYSTEM RESET primary_conninfo"); err != nil {
+	if err := pm.adminExec(execCtx, "ALTER SYSTEM RESET primary_conninfo"); err != nil {
 		pm.logger.ErrorContext(ctx, "failed to clear primary_conninfo", "error", err)
 		return mterrors.Wrap(err, "failed to clear primary_conninfo")
 	}
@@ -509,7 +509,7 @@ func (pm *MultipoolerManager) alterSystemSetOptions(ctx context.Context, options
 		// Explicit cancel (not defer) so timeouts don't accumulate across the loop.
 		execCtx, execCancel := context.WithTimeout(ctx, timeouts.PostgresConfigTimeout)
 		sql := fmt.Sprintf("ALTER SYSTEM SET %s = %s", opt.name, ast.QuoteStringLiteral(opt.value))
-		err := pm.exec(execCtx, sql)
+		err := pm.adminExec(execCtx, sql)
 		execCancel()
 		if err != nil {
 			return mterrors.Wrapf(err, "failed to set option %q", opt.name)
@@ -616,7 +616,7 @@ func (pm *MultipoolerManager) resetSynchronizedStandbySlots(ctx context.Context)
 func (pm *MultipoolerManager) readRestoreCommand(ctx context.Context) (string, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	result, err := pm.query(queryCtx, "SELECT current_setting('restore_command', true)")
+	result, err := pm.adminQuery(queryCtx, "SELECT current_setting('restore_command', true)")
 	if err != nil {
 		return "", mterrors.Wrap(err, "failed to read restore_command")
 	}
@@ -651,7 +651,7 @@ func (pm *MultipoolerManager) resetRestoreCommand(ctx context.Context) error {
 
 	execCtx, execCancel := context.WithTimeout(ctx, timeouts.PostgresConfigTimeout)
 	defer execCancel()
-	if err := pm.exec(execCtx, "ALTER SYSTEM RESET restore_command"); err != nil {
+	if err := pm.adminExec(execCtx, "ALTER SYSTEM RESET restore_command"); err != nil {
 		pm.logger.ErrorContext(ctx, "failed to clear restore_command", "error", err)
 		return mterrors.Wrap(err, "failed to clear restore_command")
 	}
@@ -849,7 +849,7 @@ func isNoMoreWalToReplay(waitEvent string) bool {
 func (pm *MultipoolerManager) checkNoWALSource(ctx context.Context) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	result, err := pm.query(queryCtx, "SELECT current_setting('primary_conninfo', true), current_setting('restore_command', true)")
+	result, err := pm.adminQuery(queryCtx, "SELECT current_setting('primary_conninfo', true), current_setting('restore_command', true)")
 	if err != nil {
 		return mterrors.Wrap(err, "failed to read WAL-source settings")
 	}
@@ -905,7 +905,7 @@ func (pm *MultipoolerManager) queryReplayProgress(ctx context.Context) (replayPr
 	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
 
-	result, err := pm.query(queryCtx, `SELECT
+	result, err := pm.adminQuery(queryCtx, `SELECT
 		pg_last_wal_replay_lsn(),
 		pg_last_wal_receive_lsn(),
 		pg_is_wal_replay_paused(),
@@ -973,7 +973,7 @@ func (pm *MultipoolerManager) waitForReceiverDisconnect(ctx context.Context) (*m
 		func(waitCtx context.Context) (*multipoolermanagerdatapb.StandbyReplicationStatus, bool, error) {
 			// Pull the count, the walreceiver status, and the live primary_conninfo
 			// in a single query so each poll is also a diagnostic snapshot.
-			result, err := pm.query(waitCtx, `SELECT
+			result, err := pm.adminQuery(waitCtx, `SELECT
 				(SELECT COUNT(*) FROM pg_stat_wal_receiver),
 				coalesce((SELECT status FROM pg_stat_wal_receiver), ''),
 				current_setting('primary_conninfo')`)
@@ -1033,7 +1033,7 @@ func (pm *MultipoolerManager) pauseReplication(ctx context.Context, mode multipo
 		execCtx, execCancel := context.WithTimeout(ctx, 500*time.Millisecond)
 		defer execCancel()
 
-		if err := pm.exec(execCtx, "SELECT pg_wal_replay_pause()"); err != nil {
+		if err := pm.adminExec(execCtx, "SELECT pg_wal_replay_pause()"); err != nil {
 			pm.logger.ErrorContext(ctx, "failed to pause WAL replay", "error", err)
 			return nil, mterrors.Wrap(err, "failed to pause WAL replay")
 		}
@@ -1091,7 +1091,7 @@ func (pm *MultipoolerManager) pauseReplication(ctx context.Context, mode multipo
 		// Now that receiver is disconnected, pause replay
 		execCtx, execCancel := context.WithTimeout(ctx, 500*time.Millisecond)
 		defer execCancel()
-		if err := pm.exec(execCtx, "SELECT pg_wal_replay_pause()"); err != nil {
+		if err := pm.adminExec(execCtx, "SELECT pg_wal_replay_pause()"); err != nil {
 			pm.logger.ErrorContext(ctx, "failed to pause WAL replay", "error", err)
 			return nil, mterrors.Wrap(err, "failed to pause WAL replay")
 		}
@@ -1121,7 +1121,7 @@ func (pm *MultipoolerManager) resumeWALReplay(ctx context.Context) error {
 	execCtx, execCancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer execCancel()
 
-	if err := pm.exec(execCtx, "SELECT pg_wal_replay_resume()"); err != nil {
+	if err := pm.adminExec(execCtx, "SELECT pg_wal_replay_resume()"); err != nil {
 		pm.logger.ErrorContext(ctx, "failed to resume WAL replay", "error", err)
 		return mterrors.Wrap(err, "failed to resume WAL replay")
 	}
@@ -1144,7 +1144,7 @@ func (pm *MultipoolerManager) validateExpectedLSN(ctx context.Context, expectedL
 	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
 	sql := "SELECT pg_last_wal_replay_lsn()::text, pg_is_wal_replay_paused()"
-	result, err := pm.query(queryCtx, sql)
+	result, err := pm.adminQuery(queryCtx, sql)
 	if err != nil {
 		pm.logger.ErrorContext(ctx, "failed to get current replay LSN and pause state", "error", err)
 		return mterrors.Wrap(err, "failed to get current replay LSN and pause state")
@@ -1196,7 +1196,7 @@ func (pm *MultipoolerManager) applySynchronousStandbyNames(ctx context.Context, 
 
 	// ALTER SYSTEM SET doesn't support parameterized queries, so we use string formatting
 	sql := "ALTER SYSTEM SET synchronous_standby_names = " + ast.QuoteStringLiteral(value)
-	if err := pm.exec(execCtx, sql); err != nil {
+	if err := pm.adminExec(execCtx, sql); err != nil {
 		pm.logger.ErrorContext(ctx, "failed to set synchronous_standby_names", "error", err)
 		return mterrors.Wrap(err, "failed to set synchronous_standby_names")
 	}
@@ -1220,7 +1220,7 @@ func (pm *MultipoolerManager) setSynchronousStandbyNames(ctx context.Context, sy
 		defer execCancel()
 
 		pm.logger.InfoContext(ctx, "clearing synchronous_standby_names (empty standby list)")
-		if err := pm.exec(execCtx, "ALTER SYSTEM RESET synchronous_standby_names"); err != nil {
+		if err := pm.adminExec(execCtx, "ALTER SYSTEM RESET synchronous_standby_names"); err != nil {
 			pm.logger.ErrorContext(ctx, "failed to clear synchronous_standby_names", "error", err)
 			return mterrors.Wrap(err, "failed to clear synchronous_standby_names")
 		}
@@ -1307,7 +1307,7 @@ func (pm *MultipoolerManager) clearSyncReplicationForDemotion(ctx context.Contex
 
 	// ALTER SYSTEM writes to postgresql.auto.conf (not WAL), so it doesn't require
 	// sync replication acknowledgment and won't block.
-	if err := pm.exec(execCtx, "ALTER SYSTEM RESET synchronous_standby_names"); err != nil {
+	if err := pm.adminExec(execCtx, "ALTER SYSTEM RESET synchronous_standby_names"); err != nil {
 		pm.logger.WarnContext(ctx, "failed to clear synchronous_standby_names for demotion", "error", err)
 		return mterrors.Wrap(err, "failed to clear synchronous_standby_names for demotion")
 	}
@@ -1365,7 +1365,7 @@ func (pm *MultipoolerManager) getConnectedFollowerIDs(ctx context.Context) ([]*c
 	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
 	sql := "SELECT application_name FROM pg_stat_replication WHERE application_name IS NOT NULL AND application_name != ''"
-	result, err := pm.query(queryCtx, sql)
+	result, err := pm.adminQuery(queryCtx, sql)
 	if err != nil {
 		pm.logger.ErrorContext(ctx, "failed to query pg_stat_replication", "error", err)
 		return nil, mterrors.Wrap(err, "failed to query connected followers")

--- a/go/services/multipooler/internal/manager/pg_replication.go
+++ b/go/services/multipooler/internal/manager/pg_replication.go
@@ -68,7 +68,7 @@ import (
 func (pm *MultipoolerManager) postgresMode(ctx context.Context) (pgmode.Mode, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	result, err := pm.query(queryCtx, "SELECT pg_is_in_recovery()")
+	result, err := pm.adminQuery(queryCtx, "SELECT pg_is_in_recovery()")
 	if err != nil {
 		return pgmode.Unknown, fmt.Errorf("failed to query pg_is_in_recovery: %w", err)
 	}
@@ -191,7 +191,7 @@ func (pm *MultipoolerManager) rewindSourceReady(ctx context.Context) (bool, erro
 		(SELECT timeline_id FROM pg_control_checkpoint())
 		= ('x' || substring(pg_walfile_name(pg_current_wal_lsn()) from 1 for 8))::bit(32)::int
 	END`
-	result, err := pm.query(queryCtx, sql)
+	result, err := pm.adminQuery(queryCtx, sql)
 	if err != nil {
 		return false, mterrors.Wrap(err, "failed to query rewind-source readiness")
 	}
@@ -206,7 +206,7 @@ func (pm *MultipoolerManager) rewindSourceReady(ctx context.Context) (bool, erro
 func (pm *MultipoolerManager) getStandbyReplayLSN(ctx context.Context) (string, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	result, err := pm.query(queryCtx, "SELECT pg_last_wal_replay_lsn()::text")
+	result, err := pm.adminQuery(queryCtx, "SELECT pg_last_wal_replay_lsn()::text")
 	if err != nil {
 		return "", mterrors.Wrap(err, "failed to get replay LSN")
 	}
@@ -450,7 +450,7 @@ func (pm *MultipoolerManager) waitForReplicationPause(ctx context.Context) (*mul
 func (pm *MultipoolerManager) readPrimaryConnInfo(ctx context.Context) (string, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	result, err := pm.query(queryCtx, "SELECT current_setting('primary_conninfo', true)")
+	result, err := pm.adminQuery(queryCtx, "SELECT current_setting('primary_conninfo', true)")
 	if err != nil {
 		return "", mterrors.Wrap(err, "failed to read primary_conninfo")
 	}

--- a/go/services/multipooler/internal/manager/pg_replication_test.go
+++ b/go/services/multipooler/internal/manager/pg_replication_test.go
@@ -668,12 +668,19 @@ func TestPostgresMode(t *testing.T) {
 	}
 }
 
-func TestControlPlaneProbesUseAdminPool(t *testing.T) {
+// TestControlPlaneQueriesUseAdminPool pins the pool routing of the manager's
+// control-plane queries: everything issued via the adminQuery/adminExec helper
+// family must go to the admin (true-superuser) pool, never the regular pool,
+// so failover-path work cannot starve behind saturated user traffic. Each
+// query consumes exactly one mock pattern and increments AdminQueryCount, so
+// AdminQueryCount == pattern count proves none went to the regular pool.
+func TestControlPlaneQueriesUseAdminPool(t *testing.T) {
 	pm, queryService := newTestManagerWithMock(t, "default", "0-inf")
 	queryService.AddQueryPatternOnce("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"f"}}))
 	queryService.AddQueryPatternOnce("timeline_id FROM pg_control_checkpoint", mock.MakeQueryResult([]string{"ready"}, [][]any{{"t"}}))
 	queryService.AddQueryPatternOnce("SELECT pg_last_wal_replay_lsn", mock.MakeQueryResult([]string{"pg_last_wal_replay_lsn"}, [][]any{{"0/2000000"}}))
 	queryService.AddQueryPatternOnce("primary_conninfo", mock.MakeQueryResult([]string{"current_setting"}, [][]any{{"host=primary"}}))
+	queryService.AddQueryPatternOnce("SELECT pg_current_wal_lsn", mock.MakeQueryResult([]string{"pg_current_wal_lsn"}, [][]any{{"0/3000000"}}))
 
 	ctx := context.Background()
 	mode, err := pm.postgresMode(ctx)
@@ -688,8 +695,11 @@ func TestControlPlaneProbesUseAdminPool(t *testing.T) {
 	connInfo, err := pm.readPrimaryConnInfo(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "host=primary", connInfo)
+	primaryLSN, err := pm.getPrimaryLSN(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "0/3000000", primaryLSN)
 
-	assert.Equal(t, 4, queryService.AdminQueryCount())
+	assert.Equal(t, 5, queryService.AdminQueryCount())
 	assert.NoError(t, queryService.ExpectationsWereMet())
 }
 

--- a/go/services/multipooler/internal/manager/pg_replication_test.go
+++ b/go/services/multipooler/internal/manager/pg_replication_test.go
@@ -668,6 +668,31 @@ func TestPostgresMode(t *testing.T) {
 	}
 }
 
+func TestControlPlaneProbesUseAdminPool(t *testing.T) {
+	pm, queryService := newTestManagerWithMock(t, "default", "0-inf")
+	queryService.AddQueryPatternOnce("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"f"}}))
+	queryService.AddQueryPatternOnce("timeline_id FROM pg_control_checkpoint", mock.MakeQueryResult([]string{"ready"}, [][]any{{"t"}}))
+	queryService.AddQueryPatternOnce("SELECT pg_last_wal_replay_lsn", mock.MakeQueryResult([]string{"pg_last_wal_replay_lsn"}, [][]any{{"0/2000000"}}))
+	queryService.AddQueryPatternOnce("primary_conninfo", mock.MakeQueryResult([]string{"current_setting"}, [][]any{{"host=primary"}}))
+
+	ctx := context.Background()
+	mode, err := pm.postgresMode(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, pgmode.Primary, mode)
+	ready, err := pm.rewindSourceReady(ctx)
+	require.NoError(t, err)
+	assert.True(t, ready)
+	lsn, err := pm.getStandbyReplayLSN(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "0/2000000", lsn)
+	connInfo, err := pm.readPrimaryConnInfo(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "host=primary", connInfo)
+
+	assert.Equal(t, 4, queryService.AdminQueryCount())
+	assert.NoError(t, queryService.ExpectationsWereMet())
+}
+
 func TestGetPrimaryLSN(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/go/services/multipooler/internal/manager/rpc_initialization.go
+++ b/go/services/multipooler/internal/manager/rpc_initialization.go
@@ -120,7 +120,7 @@ func (pm *MultipoolerManager) isPostgresRunning(ctx context.Context) bool {
 	if pm.pgctldClient == nil {
 		// No pgctld client — fall back to connection-based check.
 		// Without pgctld we can't distinguish a stopped-but-alive process from a dead one.
-		_, err := pm.query(ctx, "SELECT 1")
+		_, err := pm.adminQuery(ctx, "SELECT 1")
 		return err == nil
 	}
 
@@ -140,7 +140,7 @@ func (pm *MultipoolerManager) isPostgresRunning(ctx context.Context) bool {
 func (pm *MultipoolerManager) isPostgresReady(ctx context.Context) bool {
 	if pm.pgctldClient == nil {
 		// No pgctld client, try a simple query to check if PostgreSQL is responding
-		_, err := pm.query(ctx, "SELECT 1")
+		_, err := pm.adminQuery(ctx, "SELECT 1")
 		return err == nil
 	}
 
@@ -225,7 +225,7 @@ func (pm *MultipoolerManager) removeDataDirectory() error {
 // waitForDatabaseConnection waits for the database connection to become available
 func (pm *MultipoolerManager) waitForDatabaseConnection(ctx context.Context) error {
 	// Test if database is already reachable
-	if _, err := pm.query(ctx, "SELECT 1"); err == nil {
+	if _, err := pm.adminQuery(ctx, "SELECT 1"); err == nil {
 		// Start heartbeat tracker if not already running
 		if pm.replTracker == nil {
 			shardID := []byte("0") // default shard ID
@@ -255,7 +255,7 @@ func (pm *MultipoolerManager) waitForDatabaseConnection(ctx context.Context) err
 		}
 
 		// Try to query the database
-		if _, queryErr := pm.query(ctx, "SELECT 1"); queryErr == nil {
+		if _, queryErr := pm.adminQuery(ctx, "SELECT 1"); queryErr == nil {
 			pm.logger.InfoContext(ctx, "database connection established successfully", "attempts", attempt)
 
 			// Start heartbeat tracker if not already running

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -631,7 +631,7 @@ func (pm *MultipoolerManager) getPrimaryStatusInternal(ctx context.Context) (*mu
 	// capacity exhaustion (connected followers == max_wal_senders) is visible.
 	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	result, err := pm.query(queryCtx,
+	result, err := pm.adminQuery(queryCtx,
 		"SELECT current_setting('synchronous_standby_names'), current_setting('synchronous_commit'), current_setting('max_wal_senders')")
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to query replication settings")

--- a/go/services/multipooler/internal/manager/rpc_reload_config.go
+++ b/go/services/multipooler/internal/manager/rpc_reload_config.go
@@ -173,7 +173,7 @@ func (pm *MultipoolerManager) checkExpectedSettings(
 	// their context reads as NULL (empty, treated as non-postmaster).
 	queryCtx, cancel := context.WithTimeout(ctx, timeouts.PostgresConfigTimeout)
 	defer cancel()
-	result, err := qs.Query(queryCtx, `SELECT fs.name, fs.setting, fs.applied, fs.error, s.context
+	result, err := qs.QueryAdmin(queryCtx, `SELECT fs.name, fs.setting, fs.applied, fs.error, s.context
 FROM pg_file_settings fs
 LEFT JOIN pg_settings s ON s.name = fs.name
 ORDER BY fs.seqno`)

--- a/go/test/endtoend/multiorch/saturated_pool_failover_test.go
+++ b/go/test/endtoend/multiorch/saturated_pool_failover_test.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiorch
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+)
+
+// TestFailoverWithSaturatedUserPools is a regression test for control-plane
+// recovery probes sharing capacity with user traffic.
+//
+// The failover-critical probes (pg_is_in_recovery() and friends) used to run
+// on the per-user regular pool. Under user-traffic saturation the probe's
+// borrow queued behind user queries and timed out at its 500ms budget, the
+// postgres monitor could not determine the node's role, and failover stalled
+// exactly when it was most needed. The probes now run on the separate admin
+// pool, which user traffic can never exhaust.
+//
+// The test saturates every pooler's regular pool with long-running user
+// statements (the e2e test user is "postgres" — the same user the internal
+// queries run as, so client sessions and internal borrows contend for the
+// same per-user pool), verifies saturation server-side via pg_stat_activity
+// on each node's postgres, then kills the primary and requires a new primary
+// to be elected while the pools stay saturated.
+func TestFailoverWithSaturatedUserPools(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping TestFailoverWithSaturatedUserPools in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found")
+	}
+
+	// Tiny global capacity so a handful of held sessions saturates the regular
+	// pool. With the default reserved-ratio of 0.2, regular capacity is
+	// int64(4 * 0.8) = 3 connections per pooler.
+	const regularCapacity = 3
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultiorchCount(3),
+		shardsetup.WithMultigateway(),
+		shardsetup.WithMultigatewayReplicaPort(),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+		// Short grace period: this test hard-kills the primary, so the grace
+		// window only delays the failover the test is waiting for.
+		shardsetup.WithLeaderFailoverGracePeriod("2s", "2s"),
+		shardsetup.WithMultipoolerExtraArgs("--connpool-global-capacity=4"),
+	)
+	defer cleanup()
+
+	setup.StartMultiorchs(t.Context(), t)
+	setup.WaitForMultigatewayQueryServing(t)
+
+	primary := setup.GetPrimary(t)
+	require.NotNil(t, primary, "primary instance should exist")
+	oldPrimaryName := setup.PrimaryName
+	t.Logf("Initial primary: %s", oldPrimaryName)
+
+	// Wait for the replica-reads port to serve before saturating through it.
+	roDSN := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayReplicaPgPort, "sslmode=disable", "connect_timeout=5")
+	roDB, err := sql.Open("postgres", roDSN)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		var one int
+		return roDB.QueryRow("SELECT 1").Scan(&one) == nil
+	}, 60*time.Second, time.Second, "replica-reads port did not become ready")
+	roDB.Close()
+
+	// Saturate the regular pools: each session runs a long pg_sleep as an
+	// autocommit statement, pinning one regular-pool connection for the test's
+	// lifetime. (Transactions would pin *reserved*-pool connections instead —
+	// the probes borrow from the regular pool, so plain statements it is.)
+	// Sessions beyond pool capacity queue on the borrow or error; both are
+	// fine, the first regularCapacity holders per pooler are what matter. The
+	// replica port routes randomly across standbys, so open enough sessions
+	// that every standby fills with overwhelming probability.
+	holdCtx, cancelHolds := context.WithCancel(context.Background())
+	defer cancelHolds()
+	var holdWG sync.WaitGroup
+	t.Cleanup(holdWG.Wait)
+	t.Cleanup(cancelHolds)
+
+	holdSessions := func(port, n int) {
+		dsn := shardsetup.GetTestUserDSN("localhost", port, "sslmode=disable", "connect_timeout=5")
+		for range n {
+			db, err := sql.Open("postgres", dsn)
+			require.NoError(t, err)
+			t.Cleanup(func() { db.Close() })
+			db.SetMaxOpenConns(1)
+			holdWG.Go(func() {
+				// Errors are expected: sessions beyond capacity may time out,
+				// and primary-side holders die when the primary is killed.
+				_, _ = db.ExecContext(holdCtx, "SELECT pg_sleep(600)")
+			})
+		}
+	}
+	holdSessions(setup.MultigatewayPgPort, 12)
+	holdSessions(setup.MultigatewayReplicaPgPort, 40)
+
+	// Server-side saturation check: count active pg_sleep backends directly on
+	// each node's postgres (bypassing the pooler). Only when every node holds
+	// at least regularCapacity of them is the regular pool provably full —
+	// client-side blocking can't distinguish "all poolers full" from "I keep
+	// getting routed to a full one".
+	directDBs := make(map[string]*sql.DB, len(setup.Multipoolers))
+	for name, inst := range setup.Multipoolers {
+		db, err := sql.Open("postgres", shardsetup.GetPostgresDSN("localhost", inst.Pgctld.PgPort, "sslmode=disable", "connect_timeout=5"))
+		require.NoError(t, err)
+		t.Cleanup(func() { db.Close() })
+		directDBs[name] = db
+	}
+	countHeld := func(db *sql.DB) (int, error) {
+		var n int
+		err := db.QueryRow(
+			`SELECT count(*) FROM pg_stat_activity
+			 WHERE state = 'active' AND query LIKE '%pg_sleep%' AND pid <> pg_backend_pid()`).Scan(&n)
+		return n, err
+	}
+	require.Eventually(t, func() bool {
+		for name, db := range directDBs {
+			n, err := countHeld(db)
+			if err != nil {
+				t.Logf("saturation check on %s: %v", name, err)
+				return false
+			}
+			if n < regularCapacity {
+				t.Logf("saturation check on %s: %d/%d regular-pool connections held", name, n, regularCapacity)
+				return false
+			}
+		}
+		return true
+	}, 90*time.Second, 2*time.Second, "regular pools did not saturate on every node")
+	t.Log("All poolers' regular pools are saturated with held user statements")
+
+	// Disable postgres auto-restart on the primary so the monitor does not
+	// resurrect it mid-failover (same reasoning as TestDeadPrimaryRecovery).
+	primaryClient, err := shardsetup.NewMultipoolerClient(primary.Multipooler.GrpcPort)
+	require.NoError(t, err)
+	_, err = primaryClient.Manager.SetPostgresRestartsEnabled(utils.WithShortDeadline(t),
+		&multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest{Enabled: false})
+	require.NoError(t, err)
+	primaryClient.Close()
+
+	t.Logf("Killing postgres on primary %s with pools saturated", oldPrimaryName)
+	setup.KillPostgres(t, oldPrimaryName)
+
+	// The regression assertion: a standby must still be promoted even though
+	// every regular pool is saturated. Before the probes moved to the admin
+	// pool, the standbys' monitors could not read pg_is_in_recovery() here and
+	// no promotion happened.
+	newPrimaryName := shardsetup.WaitForNewPrimary(t, setup, oldPrimaryName, 60*time.Second)
+	require.NotEmpty(t, newPrimaryName, "expected failover to complete despite saturated user pools")
+	t.Logf("New primary elected under pool saturation: %s", newPrimaryName)
+
+	// The regression signature: no control-plane query may ever starve on the
+	// saturated regular pool. All manager, consensus, and heartbeat queries run
+	// on the admin pool, so a "connection pool timed out" in a multipooler log
+	// means some control-plane query regressed onto the regular pool (borrow
+	// failures on the user query path surface to the client, not this log).
+	// Before the move, this window produced ~70 such lines per run
+	// (pg_is_in_recovery probe timeouts, replication-status reads,
+	// consensus.recruit's primary_conninfo reset). Wall-clock failover time
+	// cannot discriminate here — retry loops eventually limp through once held
+	// sessions die with the postgres restarts around promotion — so the borrow
+	// failures in the logs are the observable.
+	for name, inst := range setup.Multipoolers {
+		logBytes, err := os.ReadFile(inst.Multipooler.LogFile)
+		require.NoError(t, err, "reading multipooler log for %s", name)
+		for line := range strings.SplitSeq(string(logBytes), "\n") {
+			require.NotContains(t, line, "connection pool timed out",
+				"%s: a control-plane query starved on the saturated regular pool", name)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Control-plane queries in the multipooler manager ran on the regular per-user pool, sharing capacity with customer traffic. When that pool is saturated (an overloaded primary during an incident), a control-plane borrow queues behind user queries and times out at its budget (typically 500ms) before reaching postgres. The postgres monitor then can't determine the node's role and deliberately skips remediation rather than act on a guess — so data-plane saturation degrades failover exactly when it's most needed.

An e2e reproduction (saturate every regular pool with held user statements, then kill the primary) confirmed the starvation is real and not limited to the recovery probes: replication-status reads, consensus.recruit's `primary_conninfo` reset, `pg_promote()`, `CHECKPOINT`, and the demote drain all queued behind user traffic, and failover limped through on retries.

## Change

- **Commit 1** routes the four recovery probes (`pg_is_in_recovery()`, rewind-source readiness, `pg_last_wal_replay_lsn()`, `primary_conninfo`) through the admin pool.
- **Commit 2** finishes the job: the manager's admin-pool helpers (`adminQuery`/`adminExec`/`adminQueryArgs`/`adminExecArgs`) become its only query path and every call site is flipped to them explicitly (the regular-pool helpers end up caller-less and are removed — enforced by the unused lint). Consensus sync-standby management, `pg_reload_conf()`, and the reload-config status read move to `QueryAdmin` the same way.

The invariant after this PR: **the multipooler control plane (manager, consensus, heartbeat) never borrows from user-traffic pools.** Choosing the pool stays visible at each call site via the `admin*`-named helpers.

## Testing

- `TestControlPlaneQueriesUseAdminPool` (unit): pins five representative queries to the admin pool; `AdminQueryCount == pattern count` proves none ran on the regular pool.
- `TestFailoverWithSaturatedUserPools` (e2e, new): sets `--connpool-global-capacity=4`, saturates every pooler's regular pool with held `pg_sleep` statements via the gateway RW and replica-reads ports, verifies saturation server-side through `pg_stat_activity` on each node, kills the primary, and requires a new primary plus **zero** `connection pool timed out` lines in any multipooler log.
  - Negative control validated: with probes reverted to the regular pool, the test fails on the starvation assertion (~70 probe timeouts per run, monitor skipping ticks).
  - With the full change, the test passes repeatedly, and failover completes in ~44s instead of ~64s — the control plane no longer retries starved borrows.

## Notes for reviewers

- Held **transactions** would pin *reserved*-pool connections; the probes borrow from the *regular* pool, which is why the e2e saturation uses autocommit `pg_sleep` statements.
- Admin pool sizing (`--connpool-admin-capacity`, default 5) now carries the whole control plane (heartbeat was already on it). The queries are short, low-frequency, and mostly sequential — the e2e run handles a full failover under total regular-pool saturation without admin-pool contention — but sizing is worth a look.
- Follow-up (not in this PR): `Query`/`QueryArgs`/`QueryMultiStatement`/`Begin` on `InternalQueryService` now have no production callers and could be pruned.
- An eager admin-pool warm-up at `Open()` was prototyped and dropped: the monitor's continuous polling keeps the needed connection warm, and warmed connections wouldn't survive the postgres restarts that recovery scenarios involve.