### PR TITLE
feat(multigateway): auto-mark non-temporary logical slots as failover slots

### DIFF
--- a/docs/ha/logical_slot_failover_design.md
+++ b/docs/ha/logical_slot_failover_design.md
@@ -987,8 +987,48 @@ the planner until then.
 Admitting these slots is gated behind a dynamic Multigateway flag, `enable-slot-based-replication` (default
 off, mirroring the Multipooler flag of the same name and read live so it is reloadable). With the flag off the
 preamble rejects every non-temporary slot exactly as it does today, so the guard change is inert until an
-operator enables the feature. Physical (non-logical) slots and non-temporary logical slots _not_ registered
-for failover stay rejected regardless of the flag.
+operator enables the feature. Physical (non-logical) slots stay rejected regardless of the flag.
+
+### 3.2.1 Auto-marking non-temporary slots as failover slots
+
+Relaxing the guard to admit slots _registered_ for failover still leaves HA opt-in per client: a subscriber
+that runs a plain `CREATE SUBSCRIPTION` (without `WITH (failover = true)`) creates a non-temporary logical slot
+with no `FAILOVER` option, which the relaxed guard would still reject. An operator who enabled slot-based
+replication for the whole cluster therefore silently loses HA — and the slot entirely — for every such
+subscriber. Auto-marking closes that gap: with the flag on, a non-temporary logical `CREATE_REPLICATION_SLOT`
+that omits `FAILOVER` is no longer rejected but **rewritten** to inject it (`FAILOVER` is inserted as the first
+option, or a fresh `(FAILOVER)` list is appended), so the slot is _born_ `failover = true` without any client
+change. The command reply shape is unchanged, so the subscriber still works unmodified; the gateway also emits
+an advisory `NOTICE` on the rewrite so the auto-marking is observable (in a PostgreSQL subscriber's server log
+via its notice processor, or in any client's notice handler). This is the sole reliable moment to set the flag:
+`pg_alter_replication_slot` / `ALTER_REPLICATION_SLOT` requires acquiring the slot, so an already-streaming slot
+cannot be altered — creation is the one point at which the slot is inactive.
+
+The rewrite is safe because PostgreSQL never resets a slot's `failover` on its own: `walrcv_alter_slot` has a
+single backend caller (`AlterSubscription`, on an explicit `ALTER SUBSCRIPTION ... SET (failover=…)`); the apply
+worker, tablesync, reconnect, and `REFRESH` never touch it, and the slot-sync worker syncs purely on the slot's
+`failover` column. So the intended mismatch — slot `failover = true` while the subscription's `subfailover =
+false` — is stable. A slot's persistency is likewise immutable (`ReplicationSlotAlter` only changes
+`failover`/`two_phase`), so a client cannot demote an auto-marked slot to temporary to escape sync.
+
+Because the only post-creation route to a slot's `failover` flag is the `ALTER_REPLICATION_SLOT` replication
+command (there is no `pg_alter_replication_slot` SQL function), the gateway also **refuses an
+`ALTER_REPLICATION_SLOT` that sets `FAILOVER` to false** while the feature is on — the command an explicit
+`ALTER SUBSCRIPTION ... SET (failover = false)` emits. This keeps an auto-marked slot registered for failover:
+a client cannot silently opt back out and lose HA behind the "single server" abstraction. Enabling failover, or
+altering only `TWO_PHASE`, is relayed unchanged; with the feature off the command is not inspected at all.
+
+Boundaries of the rewrite:
+
+- **Command form only.** Auto-marking applies to the walsender `CREATE_REPLICATION_SLOT` command — the form a
+  real subscriber sends. The SQL-function forms (`pg_create_logical_replication_slot(...)`) cannot be rewritten
+  (no AST→SQL deparser), so they keep the plain guard: a non-temporary non-failover logical slot is **rejected**
+  (over a replication connection and, via the planner, over an ordinary one).
+- **Explicit opt-out honored.** An explicit `FAILOVER false` is a deliberate client choice and stays rejected
+  (it never appears in a real subscriber command — the walreceiver omits the option when false rather than
+  emitting `FAILOVER false`).
+- **No retroactive sweep.** Slots created before the flag was enabled are not marked; they pick up the flag only
+  when recreated.
 
 ## Part 4. Changes to Multipooler
 

--- a/go/common/mterrors/code.go
+++ b/go/common/mterrors/code.go
@@ -24,6 +24,7 @@ import (
 // PostgreSQL SQLSTATE codes used by Multigres when spoofing native PG errors.
 // See: https://www.postgresql.org/docs/current/errcodes-appendix.html
 const (
+	PgSSSuccessfulCompletion    = "00000" // successful_completion (used by NOTICE messages)
 	PgSSProtocolViolation       = "08P01" // protocol_violation
 	PgSSConnectionFailure       = "08006" // connection_failure
 	PgSSFeatureNotSupported     = "0A000" // feature_not_supported

--- a/go/common/pgprotocol/server/query.go
+++ b/go/common/pgprotocol/server/query.go
@@ -286,6 +286,20 @@ func (c *Conn) WriteError(err error) error {
 	return c.flush()
 }
 
+// WriteNotice writes a NoticeResponse to the client and flushes it. Like
+// WriteError, it is the exported entry point for handlers in other packages
+// that take over a connection outside the normal command loop and need to emit
+// an informational NOTICE — e.g. the replication preamble telling a client its
+// slot was registered for failover. The diagnostic's Severity should be a
+// notice level ("NOTICE", "WARNING", ...); a NoticeResponse is advisory and
+// valid at any point in a command cycle.
+func (c *Conn) WriteNotice(diag *mterrors.PgDiagnostic) error {
+	if werr := c.writeNoticeResponse(diag); werr != nil {
+		return werr
+	}
+	return c.flush()
+}
+
 // writePgDiagnosticResponse writes a PostgreSQL diagnostic response (error or notice).
 // The msgType should be MsgErrorResponse ('E') or MsgNoticeResponse ('N').
 // This unified function handles all 14 PostgreSQL diagnostic fields.

--- a/go/services/multigateway/handler/replication_preamble.go
+++ b/go/services/multigateway/handler/replication_preamble.go
@@ -334,34 +334,34 @@ const (
 	failoverDisabled                       // FAILOVER <false-ish>
 )
 
-// createReplicationSlotFailover classifies the FAILOVER option in the tokens
-// following the LOGICAL keyword of a CREATE_REPLICATION_SLOT command. The first
-// token is the output plugin; its options follow in PostgreSQL 17's
-// parenthesized, comma-separated list — e.g. `pgoutput (FAILOVER, SNAPSHOT
-// 'nothing')`. Parentheses and commas are normalized to spaces so an option
-// glued to a paren or comma is still seen as its own token. A bare FAILOVER
-// means enabled; an explicit boolean value (FAILOVER false/off/no/0/...) is
-// interpreted with sqltypes.ParseBool, which mirrors PostgreSQL's own
-// parse_bool_with_len. A value it can't parse leaves the option enabled (the
-// conservative direction — never silently disables). The three states let the
-// caller tell an absent option (auto-marked) apart from a deliberate opt-out
-// (rejected). The only misread would be an output plugin literally named
-// "failover", which does not exist.
-func createReplicationSlotFailover(tokens []string) failoverOption {
+// slotOptionTokens splits a replication-command option list into individual
+// option tokens. Parentheses and commas are normalized to spaces so an option
+// glued to a paren or comma — e.g. the glued form `pgoutput(FAILOVER)` or
+// `(FAILOVER,SNAPSHOT ...)` — still separates into its own token, then the
+// result is whitespace-split.
+func slotOptionTokens(tokens []string) []string {
 	normalized := strings.Map(func(r rune) rune {
 		if r == '(' || r == ')' || r == ',' {
 			return ' '
 		}
 		return r
 	}, strings.Join(tokens, " "))
-	opts := strings.Fields(normalized)
+	return strings.Fields(normalized)
+}
+
+// failoverFromOptions classifies the FAILOVER option within an already-split
+// option list (no output plugin among the tokens). A bare FAILOVER means
+// enabled; an explicit boolean value (FAILOVER false/off/no/0/...) is
+// interpreted with sqltypes.ParseBool, which mirrors PostgreSQL's own
+// parse_bool_with_len. A value it can't parse leaves the option enabled (the
+// conservative direction — never silently disables). The three states let a
+// caller tell an absent option (auto-marked) apart from a deliberate opt-out
+// (rejected).
+func failoverFromOptions(opts []string) failoverOption {
 	for i, opt := range opts {
 		if !strings.EqualFold(opt, "FAILOVER") {
 			continue
 		}
-		// A bare FAILOVER means enabled; if an explicit boolean value follows,
-		// honor it. A following token that isn't a boolean (another option) or
-		// the end of the list leaves FAILOVER at its bare, enabled meaning.
 		if i+1 < len(opts) {
 			if v, ok := sqltypes.ParseBool(strings.Trim(opts[i+1], "'\"")); ok {
 				if v {
@@ -373,6 +373,22 @@ func createReplicationSlotFailover(tokens []string) failoverOption {
 		return failoverEnabled
 	}
 	return failoverAbsent
+}
+
+// createReplicationSlotFailover classifies the FAILOVER option in the tokens
+// following the LOGICAL keyword of a CREATE_REPLICATION_SLOT command, e.g.
+// `pgoutput (FAILOVER, SNAPSHOT 'nothing')` or the glued form
+// `pgoutput(FAILOVER)`. The first option token is the required output_plugin
+// argument, not an option, so it is dropped before scanning — otherwise a
+// plugin literally named "failover" (client-controlled) would be misread as an
+// already-enabled option and wrongly suppress auto-marking. Dropping the plugin
+// after normalization handles both the spaced and glued forms.
+func createReplicationSlotFailover(tokens []string) failoverOption {
+	opts := slotOptionTokens(tokens)
+	if len(opts) == 0 {
+		return failoverAbsent
+	}
+	return failoverFromOptions(opts[1:]) // opts[0] is the output_plugin
 }
 
 // createReplicationSlotHasFailover reports whether the option list requests
@@ -455,15 +471,16 @@ func rewriteCreateReplicationSlotAddFailover(cmd string) (string, bool) {
 // command fully enforces that an auto-marked slot stays a failover slot.
 // Enabling failover, or changing only TWO_PHASE, is left alone.
 //
-// The option list follows the slot name (fields[1]); createReplicationSlotFailover
-// classifies the FAILOVER option within it (a physical slot has no FAILOVER
-// option and so is never disabled here).
+// The option list follows the slot name (fields[1]) and — unlike the CREATE
+// form — has no output_plugin, so it is classified directly with
+// failoverFromOptions (not createReplicationSlotFailover, which would drop the
+// first real option as if it were a plugin).
 func alterReplicationSlotDisablesFailover(cmd string) bool {
 	fields := strings.Fields(cmd)
 	if len(fields) < 2 || !strings.EqualFold(fields[0], "ALTER_REPLICATION_SLOT") {
 		return false
 	}
-	return createReplicationSlotFailover(fields[2:]) == failoverDisabled
+	return failoverFromOptions(slotOptionTokens(fields[2:])) == failoverDisabled
 }
 
 // nonTemporaryReplicationSlotSQLFuncError returns a rejection error if cmd

--- a/go/services/multigateway/handler/replication_preamble.go
+++ b/go/services/multigateway/handler/replication_preamble.go
@@ -168,10 +168,45 @@ func runReplicationPreamble(
 				}
 				return false, nil, rejectErr
 			}
+
+			// 3b. Enforce failover: with the feature on, refuse an
+			// ALTER_REPLICATION_SLOT that would turn FAILOVER off. Multigres
+			// auto-marks every non-temporary logical slot as a failover slot
+			// (step 3c), so it will not let a client silently opt back out and
+			// lose HA. Enabling failover or changing only TWO_PHASE passes
+			// through.
+			if admitFailoverSlots && alterReplicationSlotDisablesFailover(cmd) {
+				rejectErr := mterrors.NewFeatureNotSupported(
+					"ALTER_REPLICATION_SLOT cannot disable FAILOVER: Multigres keeps every non-temporary logical slot registered for failover",
+				)
+				if werr := conn.WriteError(rejectErr); werr != nil {
+					return false, nil, werr
+				}
+				return false, nil, rejectErr
+			}
+
+			// 3c. Auto-mark: with the feature on, inject FAILOVER into a
+			// non-temporary logical CREATE_REPLICATION_SLOT that omits it, so
+			// the slot is created as a failover slot without client opt-in.
+			// The rewritten command replaces the body forwarded to the pooler
+			// below; length stays in sync (== len(body)). A NOTICE tells the
+			// client its slot was registered for failover — advisory, and valid
+			// before the command's own result (postgres emits notices mid-command
+			// the same way). For a real subscriber it surfaces in that server's
+			// log via its notice processor.
+			if admitFailoverSlots {
+				if rewritten, changed := rewriteCreateReplicationSlotAddFailover(cmd); changed {
+					body = append([]byte(rewritten), 0)
+					length = len(body)
+					if werr := conn.WriteNotice(autoFailoverNotice); werr != nil {
+						return false, nil, werr
+					}
+				}
+			}
 		}
 
-		// 4. Forward the (accepted) command to the pooler's replication stream
-		// verbatim.
+		// 4. Forward the (accepted, possibly rewritten) command to the pooler's
+		// replication stream.
 		raw := rawClientMessage(msgType, length, body)
 		if serr := stream.Send(&multipoolerservice.StreamReplicationRequest{
 			Msg: &multipoolerservice.StreamReplicationRequest_Data{Data: raw},
@@ -230,28 +265,31 @@ func unsupportedPreambleMessageError(msgType byte) error {
 	)
 }
 
-// nonTemporaryCreateReplicationSlotError returns a rejection error if cmd is
-// a CREATE_REPLICATION_SLOT command that does not request a TEMPORARY slot,
-// or nil if cmd is anything else / already requests TEMPORARY. A non-temporary
+// nonTemporaryCreateReplicationSlotError returns a rejection error if cmd is a
+// CREATE_REPLICATION_SLOT command that does not request a TEMPORARY slot, or
+// nil if cmd is anything else / already requests TEMPORARY. A non-temporary
 // slot could not previously be carried across a primary failover, so only
 // ephemeral (client-lifetime) slots were safe.
 //
-// When admitFailoverSlots is true (the slot-based-replication feature is on) a
-// non-temporary LOGICAL slot registered for failover is also admitted: such a
-// slot is synced to standbys and can be transitioned across a promotion. This
-// is exactly the command a real PostgreSQL 17 subscriber sends for
-// CREATE SUBSCRIPTION ... WITH (failover = true) — the FAILOVER option rides in
-// the CREATE_REPLICATION_SLOT command itself (verified in
-// go/test/endtoend/subscriptionwire), so no ALTER_REPLICATION_SLOT follow-up
+// When admitFailoverSlots is true (the slot-based-replication feature is on)
+// every non-temporary LOGICAL slot is admitted, not just one that already
+// requests failover: a slot registered for failover (the command a real
+// PostgreSQL 17 subscriber sends for CREATE SUBSCRIPTION ... WITH (failover =
+// true), verified in go/test/endtoend/subscriptionwire) is admitted as-is, and
+// one that omits FAILOVER is auto-marked by
+// rewriteCreateReplicationSlotAddFailover before it reaches postgres so it too
+// becomes a failover slot. Only a deliberate FAILOVER false is an opt-out and
+// stays rejected. Because the FAILOVER option rides in the
+// CREATE_REPLICATION_SLOT command itself, no ALTER_REPLICATION_SLOT follow-up
 // needs to be tracked.
 //
 // No grammar exists in this codebase for the replication protocol's command
-// language (see go/common/parser/ast/replication.go — the AST nodes exist
-// but nothing constructs them), so this is deliberately a lightweight
-// tokenizer, not a parser: CREATE_REPLICATION_SLOT slot_name [TEMPORARY]
-// {PHYSICAL | LOGICAL output_plugin [ ( option [, ...] ) ]}. TEMPORARY, if
-// present, appears between the slot name and the PHYSICAL/LOGICAL keyword; the
-// FAILOVER option appears in the parenthesized list after the plugin.
+// language (see go/common/parser/ast/replication.go — the AST nodes exist but
+// nothing constructs them), so this is deliberately a lightweight tokenizer,
+// not a parser: CREATE_REPLICATION_SLOT slot_name [TEMPORARY] {PHYSICAL |
+// LOGICAL output_plugin [ ( option [, ...] ) ]}. TEMPORARY, if present, appears
+// between the slot name and the PHYSICAL/LOGICAL keyword; the FAILOVER option
+// appears in the parenthesized list after the plugin.
 func nonTemporaryCreateReplicationSlotError(cmd string, admitFailoverSlots bool) error {
 	fields := strings.Fields(cmd)
 	if len(fields) == 0 || !strings.EqualFold(fields[0], "CREATE_REPLICATION_SLOT") {
@@ -273,31 +311,43 @@ func nonTemporaryCreateReplicationSlotError(cmd string, admitFailoverSlots bool)
 			break
 		}
 	}
-	// Non-temporary. Admit only a LOGICAL failover slot, and only when the
-	// feature is enabled.
+	// Non-temporary. With the feature enabled, admit any LOGICAL slot except an
+	// explicit opt-out: one that already requests failover is a failover slot
+	// as-is, and one that omits FAILOVER is auto-marked — the option is injected
+	// before the command reaches postgres (rewriteCreateReplicationSlotAddFailover).
+	// A deliberate FAILOVER false stays rejected, as do PHYSICAL slots, which
+	// cannot be failover slots.
 	if admitFailoverSlots && kindIdx >= 0 && strings.EqualFold(fields[kindIdx], "LOGICAL") &&
-		createReplicationSlotHasFailover(fields[kindIdx+1:]) {
+		createReplicationSlotFailover(fields[kindIdx+1:]) != failoverDisabled {
 		return nil
 	}
 	return mterrors.NewNonTemporaryReplicationSlotError("CREATE_REPLICATION_SLOT", "TEMPORARY")
 }
 
-// createReplicationSlotHasFailover reports whether the tokens following the
-// LOGICAL keyword of a CREATE_REPLICATION_SLOT command request failover. The
-// first token is the output plugin; its options follow in PostgreSQL 17's
+// failoverOption is the state of the FAILOVER option in the parenthesized
+// option list of a CREATE_REPLICATION_SLOT ... LOGICAL command.
+type failoverOption int
+
+const (
+	failoverAbsent   failoverOption = iota // no FAILOVER option present
+	failoverEnabled                        // FAILOVER, or FAILOVER <true-ish>
+	failoverDisabled                       // FAILOVER <false-ish>
+)
+
+// createReplicationSlotFailover classifies the FAILOVER option in the tokens
+// following the LOGICAL keyword of a CREATE_REPLICATION_SLOT command. The first
+// token is the output plugin; its options follow in PostgreSQL 17's
 // parenthesized, comma-separated list — e.g. `pgoutput (FAILOVER, SNAPSHOT
 // 'nothing')`. Parentheses and commas are normalized to spaces so an option
 // glued to a paren or comma is still seen as its own token. A bare FAILOVER
-// means true; an explicit boolean value (FAILOVER false/off/no/0/...) is
+// means enabled; an explicit boolean value (FAILOVER false/off/no/0/...) is
 // interpreted with sqltypes.ParseBool, which mirrors PostgreSQL's own
-// parse_bool_with_len.
-//
-// It is conservative in the safe direction: it admits only when a FAILOVER
-// option is unambiguously present and not set false, so a parse it doesn't
-// understand rejects (never wrongly admits a non-failover, non-temporary slot).
-// The only false positive would be an output plugin literally named "failover",
-// which does not exist.
-func createReplicationSlotHasFailover(tokens []string) bool {
+// parse_bool_with_len. A value it can't parse leaves the option enabled (the
+// conservative direction — never silently disables). The three states let the
+// caller tell an absent option (auto-marked) apart from a deliberate opt-out
+// (rejected). The only misread would be an output plugin literally named
+// "failover", which does not exist.
+func createReplicationSlotFailover(tokens []string) failoverOption {
 	normalized := strings.Map(func(r rune) rune {
 		if r == '(' || r == ')' || r == ',' {
 			return ' '
@@ -306,19 +356,114 @@ func createReplicationSlotHasFailover(tokens []string) bool {
 	}, strings.Join(tokens, " "))
 	opts := strings.Fields(normalized)
 	for i, opt := range opts {
-		if strings.EqualFold(opt, "FAILOVER") {
-			// A bare FAILOVER means true; if an explicit boolean value follows,
-			// honor it. A following token that isn't a boolean (another option,
-			// or end of list) leaves FAILOVER at its bare "true".
-			if i+1 < len(opts) {
-				if v, ok := sqltypes.ParseBool(strings.Trim(opts[i+1], "'\"")); ok {
-					return v
+		if !strings.EqualFold(opt, "FAILOVER") {
+			continue
+		}
+		// A bare FAILOVER means enabled; if an explicit boolean value follows,
+		// honor it. A following token that isn't a boolean (another option) or
+		// the end of the list leaves FAILOVER at its bare, enabled meaning.
+		if i+1 < len(opts) {
+			if v, ok := sqltypes.ParseBool(strings.Trim(opts[i+1], "'\"")); ok {
+				if v {
+					return failoverEnabled
 				}
+				return failoverDisabled
 			}
-			return true
+		}
+		return failoverEnabled
+	}
+	return failoverAbsent
+}
+
+// createReplicationSlotHasFailover reports whether the option list requests
+// failover (present and not set false). Retained as the predicate the
+// command-form guard and its tests read.
+func createReplicationSlotHasFailover(tokens []string) bool {
+	return createReplicationSlotFailover(tokens) == failoverEnabled
+}
+
+// autoFailoverNotice is the advisory NOTICE the gateway sends a client when it
+// auto-marks the client's logical slot as a failover slot (preamble step 3c),
+// so the change is observable — in a PostgreSQL subscriber's server log via its
+// notice processor, or in any client's notice handler. The content is static,
+// and NoticeResponse serialization does not mutate the diagnostic, so a single
+// shared instance is safe.
+var autoFailoverNotice = mterrors.NewPgNotice(
+	"NOTICE", mterrors.PgSSSuccessfulCompletion,
+	"multigres registered this replication slot for failover so it survives primary failover",
+	"",
+)
+
+// rewriteCreateReplicationSlotAddFailover injects a FAILOVER option into a
+// non-temporary LOGICAL CREATE_REPLICATION_SLOT command that omits one, so the
+// slot is created as a failover slot without the client having to ask for it —
+// the auto-marking behavior enabled alongside slot-based replication. It
+// returns the rewritten command and true when a rewrite
+// applies, or ("", false) otherwise: for a temporary slot, a physical slot, a
+// slot that already carries FAILOVER (enabled or explicitly disabled), or any
+// command that is not CREATE_REPLICATION_SLOT.
+//
+// The grammar is the one nonTemporaryCreateReplicationSlotError tokenizes:
+// CREATE_REPLICATION_SLOT slot_name [TEMPORARY]
+// {PHYSICAL | LOGICAL output_plugin [ ( option [, ...] ) ]}. FAILOVER is
+// inserted as the first option of the parenthesized list (`(FAILOVER, ...)`),
+// or a fresh `(FAILOVER)` list is appended when the plugin has no option list.
+// A slot name and output plugin are PostgreSQL identifiers restricted to
+// [a-z0-9_], so the first '(' in the command is unambiguously the option
+// list's opening paren.
+func rewriteCreateReplicationSlotAddFailover(cmd string) (string, bool) {
+	fields := strings.Fields(cmd)
+	if len(fields) < 4 || !strings.EqualFold(fields[0], "CREATE_REPLICATION_SLOT") {
+		return "", false
+	}
+	kindIdx := -1
+	for i := 2; i < len(fields); i++ {
+		if strings.EqualFold(fields[i], "TEMPORARY") || strings.EqualFold(fields[i], "PHYSICAL") {
+			return "", false
+		}
+		if strings.EqualFold(fields[i], "LOGICAL") {
+			kindIdx = i
+			break
 		}
 	}
-	return false
+	if kindIdx < 0 || kindIdx+1 >= len(fields) {
+		return "", false // no output plugin
+	}
+	// Only inject when FAILOVER is entirely absent; a client-supplied value
+	// (enabled or a deliberate false) is left untouched.
+	if createReplicationSlotFailover(fields[kindIdx+1:]) != failoverAbsent {
+		return "", false
+	}
+	if open := strings.IndexByte(cmd, '('); open >= 0 {
+		rest := cmd[open+1:]
+		// An empty option list `()` must not become `(FAILOVER, )`.
+		if strings.HasPrefix(strings.TrimLeft(rest, " \t"), ")") {
+			return cmd[:open+1] + "FAILOVER" + rest, true
+		}
+		return cmd[:open+1] + "FAILOVER, " + rest, true
+	}
+	return strings.TrimRight(cmd, " \t") + " (FAILOVER)", true
+}
+
+// alterReplicationSlotDisablesFailover reports whether cmd is an
+// ALTER_REPLICATION_SLOT command that sets FAILOVER to a false value. PostgreSQL
+// emits exactly this for ALTER SUBSCRIPTION ... SET (failover = false):
+// `ALTER_REPLICATION_SLOT "slot" ( FAILOVER false );` (see libpqrcv_alter_slot;
+// the option always carries an explicit true/false, and TWO_PHASE may ride
+// alongside it). It is the only way to change a slot's failover after creation —
+// there is no pg_alter_replication_slot SQL function — so intercepting this
+// command fully enforces that an auto-marked slot stays a failover slot.
+// Enabling failover, or changing only TWO_PHASE, is left alone.
+//
+// The option list follows the slot name (fields[1]); createReplicationSlotFailover
+// classifies the FAILOVER option within it (a physical slot has no FAILOVER
+// option and so is never disabled here).
+func alterReplicationSlotDisablesFailover(cmd string) bool {
+	fields := strings.Fields(cmd)
+	if len(fields) < 2 || !strings.EqualFold(fields[0], "ALTER_REPLICATION_SLOT") {
+		return false
+	}
+	return createReplicationSlotFailover(fields[2:]) == failoverDisabled
 }
 
 // nonTemporaryReplicationSlotSQLFuncError returns a rejection error if cmd

--- a/go/services/multigateway/handler/replication_preamble_test.go
+++ b/go/services/multigateway/handler/replication_preamble_test.go
@@ -305,6 +305,10 @@ func TestCreateReplicationSlotHasFailover(t *testing.T) {
 		{"failover off unquoted", []string{"pgoutput", "(FAILOVER", "off)"}, false},
 		{"no options", []string{"pgoutput"}, false},
 		{"other options only", []string{"pgoutput", "(TWO_PHASE,", "SNAPSHOT", "'use')"}, false},
+		// The output plugin token is dropped before scanning, so a plugin named
+		// "failover" is not mistaken for the option.
+		{"plugin named failover, no failover option", []string{"failover", "(SNAPSHOT", "'nothing')"}, false},
+		{"plugin named failover, with failover option", []string{"failover", "(FAILOVER)"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -378,6 +382,11 @@ func TestRewriteCreateReplicationSlotAddFailover(t *testing.T) {
 		{"physical unchanged", "CREATE_REPLICATION_SLOT s1 PHYSICAL", "", false},
 		{"non-CRS command unchanged", "START_REPLICATION SLOT s1 LOGICAL 0/0", "", false},
 		{"malformed no plugin unchanged", "CREATE_REPLICATION_SLOT s1 LOGICAL", "", false},
+		// Regression: an output plugin literally named "failover" (client-
+		// controlled) must not be misread as an already-enabled option — the
+		// slot must still be auto-marked.
+		{"plugin named failover still auto-marked", "CREATE_REPLICATION_SLOT s1 LOGICAL failover (SNAPSHOT 'nothing')", "CREATE_REPLICATION_SLOT s1 LOGICAL failover (FAILOVER, SNAPSHOT 'nothing')", true},
+		{"plugin named failover no options still auto-marked", "CREATE_REPLICATION_SLOT s1 LOGICAL failover", "CREATE_REPLICATION_SLOT s1 LOGICAL failover (FAILOVER)", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/go/services/multigateway/handler/replication_preamble_test.go
+++ b/go/services/multigateway/handler/replication_preamble_test.go
@@ -212,9 +212,12 @@ func TestNonTemporaryCreateReplicationSlotError(t *testing.T) {
 }
 
 // TestNonTemporaryCreateReplicationSlotError_Failover covers the command-form
-// guard once the slot-based-replication feature admits failover slots: a
-// non-temporary LOGICAL slot registered for failover is accepted, everything
-// else non-temporary is still rejected, and admitting is gated on the flag.
+// guard once the slot-based-replication feature is on: every non-temporary
+// LOGICAL slot is admitted (one requesting failover as-is, one omitting it for
+// auto-marking), only a deliberate FAILOVER false and PHYSICAL slots are
+// rejected, and admitting is gated on the flag. The actual FAILOVER injection
+// for the omitted case is covered by TestRewriteCreateReplicationSlotAddFailover
+// and TestRunReplicationPreamble_AutoMarksFailoverSlot.
 func TestNonTemporaryCreateReplicationSlotError_Failover(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -230,7 +233,11 @@ func TestNonTemporaryCreateReplicationSlotError_Failover(t *testing.T) {
 		{"FAILOVER glued to plugin admitted", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput(FAILOVER)", true, false},
 		{"TWO_PHASE before FAILOVER admitted", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput (TWO_PHASE, FAILOVER)", true, false},
 		{"failover rejected when feature disabled", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput (FAILOVER)", false, true},
-		{"non-failover logical rejected when enabled", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput", true, true},
+		{"non-failover logical rejected when feature disabled", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput", false, true},
+		// With the feature on, a non-failover logical slot is admitted for
+		// auto-marking (FAILOVER is injected downstream), no longer rejected.
+		{"non-failover logical admitted (auto-marked) when enabled", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput", true, false},
+		{"non-failover logical with other options admitted when enabled", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput (SNAPSHOT 'nothing')", true, false},
 		{"physical rejected when enabled", "CREATE_REPLICATION_SLOT s1 PHYSICAL", true, true},
 		{"explicit FAILOVER false rejected when enabled", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput (FAILOVER 'false')", true, true},
 		{"explicit FAILOVER off rejected when enabled", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput (FAILOVER off)", true, true},
@@ -334,6 +341,192 @@ func TestRunReplicationPreamble_AdmitsFailoverSlotWhenEnabled(t *testing.T) {
 	// The failover CREATE_REPLICATION_SLOT was relayed to the pooler verbatim.
 	require.Len(t, stream.sentRaw, 2)
 	assert.Contains(t, string(stream.sentRaw[0]), "FAILOVER")
+
+	// A slot that already requested failover is not rewritten, so no auto-mark
+	// NOTICE is emitted — the first thing the client sees is the command result.
+	out := testConn.WriteBuf.Bytes()
+	require.NotEmpty(t, out)
+	assert.NotEqual(t, byte(protocol.MsgNoticeResponse), out[0], "no NOTICE when the client already requested failover")
+}
+
+// TestRewriteCreateReplicationSlotAddFailover covers the auto-marking rewrite:
+// a non-temporary logical slot missing FAILOVER gets it injected as the first
+// option (or a fresh option list), while temporary/physical slots, slots that
+// already specify FAILOVER (enabled or an explicit false), and non-CRS commands
+// are left untouched.
+func TestRewriteCreateReplicationSlotAddFailover(t *testing.T) {
+	type testCase struct {
+		name        string
+		cmd         string
+		want        string
+		wantChanged bool
+	}
+
+	tests := []testCase{
+		// The exact command a real PostgreSQL subscriber sends for a plain
+		// CREATE SUBSCRIPTION (no failover): SNAPSHOT is always present, so the
+		// option list exists and FAILOVER is inserted first.
+		{"subscriber form gets failover first", `CREATE_REPLICATION_SLOT "sub" LOGICAL pgoutput (SNAPSHOT 'nothing')`, `CREATE_REPLICATION_SLOT "sub" LOGICAL pgoutput (FAILOVER, SNAPSHOT 'nothing')`, true},
+		{"no option list gets a fresh one", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput (FAILOVER)", true},
+		{"paren glued to plugin", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput(SNAPSHOT 'nothing')", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput(FAILOVER, SNAPSHOT 'nothing')", true},
+		{"two_phase preserved after injected failover", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput (TWO_PHASE)", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput (FAILOVER, TWO_PHASE)", true},
+		{"empty option list", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput ()", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput (FAILOVER)", true},
+		{"already has failover unchanged", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput (FAILOVER)", "", false},
+		{"already has failover with others unchanged", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput (FAILOVER, SNAPSHOT 'nothing')", "", false},
+		{"explicit failover false unchanged", "CREATE_REPLICATION_SLOT s1 LOGICAL pgoutput (FAILOVER 'false')", "", false},
+		{"temporary unchanged", "CREATE_REPLICATION_SLOT s1 TEMPORARY LOGICAL pgoutput", "", false},
+		{"physical unchanged", "CREATE_REPLICATION_SLOT s1 PHYSICAL", "", false},
+		{"non-CRS command unchanged", "START_REPLICATION SLOT s1 LOGICAL 0/0", "", false},
+		{"malformed no plugin unchanged", "CREATE_REPLICATION_SLOT s1 LOGICAL", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, changed := rewriteCreateReplicationSlotAddFailover(tt.cmd)
+			assert.Equal(t, tt.wantChanged, changed)
+			if tt.wantChanged {
+				assert.Equal(t, tt.want, got)
+				// The rewrite must still read as a failover slot to the guard.
+				assert.NoError(t, nonTemporaryCreateReplicationSlotError(got, true))
+			} else {
+				assert.Empty(t, got)
+			}
+		})
+	}
+}
+
+// TestRunReplicationPreamble_AutoMarksFailoverSlot drives a plain (no-failover)
+// subscriber CREATE_REPLICATION_SLOT through the preamble with the feature on
+// and confirms the command forwarded to the pooler has FAILOVER injected, while
+// the following START_REPLICATION is relayed verbatim.
+func TestRunReplicationPreamble_AutoMarksFailoverSlot(t *testing.T) {
+	var clientInput bytes.Buffer
+	writeQueryMessage(&clientInput, `CREATE_REPLICATION_SLOT "sub_orders" LOGICAL pgoutput (SNAPSHOT 'nothing')`)
+	writeQueryMessage(&clientInput, "START_REPLICATION SLOT sub_orders LOGICAL 0/0")
+
+	createSlotResp := bytes.Join([][]byte{
+		frameMessage(protocol.MsgCommandComplete, []byte("CREATE_REPLICATION_SLOT\x00")),
+		frameMessage(protocol.MsgReadyForQuery, []byte{'I'}),
+	}, nil)
+	startReplResp := frameMessage(protocol.MsgCopyBothResponse, []byte{0, 0, 0})
+
+	stream := &scriptedReplStream{
+		ctx:       context.Background(),
+		responses: [][]byte{createSlotResp, startReplResp},
+	}
+	testConn := server.NewTestConn(&clientInput)
+
+	streaming, _, err := runReplicationPreamble(testConn.Conn, stream, true)
+	require.NoError(t, err)
+	assert.True(t, streaming)
+
+	// The pooler receives the rewritten command with FAILOVER injected first.
+	require.Len(t, stream.sentRaw, 2)
+	wantCmd := `CREATE_REPLICATION_SLOT "sub_orders" LOGICAL pgoutput (FAILOVER, SNAPSHOT 'nothing')`
+	assert.Equal(t, frameMessage(protocol.MsgQuery, append([]byte(wantCmd), 0)), stream.sentRaw[0])
+	// START_REPLICATION is not a slot-creating command and rides through as-is.
+	assert.Equal(t, frameMessage(protocol.MsgQuery, append([]byte("START_REPLICATION SLOT sub_orders LOGICAL 0/0"), 0)), stream.sentRaw[1])
+
+	// The client is told, via an advisory NOTICE emitted before the command's
+	// own result, that its slot was auto-marked for failover.
+	out := testConn.WriteBuf.Bytes()
+	require.NotEmpty(t, out)
+	assert.Equal(t, byte(protocol.MsgNoticeResponse), out[0], "auto-mark should emit a NOTICE to the client first")
+	assert.Contains(t, string(out), "registered this replication slot for failover")
+}
+
+// TestRunReplicationPreamble_NoAutoMarkWhenDisabled confirms that with the
+// feature off, a plain non-failover slot is rejected (not rewritten) — the
+// pooler never sees it.
+func TestRunReplicationPreamble_NoAutoMarkWhenDisabled(t *testing.T) {
+	var clientInput bytes.Buffer
+	writeQueryMessage(&clientInput, `CREATE_REPLICATION_SLOT "sub_orders" LOGICAL pgoutput (SNAPSHOT 'nothing')`)
+
+	stream := &scriptedReplStream{ctx: context.Background()}
+	testConn := server.NewTestConn(&clientInput)
+
+	streaming, _, err := runReplicationPreamble(testConn.Conn, stream, false)
+	require.Error(t, err)
+	assert.False(t, streaming)
+	assert.Empty(t, stream.sentRaw)
+}
+
+// TestAlterReplicationSlotDisablesFailover covers the classifier that backs the
+// failover-enforcement guard: only an ALTER_REPLICATION_SLOT that sets FAILOVER
+// to a false value is a disable; enabling it, or altering only TWO_PHASE, is not.
+// The command forms are exactly what PostgreSQL's libpqrcv_alter_slot emits.
+func TestAlterReplicationSlotDisablesFailover(t *testing.T) {
+	type testCase struct {
+		name string
+		cmd  string
+		want bool
+	}
+
+	tests := []testCase{
+		{"disable failover", `ALTER_REPLICATION_SLOT "sub" ( FAILOVER false );`, true},
+		{"disable failover off", `ALTER_REPLICATION_SLOT "sub" ( FAILOVER off );`, true},
+		{"disable with two_phase", `ALTER_REPLICATION_SLOT "sub" ( FAILOVER false, TWO_PHASE true );`, true},
+		{"case-insensitive", `alter_replication_slot "sub" ( failover false );`, true},
+		{"enable failover", `ALTER_REPLICATION_SLOT "sub" ( FAILOVER true );`, false},
+		{"enable with two_phase", `ALTER_REPLICATION_SLOT "sub" ( FAILOVER true, TWO_PHASE false );`, false},
+		{"two_phase only", `ALTER_REPLICATION_SLOT "sub" ( TWO_PHASE true );`, false},
+		{"slot literally named failover, two_phase only", `ALTER_REPLICATION_SLOT "failover" ( TWO_PHASE true );`, false},
+		{"not an alter command", `CREATE_REPLICATION_SLOT s LOGICAL pgoutput (FAILOVER)`, false},
+		{"identify_system", "IDENTIFY_SYSTEM", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, alterReplicationSlotDisablesFailover(tt.cmd))
+		})
+	}
+}
+
+// TestRunReplicationPreamble_RejectsAlterDisablingFailover verifies that with
+// the feature on, an ALTER_REPLICATION_SLOT that turns FAILOVER off is rejected
+// before the pooler sees it, keeping an auto-marked slot a failover slot.
+func TestRunReplicationPreamble_RejectsAlterDisablingFailover(t *testing.T) {
+	var clientInput bytes.Buffer
+	writeQueryMessage(&clientInput, `ALTER_REPLICATION_SLOT "sub_orders" ( FAILOVER false );`)
+
+	stream := &scriptedReplStream{ctx: context.Background()}
+	testConn := server.NewTestConn(&clientInput)
+
+	streaming, _, err := runReplicationPreamble(testConn.Conn, stream, true)
+	require.Error(t, err)
+	assert.False(t, streaming)
+	assert.Empty(t, stream.sentRaw, "the disabling ALTER must not reach the pooler")
+}
+
+// TestRunReplicationPreamble_AllowsAlterEnablingFailover verifies the guard is
+// one-directional: enabling failover (and altering only TWO_PHASE) is relayed to
+// the pooler, and with the feature off nothing is inspected at all.
+func TestRunReplicationPreamble_AllowsAlterEnablingFailover(t *testing.T) {
+	cases := []struct {
+		name          string
+		cmd           string
+		admitFailover bool
+	}{
+		{"enable failover, feature on", `ALTER_REPLICATION_SLOT "sub_orders" ( FAILOVER true );`, true},
+		{"two_phase only, feature on", `ALTER_REPLICATION_SLOT "sub_orders" ( TWO_PHASE true );`, true},
+		{"disable failover, feature off passes through", `ALTER_REPLICATION_SLOT "sub_orders" ( FAILOVER false );`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var clientInput bytes.Buffer
+			writeQueryMessage(&clientInput, tc.cmd)
+
+			resp := bytes.Join([][]byte{
+				frameMessage(protocol.MsgCommandComplete, []byte("ALTER_REPLICATION_SLOT\x00")),
+				frameMessage(protocol.MsgReadyForQuery, []byte{'I'}),
+			}, nil)
+			stream := &scriptedReplStream{ctx: context.Background(), responses: [][]byte{resp}}
+			testConn := server.NewTestConn(&clientInput)
+
+			_, _, err := runReplicationPreamble(testConn.Conn, stream, tc.admitFailover)
+			require.NoError(t, err)
+			require.Len(t, stream.sentRaw, 1)
+			assert.Equal(t, frameMessage(protocol.MsgQuery, append([]byte(tc.cmd), 0)), stream.sentRaw[0])
+		})
+	}
 }
 
 // TestRunReplicationPreamble_HappyPath drives IDENTIFY_SYSTEM ->

--- a/go/test/endtoend/multiorch/slot_sync_test.go
+++ b/go/test/endtoend/multiorch/slot_sync_test.go
@@ -15,12 +15,14 @@
 package multiorch
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
 	"github.com/multigres/multigres/go/test/utils"
 )
@@ -133,4 +135,134 @@ func TestSlotSyncPropagatesFailoverSlot(t *testing.T) {
 		return ready
 	}, 30*time.Second, 1*time.Second,
 		"failover slot %q should become failover-ready on standby %s via native slot-sync", slot, standbyName)
+}
+
+// TestSlotSyncPropagatesAutoMarkedFailoverSlot is the end-to-end proof of the
+// auto-marking feature through the full stack: a client creates a plain,
+// non-failover logical slot through the multigateway (feature on), the gateway
+// injects FAILOVER into the CREATE_REPLICATION_SLOT before it reaches postgres,
+// and the resulting failover slot on the primary is propagated to the standby by
+// native slot-sync until it is failover-ready — all without the client asking
+// for failover. It ties the gateway rewrite (unit-tested in the multigateway
+// handler) to the slot-sync machinery (TestSlotSyncPropagatesFailoverSlot) in one
+// path: create-through-gateway → auto-marked on primary → synced on standby.
+func TestSlotSyncPropagatesAutoMarkedFailoverSlot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end auto-mark slot-sync test (short mode)")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("Skipping end-to-end auto-mark slot-sync test (no postgres binaries)")
+	}
+
+	// Primary + one standby with slot-based replication on, plus a multigateway
+	// that also has the feature on so it auto-marks non-failover logical slots.
+	setup, cleanup := shardsetup.NewIsolated(
+		t,
+		shardsetup.WithMultipoolerCount(2),
+		shardsetup.WithoutInitialization(),
+		shardsetup.WithDurabilityPolicy("AT_LEAST_2"),
+		shardsetup.WithMultipoolerExtraArgs("--enable-slot-based-replication=true"),
+		shardsetup.WithMultigatewayExtraArgs("--enable-slot-based-replication=true"),
+	)
+	defer cleanup()
+
+	watchTargets := []string{"postgres/default/0-inf"}
+	config := &shardsetup.SetupConfig{CellName: setup.CellName}
+	mo, moCleanup := setup.CreateMultiorchInstance(t, "test-multiorch", watchTargets, config)
+	require.NoError(t, mo.Start(t.Context(), t), "should start multiorch")
+	t.Cleanup(moCleanup)
+
+	primaryName := waitForShardReady(t, setup, 1, 60*time.Second)
+	require.NotEmpty(t, primaryName, "multiorch should bootstrap the shard")
+
+	// Under WithoutInitialization the gateway starts before bootstrap, so wait
+	// until it has discovered the freshly promoted primary and can route.
+	setup.WaitForMultigatewayQueryServing(t)
+
+	primary := setup.Multipoolers[primaryName]
+	var standby *shardsetup.MultipoolerInstance
+	var standbyName string
+	for name, inst := range setup.Multipoolers {
+		if name != primaryName {
+			standby, standbyName = inst, name
+			break
+		}
+	}
+	require.NotNil(t, standby, "expected a standby distinct from the primary")
+
+	primaryDB := connectToPostgres(t, filepath.Join(primary.Pgctld.PoolerDir, "pg_sockets"), primary.Pgctld.PgPort)
+	defer primaryDB.Close()
+	standbyDB := connectToPostgres(t, filepath.Join(standby.Pgctld.PoolerDir, "pg_sockets"), standby.Pgctld.PgPort)
+	defer standbyDB.Close()
+
+	execCtx := utils.WithTimeout(t, 10*time.Second)
+	_, err := primaryDB.ExecContext(execCtx, "CREATE TABLE IF NOT EXISTS mg_e2e_automark_probe (id bigint)")
+	require.NoError(t, err, "create probe table on primary %s", primaryName)
+
+	const slot = "mg_e2e_automark"
+
+	// Create the logical slot THROUGH the gateway with NO failover option. With
+	// the feature on the gateway rewrites the command to inject FAILOVER, so the
+	// slot is born a failover slot on the primary without the client asking.
+	gwConn := dialGatewayReplicationConn(t, setup)
+	createCtx := utils.WithTimeout(t, 15*time.Second)
+	_, err = gwConn.Query(createCtx, fmt.Sprintf(
+		"CREATE_REPLICATION_SLOT %s LOGICAL test_decoding (SNAPSHOT 'nothing')", slot,
+	))
+	require.NoError(t, err, "create (auto-marked) logical slot through gateway")
+	require.NoError(t, gwConn.Close(), "close gateway replication connection")
+
+	// The gateway auto-marked it: on the primary the slot is a persistent
+	// failover slot even though the command carried no FAILOVER option.
+	var temporary, failover bool
+	qctx := utils.WithTimeout(t, 5*time.Second)
+	require.NoError(t, primaryDB.QueryRowContext(qctx,
+		"SELECT temporary, failover FROM pg_replication_slots WHERE slot_name = $1", slot).Scan(&temporary, &failover))
+	require.False(t, temporary, "auto-marked slot must be persistent")
+	require.True(t, failover, "gateway must inject FAILOVER for a non-failover CREATE_REPLICATION_SLOT")
+
+	// Native slot-sync then propagates it to the standby until it is
+	// failover-ready (same drain technique as TestSlotSyncPropagatesFailoverSlot:
+	// write + drain to advance catalog_xmin past the standby's horizon).
+	require.Eventually(t, func() bool {
+		pctx := utils.WithTimeout(t, 5*time.Second)
+		if _, err := primaryDB.ExecContext(pctx, "INSERT INTO mg_e2e_automark_probe VALUES (1)"); err != nil {
+			return false
+		}
+		if _, err := primaryDB.ExecContext(pctx,
+			"SELECT count(*) FROM pg_logical_slot_get_changes($1, NULL, NULL)", slot); err != nil {
+			return false
+		}
+		var ready bool
+		sctx := utils.WithTimeout(t, 5*time.Second)
+		if err := standbyDB.QueryRowContext(sctx,
+			`SELECT synced AND NOT temporary AND invalidation_reason IS NULL
+			   FROM pg_replication_slots WHERE slot_name = $1`, slot).Scan(&ready); err != nil {
+			return false
+		}
+		return ready
+	}, 30*time.Second, 1*time.Second,
+		"auto-marked failover slot %q should become failover-ready on standby %s via native slot-sync", slot, standbyName)
+}
+
+// dialGatewayReplicationConn opens a `replication=database` connection through
+// the multigateway PG port, the path that triggers the gateway's auto-marking
+// rewrite. Mirrors the helper of the same name in the shardsetup package's
+// replication-stream tests (unexported there, so reimplemented here).
+func dialGatewayReplicationConn(t *testing.T, setup *shardsetup.ShardSetup) *client.Conn {
+	t.Helper()
+	ctx := utils.WithTimeout(t, 15*time.Second)
+	cfg := client.Config{
+		Host:        "localhost",
+		Port:        setup.MultigatewayPgPort,
+		User:        shardsetup.DefaultTestUser,
+		Password:    shardsetup.TestPostgresPassword,
+		Database:    "postgres",
+		DialTimeout: 10 * time.Second,
+		Parameters:  map[string]string{"replication": "database"},
+	}
+	conn, err := client.Connect(ctx, ctx, &cfg)
+	require.NoError(t, err, "open replication-mode connection through gateway")
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
 }

--- a/go/test/endtoend/subscriptionwire/subscription_wire_test.go
+++ b/go/test/endtoend/subscriptionwire/subscription_wire_test.go
@@ -64,7 +64,8 @@ func TestCreateSubscriptionFailoverWireBehavior(t *testing.T) {
 	// Publisher: wal_level=logical for logical decoding, and
 	// log_replication_commands=on so every replication-protocol command it
 	// receives is written verbatim to the server log — our observation point.
-	publisher := startPostgres(t, ctx, "publisher",
+	publisher := startPostgres(
+		t, ctx, "publisher",
 		"wal_level = logical",
 		"log_replication_commands = on",
 		"max_wal_senders = 10",
@@ -72,7 +73,8 @@ func TestCreateSubscriptionFailoverWireBehavior(t *testing.T) {
 	)
 	// Subscriber is an ordinary primary; wal_level=logical is harmless and keeps
 	// the two configs uniform.
-	subscriber := startPostgres(t, ctx, "subscriber",
+	subscriber := startPostgres(
+		t, ctx, "subscriber",
 		"wal_level = logical",
 	)
 
@@ -92,7 +94,8 @@ func TestCreateSubscriptionFailoverWireBehavior(t *testing.T) {
 	conninfo := fmt.Sprintf("host=localhost port=%d user=%s dbname=postgres", publisher.port, pgSuperuser)
 	mustExec(t, ctx, subConn, fmt.Sprintf(
 		`CREATE SUBSCRIPTION %s CONNECTION '%s' PUBLICATION %s WITH (failover = true, copy_data = true)`,
-		subscriptionName, conninfo, publicationName))
+		subscriptionName, conninfo, publicationName,
+	))
 
 	// The main slot exists on the publisher once CREATE SUBSCRIPTION returns;
 	// poll to be robust against any lag, then read its recorded state.
@@ -164,6 +167,85 @@ func TestTemporaryFailoverSlotRejected(t *testing.T) {
 	var pgErr *pgconn.PgError
 	require.ErrorAs(t, err, &pgErr)
 	assert.Equal(t, "cannot enable failover for a temporary replication slot", pgErr.Message)
+}
+
+// TestAutoMarkedFailoverSlotSurvivesSubscriptionReconnect is the empirical
+// confirmation of the auto-marking correctness claim: a slot the
+// gateway made a failover slot without the subscriber asking keeps
+// failover=true even though the subscription's own subfailover=false, and that
+// mismatch survives a subscription reconnect.
+//
+// It reproduces the auto-marked end state directly against a real publisher —
+// pre-creating the subscription's main slot as a failover slot (what the
+// gateway's rewritten CREATE_REPLICATION_SLOT produces) and attaching a plain
+// CREATE SUBSCRIPTION (failover defaults to false, create_slot = false) to it —
+// so no gateway is needed to prove the PostgreSQL-side behavior the feature
+// relies on. The gateway rewrite itself is covered by the multigateway handler
+// unit tests.
+func TestAutoMarkedFailoverSlotSurvivesSubscriptionReconnect(t *testing.T) {
+	skipUnlessPostgres17(t)
+
+	ctx := utils.WithTimeout(t, 90*time.Second)
+
+	publisher := startPostgres(
+		t, ctx, "publisher",
+		"wal_level = logical",
+		"max_wal_senders = 10",
+		"max_replication_slots = 10",
+	)
+	subscriber := startPostgres(
+		t, ctx, "subscriber",
+		"wal_level = logical",
+	)
+
+	pubConn := connect(t, ctx, publisher.port)
+	defer pubConn.Close(ctx)
+	mustExec(t, ctx, pubConn, `CREATE TABLE orders (id int PRIMARY KEY, note text)`)
+	mustExec(t, ctx, pubConn, `CREATE PUBLICATION `+publicationName+` FOR TABLE orders`)
+
+	// Simulate the gateway's auto-marking: create the subscription's main slot
+	// as a failover slot up front, exactly the end state the rewritten
+	// CREATE_REPLICATION_SLOT ... (FAILOVER, ...) command yields.
+	mustExec(t, ctx, pubConn, fmt.Sprintf(
+		`SELECT pg_create_logical_replication_slot('%s', 'pgoutput', false, false, true)`, subscriptionName,
+	))
+
+	temporary, failover := waitForSlot(t, ctx, pubConn, subscriptionName)
+	require.False(t, temporary, "auto-marked slot must be persistent")
+	require.True(t, failover, "auto-marked slot must be a failover slot")
+
+	subConn := connect(t, ctx, subscriber.port)
+	defer subConn.Close(ctx)
+	mustExec(t, ctx, subConn, `CREATE TABLE orders (id int PRIMARY KEY, note text)`)
+
+	// A plain subscriber — no WITH (failover = true) — attached to the
+	// pre-created failover slot. subfailover is therefore false while the slot
+	// is failover=true: the deliberate mismatch the feature creates.
+	conninfo := fmt.Sprintf("host=localhost port=%d user=%s dbname=postgres", publisher.port, pgSuperuser)
+	mustExec(t, ctx, subConn, fmt.Sprintf(
+		`CREATE SUBSCRIPTION %s CONNECTION '%s' PUBLICATION %s WITH (failover = false, create_slot = false, copy_data = true)`,
+		subscriptionName, conninfo, publicationName,
+	))
+
+	var subFailover bool
+	require.NoError(t, subConn.QueryRow(ctx,
+		`SELECT subfailover FROM pg_subscription WHERE subname = $1`, subscriptionName).Scan(&subFailover))
+	require.False(t, subFailover, "subscription must not have opted into failover (that is the point)")
+
+	// Force the apply worker to tear down and reconnect. Per PostgreSQL's
+	// design the only thing that resets a slot's failover is an explicit
+	// ALTER SUBSCRIPTION ... SET (failover = ...); a plain reconnect must not.
+	mustExec(t, ctx, subConn, fmt.Sprintf(`ALTER SUBSCRIPTION %s DISABLE`, subscriptionName))
+	mustExec(t, ctx, subConn, fmt.Sprintf(`ALTER SUBSCRIPTION %s ENABLE`, subscriptionName))
+
+	// The slot must still be a failover slot after the reconnect.
+	temporary, failover = waitForSlot(t, ctx, pubConn, subscriptionName)
+	assert.False(t, temporary, "slot must stay persistent across the subscription reconnect")
+	assert.True(t, failover, "auto-marked failover flag must survive the subscription reconnect despite subfailover=false")
+
+	// Clean up the subscription so its slot is released before the publisher is
+	// torn down (DROP SUBSCRIPTION drops the remote slot).
+	mustExec(t, ctx, subConn, `DROP SUBSCRIPTION `+subscriptionName)
 }
 
 // skipUnlessPostgres17 skips the test unless PostgreSQL 17+ binaries are on PATH.


### PR DESCRIPTION
## Situation

With slot-based replication enabled, Multigres can carry a client's logical replication slot across a primary failover: a persistent (non-temporary) logical slot registered for failover is synced to standbys by PostgreSQL's native slot-sync worker and survives promotion. Today this is opt-in per client — a subscriber must run `CREATE SUBSCRIPTION ... WITH (failover = true)`, which rides through as `CREATE_REPLICATION_SLOT ... (FAILOVER)`. A non-temporary logical slot created without that option is rejected outright by the gateway preamble.

```mermaid
sequenceDiagram
    autonumber
    participant C as Consumer
    participant G as Gateway
    participant P as Primary
    Note over C,P: BEFORE — opt-in required
    C->>G: CREATE_REPLICATION_SLOT s LOGICAL pgoutput (SNAPSHOT nothing)
    G--xC: ERROR — non-temporary slot rejected
    Note over C: subscriber must add WITH (failover = true) or lose HA
```

## Problem

This makes HA opt-in per subscriber. Any consumer that forgets `failover = true` is not merely un-protected — it is refused entirely. An operator who enabled slot-based replication cluster-wide still silently loses HA for every such slot. Since Multigres aims to look and behave like a single server, it is a gap that it does not automatically create and administer failover slots when a client requests a non-temporary slot.

## Solution

When the feature is on, the gateway rewrites the client's `CREATE_REPLICATION_SLOT` to inject `FAILOVER` before it reaches PostgreSQL, so every non-temporary logical slot is born a failover slot with no client change. The command reply is unchanged, so the subscriber still works unmodified. Native slot-sync then propagates the slot to standbys exactly as in the opt-in path.

```mermaid
sequenceDiagram
    autonumber
    participant C as Consumer
    participant G as Gateway
    participant P as Primary
    participant S as Standby
    Note over C,S: AFTER — auto-marked (feature on)
    C->>G: CREATE_REPLICATION_SLOT s LOGICAL pgoutput (SNAPSHOT nothing)
    G->>P: CREATE_REPLICATION_SLOT s LOGICAL pgoutput (FAILOVER, SNAPSHOT nothing)
    P-->>G: slot created, failover=true
    G-->>C: slot created (reply unchanged) + NOTICE
    P->>S: native slot-sync copies the failover slot
    Note over C,S: on promotion, consumer resumes from its own origin LSN
```

## How it works

- **Mechanism — wire-rewrite at creation.** `FAILOVER` is inserted as the first option of the parenthesized option list (`(FAILOVER, ...)`), or a fresh `(FAILOVER)` list is appended when the plugin has none. Creation is the only reliable moment: altering `failover` on an existing slot requires acquiring it, and a streaming subscriber's slot is active, so it cannot be altered in place.
- **Gating.** Reuses the existing dynamic `enable-slot-based-replication` flag (default off). With the flag off, behavior is byte-for-byte unchanged: every non-temporary slot is rejected exactly as before.
- **Scope.** The walsender `CREATE_REPLICATION_SLOT` command form (what a real subscriber sends). The core change is isolated to `go/services/multigateway/handler/replication_preamble.go`.
- **Enforcement.** With the feature on, the gateway also rejects an `ALTER_REPLICATION_SLOT` that turns `FAILOVER` off (the command `ALTER SUBSCRIPTION ... SET (failover = false)` emits), so an auto-marked slot cannot be silently opted back out. Enabling failover or changing only `TWO_PHASE` passes through. This replication command is the only post-creation route to the flag — there is no `pg_alter_replication_slot` SQL function — so intercepting it fully enforces the invariant.
- **Observability.** On a rewrite the gateway sends the client an advisory `NOTICE` that the slot was registered for failover. For a PostgreSQL subscriber this surfaces in that server's log via its notice processor; the command result itself is unchanged.

## Why it is safe (verified against PostgreSQL source)

- A slot's `failover` is set at creation and never silently reset: `walrcv_alter_slot` has a single backend caller — an explicit `ALTER SUBSCRIPTION ... SET (failover = ...)`. The apply worker, tablesync, reconnect, and REFRESH never touch it, and the slot-sync worker syncs purely on the slot's `failover` column. So the intended mismatch — slot `failover = true` while the subscription's `subfailover = false` — is stable.
- The walreceiver emits `FAILOVER` only when true, never `FAILOVER false`, so a plain `CREATE SUBSCRIPTION` sends the option list without a failover option — exactly the case we rewrite.
- A slot's persistency is immutable after creation, so a client cannot demote an auto-marked slot to temporary to escape sync.

## Boundaries / non-goals

- SQL-function forms (`pg_create_logical_replication_slot(...)`) are not rewritten — there is no AST-to-SQL deparser — so they keep the plain guard: a non-temporary non-failover logical slot stays rejected.
- An explicit `FAILOVER false` is honored as a deliberate opt-out and stays rejected (it never appears in a real subscriber command).
- No retroactive sweep — slots created before the flag was enabled pick up failover only when recreated.

## Testing

- **Unit** — the rewrite classifier, the `ALTER_REPLICATION_SLOT` disable classifier, and the preamble forward/reject/allow paths (including asserting the bytes forwarded to the pooler carry `FAILOVER` and that the NOTICE is emitted only on a rewrite).
- **Wire e2e** (`subscriptionwire`) — against real PostgreSQL, an auto-marked slot keeps `failover = true` across a subscription reconnect even though its `subfailover = false`.
- **Failover e2e** (`multiorch`) — a non-failover slot created through the multigateway is auto-marked on the primary and becomes failover-ready on the standby via native slot-sync, end to end.
- **Manual, real Kubernetes (kind)** — validated the full path on a 3-node cluster: auto-mark + client NOTICE, `ALTER_REPLICATION_SLOT ... (FAILOVER false)` rejected, and the auto-marked slot synced to failover-ready on both standbys.

Fixes MUL-1407
