### PR TITLE
feat(multigateway): gate keep-transaction-on-gateway-rejection behind a flag

### DIFF
--- a/go/services/multigateway/handler/handler.go
+++ b/go/services/multigateway/handler/handler.go
@@ -121,6 +121,19 @@ type MultigatewayHandler struct {
 	// reloads; nil reads as disabled. Set via SetSlotBasedReplicationEnabled.
 	slotBasedReplicationEnabled func() bool
 
+	// keepTxnOnGatewayRejection reports, read live, whether a gateway policy
+	// rejection (a *mterrors.GatewayRejection, e.g. feature_not_supported) should
+	// leave an open explicit transaction in-block rather than aborting it. The
+	// rejection never reached the backend, so the backend transaction is still
+	// open; keeping the session in-block lets the client continue. Off by default
+	// so clients see PostgreSQL's contract — any error on the wire aborts the
+	// transaction. Opt-in for pg_regress and associated suites, which drive long
+	// transactions that create functions the gateway refuses and would otherwise
+	// cascade into "current transaction is aborted" noise. Dynamic so it tracks
+	// config reloads; nil reads as disabled. Set via
+	// SetKeepTransactionOnGatewayRejection.
+	keepTxnOnGatewayRejection func() bool
+
 	// normalQueryLogSampleRate controls 1/N sampling for normal-path query
 	// logs. 0 disables sampling (handler level alone governs emission); 1
 	// emits every normal query; N>1 emits every Nth. Normal queries always
@@ -175,6 +188,32 @@ func (h *MultigatewayHandler) SetSlotBasedReplicationEnabled(enabled func() bool
 // non-temporary logical failover slot, reading the dynamic gate live.
 func (h *MultigatewayHandler) admitsFailoverSlots() bool {
 	return h.slotBasedReplicationEnabled != nil && h.slotBasedReplicationEnabled()
+}
+
+// SetKeepTransactionOnGatewayRejection wires the dynamic getter that controls
+// whether a gateway policy rejection leaves an open explicit transaction
+// in-block instead of aborting it. Must be called before connections are
+// accepted. A nil getter (the default) keeps the feature off, so gateway
+// rejections abort the transaction like any other wire error.
+func (h *MultigatewayHandler) SetKeepTransactionOnGatewayRejection(enabled func() bool) {
+	h.keepTxnOnGatewayRejection = enabled
+}
+
+// keepsTransactionOnGatewayRejection reports whether a gateway policy rejection
+// should leave an open explicit transaction in-block, reading the dynamic gate
+// live.
+func (h *MultigatewayHandler) keepsTransactionOnGatewayRejection() bool {
+	return h.keepTxnOnGatewayRejection != nil && h.keepTxnOnGatewayRejection()
+}
+
+// abortsTransactionOnError reports whether an error returned while a statement
+// executed in an open explicit transaction (TxnStatusInBlock) should transition
+// the session to the aborted state. Any backend error aborts. A gateway policy
+// rejection never reached the backend, so it aborts too by default (matching
+// PostgreSQL's "any wire error ends the transaction" contract) unless
+// keep-transaction-on-gateway-rejection is enabled.
+func (h *MultigatewayHandler) abortsTransactionOnError(err error) bool {
+	return !(h.keepsTransactionOnGatewayRejection() && mterrors.IsGatewayRejection(err))
 }
 
 // SetQueryRegistry attaches a per-query-shape registry to the handler.
@@ -352,8 +391,9 @@ func (h *MultigatewayHandler) HandleQuery(ctx context.Context, conn *server.Conn
 			// If we're in an active transaction and the query failed,
 			// transition to aborted state. The client must ROLLBACK to recover.
 			// A gateway policy rejection (feature_not_supported) never reached the
-			// backend, so its transaction is still open — leave the session in-block.
-			if conn.TxnStatus() == protocol.TxnStatusInBlock && !mterrors.IsGatewayRejection(err) {
+			// backend, so with keep-transaction-on-gateway-rejection enabled we
+			// leave the session in-block instead of aborting.
+			if conn.TxnStatus() == protocol.TxnStatusInBlock && h.abortsTransactionOnError(err) {
 				conn.SetTxnStatus(protocol.TxnStatusFailed)
 			}
 		}
@@ -463,9 +503,10 @@ func (h *MultigatewayHandler) HandleParse(ctx context.Context, conn *server.Conn
 	// transaction, where those locks would be released before the next statement.
 	if conn.TxnStatus() == protocol.TxnStatusInBlock {
 		if err := h.executor.EagerParseInTransaction(ctx, conn, h.getConnectionState(conn), queryStr, paramTypes); err != nil {
-			// A gateway policy rejection never reached the backend, so its
-			// transaction is still open — leave the session in-block.
-			if conn.TxnStatus() == protocol.TxnStatusInBlock && !mterrors.IsGatewayRejection(err) {
+			// A gateway policy rejection never reached the backend, so with
+			// keep-transaction-on-gateway-rejection enabled we leave the session
+			// in-block instead of aborting.
+			if conn.TxnStatus() == protocol.TxnStatusInBlock && h.abortsTransactionOnError(err) {
 				conn.SetTxnStatus(protocol.TxnStatusFailed)
 			}
 			return err
@@ -580,9 +621,10 @@ func (h *MultigatewayHandler) HandleExecute(ctx context.Context, conn *server.Co
 	execStart := time.Now()
 	result, err := h.executor.PortalStreamExecute(ctx, conn, state, portalInfo, maxRows, includeDescribe, countingCallback)
 	if err != nil {
-		// A gateway policy rejection never reached the backend, so its transaction
-		// is still open — leave the session in-block.
-		if conn.TxnStatus() == protocol.TxnStatusInBlock && !mterrors.IsGatewayRejection(err) {
+		// A gateway policy rejection never reached the backend, so with
+		// keep-transaction-on-gateway-rejection enabled we leave the session
+		// in-block instead of aborting.
+		if conn.TxnStatus() == protocol.TxnStatusInBlock && h.abortsTransactionOnError(err) {
 			conn.SetTxnStatus(protocol.TxnStatusFailed)
 		}
 	}

--- a/go/services/multigateway/handler/handler_test.go
+++ b/go/services/multigateway/handler/handler_test.go
@@ -628,6 +628,67 @@ func TestHandleQuery_ErrorInTransactionSetsAbortedState(t *testing.T) {
 	require.Equal(t, protocol.TxnStatusFailed, conn.TxnStatus())
 }
 
+// TestHandleQuery_GatewayRejectionInTransactionAbortsByDefault verifies that,
+// with keep-transaction-on-gateway-rejection off (the default), a gateway policy
+// rejection aborts the open transaction like any other wire error — matching
+// PostgreSQL's contract that clients expect.
+func TestHandleQuery_GatewayRejectionInTransactionAbortsByDefault(t *testing.T) {
+	logger := slog.Default()
+	executor := &mockExecutor{streamExecuteErr: mterrors.NewFeatureNotSupported("nope")}
+	h := NewMultigatewayHandler(executor, logger, 0)
+	conn := server.NewTestConn(&bytes.Buffer{}).Conn
+
+	conn.SetTxnStatus(protocol.TxnStatusInBlock)
+
+	err := h.HandleQuery(context.Background(), conn, "SELECT 1", func(_ context.Context, _ *sqltypes.Result) error {
+		return nil
+	})
+
+	require.Error(t, err)
+	require.Equal(t, protocol.TxnStatusFailed, conn.TxnStatus())
+}
+
+// TestHandleQuery_GatewayRejectionKeepsTransactionWhenEnabled verifies that,
+// with keep-transaction-on-gateway-rejection enabled, a gateway policy rejection
+// leaves the transaction in-block (the backend never saw it, so it is still
+// open). Other errors still abort — see the guard on the backend-error case.
+func TestHandleQuery_GatewayRejectionKeepsTransactionWhenEnabled(t *testing.T) {
+	logger := slog.Default()
+	executor := &mockExecutor{streamExecuteErr: mterrors.NewFeatureNotSupported("nope")}
+	h := NewMultigatewayHandler(executor, logger, 0)
+	h.SetKeepTransactionOnGatewayRejection(func() bool { return true })
+	conn := server.NewTestConn(&bytes.Buffer{}).Conn
+
+	conn.SetTxnStatus(protocol.TxnStatusInBlock)
+
+	err := h.HandleQuery(context.Background(), conn, "SELECT 1", func(_ context.Context, _ *sqltypes.Result) error {
+		return nil
+	})
+
+	require.Error(t, err)
+	require.Equal(t, protocol.TxnStatusInBlock, conn.TxnStatus())
+}
+
+// TestHandleQuery_BackendErrorAbortsEvenWhenKeepEnabled verifies that enabling
+// keep-transaction-on-gateway-rejection does not change the abort behavior for
+// real backend errors — only gateway rejections are spared.
+func TestHandleQuery_BackendErrorAbortsEvenWhenKeepEnabled(t *testing.T) {
+	logger := slog.Default()
+	executor := &mockExecutor{streamExecuteErr: errors.New("query failed")}
+	h := NewMultigatewayHandler(executor, logger, 0)
+	h.SetKeepTransactionOnGatewayRejection(func() bool { return true })
+	conn := server.NewTestConn(&bytes.Buffer{}).Conn
+
+	conn.SetTxnStatus(protocol.TxnStatusInBlock)
+
+	err := h.HandleQuery(context.Background(), conn, "SELECT 1", func(_ context.Context, _ *sqltypes.Result) error {
+		return nil
+	})
+
+	require.Error(t, err)
+	require.Equal(t, protocol.TxnStatusFailed, conn.TxnStatus())
+}
+
 // TestHandleQuery_ErrorOutsideTransactionStaysIdle tests that a query error
 // outside a transaction does not change the transaction state.
 func TestHandleQuery_ErrorOutsideTransactionStaysIdle(t *testing.T) {

--- a/go/services/multigateway/handler/transaction_helpers.go
+++ b/go/services/multigateway/handler/transaction_helpers.go
@@ -284,15 +284,16 @@ func (h *MultigatewayHandler) executeWithImplicitTransaction(
 			if isImplicitTx {
 				// Auto-rollback implicit transaction on failure.
 				rollbackImplicit()
-			} else if conn.TxnStatus() == protocol.TxnStatusInBlock && !mterrors.IsGatewayRejection(execErr) {
+			} else if conn.TxnStatus() == protocol.TxnStatusInBlock && h.abortsTransactionOnError(execErr) {
 				// Explicit transaction: enter aborted state only if the failing
 				// statement left the transaction open. Transaction-ending statements
 				// such as failed PREPARE TRANSACTION can return an error after the
 				// backend has already gone idle; their primitive owns that transition.
 				//
 				// A gateway policy rejection (feature_not_supported) never reached the
-				// backend, so the backend transaction is still open — leave the session
-				// in-block so the client can keep working, matching backend state.
+				// backend, so with keep-transaction-on-gateway-rejection enabled we
+				// leave the session in-block so the client can keep working, matching
+				// backend state.
 				conn.SetTxnStatus(protocol.TxnStatusFailed)
 			}
 			return execErr

--- a/go/services/multigateway/init.go
+++ b/go/services/multigateway/init.go
@@ -68,6 +68,12 @@ type Multigateway struct {
 	// slotBasedReplicationEnabled gates admitting non-temporary logical failover
 	// slots in the replication preamble (default off, dynamic/reloadable).
 	slotBasedReplicationEnabled viperutil.Value[bool]
+	// keepTransactionOnGatewayRejection, when enabled, leaves an open explicit
+	// transaction in-block after a gateway policy rejection (feature_not_supported)
+	// instead of aborting it. Off by default so clients see PostgreSQL's contract
+	// (any wire error aborts the transaction); opt-in for pg_regress and associated
+	// suites (default off, dynamic/reloadable).
+	keepTransactionOnGatewayRejection viperutil.Value[bool]
 	// poolerGateway manages connections to poolers and owns the lifecycle
 	// of the underlying pooler cache (topology watch + per-pooler health
 	// streams + per-pooler connection riders).
@@ -231,6 +237,12 @@ func NewMultigateway() *Multigateway {
 			Dynamic:  true,
 			EnvVars:  []string{"MT_ENABLE_SLOT_BASED_REPLICATION"},
 		}),
+		keepTransactionOnGatewayRejection: viperutil.Configure(reg, "keep-transaction-on-gateway-rejection", viperutil.Options[bool]{
+			Default:  false,
+			FlagName: "keep-transaction-on-gateway-rejection",
+			Dynamic:  true,
+			EnvVars:  []string{"MT_KEEP_TRANSACTION_ON_GATEWAY_REJECTION"},
+		}),
 		pgReplicaPort: viperutil.Configure(reg, "pg-replica-port", viperutil.Options[int]{
 			Default:  0,
 			FlagName: "pg-replica-port",
@@ -288,6 +300,7 @@ func (mg *Multigateway) RegisterFlags(fs *pflag.FlagSet) {
 	fs.String("pg-tls-key-file", mg.pgTLSKeyFile.Default(), "path to TLS private key file for PostgreSQL SSL connections")
 	fs.Bool("pg-require-ssl", mg.pgRequireSSL.Default(), "require TLS for all client PostgreSQL connections; multigateway fails to start if no cert/key is configured. CancelRequest still permitted over plaintext.")
 	fs.Bool("enable-slot-based-replication", mg.slotBasedReplicationEnabled.Default(), "admit non-temporary logical replication slots registered for failover (slot-based replication). Default off.")
+	fs.Bool("keep-transaction-on-gateway-rejection", mg.keepTransactionOnGatewayRejection.Default(), "leave an open explicit transaction in-block after a gateway policy rejection (feature_not_supported) instead of aborting it. Off by default so clients see PostgreSQL's contract that any wire error aborts the transaction; intended for pg_regress and compatibility test suites.")
 	fs.Int("pg-replica-port", mg.pgReplicaPort.Default(), "optional port for replica-reads connections; 0 disables the replica listener")
 	fs.Int("low-replication-lag-ms", mg.pgReplicaLowLagMs.Default(), "replicas at or below this lag (milliseconds) are preferred; 0 treats all replicas equally")
 	fs.Int("high-replication-lag-tolerance-ms", mg.pgReplicaHighLagToleranceMs.Default(), "absolute max lag (milliseconds) for replicas; 0 means no upper bound")
@@ -308,6 +321,7 @@ func (mg *Multigateway) RegisterFlags(fs *pflag.FlagSet) {
 		mg.pgTLSKeyFile,
 		mg.pgRequireSSL,
 		mg.slotBasedReplicationEnabled,
+		mg.keepTransactionOnGatewayRejection,
 		mg.pgReplicaPort,
 		mg.pgReplicaLowLagMs,
 		mg.pgReplicaHighLagToleranceMs,
@@ -490,6 +504,7 @@ func (mg *Multigateway) Init(ctx context.Context) error {
 	mg.pgHandler.SetQueryRegistry(mg.queryRegistry)
 	mg.pgHandler.SetNormalQueryLogSampleRate(queryLogSampleRate)
 	mg.pgHandler.SetSlotBasedReplicationEnabled(mg.slotBasedReplicationEnabled.Get)
+	mg.pgHandler.SetKeepTransactionOnGatewayRejection(mg.keepTransactionOnGatewayRejection.Get)
 
 	// Wire LISTEN/NOTIFY notification manager.
 	// Uses a lazy client getter that resolves the primary pooler connection
@@ -541,6 +556,7 @@ func (mg *Multigateway) Init(ctx context.Context) error {
 		replicaHandler.SetQueryRegistry(mg.queryRegistry)
 		replicaHandler.SetNormalQueryLogSampleRate(queryLogSampleRate)
 		replicaHandler.SetSlotBasedReplicationEnabled(mg.slotBasedReplicationEnabled.Get)
+		replicaHandler.SetKeepTransactionOnGatewayRejection(mg.keepTransactionOnGatewayRejection.Get)
 		replicaAddr := fmt.Sprintf("%s:%d", mg.pgBindAddress.Get(), replicaPort)
 		mg.pgReplicaListener, err = server.NewListener(server.ListenerConfig{
 			Address:               replicaAddr,

--- a/go/test/endtoend/pgregresstest/main_test.go
+++ b/go/test/endtoend/pgregresstest/main_test.go
@@ -180,6 +180,13 @@ var setupManager = shardsetup.NewSharedSetupManager(func(t *testing.T) *shardset
 	opts := []shardsetup.SetupOption{
 		shardsetup.WithMultipoolerCount(2), // primary + standby
 		shardsetup.WithMultigateway(),      // enable multigateway for PostgreSQL connections
+		// pg_regress drives long transactions that create functions the gateway
+		// refuses (feature_not_supported). Keep those transactions open on a
+		// gateway rejection instead of aborting, so a single refused statement
+		// doesn't cascade into "current transaction is aborted" across the rest of
+		// the script. Clients get PostgreSQL's default (abort on any error); this
+		// opt-in is scoped to the compatibility suites.
+		shardsetup.WithMultigatewayExtraArgs("--keep-transaction-on-gateway-rejection"),
 		// Generated PostgreSQL allows 60 connections. Keep pooled capacity below
 		// that ceiling so admin and monitoring connections retain headroom.
 		shardsetup.WithMultipoolerExtraArgs("--connpool-global-capacity=50"),

--- a/go/test/endtoend/shardsetup/multigateway_unsafe.go
+++ b/go/test/endtoend/shardsetup/multigateway_unsafe.go
@@ -57,7 +57,10 @@ func (s *ShardSetup) StartUnsafeMultigateway(t *testing.T) int {
 		LogFile:     filepath.Join(s.TempDir, "multigateway-unsafe.log"),
 		Environment: os.Environ(),
 		// Disable the unsafe-statement rejections for this gateway only.
-		ExtraArgs: []string{"--unsafe-pooler-mode"},
+		// Keep transactions open on a gateway rejection too, matching the primary
+		// pg_regress gateway so the same long transaction scripts don't cascade
+		// into aborted-transaction errors when routed here.
+		ExtraArgs: []string{"--unsafe-pooler-mode", "--keep-transaction-on-gateway-rejection"},
 	}
 	if s.MultigatewayTLSCertPaths != nil {
 		inst.TLSCertFile = s.MultigatewayTLSCertPaths.ServerCertFile

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -171,6 +171,18 @@ func WithMultigateway() SetupOption {
 	}
 }
 
+// WithMultigatewayExtraArgs adds extra CLI flags to the multigateway process
+// in the test setup. Implies WithMultigateway(). Use for gateway tuning that has
+// no dedicated option yet, e.g. shardsetup.WithMultigatewayExtraArgs(
+// "--keep-transaction-on-gateway-rejection"). Flags are appended last, so they
+// override the multigateway defaults.
+func WithMultigatewayExtraArgs(args ...string) SetupOption {
+	return func(c *SetupConfig) {
+		c.EnableMultigateway = true
+		c.MultigatewayExtraArgs = append(c.MultigatewayExtraArgs, args...)
+	}
+}
+
 // WithMultiadmin enables multiadmin in the test setup (default: disabled).
 // Multiadmin is started after shard bootstrap and exposes HTTP + gRPC APIs
 // against the same etcd topology used by the rest of the cluster. The


### PR DESCRIPTION
## Summary

- A gateway policy rejection (feature_not_supported) never reaches the backend, so the transaction stays open. The gateway used to always leave the session in-block, which surprises clients that expect any wire error to close the transaction (PostgreSQL's contract, raised in #1352 review).
- Make that opt-in via `--keep-transaction-on-gateway-rejection` (default off, dynamic): off, rejections abort the transaction like any other error; on, they leave it in-block.
- pg_regress and the associated compatibility suites opt in, so a single refused statement in a long transaction doesn't cascade into "current transaction is aborted".