### PR TITLE
docs(kubernetes): document probe semantics and StatefulSet integration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,9 @@ Browse the design and reference docs by area:
 
 ## Alpha Deployment Notes
 
+- **[Integration with Kubernetes](./kubernetes/integration.md)** — how the
+  Multipooler and pgctld present to Kubernetes, and what the readiness and
+  liveness probes mean.
 - **[Getting started on EKS](./kubernetes/eks.md)**
 
 ## Release Documentation

--- a/docs/ha/recovery.md
+++ b/docs/ha/recovery.md
@@ -1,79 +1,98 @@
 # When We Change the Rules: Recovery & Orchestration
 
 This doc covers _when_ and _why_ a rule change is triggered — the
-responsibility of **multiorch**, the orchestrator. It assumes you've read
+responsibility of **Multiorch**, the orchestrator. It assumes you've read
 [the consensus overview](consensus-overview.md) and
 [the state model](state-model.md). _How_ a rule change is carried out safely is
 [rule-change.md](rule-change.md); this doc decides when to start one.
 
-> **Status:** skeleton. The high-level responsibilities below are accurate; the
-> detailed mechanics are TODO and will be filled in incrementally.
+> [!NOTE]
+> **Status:** skeleton. The high-level responsibilities below are accurate. The
+> detailed mechanics are not yet documented and will be filled in incrementally.
 
 ## Purpose and boundary
 
-multiorch watches the health of every pooler in a shard and drives the cohort
+Multiorch watches the health of every pooler in a shard and drives the cohort
 back to a healthy state when something changes. It owns the _decision_ to change
 the rules; it delegates the _mechanism_ to the rule-change protocol. It has
 three most-important responsibilities:
 
 ### 1. Failover when the leader is dead — a coordinator-led rule change
 
-When the consensus leader is unreachable or unhealthy, multiorch acts as the
+When the consensus leader is unreachable or unhealthy, Multiorch acts as the
 coordinator and runs a [coordinator-led rule change](rule-change.md) (recruit →
 promote) to appoint a new leader. This is the failure path: the old leader
 cannot cooperate, so an external coordinator must eliminate any rogue quorum and
 elect the most-advanced surviving pooler.
 
-> TODO: how a dead leader is detected — health streams, heartbeat timeout, the
-> `LEADERSHIP_SIGNAL_REQUESTING_DEMOTION` fast path. The entry point is
-> `AppointLeaderAction` → `Coordinator.AppointLeader`.
+Leader fitness reaches Multiorch on the **health stream**, not through
+Kubernetes probes — a pooler stays Ready (and keeps its Service endpoint) even
+when its Postgres is down, precisely so the coordinator can still observe it.
+See [Readiness and Liveness](../kubernetes/integration.md#readiness-and-liveness)
+for why probe state and component health are deliberately separated.
+
+> [!NOTE]
+> Not yet documented: how a dead leader is detected — the heartbeat timeout on
+> the health stream and the `LEADERSHIP_SIGNAL_REQUESTING_DEMOTION` fast path.
+> The entry point is `AppointLeaderAction` → `Coordinator.AppointLeader`.
 
 ### 2. Cohort membership changes — a leader-led rule change
 
-As poolers are provisioned and deprovisioned, multiorch adjusts cohort
+As poolers are provisioned and deprovisioned, Multiorch adjusts cohort
 membership. Unlike failover, the leader is healthy here, so the change goes
 **through the primary pooler's update-rules endpoint** — a leader-led rule
 change. The leader writes the new rule itself (new cohort, same term, bumped
 `leader_subterm`), with no external coordinator needed.
 
-> TODO: name and link the exact update-rules RPC and its handler; describe the
-> add-member vs remove-member flows and how the durability policy's
+> [!NOTE]
+> Not yet documented: the exact update-rules RPC and its handler, the
+> add-member versus remove-member flows, and how the durability policy's
 > achievability is re-checked against the new cohort.
 
 ### 3. Keeping poolers pointed at the right primary — SetPrimary reconciliation
 
-Even with no rule change in flight, multiorch continually reconciles each
+Even with no rule change in flight, Multiorch continually reconciles each
 pooler's replication target, calling `SetPrimary` to keep every follower and
 observer pointed at the current leader. This repairs poolers that drifted —
-restarted, were partitioned, or were told about a primary while postgres was
+restarted, were partitioned, or were told about a primary while Postgres was
 down — without electing anyone or bumping the rule. `SetPrimary`'s rule comparison
 makes a redundant call a safe no-op, so this can run freely.
 
-> TODO: document the reconciliation trigger (`FixReplicationAction`), how the
-> coordinator decides a pooler needs re-pointing (comparing published
+> [!NOTE]
+> Not yet documented: the reconciliation trigger (`FixReplicationAction`), how
+> the coordinator decides a pooler needs re-pointing (comparing published
 > `ReplicationPrimary` against the current rule via `ReplicationPrimaryMatches`),
 > and how this interacts with pg_rewind for diverged followers.
 
 ## The recovery loop
 
-> TODO: document the engine and its loops (healthcheck, recovery, maintenance),
-> the analyze → detect → dedup/prioritize → validate → act cycle, and the action
-> registry (`AppointLeaderAction`, `DemoteStaleLeaderAction`,
+> [!NOTE]
+> Not yet documented: the engine and its loops (healthcheck, recovery,
+> maintenance), the analyze → detect → dedup/prioritize → validate → act cycle,
+> and the action registry (`AppointLeaderAction`, `DemoteStaleLeaderAction`,
 > `FixReplicationAction`, `ReconcileCohortAction`, `ShardInitAction`).
 > Files: `go/services/multiorch/recovery/`.
 
 ## Health input and leadership signaling
 
-> TODO: how poolers report fitness to the coordinator — the health stream,
-> `LeadershipStatus` / `LeadershipSignal` (ACTIVE, REQUESTING_DEMOTION), and
-> `CohortEligibilityStatus`. This is the signaling layer the state model defers
-> to recovery.
+Poolers report fitness on the **health stream** — the out-of-band channel that
+carries Postgres up/down, replication lag, and quarantine lifecycle to
+Multiorch and the operator. This is deliberately kept off the Kubernetes
+readiness/liveness probes. See
+[Where component health actually goes](../kubernetes/integration.md#where-component-health-actually-goes)
+for the boundary and its consequences.
+
+> [!NOTE]
+> Not yet documented: the concrete signaling types — `LeadershipStatus` /
+> `LeadershipSignal` (ACTIVE, REQUESTING_DEMOTION) and `CohortEligibilityStatus`.
+> This is the signaling layer the state model defers to recovery.
 
 ## Scenarios
 
-> TODO: walk concrete cases end to end — clean leader failover, stale-primary
-> demotion, a pooler joining the cohort, a pooler leaving — and how the
-> consensus rules apply in each.
+> [!NOTE]
+> Not yet documented: concrete cases walked end to end — clean leader failover,
+> stale-primary demotion, a pooler joining the cohort, a pooler leaving — and
+> how the consensus rules apply in each.
 
 ## See also
 

--- a/docs/kubernetes/integration.md
+++ b/docs/kubernetes/integration.md
@@ -1,0 +1,227 @@
+# Integration with Kubernetes
+
+This doc explains how Multigres's per-node services — the Multipooler and its
+co-located pgctld — present themselves to Kubernetes, and in particular what the
+readiness and liveness probes do and deliberately do _not_ mean. It is
+deployment-agnostic: it describes the semantics the binaries expose, not any one
+manifest. The [kind demo](../../demo/k8s/) and the
+[Multigres operator](https://github.com/multigres/multigres-operator) both build
+on these semantics.
+
+If you are looking for a concrete cluster setup, see
+[Getting started on EKS](./eks.md).
+
+## Readiness and Liveness
+
+Every Multigres service embeds a small HTTP server (`servenv`) that exposes two
+probe endpoints alongside its gRPC control plane:
+
+- **`/live`** — the process is up. It always returns `200` once the HTTP server
+  is serving. It makes no assertion about any dependency. This backs the
+  Kubernetes **liveness** probe: if the process is running, it is live.
+- **`/ready`** — the process's gRPC control plane is accepting RPCs. It runs the
+  registered readiness checks and returns `503` if any fails. This backs the
+  Kubernetes **readiness** probe.
+
+> [!NOTE]
+> The key design decision is what `/ready` covers. For both the Multipooler and
+> pgctld, **readiness reflects only whether that service's own gRPC control plane
+> is accepting connections — not whether Postgres is up.**
+
+### What `/ready` checks
+
+Both services register a single readiness check that dials their own gRPC server
+and confirms a listener is actually accepting connections. The probe prefers the
+gRPC Unix socket and falls back to a TCP dial on the configured bind address
+when only a port is set. A successful dial distinguishes a live listener from a
+stale socket file left behind by a crash. The implementations are intentionally
+kept as small, self-contained probes:
+
+- Multipooler: [`go/services/multipooler/ready.go`](../../go/services/multipooler/ready.go),
+  registered in [`go/services/multipooler/init.go`](../../go/services/multipooler/init.go).
+- pgctld: `go/cmd/pgctld/command/ready.go`, registered in
+  [`go/cmd/pgctld/command/server.go`](../../go/cmd/pgctld/command/server.go).
+
+Postgres health, replication mode, replication lag, and quarantine lifecycle are
+all **excluded** from the probe on purpose.
+
+### Why Postgres health is excluded
+
+A Multipooler whose Postgres is down must stay reachable. It still needs to
+serve control RPCs and keep publishing on its health stream so the orchestrator
+and the operator can observe it and drive it back to health. If Postgres-down
+flipped the pod to _not ready_, Kubernetes would pull it from the Service
+endpoints and DNS — exactly the wrong move, because it would hide the node from
+the very control plane responsible for recovering it. So readiness is scoped to
+the control plane's own reachability, and detailed component health travels
+out-of-band.
+
+The same reasoning applies to pgctld: a pod whose Postgres is down must not be
+pulled from Service endpoints, so operators and the control plane can still
+reach it to observe and restart Postgres.
+
+### Where component health actually goes
+
+Detailed per-node health — Postgres up or down, recovery mode, replication lag,
+and the quarantine lifecycle — is carried **out-of-band on the health stream**,
+not through the Kubernetes probes. The health stream is consumed by
+[Multiorch](../ha/recovery.md) (for consensus and failover decisions) and by the
+operator (for pod-level remediation). Surfacing this state through probes would
+conflate "is this node reachable?" with "is this node's database healthy?",
+which are two different questions with two different consumers.
+
+### Consequence: a dead-Postgres pod stays Running and Ready
+
+Because the probes never look at Postgres, **a pod whose Postgres is dead stays
+`Running` and `Ready`.** That is by design — but it means recovering it is a
+_health-stream-consumer_ responsibility, not something the kubelet will do for
+you:
+
+- When Postgres is unrecoverable, the Multipooler latches itself into
+  `LIFECYCLE_QUARANTINED` and publishes that on its own topology record (see
+  [`quarantine.go`](../../go/services/multipooler/internal/manager/quarantine.go)).
+  The **operator** watches for that marker and drives replacement — delete the
+  pod, wipe its data directory, and let it re-bootstrap from a backup.
+- On the [kind demo](../../demo/k8s/), there is **no operator** consuming that
+  signal. Nothing reacts to the quarantine marker, so such a node stays dead
+  until you manually intervene:
+
+```bash
+kubectl delete pod <multipooler-pod>
+```
+
+The liveness probe will not save you here either: the process is still up and
+serving RPCs, so it is genuinely live — Postgres being dead is not a
+process-liveness failure.
+
+## Packaging as a StatefulSet
+
+The [kind demo](../../demo/k8s/k8s-multipooler-statefulset.yaml) packages each
+node as a **StatefulSet** pod that co-locates two containers — the Multipooler
+and its pgctld — sharing the same data directory. A StatefulSet is a natural fit
+because a Multigres node has **durable identity**: it owns a specific Postgres
+data directory and registers itself in the topology, so a pod that restarts must
+come back as the _same_ node rather than a fresh interchangeable replica.
+
+Two StatefulSet properties are what the design actually relies on:
+
+- **Stable pod identity.** Each replica gets a fixed ordinal name
+  (`multipooler-zone1-0`, `-1`, …). The demo threads that name through
+  `POD_NAME` / `POD_INDEX` into the container — for example the per-pod Postgres
+  data directory is carved out with `subPathExpr: $(POD_NAME)` — so a pod keeps
+  its own data across restarts instead of adopting another pod's.
+- **Stable network identity.** A headless Service (`clusterIP: None`) gives each
+  pod a predictable per-pod DNS name. That is what lets the control plane and
+  peers address an individual node directly — for control RPCs, the health
+  stream, and Postgres replication — rather than through a load-balanced VIP.
+
+This is a demo packaging choice, not a fixed part of the design. The manifest
+itself flags that a StatefulSet may not survive contact with multiple shards or
+zones, in which case pod management moves to the
+[Multigres operator](https://github.com/multigres/multigres-operator). The probe
+semantics above hold regardless of how the pods are managed.
+
+### Where the StatefulSet view and the Multiorch view diverge
+
+The deeper reason a StatefulSet does not scale to the full design is that its
+controller and Multiorch are **two independent controllers with two different
+notions of node health and identity**, and neither defers to the other.
+
+The StatefulSet controller sequences pod lifecycle purely by **ordinal and
+readiness**: a `RollingUpdate` restarts pods in reverse-ordinal order, waiting
+only for each to report Ready before moving to the next, and a scale-down always
+deletes the highest ordinal first. But — as established above — Ready means only
+"this pod's gRPC control plane is accepting". It says nothing about _consensus
+role_. From the view of the StatefulSet, `multipooler-zone1-0` (say, the current
+leader) and `-2` (a follower) are interchangeable Ready pods. The view of
+Multiorch is the opposite: it cares which node is the leader, which followers
+are caught up, and whether the surviving cohort still satisfies its durability
+policy.
+
+That mismatch bites concretely:
+
+- **A rolling restart can evict the leader.** If ordinal `-0` happens to be the
+  elected leader, `kubectl rollout restart` deletes and recreates it like any
+  other pod, with no demote-and-hand-off first. Multiorch only learns of it
+  after the fact — the health stream from `-0` goes silent — and is forced into
+  an _unplanned_ failover, where a role-aware sequence would have handed
+  leadership off cleanly before the pod went down.
+- **A scale-down can pick the wrong victim.** `kubectl scale --replicas=2`
+  removes `-2` regardless of whether dropping that node leaves the cohort below
+  the quorum its durability policy requires. The StatefulSet has no way to ask
+  "is this node safe to remove?" Multiorch, which re-checks durability
+  achievability against the new cohort on every membership change, would have
+  refused or chosen a different node.
+- **Recreating a pod restores its broken data.** The same stable-identity
+  property that makes StatefulSets attractive fights recovery: deleting a pod
+  brings it back with the _same_ data directory. That is right for a transient
+  crash, but wrong for the unrecoverable-Postgres case above — a plain
+  `kubectl delete pod` heals the pod straight back into its broken state.
+  Genuine replacement (wipe + re-bootstrap from backup) is a decision only a
+  health-stream consumer can make, which is why the operator, not the
+  StatefulSet controller, owns it.
+
+In each case the StatefulSet is doing exactly what it was designed to do. It
+simply lacks the consensus-role and durability context that lives in Multiorch.
+An operator that manages pods directly can consume the health stream and
+sequence these actions with that context, which is the direction the manifest's
+own comment points to.
+
+### Graceful shutdown can march the cohort below quorum
+
+The sharpest version of this mismatch shows up during a _graceful_ shutdown —
+what a rolling update, a node drain, or a scale-down actually does. Each sends
+SIGTERM to the **Multipooler process**, which runs its `GracefulShutdown`
+sequence (registered as a `senv.OnTermSync` hook in
+[`manager.go`](../../go/services/multipooler/internal/manager/manager.go)): it
+drains, advertises cohort ineligibility, stops Postgres, and then the process
+exits, writing `LIFECYCLE_SHUTDOWN` to its topology record on the way out. Note
+this takes the _whole node_ down — it is not a "stop Postgres only" operation
+and not an RPC. A container whose process has exited is recreated (rolling
+update / delete) or intentionally removed (scale-down), so the graceful path
+itself self-heals. The wedge comes from the _pace_ of an ordered rollout, not
+from any single node failing to restart:
+
+- **Ready does not mean "rejoined the cohort."** A `RollingUpdate` waits only
+  for each restarted pod to report Ready before it moves on to the next. But
+  Ready means the gRPC control plane is accepting (see above). It says nothing
+  about whether that pod's Postgres has finished catching up and rejoined the
+  durability cohort. So the rollout can take the _next_ pod down while the
+  previous one is Ready-but-not-yet-caught-up.
+
+Put together, an ordered rollout can retire nodes faster than they actually
+rejoin the cohort, walking the shard below its durability quorum. At that point
+Multiorch does the correct thing — it refuses to elect a leader, because
+promoting below quorum risks split-brain and data loss — and the shard wedges
+with no writable primary. There is no automated escape from a genuine
+below-quorum state: recovery needs enough members restored, by the operator or,
+on the kind demo, by a human. A quorum-aware controller would gate each step on
+cohort re-join rather than on the readiness probe. A StatefulSet has no way to
+express that condition.
+
+> [!NOTE]
+> Do not confuse this with the "Ready-but-dead" case above. That one is _not_ a
+> graceful shutdown: it is an out-of-band Postgres death (for example `SIGINT`
+> to the postmaster) under a Multipooler that never received SIGTERM. The pooler
+> and pgctld keep answering RPCs, the pod stays Ready, and — because
+> `GracefulShutdown` never ran and nothing marks the node for replacement —
+> nothing recreates it. There is no managed operation for "leave the cohort but
+> keep the pod up and Ready"; a graceful shutdown always takes the whole node
+> down.
+
+### Probes on the demo manifest
+
+Note that in that same StatefulSet the pgctld container defines **no** liveness
+or readiness probe, even though the binary registers a `/ready` gRPC-accepting
+check. This is a property of that particular manifest, not of the binary —
+pgctld exposes the same `/live` and `/ready` semantics described above, and a
+deployment (such as the operator's) may wire probes to them.
+
+## See also
+
+- [Recovery & orchestration](../ha/recovery.md) — how Multiorch consumes the
+  health stream to detect failures and reconcile the cohort.
+- [Getting started on EKS](./eks.md) — a concrete deployment path using the
+  operator.
+- [pgctld init](../pgctld-init.md) — data-directory initialization for the
+  Postgres node.


### PR DESCRIPTION
## Situation

Nothing in the docs explains what the Kubernetes readiness and liveness probes actually mean for the per-node services (Multipooler and pgctld). The principle lives only in code comments (`init.go`, `ready.go`, `server.go`) and is restated in one demo manifest. That gap matters: the probe design is deliberately counter-intuitive — `/ready` reflects only whether a service's own gRPC control plane is accepting RPCs, **not** whether Postgres is up — and a recent cluster-wedge investigation showed the operational consequences are easy to get wrong (a Postgres-down pod stays `Running`/`Ready` on purpose, and a StatefulSet's view of node health diverges from Multiorch's in ways that can wedge a shard).

## What this PR does

Adds `docs/kubernetes/integration.md`, a deployment-agnostic conceptual doc titled "Integration with Kubernetes", with a **Readiness and Liveness** section covering both Multipooler and pgctld:

- **Live** = the process is up. **Ready** = the service's own gRPC control plane is accepting RPCs — not whether Postgres is up.
- Detailed component health (Postgres up/down, replication lag, quarantine lifecycle) is carried out-of-band on the health stream and consumed by Multiorch and the operator. It is deliberately not surfaced through k8s probes, so a Postgres-down pooler stays reachable and keeps reporting.
- Consequence: a dead-Postgres pod stays `Running`/`Ready`; recovering it is a health-stream-consumer responsibility (the operator reacting to the `LIFECYCLE_QUARANTINED` topo marker), not a kubelet restart. On the operator-less kind demo, such a node stays dead until a manual `kubectl delete pod`.

It also documents StatefulSet packaging and, importantly, **where the StatefulSet controller's view and Multiorch's view diverge** — role-blind rolling restarts, quorum-blind scale-downs, identity reuse that restores broken data, and how a *graceful* shutdown can march the cohort below durability quorum and wedge the shard. This last part is the direct write-up of the cluster-wedge investigation that motivated the doc.

## Wiring

- Adds the doc to the index in `docs/README.md`.
- Fills the two placeholder health-stream TODOs in `docs/ha/recovery.md` by cross-linking to the new section rather than restating.
- Normalizes `Postgres`/`Multiorch` naming in `docs/ha/recovery.md` to match repo conventions.

## Notes

- Docs-only change; no code or generated files touched.
- Conforms to the repo's markdownlint (`MD013`, 120-col) and the service-name naming linter.
