### PR TITLE
test(pgregress): record temporary function divergence in explain

### DIFF
--- a/go/services/multipooler/internal/manager/logical_slots.go
+++ b/go/services/multipooler/internal/manager/logical_slots.go
@@ -378,7 +378,7 @@ func (pm *MultipoolerManager) dropOrphanedFailoverSlots(ctx context.Context) err
 
 	execCtx, cancel := context.WithTimeout(ctx, logicalSlotWriteTimeout)
 	defer cancel()
-	if err := pm.execArgs(execCtx, dropOrphanedFailoverSlotsSQL); err != nil {
+	if err := pm.adminExecArgs(execCtx, dropOrphanedFailoverSlotsSQL); err != nil {
 		return mterrors.Wrap(err, "failed to drop orphaned logical failover slots")
 	}
 

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/explain.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/explain.patch
@@ -1,0 +1,31 @@
+# Known divergence (by design): CREATE FUNCTION pg_temp.mysin is rejected —
+# creating objects in pg_temp via schema qualification is not supported under
+# connection pooling (PostgreSQL has no CREATE TEMP FUNCTION spelling, so this
+# concedes temporary functions). The subsequent explain_filter over
+# pg_temp.mysin then fails to resolve the function. The session-private pg_temp
+# namespace also rules out preseeding; allowing the CREATE would require the
+# temp-pin treatment CREATE TEMP TABLE gets.
+--- a
++++ b
+@@ -635,14 +635,14 @@
+ create temp table t1(f1 float8);
+ create function pg_temp.mysin(float8) returns float8 language plpgsql
+ as 'begin return sin($1); end';
++ERROR: creating objects in pg_temp via schema qualification is not supported under connection pooling; use CREATE TEMP/TEMPORARY instead
+ select explain_filter('explain (verbose) select * from t1 where pg_temp.mysin(f1) < 0.5');
+-explain_filter
+-------------------------------------------------------------
+-Seq Scan on pg_temp.t1 (cost=N.N..N.N rows=N width=N)
+-Output: f1
+-Filter: (pg_temp.mysin(t1.f1) < 'N.N'::double precision)
+-(3 rows)
+-
++ERROR: function pg_temp.mysin(double precision) does not exist
++LINE 1: explain (verbose) select * from t1 where pg_temp.mysin(f1) <...
++^
++HINT: No function matches the given name and argument types. You might need to add explicit type casts.
++QUERY: explain (verbose) select * from t1 where pg_temp.mysin(f1) < 0.5
++CONTEXT: PL/pgSQL function explain_filter(text) line 5 at FOR over EXECUTE statement
+ -- Test compute_query_id
+ set compute_query_id = on;
+ select explain_filter('explain (verbose) select * from int8_tbl i8');


### PR DESCRIPTION
## Summary

- record the intentional rejection of schema-qualified temporary functions under connection pooling
- accept the resulting `pg_temp.mysin` lookup failure in the `explain` regression fixture
- restore the orphaned failover-slot cleanup call after manager control-plane queries moved to the admin pool
- isolate the fixture update from the larger query-serving changes in #1302 and #1352

## Testing

- `go test -short ./go/services/multipooler/internal/manager -count=1`
- the extracted `explain` hunk was exercised by the PostgreSQL compatibility run on #1302
- `explain` on `main` still has the separate prepared-statement residual addressed by #1302