### PR TITLE
feat(multipooler): scrub pooled connections for session-state divergence

### DIFF
--- a/docs/query_serving/connection_pooling.md
+++ b/docs/query_serving/connection_pooling.md
@@ -571,7 +571,13 @@ divergence, closes it and eagerly opens a replacement into the same slot
 (eager because a freed slot cannot wake a waitlisted client). Divergent
 backends are always replaced, never reconciled: divergence means tracking
 was bypassed, and what a checker observes is only part of what the untracked
-code may have done.
+code may have done. A probe that fails or times out is treated the same way:
+an unverified backend may still carry hidden state, and a client could
+induce probe failures deliberately, so the scrubber fails closed and
+replaces it (churn is bounded to one connection per tick). While a probe is
+in flight the held connection counts as borrowed, so `Available` and the
+idle-limit math stay accurate; pool close cancels the scrub context before
+draining, so a slow probe never delays shutdown.
 
 Checkers implement `connpool.ConnChecker` (`Name` + `Check`) and are
 registered on a pool before `Open`; checkers only detect, the scrubber acts.

--- a/docs/query_serving/connection_pooling.md
+++ b/docs/query_serving/connection_pooling.md
@@ -555,6 +555,50 @@ map.
 See [session_settings.md](./session_settings.md) for statement
 classification and known limitations.
 
+### Session-state scrubber
+
+Because the pool trusts settings labels absolutely (a pointer-equal bucket
+hit and a clean-stack checkout both run zero SQL), any backend mutation that
+escapes gateway tracking — a `set_config` hidden in a routine body, a
+tracking bug, out-of-band DDL — would silently leak to the next borrower.
+The scrubber is the detection net for that class of failure.
+
+A background worker per pool pops one idle connection per tick (rotating
+across the clean stack and all settings buckets), runs every registered
+**state checker** against it, and either returns it — with its idle clock
+intact, so scrubbing never defeats idle-timeout shrinking — or, on any
+divergence, closes it and eagerly opens a replacement into the same slot
+(eager because a freed slot cannot wake a waitlisted client). Divergent
+backends are always replaced, never reconciled: divergence means tracking
+was bypassed, and what a checker observes is only part of what the untracked
+code may have done.
+
+Checkers implement `connpool.ConnChecker` (`Name` + `Check`) and are
+registered on a pool before `Open`; checkers only detect, the scrubber acts.
+The first checker, `session_state`, compares the tracked settings label
+against the backend's real session GUC state in one round trip:
+`pg_settings WHERE source = 'session'` for ordinary GUCs, explicit
+`current_setting('role')` / `session_user` for the identity GUCs
+(`GUC_NO_SHOW_ALL` — never visible in `pg_settings`), and per-name
+`current_setting(name, missing_ok)` for tracked custom (placeholder) GUCs,
+which `pg_settings` also hides. Value spellings are normalized through a
+statement-local `set_config(..., is_local := true)` probe so `'65536'` vs
+`'64MB'` never counts as divergence. Findings carry GUC names only, never
+values. One blind spot remains: an *untracked* custom GUC set behind
+tracking's back is unenumerable from SQL; the creation-time rejection gates
+are the defense for that class. Future checkers (prepared statements vs
+`pg_prepared_statements`, residual advisory locks, temp-schema leftovers)
+register the same way.
+
+Operationally: `--connpool-session-scrub-interval` (default 10s, `0`
+disables) controls the tick on both the regular pool and the reserved pool's
+underlying pool. Outcomes are exported as
+`mg.pooler.session_scrub.{checked,divergence,errors}` with `pool_type`,
+`checker`, and divergence-`kind` attributes — **any nonzero divergence count
+means session-state tracking was bypassed and warrants investigation**. The
+scrubber is a sampler: it narrows the leak window and raises the alarm, but
+the gateway's tracking and rejection gates remain the correctness boundary.
+
 ## User Management and RLS
 
 ### Per-User Connection Pools

--- a/docs/query_serving/connection_pooling.md
+++ b/docs/query_serving/connection_pooling.md
@@ -584,7 +584,7 @@ against the backend's real session GUC state in one round trip:
 which `pg_settings` also hides. Value spellings are normalized through a
 statement-local `set_config(..., is_local := true)` probe so `'65536'` vs
 `'64MB'` never counts as divergence. Findings carry GUC names only, never
-values. One blind spot remains: an *untracked* custom GUC set behind
+values. One blind spot remains: an _untracked_ custom GUC set behind
 tracking's back is unenumerable from SQL; the creation-time rejection gates
 are the defense for that class. Future checkers (prepared statements vs
 `pg_prepared_statements`, residual advisory locks, temp-schema leftovers)

--- a/docs/query_serving/connection_pooling.md
+++ b/docs/query_serving/connection_pooling.md
@@ -590,6 +590,13 @@ are the defense for that class. Future checkers (prepared statements vs
 `pg_prepared_statements`, residual advisory locks, temp-schema leftovers)
 register the same way.
 
+The untracked rule imposes a bootstrap invariant: connection setup must not
+create session-source GUC state outside the settings label — bootstrap
+settings must arrive via startup-packet parameters (`source='client'`) or be
+reflected in the label, or the scrubber would replace every connection each
+sweep. The e2e scrubber test asserts zero divergence from normal traffic as
+the canary for this invariant.
+
 Operationally: `--connpool-session-scrub-interval` (default 10s, `0`
 disables) controls the tick on both the regular pool and the reserved pool's
 underlying pool. Outcomes are exported as

--- a/docs/query_serving/session_settings.md
+++ b/docs/query_serving/session_settings.md
@@ -134,6 +134,14 @@ Gateway-managed variables are described in
   work); `go/test/endtoend/queryserving/session_state_leak_test.go` is the
   skipped acceptance test for that gate. The same applies to state-mutating
   calls reachable through views, triggers, casts, and C extensions.
+  Since the pool's session-state scrubber (see
+  [connection_pooling.md](./connection_pooling.md#session-state-scrubber))
+  landed, such leaks on defined GUCs and identity are detected on idle pooled
+  backends, alarmed via metrics, and repaired by replacing the backend —
+  bounding the leak window to roughly one scrub sweep rather than the
+  backend's lifetime. The scrubber is a sampling net, not the fix: untracked
+  *custom* (placeholder) GUCs remain invisible to it, and the rejection gates
+  remain the correctness boundary.
 - Row-limited portal fetches (`Execute` with `maxRows`) on statements that
   combine a gateway-managed `set_config` bound value or a gateway-managed
   `current_setting` read lose portal suspension: those statements run through

--- a/docs/query_serving/session_settings.md
+++ b/docs/query_serving/session_settings.md
@@ -140,7 +140,7 @@ Gateway-managed variables are described in
   backends, alarmed via metrics, and repaired by replacing the backend —
   bounding the leak window to roughly one scrub sweep rather than the
   backend's lifetime. The scrubber is a sampling net, not the fix: untracked
-  *custom* (placeholder) GUCs remain invisible to it, and the rejection gates
+  _custom_ (placeholder) GUCs remain invisible to it, and the rejection gates
   remain the correctness boundary.
 - Row-limited portal fetches (`Execute` with `maxRows`) on statements that
   combine a gateway-managed `set_config` bound value or a gateway-managed

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -142,6 +142,37 @@ const (
 	// released all of its advisory locks and the backend can be unpinned.
 	PgLocksAdvisoryProbeSQL = "SELECT EXISTS (SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND pid = pg_backend_pid())"
 
+	// SessionSourceProbeSQL is the session-state probe run by the multipooler
+	// scrubber. It reads the backend's real session GUC state in one
+	// round trip and compares it against the connection's tracked settings label.
+	// Three sources are combined, because pg_settings alone cannot see everything
+	// (verified on PostgreSQL 17):
+	//
+	//   - 'session' rows: pg_settings WHERE source = 'session' — every defined
+	//     GUC whose current value was installed by this session (SET,
+	//     set_config(..., false), including any hidden inside routine bodies).
+	//     current_setting() is used instead of pg_settings.setting because it
+	//     returns the SHOW-style display form, which is also what set_config
+	//     returns in the normalization probe, keeping comparisons
+	//     apples-to-apples.
+	//   - 'identity' rows: role and session_authorization are GUC_NO_SHOW_ALL —
+	//     they NEVER appear in pg_settings — so they are read explicitly.
+	//     current_setting('role') reports 'none' when no SET ROLE is in effect;
+	//     session_user is the current session authorization.
+	//   - 'custom' rows: placeholder GUCs (names with a dot, e.g. 'my.tenant')
+	//     are also hidden from pg_settings until an extension defines them, so
+	//     every custom name in the tracked label is read explicitly with
+	//     current_setting(name, missing_ok := true), which returns NULL when the
+	//     session has never seen the GUC.
+	//
+	// Known blind spot: a custom GUC set behind tracking's back on a connection
+	// whose label does not contain it is undetectable — placeholder GUCs cannot
+	// be enumerated from SQL. The creation-time rejection gates remain the
+	// defense for that class.
+	SessionSourceProbeSQL = "SELECT name, current_setting(name), 'session' FROM pg_settings WHERE source = 'session'" +
+		" UNION ALL SELECT 'role', pg_catalog.current_setting('role'), 'identity'" +
+		" UNION ALL SELECT 'session_authorization', session_user::text, 'identity'"
+
 	// RestoreCommandPIDFile is the filename (joined onto the pooler directory)
 	// that `pgctld restore-wrapper` writes its own PID to, so pgctld's
 	// StopRestoreCommand RPC can check liveness or signal it. Shared between

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -155,6 +155,9 @@ const (
 	//     returns the SHOW-style display form, which is also what set_config
 	//     returns in the normalization probe, keeping comparisons
 	//     apples-to-apples.
+	//     Both pg_settings and current_setting are schema-qualified: pg_temp
+	//     is searched before pg_catalog for unqualified relation names, and a
+	//     client's search_path could shadow an unqualified function name.
 	//   - 'identity' rows: role and session_authorization are GUC_NO_SHOW_ALL —
 	//     they NEVER appear in pg_settings — so they are read explicitly.
 	//     current_setting('role') reports 'none' when no SET ROLE is in effect;
@@ -169,7 +172,7 @@ const (
 	// whose label does not contain it is undetectable — placeholder GUCs cannot
 	// be enumerated from SQL. The creation-time rejection gates remain the
 	// defense for that class.
-	SessionSourceProbeSQL = "SELECT name, current_setting(name), 'session' FROM pg_settings WHERE source = 'session'" +
+	SessionSourceProbeSQL = "SELECT name, pg_catalog.current_setting(name), 'session' FROM pg_catalog.pg_settings WHERE source = 'session'" +
 		" UNION ALL SELECT 'role', pg_catalog.current_setting('role'), 'identity'" +
 		" UNION ALL SELECT 'session_authorization', session_user::text, 'identity'"
 

--- a/go/common/pgprotocol/client/conn.go
+++ b/go/common/pgprotocol/client/conn.go
@@ -325,6 +325,12 @@ func (c *Conn) ServerParams() map[string]string {
 	return c.serverParams
 }
 
+// User returns the PostgreSQL user this connection was configured to
+// authenticate as.
+func (c *Conn) User() string {
+	return c.config.User
+}
+
 // TxnStatus returns the current transaction status.
 func (c *Conn) TxnStatus() protocol.TransactionStatus {
 	return c.txnStatus

--- a/go/observability/metriccatalog/catalog_generated.go
+++ b/go/observability/metriccatalog/catalog_generated.go
@@ -54,7 +54,7 @@ type Metric struct {
 }
 
 // Metrics is the catalog of every metric Multigres defines, sorted by OTel name.
-// There are 136 metrics.
+// There are 139 metrics.
 var Metrics = []Metric{
 	{
 		OTelName:       "db.client.connection.count",
@@ -412,7 +412,7 @@ var Metrics = []Metric{
 		Unit:           "s",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:283",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:294",
 		PrometheusName: "mg_pooler_auth_credential_query_duration_seconds",
 		Series:         []string{"mg_pooler_auth_credential_query_duration_seconds_bucket", "mg_pooler_auth_credential_query_duration_seconds_count", "mg_pooler_auth_credential_query_duration_seconds_sum"},
 	},
@@ -422,7 +422,7 @@ var Metrics = []Metric{
 		Unit:           "{error}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:295",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:306",
 		PrometheusName: "mg_pooler_auth_credential_query_errors_total",
 		Series:         []string{"mg_pooler_auth_credential_query_errors_total"},
 	},
@@ -432,7 +432,7 @@ var Metrics = []Metric{
 		Unit:           "s",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:263",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:274",
 		PrometheusName: "mg_pooler_client_wait_time_seconds_total",
 		Series:         []string{"mg_pooler_client_wait_time_seconds_total"},
 	},
@@ -442,7 +442,7 @@ var Metrics = []Metric{
 		Unit:           "{connection}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:213",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:224",
 		PrometheusName: "mg_pooler_client_waiting_connections",
 		Series:         []string{"mg_pooler_client_waiting_connections"},
 	},
@@ -452,7 +452,7 @@ var Metrics = []Metric{
 		Unit:           "{connection}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:233",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:244",
 		PrometheusName: "mg_pooler_config_max_server_connections",
 		Series:         []string{"mg_pooler_config_max_server_connections"},
 	},
@@ -462,7 +462,7 @@ var Metrics = []Metric{
 		Unit:           "{database}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:193",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:204",
 		PrometheusName: "mg_pooler_databases",
 		Series:         []string{"mg_pooler_databases"},
 	},
@@ -542,7 +542,7 @@ var Metrics = []Metric{
 		Unit:           "{connection}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:243",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:254",
 		PrometheusName: "mg_pooler_pool_capacity",
 		Series:         []string{"mg_pooler_pool_capacity"},
 	},
@@ -552,7 +552,7 @@ var Metrics = []Metric{
 		Unit:           "{connection}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:253",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:264",
 		PrometheusName: "mg_pooler_pool_current_connections",
 		Series:         []string{"mg_pooler_pool_current_connections"},
 	},
@@ -562,7 +562,7 @@ var Metrics = []Metric{
 		Unit:           "{pool}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:173",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:184",
 		PrometheusName: "mg_pooler_pools",
 		Series:         []string{"mg_pooler_pools"},
 	},
@@ -572,7 +572,7 @@ var Metrics = []Metric{
 		Unit:           "{query}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:273",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:284",
 		PrometheusName: "mg_pooler_queries_pooled_total",
 		Series:         []string{"mg_pooler_queries_pooled_total"},
 	},
@@ -762,7 +762,7 @@ var Metrics = []Metric{
 		Unit:           "{connection}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:223",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:234",
 		PrometheusName: "mg_pooler_reserved_active_connections",
 		Series:         []string{"mg_pooler_reserved_active_connections"},
 	},
@@ -772,7 +772,7 @@ var Metrics = []Metric{
 		Unit:           "{connection}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:203",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:214",
 		PrometheusName: "mg_pooler_server_connections",
 		Series:         []string{"mg_pooler_server_connections"},
 	},
@@ -817,6 +817,36 @@ var Metrics = []Metric{
 		Series:         []string{"mg_pooler_serving_transitions_total"},
 	},
 	{
+		OTelName:       "mg.pooler.session_scrub.checked",
+		Constructor:    "Int64Counter",
+		Unit:           "{connection}",
+		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/pools/connpool",
+		Binaries:       []string{"multipooler"},
+		Source:         "go/services/multipooler/internal/pools/connpool/metrics.go:162",
+		PrometheusName: "mg_pooler_session_scrub_checked_total",
+		Series:         []string{"mg_pooler_session_scrub_checked_total"},
+	},
+	{
+		OTelName:       "mg.pooler.session_scrub.divergence",
+		Constructor:    "Int64Counter",
+		Unit:           "{guc}",
+		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/pools/connpool",
+		Binaries:       []string{"multipooler"},
+		Source:         "go/services/multipooler/internal/pools/connpool/metrics.go:172",
+		PrometheusName: "mg_pooler_session_scrub_divergence_total",
+		Series:         []string{"mg_pooler_session_scrub_divergence_total"},
+	},
+	{
+		OTelName:       "mg.pooler.session_scrub.errors",
+		Constructor:    "Int64Counter",
+		Unit:           "{error}",
+		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/pools/connpool",
+		Binaries:       []string{"multipooler"},
+		Source:         "go/services/multipooler/internal/pools/connpool/metrics.go:182",
+		PrometheusName: "mg_pooler_session_scrub_errors_total",
+		Series:         []string{"mg_pooler_session_scrub_errors_total"},
+	},
+	{
 		OTelName:       "mg.pooler.txn.duration",
 		Constructor:    "Float64Histogram",
 		Unit:           "s",
@@ -842,7 +872,7 @@ var Metrics = []Metric{
 		Unit:           "",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:164",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:175",
 		PrometheusName: "mg_pooler_up",
 		Series:         []string{"mg_pooler_up"},
 	},
@@ -852,7 +882,7 @@ var Metrics = []Metric{
 		Unit:           "{user}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:183",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:194",
 		PrometheusName: "mg_pooler_users",
 		Series:         []string{"mg_pooler_users"},
 	},
@@ -1427,7 +1457,7 @@ var Metrics = []Metric{
 //     action: keep
 //
 // Histogram families collapse to a "<base>_(bucket|count|sum)" group.
-const PrometheusKeepListRegex = `db_client_connection_count|go_config_gogc_percent|go_goroutine_count|go_memory_allocated_bytes_total|go_memory_allocations_total|go_memory_gc_goal_bytes|go_memory_used_bytes|go_processor_limit|mg_gateway_auth_attempts_total|mg_gateway_auth_credential_lookup_duration_seconds_(bucket|count|sum)|mg_gateway_auth_credential_lookup_rate_total|mg_gateway_auth_scram_duration_seconds_(bucket|count|sum)|mg_gateway_client_connections|mg_gateway_notification_streams|mg_gateway_notifications_dropped_total|mg_gateway_query_duration_seconds_(bucket|count|sum)|mg_gateway_query_errors_total|mg_gateway_query_exec_duration_seconds_(bucket|count|sum)|mg_gateway_query_info|mg_gateway_query_log_emits_total|mg_gateway_query_parse_duration_seconds_(bucket|count|sum)|mg_gateway_query_plan_duration_seconds_(bucket|count|sum)|mg_gateway_query_rows_returned_(bucket|count|sum)|mg_gateway_query_table_queries_total|mg_gateway_replication_bytes_total|mg_gateway_replication_chunks_total|mg_gateway_tls_connections_total|mg_gateway_tls_direct_rejected_total|mg_gateway_tls_handshake_duration_seconds_(bucket|count|sum)|mg_gateway_tls_plaintext_rejected_total|mg_gateway_tls_sslrequest_declined_total|mg_gateway_transaction_count_total|mg_gateway_transaction_duration_seconds_(bucket|count|sum)|mg_plancache_hits_total|mg_plancache_misses_total|mg_pooler_auth_credential_query_duration_seconds_(bucket|count|sum)|mg_pooler_auth_credential_query_errors_total|mg_pooler_client_wait_time_seconds_total|mg_pooler_client_waiting_connections|mg_pooler_config_max_server_connections|mg_pooler_databases|mg_pooler_drain_duration_seconds_(bucket|count|sum)|mg_pooler_drain_force_closed_total|mg_pooler_drain_outcome_total|mg_pooler_logical_failover_count_total|mg_pooler_logical_failover_duration_seconds_(bucket|count|sum)|mg_pooler_logical_failover_slots|mg_pooler_logical_failover_slots_dropped_total|mg_pooler_pool_capacity|mg_pooler_pool_current_connections|mg_pooler_pools|mg_pooler_queries_pooled_total|mg_pooler_query_duration_seconds_(bucket|count|sum)|mg_pooler_query_errors_total|mg_pooler_query_pool_acquire_duration_seconds_(bucket|count|sum)|mg_pooler_query_rows_(bucket|count|sum)|mg_pooler_replication_active|mg_pooler_replication_active_connections|mg_pooler_replication_bytes_total|mg_pooler_replication_chunks_total|mg_pooler_replication_duration_seconds_(bucket|count|sum)|mg_pooler_replication_forward_latency_milliseconds_(bucket|count|sum)|mg_pooler_replication_lag_seconds|mg_pooler_replication_last_ack_age_seconds|mg_pooler_replication_last_message_age_seconds|mg_pooler_replication_replay_lag_seconds|mg_pooler_replication_setup_errors_total|mg_pooler_replication_setup_latency_seconds_(bucket|count|sum)|mg_pooler_replication_slot_retained_wal_bytes|mg_pooler_replication_terminations_total|mg_pooler_reserved_active_connections|mg_pooler_server_conn_open_errors_total|mg_pooler_server_conn_opened_total|mg_pooler_server_conn_setup_duration_seconds_(bucket|count|sum)|mg_pooler_server_connections|mg_pooler_serving_transitions_total|mg_pooler_txn_duration_seconds_(bucket|count|sum)|mg_pooler_txn_outcomes_total|mg_pooler_up|mg_pooler_users|mg_pubsub_channels|mg_pubsub_notifications_dropped_total|mg_pubsub_reconnect_gap_duration_seconds_(bucket|count|sum)|mg_pubsub_reconnects_total|mg_pubsub_subscribers|mg_scatter_execute_duration_seconds_(bucket|count|sum)|mg_scatter_execute_errors_total|mg_servenv_auth_attempts_total|multigateway_buffer_failover_duration_seconds_(bucket|count|sum)|multigateway_buffer_failovers_total|multigateway_buffer_queue_depth|multigateway_buffer_requests_buffered_total|multigateway_buffer_requests_drained_total|multigateway_buffer_requests_evicted_total|multigateway_buffer_requests_failed_unbuffered_total|multigateway_buffer_requests_skipped_total|multigateway_buffer_wait_duration_seconds_(bucket|count|sum)|multiorch_recovery_action_duration_milliseconds_(bucket|count|sum)|multiorch_recovery_detected_problems|multiorch_recovery_errors_total|multiorch_recovery_pooler_store_size|multiorch_recovery_stream_connected|multiorch_recovery_stream_snapshots_received|multipooler_rewind_checkpoint_wait_duration_seconds_(bucket|count|sum)|multipooler_rewind_execution_duration_seconds_(bucket|count|sum)|pgbackrest_backup_attempts_total|pgbackrest_backup_complete_count|pgbackrest_backup_duration_seconds_(bucket|count|sum)|pgbackrest_backup_failures_since_success|pgbackrest_backup_failures_total|pgbackrest_backup_in_progress|pgbackrest_backup_in_progress_duration_seconds|pgbackrest_backup_last_success_age_seconds|pgbackrest_backup_lease_held|pgbackrest_backup_lease_lost_total|pgbackrest_backup_lock_wait_seconds_(bucket|count|sum)|pgbackrest_backup_ready|pgbackrest_backup_successes_total|pgbackrest_backup_verify_duration_seconds_(bucket|count|sum)|pgbackrest_restore_attempts_total|pgbackrest_restore_duration_seconds_(bucket|count|sum)|pgbackrest_restore_failures_total|pgbackrest_restore_successes_total|pgbackrest_server_restart_count|pgbackrest_server_up|pgbackrest_server_uptime|pgbackrest_wal_archive_lag_seconds|process_cpu_time_seconds_total|process_memory_usage_bytes|process_memory_virtual_bytes|rpcclient_connection_cache_size|rpcclient_connection_creates_total|rpcclient_connection_dial_duration_seconds_(bucket|count|sum)|rpcclient_connection_dial_timeouts_total|rpcclient_connection_reuses_total|topoclient_lock_duration_seconds_(bucket|count|sum)`
+const PrometheusKeepListRegex = `db_client_connection_count|go_config_gogc_percent|go_goroutine_count|go_memory_allocated_bytes_total|go_memory_allocations_total|go_memory_gc_goal_bytes|go_memory_used_bytes|go_processor_limit|mg_gateway_auth_attempts_total|mg_gateway_auth_credential_lookup_duration_seconds_(bucket|count|sum)|mg_gateway_auth_credential_lookup_rate_total|mg_gateway_auth_scram_duration_seconds_(bucket|count|sum)|mg_gateway_client_connections|mg_gateway_notification_streams|mg_gateway_notifications_dropped_total|mg_gateway_query_duration_seconds_(bucket|count|sum)|mg_gateway_query_errors_total|mg_gateway_query_exec_duration_seconds_(bucket|count|sum)|mg_gateway_query_info|mg_gateway_query_log_emits_total|mg_gateway_query_parse_duration_seconds_(bucket|count|sum)|mg_gateway_query_plan_duration_seconds_(bucket|count|sum)|mg_gateway_query_rows_returned_(bucket|count|sum)|mg_gateway_query_table_queries_total|mg_gateway_replication_bytes_total|mg_gateway_replication_chunks_total|mg_gateway_tls_connections_total|mg_gateway_tls_direct_rejected_total|mg_gateway_tls_handshake_duration_seconds_(bucket|count|sum)|mg_gateway_tls_plaintext_rejected_total|mg_gateway_tls_sslrequest_declined_total|mg_gateway_transaction_count_total|mg_gateway_transaction_duration_seconds_(bucket|count|sum)|mg_plancache_hits_total|mg_plancache_misses_total|mg_pooler_auth_credential_query_duration_seconds_(bucket|count|sum)|mg_pooler_auth_credential_query_errors_total|mg_pooler_client_wait_time_seconds_total|mg_pooler_client_waiting_connections|mg_pooler_config_max_server_connections|mg_pooler_databases|mg_pooler_drain_duration_seconds_(bucket|count|sum)|mg_pooler_drain_force_closed_total|mg_pooler_drain_outcome_total|mg_pooler_logical_failover_count_total|mg_pooler_logical_failover_duration_seconds_(bucket|count|sum)|mg_pooler_logical_failover_slots|mg_pooler_logical_failover_slots_dropped_total|mg_pooler_pool_capacity|mg_pooler_pool_current_connections|mg_pooler_pools|mg_pooler_queries_pooled_total|mg_pooler_query_duration_seconds_(bucket|count|sum)|mg_pooler_query_errors_total|mg_pooler_query_pool_acquire_duration_seconds_(bucket|count|sum)|mg_pooler_query_rows_(bucket|count|sum)|mg_pooler_replication_active|mg_pooler_replication_active_connections|mg_pooler_replication_bytes_total|mg_pooler_replication_chunks_total|mg_pooler_replication_duration_seconds_(bucket|count|sum)|mg_pooler_replication_forward_latency_milliseconds_(bucket|count|sum)|mg_pooler_replication_lag_seconds|mg_pooler_replication_last_ack_age_seconds|mg_pooler_replication_last_message_age_seconds|mg_pooler_replication_replay_lag_seconds|mg_pooler_replication_setup_errors_total|mg_pooler_replication_setup_latency_seconds_(bucket|count|sum)|mg_pooler_replication_slot_retained_wal_bytes|mg_pooler_replication_terminations_total|mg_pooler_reserved_active_connections|mg_pooler_server_conn_open_errors_total|mg_pooler_server_conn_opened_total|mg_pooler_server_conn_setup_duration_seconds_(bucket|count|sum)|mg_pooler_server_connections|mg_pooler_serving_transitions_total|mg_pooler_session_scrub_checked_total|mg_pooler_session_scrub_divergence_total|mg_pooler_session_scrub_errors_total|mg_pooler_txn_duration_seconds_(bucket|count|sum)|mg_pooler_txn_outcomes_total|mg_pooler_up|mg_pooler_users|mg_pubsub_channels|mg_pubsub_notifications_dropped_total|mg_pubsub_reconnect_gap_duration_seconds_(bucket|count|sum)|mg_pubsub_reconnects_total|mg_pubsub_subscribers|mg_scatter_execute_duration_seconds_(bucket|count|sum)|mg_scatter_execute_errors_total|mg_servenv_auth_attempts_total|multigateway_buffer_failover_duration_seconds_(bucket|count|sum)|multigateway_buffer_failovers_total|multigateway_buffer_queue_depth|multigateway_buffer_requests_buffered_total|multigateway_buffer_requests_drained_total|multigateway_buffer_requests_evicted_total|multigateway_buffer_requests_failed_unbuffered_total|multigateway_buffer_requests_skipped_total|multigateway_buffer_wait_duration_seconds_(bucket|count|sum)|multiorch_recovery_action_duration_milliseconds_(bucket|count|sum)|multiorch_recovery_detected_problems|multiorch_recovery_errors_total|multiorch_recovery_pooler_store_size|multiorch_recovery_stream_connected|multiorch_recovery_stream_snapshots_received|multipooler_rewind_checkpoint_wait_duration_seconds_(bucket|count|sum)|multipooler_rewind_execution_duration_seconds_(bucket|count|sum)|pgbackrest_backup_attempts_total|pgbackrest_backup_complete_count|pgbackrest_backup_duration_seconds_(bucket|count|sum)|pgbackrest_backup_failures_since_success|pgbackrest_backup_failures_total|pgbackrest_backup_in_progress|pgbackrest_backup_in_progress_duration_seconds|pgbackrest_backup_last_success_age_seconds|pgbackrest_backup_lease_held|pgbackrest_backup_lease_lost_total|pgbackrest_backup_lock_wait_seconds_(bucket|count|sum)|pgbackrest_backup_ready|pgbackrest_backup_successes_total|pgbackrest_backup_verify_duration_seconds_(bucket|count|sum)|pgbackrest_restore_attempts_total|pgbackrest_restore_duration_seconds_(bucket|count|sum)|pgbackrest_restore_failures_total|pgbackrest_restore_successes_total|pgbackrest_server_restart_count|pgbackrest_server_up|pgbackrest_server_uptime|pgbackrest_wal_archive_lag_seconds|process_cpu_time_seconds_total|process_memory_usage_bytes|process_memory_virtual_bytes|rpcclient_connection_cache_size|rpcclient_connection_creates_total|rpcclient_connection_dial_duration_seconds_(bucket|count|sum)|rpcclient_connection_dial_timeouts_total|rpcclient_connection_reuses_total|topoclient_lock_duration_seconds_(bucket|count|sum)`
 
 // PrometheusKeepListByBinary maps each binary to a keep-list regex covering only
 // the series that binary exposes, for scoping a keep rule per Prometheus scrape
@@ -1439,7 +1469,7 @@ var PrometheusKeepListByBinary = map[string]string{
 	"multigateway": `go_config_gogc_percent|go_goroutine_count|go_memory_allocated_bytes_total|go_memory_allocations_total|go_memory_gc_goal_bytes|go_memory_used_bytes|go_processor_limit|mg_gateway_auth_attempts_total|mg_gateway_auth_credential_lookup_duration_seconds_(bucket|count|sum)|mg_gateway_auth_credential_lookup_rate_total|mg_gateway_auth_scram_duration_seconds_(bucket|count|sum)|mg_gateway_client_connections|mg_gateway_notification_streams|mg_gateway_notifications_dropped_total|mg_gateway_query_duration_seconds_(bucket|count|sum)|mg_gateway_query_errors_total|mg_gateway_query_exec_duration_seconds_(bucket|count|sum)|mg_gateway_query_info|mg_gateway_query_log_emits_total|mg_gateway_query_parse_duration_seconds_(bucket|count|sum)|mg_gateway_query_plan_duration_seconds_(bucket|count|sum)|mg_gateway_query_rows_returned_(bucket|count|sum)|mg_gateway_query_table_queries_total|mg_gateway_replication_bytes_total|mg_gateway_replication_chunks_total|mg_gateway_tls_connections_total|mg_gateway_tls_direct_rejected_total|mg_gateway_tls_handshake_duration_seconds_(bucket|count|sum)|mg_gateway_tls_plaintext_rejected_total|mg_gateway_tls_sslrequest_declined_total|mg_gateway_transaction_count_total|mg_gateway_transaction_duration_seconds_(bucket|count|sum)|mg_plancache_hits_total|mg_plancache_misses_total|mg_scatter_execute_duration_seconds_(bucket|count|sum)|mg_scatter_execute_errors_total|mg_servenv_auth_attempts_total|multigateway_buffer_failover_duration_seconds_(bucket|count|sum)|multigateway_buffer_failovers_total|multigateway_buffer_queue_depth|multigateway_buffer_requests_buffered_total|multigateway_buffer_requests_drained_total|multigateway_buffer_requests_evicted_total|multigateway_buffer_requests_failed_unbuffered_total|multigateway_buffer_requests_skipped_total|multigateway_buffer_wait_duration_seconds_(bucket|count|sum)|process_cpu_time_seconds_total|process_memory_usage_bytes|process_memory_virtual_bytes|rpcclient_connection_cache_size|rpcclient_connection_creates_total|rpcclient_connection_dial_duration_seconds_(bucket|count|sum)|rpcclient_connection_dial_timeouts_total|rpcclient_connection_reuses_total|topoclient_lock_duration_seconds_(bucket|count|sum)`,
 	"multigres":    `go_config_gogc_percent|go_goroutine_count|go_memory_allocated_bytes_total|go_memory_allocations_total|go_memory_gc_goal_bytes|go_memory_used_bytes|go_processor_limit|mg_servenv_auth_attempts_total|process_cpu_time_seconds_total|process_memory_usage_bytes|process_memory_virtual_bytes|topoclient_lock_duration_seconds_(bucket|count|sum)`,
 	"multiorch":    `go_config_gogc_percent|go_goroutine_count|go_memory_allocated_bytes_total|go_memory_allocations_total|go_memory_gc_goal_bytes|go_memory_used_bytes|go_processor_limit|mg_servenv_auth_attempts_total|multiorch_recovery_action_duration_milliseconds_(bucket|count|sum)|multiorch_recovery_detected_problems|multiorch_recovery_errors_total|multiorch_recovery_pooler_store_size|multiorch_recovery_stream_connected|multiorch_recovery_stream_snapshots_received|process_cpu_time_seconds_total|process_memory_usage_bytes|process_memory_virtual_bytes|rpcclient_connection_cache_size|rpcclient_connection_creates_total|rpcclient_connection_dial_duration_seconds_(bucket|count|sum)|rpcclient_connection_dial_timeouts_total|rpcclient_connection_reuses_total|topoclient_lock_duration_seconds_(bucket|count|sum)`,
-	"multipooler":  `db_client_connection_count|go_config_gogc_percent|go_goroutine_count|go_memory_allocated_bytes_total|go_memory_allocations_total|go_memory_gc_goal_bytes|go_memory_used_bytes|go_processor_limit|mg_pooler_auth_credential_query_duration_seconds_(bucket|count|sum)|mg_pooler_auth_credential_query_errors_total|mg_pooler_client_wait_time_seconds_total|mg_pooler_client_waiting_connections|mg_pooler_config_max_server_connections|mg_pooler_databases|mg_pooler_drain_duration_seconds_(bucket|count|sum)|mg_pooler_drain_force_closed_total|mg_pooler_drain_outcome_total|mg_pooler_logical_failover_count_total|mg_pooler_logical_failover_duration_seconds_(bucket|count|sum)|mg_pooler_logical_failover_slots|mg_pooler_logical_failover_slots_dropped_total|mg_pooler_pool_capacity|mg_pooler_pool_current_connections|mg_pooler_pools|mg_pooler_queries_pooled_total|mg_pooler_query_duration_seconds_(bucket|count|sum)|mg_pooler_query_errors_total|mg_pooler_query_pool_acquire_duration_seconds_(bucket|count|sum)|mg_pooler_query_rows_(bucket|count|sum)|mg_pooler_replication_active|mg_pooler_replication_active_connections|mg_pooler_replication_bytes_total|mg_pooler_replication_chunks_total|mg_pooler_replication_duration_seconds_(bucket|count|sum)|mg_pooler_replication_forward_latency_milliseconds_(bucket|count|sum)|mg_pooler_replication_lag_seconds|mg_pooler_replication_last_ack_age_seconds|mg_pooler_replication_last_message_age_seconds|mg_pooler_replication_replay_lag_seconds|mg_pooler_replication_setup_errors_total|mg_pooler_replication_setup_latency_seconds_(bucket|count|sum)|mg_pooler_replication_slot_retained_wal_bytes|mg_pooler_replication_terminations_total|mg_pooler_reserved_active_connections|mg_pooler_server_conn_open_errors_total|mg_pooler_server_conn_opened_total|mg_pooler_server_conn_setup_duration_seconds_(bucket|count|sum)|mg_pooler_server_connections|mg_pooler_serving_transitions_total|mg_pooler_txn_duration_seconds_(bucket|count|sum)|mg_pooler_txn_outcomes_total|mg_pooler_up|mg_pooler_users|mg_pubsub_channels|mg_pubsub_notifications_dropped_total|mg_pubsub_reconnect_gap_duration_seconds_(bucket|count|sum)|mg_pubsub_reconnects_total|mg_pubsub_subscribers|mg_servenv_auth_attempts_total|multipooler_rewind_checkpoint_wait_duration_seconds_(bucket|count|sum)|multipooler_rewind_execution_duration_seconds_(bucket|count|sum)|pgbackrest_backup_attempts_total|pgbackrest_backup_complete_count|pgbackrest_backup_duration_seconds_(bucket|count|sum)|pgbackrest_backup_failures_since_success|pgbackrest_backup_failures_total|pgbackrest_backup_in_progress|pgbackrest_backup_in_progress_duration_seconds|pgbackrest_backup_last_success_age_seconds|pgbackrest_backup_lease_held|pgbackrest_backup_lease_lost_total|pgbackrest_backup_lock_wait_seconds_(bucket|count|sum)|pgbackrest_backup_ready|pgbackrest_backup_successes_total|pgbackrest_backup_verify_duration_seconds_(bucket|count|sum)|pgbackrest_restore_attempts_total|pgbackrest_restore_duration_seconds_(bucket|count|sum)|pgbackrest_restore_failures_total|pgbackrest_restore_successes_total|pgbackrest_wal_archive_lag_seconds|process_cpu_time_seconds_total|process_memory_usage_bytes|process_memory_virtual_bytes|topoclient_lock_duration_seconds_(bucket|count|sum)`,
+	"multipooler":  `db_client_connection_count|go_config_gogc_percent|go_goroutine_count|go_memory_allocated_bytes_total|go_memory_allocations_total|go_memory_gc_goal_bytes|go_memory_used_bytes|go_processor_limit|mg_pooler_auth_credential_query_duration_seconds_(bucket|count|sum)|mg_pooler_auth_credential_query_errors_total|mg_pooler_client_wait_time_seconds_total|mg_pooler_client_waiting_connections|mg_pooler_config_max_server_connections|mg_pooler_databases|mg_pooler_drain_duration_seconds_(bucket|count|sum)|mg_pooler_drain_force_closed_total|mg_pooler_drain_outcome_total|mg_pooler_logical_failover_count_total|mg_pooler_logical_failover_duration_seconds_(bucket|count|sum)|mg_pooler_logical_failover_slots|mg_pooler_logical_failover_slots_dropped_total|mg_pooler_pool_capacity|mg_pooler_pool_current_connections|mg_pooler_pools|mg_pooler_queries_pooled_total|mg_pooler_query_duration_seconds_(bucket|count|sum)|mg_pooler_query_errors_total|mg_pooler_query_pool_acquire_duration_seconds_(bucket|count|sum)|mg_pooler_query_rows_(bucket|count|sum)|mg_pooler_replication_active|mg_pooler_replication_active_connections|mg_pooler_replication_bytes_total|mg_pooler_replication_chunks_total|mg_pooler_replication_duration_seconds_(bucket|count|sum)|mg_pooler_replication_forward_latency_milliseconds_(bucket|count|sum)|mg_pooler_replication_lag_seconds|mg_pooler_replication_last_ack_age_seconds|mg_pooler_replication_last_message_age_seconds|mg_pooler_replication_replay_lag_seconds|mg_pooler_replication_setup_errors_total|mg_pooler_replication_setup_latency_seconds_(bucket|count|sum)|mg_pooler_replication_slot_retained_wal_bytes|mg_pooler_replication_terminations_total|mg_pooler_reserved_active_connections|mg_pooler_server_conn_open_errors_total|mg_pooler_server_conn_opened_total|mg_pooler_server_conn_setup_duration_seconds_(bucket|count|sum)|mg_pooler_server_connections|mg_pooler_serving_transitions_total|mg_pooler_session_scrub_checked_total|mg_pooler_session_scrub_divergence_total|mg_pooler_session_scrub_errors_total|mg_pooler_txn_duration_seconds_(bucket|count|sum)|mg_pooler_txn_outcomes_total|mg_pooler_up|mg_pooler_users|mg_pubsub_channels|mg_pubsub_notifications_dropped_total|mg_pubsub_reconnect_gap_duration_seconds_(bucket|count|sum)|mg_pubsub_reconnects_total|mg_pubsub_subscribers|mg_servenv_auth_attempts_total|multipooler_rewind_checkpoint_wait_duration_seconds_(bucket|count|sum)|multipooler_rewind_execution_duration_seconds_(bucket|count|sum)|pgbackrest_backup_attempts_total|pgbackrest_backup_complete_count|pgbackrest_backup_duration_seconds_(bucket|count|sum)|pgbackrest_backup_failures_since_success|pgbackrest_backup_failures_total|pgbackrest_backup_in_progress|pgbackrest_backup_in_progress_duration_seconds|pgbackrest_backup_last_success_age_seconds|pgbackrest_backup_lease_held|pgbackrest_backup_lease_lost_total|pgbackrest_backup_lock_wait_seconds_(bucket|count|sum)|pgbackrest_backup_ready|pgbackrest_backup_successes_total|pgbackrest_backup_verify_duration_seconds_(bucket|count|sum)|pgbackrest_restore_attempts_total|pgbackrest_restore_duration_seconds_(bucket|count|sum)|pgbackrest_restore_failures_total|pgbackrest_restore_successes_total|pgbackrest_wal_archive_lag_seconds|process_cpu_time_seconds_total|process_memory_usage_bytes|process_memory_virtual_bytes|topoclient_lock_duration_seconds_(bucket|count|sum)`,
 	"pgctld":       `go_config_gogc_percent|go_goroutine_count|go_memory_allocated_bytes_total|go_memory_allocations_total|go_memory_gc_goal_bytes|go_memory_used_bytes|go_processor_limit|mg_servenv_auth_attempts_total|pgbackrest_server_restart_count|pgbackrest_server_up|pgbackrest_server_uptime|process_cpu_time_seconds_total|process_memory_usage_bytes|process_memory_virtual_bytes|topoclient_lock_duration_seconds_(bucket|count|sum)`,
 }
 

--- a/go/services/multipooler/internal/connpoolmanager/config.go
+++ b/go/services/multipooler/internal/connpoolmanager/config.go
@@ -124,6 +124,12 @@ type Config struct {
 	userReservedIdleTimeout       viperutil.Value[time.Duration] // For underlying pool connections
 	userReservedMaxLifetime       viperutil.Value[time.Duration]
 
+	// Session-state scrub interval for the per-user pools (0 = disabled).
+	// Each tick, every pool probes one idle connection for divergence between
+	// its tracked settings label and the backend's real session GUC state,
+	// replacing connections that diverged.
+	sessionScrubInterval viperutil.Value[time.Duration]
+
 	// Settings cache size (0 = use default)
 	settingsCacheSize viperutil.Value[int64]
 
@@ -179,6 +185,12 @@ func NewConfig(reg *viperutil.Registry) *Config {
 		userReservedInactivityTimeout = 30 * time.Second // Aggressive - kills reserved connections if client inactive
 		userReservedIdleTimeout       = 5 * time.Minute  // Less aggressive - for pool size reduction
 		userReservedMaxLifetime       = 1 * time.Hour
+
+		// Session-state scrub interval. One idle connection per pool per tick
+		// is a single fast query on an otherwise-idle backend, so a short
+		// interval keeps the divergence-detection window small at negligible
+		// cost.
+		sessionScrubInterval = 10 * time.Second
 
 		// Settings cache size
 		settingsCacheSize int64 = 1024
@@ -267,6 +279,12 @@ func NewConfig(reg *viperutil.Registry) *Config {
 			FlagName: "connpool-user-reserved-max-lifetime",
 		}),
 
+		// Session-state scrub interval
+		sessionScrubInterval: viperutil.Configure(reg, "connpool.session-scrub-interval", viperutil.Options[time.Duration]{
+			Default:  sessionScrubInterval,
+			FlagName: "connpool-session-scrub-interval",
+		}),
+
 		// Settings cache size
 		settingsCacheSize: viperutil.Configure(reg, "connpool.settings-cache-size", viperutil.Options[int64]{
 			Default:  settingsCacheSize,
@@ -339,6 +357,9 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 	fs.Duration("connpool-user-reserved-idle-timeout", c.userReservedIdleTimeout.Default(), "How long a connection in the reserved pool can remain idle before being closed")
 	fs.Duration("connpool-user-reserved-max-lifetime", c.userReservedMaxLifetime.Default(), "Maximum lifetime of a user's reserved connection before recycling")
 
+	// Session-state scrub flag
+	fs.Duration("connpool-session-scrub-interval", c.sessionScrubInterval.Default(), "How often each user pool probes one idle connection for divergence between tracked and real session GUC state, replacing divergent connections (0 = disabled)")
+
 	// Settings cache size flag
 	fs.Int64("connpool-settings-cache-size", c.settingsCacheSize.Default(), "Maximum number of unique settings combinations to cache (0 = use default)")
 
@@ -367,6 +388,7 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 		c.userReservedInactivityTimeout,
 		c.userReservedIdleTimeout,
 		c.userReservedMaxLifetime,
+		c.sessionScrubInterval,
 		c.settingsCacheSize,
 		c.globalCapacity,
 		c.reservedRatio,
@@ -568,6 +590,12 @@ func (c *Config) UserReservedIdleTimeout() time.Duration {
 // UserReservedMaxLifetime returns the per-user reserved pool max lifetime.
 func (c *Config) UserReservedMaxLifetime() time.Duration {
 	return c.userReservedMaxLifetime.Get()
+}
+
+// SessionScrubInterval returns how often each user pool probes one idle
+// connection for session-state divergence (0 = disabled).
+func (c *Config) SessionScrubInterval() time.Duration {
+	return c.sessionScrubInterval.Get()
 }
 
 // SettingsCacheSize returns the settings cache size.

--- a/go/services/multipooler/internal/connpoolmanager/manager.go
+++ b/go/services/multipooler/internal/connpoolmanager/manager.go
@@ -428,8 +428,12 @@ func (m *Manager) createUserPoolSlow(ctx context.Context, user string, clientKey
 			ConnectTimeout:    userConnectTimeout,
 			ConnectionCount:   m.metrics.RegularConnCount(),
 			ServerConnMetrics: m.metrics.ServerConnMetrics(),
+			ScrubInterval:     m.config.SessionScrubInterval(),
+			ScrubMetrics:      m.metrics.ScrubMetrics(),
 			Logger:            m.logger,
 		},
+		// The reserved pool's underlying regular pool is where clean reserved
+		// releases land after relabeling, so it is scrubbed too.
 		ReservedPoolConfig: &connpool.Config{
 			Name:              "reserved:" + user,
 			PoolType:          "reserved",
@@ -439,6 +443,8 @@ func (m *Manager) createUserPoolSlow(ctx context.Context, user string, clientKey
 			ConnectTimeout:    userConnectTimeout,
 			ConnectionCount:   m.metrics.ReservedConnCount(),
 			ServerConnMetrics: m.metrics.ServerConnMetrics(),
+			ScrubInterval:     m.config.SessionScrubInterval(),
+			ScrubMetrics:      m.metrics.ScrubMetrics(),
 			Logger:            m.logger,
 		},
 		ReservedInactivityTimeout: m.config.UserReservedInactivityTimeout(),

--- a/go/services/multipooler/internal/connpoolmanager/metrics.go
+++ b/go/services/multipooler/internal/connpoolmanager/metrics.go
@@ -68,6 +68,10 @@ type Metrics struct {
 	// setup latency), shared across all pools and tagged per-pool by pool_type.
 	serverConnMetrics connpool.ServerConnMetrics
 
+	// scrubMetrics tracks session-state scrub outcomes (probes, divergence,
+	// errors), shared across all pools and tagged per-pool by pool_type.
+	scrubMetrics connpool.ScrubMetrics
+
 	// --- Observable gauges for PgBouncer-equivalent metrics ---
 
 	// poolerUp reports whether the pooler is operational (1 = up, 0 = down).
@@ -150,6 +154,13 @@ func NewMetrics() (*Metrics, error) {
 		errs = append(errs, fmt.Errorf("ServerConnMetrics: %w", err))
 	}
 	m.serverConnMetrics = serverConnMetrics
+
+	// Session-state scrub metrics, shared across all pools.
+	scrubMetrics, err := connpool.NewScrubMetrics(meter)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("ScrubMetrics: %w", err))
+	}
+	m.scrubMetrics = scrubMetrics
 
 	// ConnectionCount for reserved pools
 	reservedCount, err := connpool.NewConnectionCount(meter)
@@ -528,6 +539,11 @@ func (m *Metrics) RegularConnCount() connpool.ConnectionCount {
 // ReservedConnCount returns the ConnectionCount metric for reserved pools.
 func (m *Metrics) ReservedConnCount() connpool.ConnectionCount {
 	return m.reservedConnCount
+}
+
+// ScrubMetrics returns the shared session-state scrub metrics.
+func (m *Metrics) ScrubMetrics() connpool.ScrubMetrics {
+	return m.scrubMetrics
 }
 
 // ServerConnMetrics returns the shared server-connection lifecycle metrics.

--- a/go/services/multipooler/internal/connstate/connection_state.go
+++ b/go/services/multipooler/internal/connstate/connection_state.go
@@ -321,9 +321,8 @@ func (s *Settings) ApplyQuery() string {
 
 	// Build apply query using set_config() for correct list GUC handling.
 	for _, k := range keys {
-		appendStmt("SELECT pg_catalog.set_config('" +
-			strings.ReplaceAll(k, "'", "''") + "', '" +
-			strings.ReplaceAll(s.Vars[k], "'", "''") + "', false)")
+		appendStmt("SELECT pg_catalog.set_config(" + ast.QuoteStringLiteral(k) + ", " +
+			ast.QuoteStringLiteral(s.Vars[k]) + ", false)")
 	}
 
 	if v, ok := s.Vars["session_authorization"]; ok {

--- a/go/services/multipooler/internal/connstate/settings_cache_test.go
+++ b/go/services/multipooler/internal/connstate/settings_cache_test.go
@@ -316,6 +316,19 @@ func TestSettingsApplyQuerySQLInjection(t *testing.T) {
 	assert.Equal(t, expected, s.ApplyQuery())
 }
 
+func TestSettingsApplyQueryBackslashInValue(t *testing.T) {
+	// Under standard_conforming_strings=off a backslash escapes the next
+	// character, so a quote-only escape of my\'app; ... would terminate the
+	// literal. Backslash values must be emitted as E'...' with the backslash
+	// doubled, which decodes identically under either setting.
+	s := NewSettings(map[string]string{
+		"application_name": `my\'app; DROP TABLE users--`,
+	}, 1)
+
+	expected := `SELECT pg_catalog.set_config('application_name', E'my\\''app; DROP TABLE users--', false)`
+	assert.Equal(t, expected, s.ApplyQuery())
+}
+
 func TestSettingsApplyQuerySingleQuoteInName(t *testing.T) {
 	// Single quotes in variable names must also be escaped.
 	s := NewSettings(map[string]string{

--- a/go/services/multipooler/internal/pools/connpool/interfaces.go
+++ b/go/services/multipooler/internal/pools/connpool/interfaces.go
@@ -21,39 +21,47 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/internal/connstate"
 )
 
-// SessionDivergence lists the GUC names on which a backend's real session
-// state disagrees with its tracked settings label. It carries names only,
-// never values: GUC values can hold sensitive data (e.g. request claims) and
-// this type flows into logs and metrics.
-type SessionDivergence struct {
-	// Untracked are GUCs with source='session' on the backend that the
-	// tracked settings label does not contain. This is the dangerous class:
-	// session state that escaped tracking (e.g. a set_config hidden in a
-	// routine body) and would leak to the next borrower.
+// Divergence lists the names on which a backend's real state disagrees with
+// the state the pool tracks for it. It carries names only, never values:
+// tracked values can hold sensitive data (e.g. request claims) and this type
+// flows into logs and metrics.
+type Divergence struct {
+	// Untracked is real backend state that tracking does not know about.
+	// This is the dangerous class: state that escaped tracking (e.g. a
+	// set_config hidden in a routine body) and would leak to the next
+	// borrower.
 	Untracked []string
 
-	// Phantom are tracked label entries with no session-source GUC on the
-	// backend: tracking claims a SET that the backend never saw (or saw
-	// reverted), so the label promises state the connection doesn't have.
+	// Phantom is tracked state with no real counterpart on the backend:
+	// tracking claims something the backend never saw (or saw reverted).
 	Phantom []string
 
-	// Mismatched are names present in both whose values still differ after
-	// asking PostgreSQL to normalize the tracked value (unit and case
-	// spellings like '64MB' vs '65536' are not divergence).
+	// Mismatched are names present on both sides whose values differ.
 	Mismatched []string
 }
 
 // IsDiverged reports whether any divergence was found.
-func (d SessionDivergence) IsDiverged() bool {
+func (d Divergence) IsDiverged() bool {
 	return len(d.Untracked)+len(d.Phantom)+len(d.Mismatched) > 0
 }
 
-// SessionStateVerifier is implemented by pooled connections that can compare
-// their tracked settings label against the backend's real session state. The
-// pool's session-state scrubber probes idle connections through this
-// interface and replaces any that report divergence.
-type SessionStateVerifier interface {
-	VerifySessionState(ctx context.Context) (SessionDivergence, error)
+// ConnChecker verifies one concern of a pooled connection's real backend
+// state against what the pool tracks for it — session GUCs, prepared
+// statements, residual locks, and so on. The pool's scrubber runs every
+// registered checker against idle connections and replaces any connection
+// that reports divergence; checkers only detect, the scrubber acts.
+//
+// Register checkers with Pool.RegisterChecker before Pool.Open.
+type ConnChecker[C Connection] interface {
+	// Name is the bounded label used for logs and metrics (e.g.
+	// "session_state").
+	Name() string
+
+	// Check compares the connection's real backend state against its
+	// tracked state. It must be side-effect-free and runs only on idle
+	// connections. An error means no verdict could be produced (the
+	// connection is not punished for it).
+	Check(ctx context.Context, conn C) (Divergence, error)
 }
 
 // Connection represents a pooled database connection.

--- a/go/services/multipooler/internal/pools/connpool/interfaces.go
+++ b/go/services/multipooler/internal/pools/connpool/interfaces.go
@@ -21,6 +21,41 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/internal/connstate"
 )
 
+// SessionDivergence lists the GUC names on which a backend's real session
+// state disagrees with its tracked settings label. It carries names only,
+// never values: GUC values can hold sensitive data (e.g. request claims) and
+// this type flows into logs and metrics.
+type SessionDivergence struct {
+	// Untracked are GUCs with source='session' on the backend that the
+	// tracked settings label does not contain. This is the dangerous class:
+	// session state that escaped tracking (e.g. a set_config hidden in a
+	// routine body) and would leak to the next borrower.
+	Untracked []string
+
+	// Phantom are tracked label entries with no session-source GUC on the
+	// backend: tracking claims a SET that the backend never saw (or saw
+	// reverted), so the label promises state the connection doesn't have.
+	Phantom []string
+
+	// Mismatched are names present in both whose values still differ after
+	// asking PostgreSQL to normalize the tracked value (unit and case
+	// spellings like '64MB' vs '65536' are not divergence).
+	Mismatched []string
+}
+
+// IsDiverged reports whether any divergence was found.
+func (d SessionDivergence) IsDiverged() bool {
+	return len(d.Untracked)+len(d.Phantom)+len(d.Mismatched) > 0
+}
+
+// SessionStateVerifier is implemented by pooled connections that can compare
+// their tracked settings label against the backend's real session state. The
+// pool's session-state scrubber probes idle connections through this
+// interface and replaces any that report divergence.
+type SessionStateVerifier interface {
+	VerifySessionState(ctx context.Context) (SessionDivergence, error)
+}
+
 // Connection represents a pooled database connection.
 // Implementations must be safe for concurrent use by a single client.
 type Connection interface {

--- a/go/services/multipooler/internal/pools/connpool/metrics.go
+++ b/go/services/multipooler/internal/pools/connpool/metrics.go
@@ -141,6 +141,95 @@ func (s ServerConnMetrics) RecordOpenError(ctx context.Context, poolType string,
 	))
 }
 
+// ScrubMetrics records session-state scrub outcomes: probes run, divergence
+// found (by kind), and probe failures. Created once by the pool owner
+// (connpoolmanager) and shared across pools; the bounded pool_type attribute
+// is supplied per call, like ServerConnMetrics.
+type ScrubMetrics struct {
+	checked    metric.Int64Counter
+	divergence metric.Int64Counter
+	errors     metric.Int64Counter
+}
+
+// NewScrubMetrics creates the session-state scrub instruments. Instruments
+// that fail to initialise fall back to noop and the joined error is returned
+// for logging.
+func NewScrubMetrics(m metric.Meter) (ScrubMetrics, error) {
+	var s ScrubMetrics
+	var errs []error
+	var err error
+
+	s.checked, err = m.Int64Counter(
+		"mg.pooler.session_scrub.checked",
+		metric.WithDescription("Idle connections probed for session-state divergence"),
+		metric.WithUnit("{connection}"),
+	)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("mg.pooler.session_scrub.checked counter: %w", err))
+		s.checked = noop.Int64Counter{}
+	}
+
+	s.divergence, err = m.Int64Counter(
+		"mg.pooler.session_scrub.divergence",
+		metric.WithDescription("GUCs found diverged between a connection's tracked settings label and its real session state (the connection is replaced); any nonzero value indicates session-state tracking was bypassed"),
+		metric.WithUnit("{guc}"),
+	)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("mg.pooler.session_scrub.divergence counter: %w", err))
+		s.divergence = noop.Int64Counter{}
+	}
+
+	s.errors, err = m.Int64Counter(
+		"mg.pooler.session_scrub.errors",
+		metric.WithDescription("Session-state scrub probes that failed to produce a verdict"),
+		metric.WithUnit("{error}"),
+	)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("mg.pooler.session_scrub.errors counter: %w", err))
+		s.errors = noop.Int64Counter{}
+	}
+
+	return s, errors.Join(errs...)
+}
+
+// RecordCheck records one completed scrub probe.
+func (s ScrubMetrics) RecordCheck(ctx context.Context, poolType string) {
+	if s.checked == nil {
+		return
+	}
+	s.checked.Add(ctx, 1, metric.WithAttributes(attribute.String("pool_type", poolType)))
+}
+
+// RecordDivergence records the diverged GUC names of one divergent
+// connection, attributed by divergence kind. Only counts are recorded, never
+// names or values.
+func (s ScrubMetrics) RecordDivergence(ctx context.Context, poolType string, div SessionDivergence) {
+	if s.divergence == nil {
+		return
+	}
+	for kind, names := range map[string][]string{
+		"untracked":  div.Untracked,
+		"phantom":    div.Phantom,
+		"mismatched": div.Mismatched,
+	} {
+		if len(names) == 0 {
+			continue
+		}
+		s.divergence.Add(ctx, int64(len(names)), metric.WithAttributes(
+			attribute.String("pool_type", poolType),
+			attribute.String("kind", kind),
+		))
+	}
+}
+
+// RecordError records a scrub probe that failed to produce a verdict.
+func (s ScrubMetrics) RecordError(ctx context.Context, poolType string) {
+	if s.errors == nil {
+		return
+	}
+	s.errors.Add(ctx, 1, metric.WithAttributes(attribute.String("pool_type", poolType)))
+}
+
 // openErrorReason maps a connection-establishment error to a bounded reason
 // label: "timeout" for context-deadline/cancel, "error" otherwise.
 func openErrorReason(err error) string {

--- a/go/services/multipooler/internal/pools/connpool/metrics.go
+++ b/go/services/multipooler/internal/pools/connpool/metrics.go
@@ -200,10 +200,10 @@ func (s ScrubMetrics) RecordCheck(ctx context.Context, poolType string) {
 	s.checked.Add(ctx, 1, metric.WithAttributes(attribute.String("pool_type", poolType)))
 }
 
-// RecordDivergence records the diverged GUC names of one divergent
-// connection, attributed by divergence kind. Only counts are recorded, never
-// names or values.
-func (s ScrubMetrics) RecordDivergence(ctx context.Context, poolType string, div SessionDivergence) {
+// RecordDivergence records one checker's diverged names on a divergent
+// connection, attributed by checker and divergence kind. Only counts are
+// recorded, never names or values.
+func (s ScrubMetrics) RecordDivergence(ctx context.Context, poolType, checker string, div Divergence) {
 	if s.divergence == nil {
 		return
 	}
@@ -217,17 +217,21 @@ func (s ScrubMetrics) RecordDivergence(ctx context.Context, poolType string, div
 		}
 		s.divergence.Add(ctx, int64(len(names)), metric.WithAttributes(
 			attribute.String("pool_type", poolType),
+			attribute.String("checker", checker),
 			attribute.String("kind", kind),
 		))
 	}
 }
 
-// RecordError records a scrub probe that failed to produce a verdict.
-func (s ScrubMetrics) RecordError(ctx context.Context, poolType string) {
+// RecordError records a checker run that failed to produce a verdict.
+func (s ScrubMetrics) RecordError(ctx context.Context, poolType, checker string) {
 	if s.errors == nil {
 		return
 	}
-	s.errors.Add(ctx, 1, metric.WithAttributes(attribute.String("pool_type", poolType)))
+	s.errors.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("pool_type", poolType),
+		attribute.String("checker", checker),
+	))
 }
 
 // openErrorReason maps a connection-establishment error to a bounded reason

--- a/go/services/multipooler/internal/pools/connpool/pool.go
+++ b/go/services/multipooler/internal/pools/connpool/pool.go
@@ -53,6 +53,9 @@ type Metrics struct {
 	idleClosed        atomic.Int64
 	diffState         atomic.Int64
 	resetState        atomic.Int64
+	scrubChecked      atomic.Int64
+	scrubDivergent    atomic.Int64
+	scrubErrors       atomic.Int64
 }
 
 func (m *Metrics) MaxLifetimeClosed() int64 { return m.maxLifetimeClosed.Load() }
@@ -63,6 +66,19 @@ func (m *Metrics) WaitTime() time.Duration  { return time.Duration(m.waitTime.Lo
 func (m *Metrics) IdleClosed() int64        { return m.idleClosed.Load() }
 func (m *Metrics) DiffStateCount() int64    { return m.diffState.Load() }
 func (m *Metrics) ResetStateCount() int64   { return m.resetState.Load() }
+
+// ScrubCheckedCount is the number of idle connections probed by the
+// session-state scrubber.
+func (m *Metrics) ScrubCheckedCount() int64 { return m.scrubChecked.Load() }
+
+// ScrubDivergentCount is the number of connections the scrubber found with
+// real session state diverged from their tracked settings label (each was
+// closed and replaced).
+func (m *Metrics) ScrubDivergentCount() int64 { return m.scrubDivergent.Load() }
+
+// ScrubErrorCount is the number of scrub probes that failed to produce a
+// verdict.
+func (m *Metrics) ScrubErrorCount() int64 { return m.scrubErrors.Load() }
 
 // Connector is a function that creates a new connection.
 // ctx is used for the dial/startup operations.
@@ -110,6 +126,17 @@ type Config struct {
 
 	// OnRecycle is called after a connection is returned to the pool (optional).
 	OnRecycle func()
+
+	// ScrubInterval is how often the session-state scrubber probes one idle
+	// connection for divergence between its tracked settings label and the
+	// backend's real session state. Divergent connections are closed and
+	// replaced. Zero disables scrubbing. Only enable on pools whose
+	// connections implement SessionStateVerifier.
+	ScrubInterval time.Duration
+
+	// ScrubMetrics records session-state scrub outcomes (optional, noop if
+	// not set). Shared across pools and created by the owner.
+	ScrubMetrics ScrubMetrics
 }
 
 // stackMask is the number of connection state stacks minus one;
@@ -181,6 +208,9 @@ type Pool[C Connection] struct {
 		onBorrow func()
 		// onRecycle is called after a connection is returned to the pool
 		onRecycle func()
+		// scrubInterval is how often the session-state scrubber probes one
+		// idle connection; zero disables scrubbing
+		scrubInterval time.Duration
 	}
 
 	Metrics Metrics
@@ -195,6 +225,9 @@ type Pool[C Connection] struct {
 	// bounded attribute applied to them. Provided via Config.
 	serverConnMetrics ServerConnMetrics
 	poolType          string
+
+	// scrubMetrics records session-state scrub outcomes. Provided via Config.
+	scrubMetrics ScrubMetrics
 }
 
 // NewPool creates a new connection pool with the given Config.
@@ -213,12 +246,14 @@ func NewPool[C Connection](ctx context.Context, config *Config) *Pool[C] {
 	pool.config.logWait = config.LogWait
 	pool.config.onBorrow = config.OnBorrow
 	pool.config.onRecycle = config.OnRecycle
+	pool.config.scrubInterval = config.ScrubInterval
 	pool.logger = config.Logger
 	if pool.logger == nil {
 		pool.logger = slog.Default()
 	}
 	pool.otelConnectionCount = config.ConnectionCount
 	pool.serverConnMetrics = config.ServerConnMetrics
+	pool.scrubMetrics = config.ScrubMetrics
 	pool.poolType = config.PoolType
 	pool.wait.init()
 
@@ -282,6 +317,16 @@ func (pool *Pool[C]) open() {
 		pool.runWorker(closeChan, idleTimeout/10, func(now time.Time) bool {
 			pool.closeIdleResources(now)
 			return true
+		})
+	}
+
+	if scrubInterval := pool.config.scrubInterval; scrubInterval > 0 {
+		// The scrub worker probes one idle connection per tick for divergence
+		// between its tracked settings label and the backend's real session
+		// state, replacing connections that diverged. See scrub.go.
+		var cursor int
+		pool.runWorker(closeChan, scrubInterval, func(_ time.Time) bool {
+			return pool.scrubOne(&cursor)
 		})
 	}
 

--- a/go/services/multipooler/internal/pools/connpool/pool.go
+++ b/go/services/multipooler/internal/pools/connpool/pool.go
@@ -228,6 +228,11 @@ type Pool[C Connection] struct {
 
 	// scrubMetrics records session-state scrub outcomes. Provided via Config.
 	scrubMetrics ScrubMetrics
+
+	// checkers verify idle connections' real backend state against tracked
+	// state; run by the scrub worker. Populated via RegisterChecker before
+	// Open, read-only afterwards.
+	checkers []ConnChecker[C]
 }
 
 // NewPool creates a new connection pool with the given Config.
@@ -320,7 +325,7 @@ func (pool *Pool[C]) open() {
 		})
 	}
 
-	if scrubInterval := pool.config.scrubInterval; scrubInterval > 0 {
+	if scrubInterval := pool.config.scrubInterval; scrubInterval > 0 && len(pool.checkers) > 0 {
 		// The scrub worker probes one idle connection per tick for divergence
 		// between its tracked settings label and the backend's real session
 		// state, replacing connections that diverged. See scrub.go.
@@ -346,6 +351,14 @@ func (pool *Pool[C]) open() {
 			return true
 		})
 	}
+}
+
+// RegisterChecker adds a state checker for the scrub worker to run against
+// idle connections. Must be called before Open (pool constructors register
+// checkers; the worker reads the slice without locking). Scrubbing runs only
+// when Config.ScrubInterval is set AND at least one checker is registered.
+func (pool *Pool[C]) RegisterChecker(c ConnChecker[C]) {
+	pool.checkers = append(pool.checkers, c)
 }
 
 // Open starts the background workers that manage the pool and gets it ready

--- a/go/services/multipooler/internal/pools/connpool/pool.go
+++ b/go/services/multipooler/internal/pools/connpool/pool.go
@@ -184,6 +184,11 @@ type Pool[C Connection] struct {
 	// ctx is the context used for background pool operations
 	ctx context.Context
 
+	// scrubCtx is derived from ctx on open and cancelled by CloseWithContext
+	// before it drains, so an in-flight scrub probe cannot delay shutdown.
+	scrubCtx    context.Context
+	scrubCancel context.CancelFunc
+
 	config struct {
 		// connect is the callback to create a new connection for the pool
 		connect Connector[C]
@@ -301,6 +306,8 @@ func (pool *Pool[C]) open() {
 		return
 	}
 	pool.capacity.Store(pool.config.maxCapacity)
+	//nolint:gosec // G118: scrubCancel is called by CloseWithContext before draining.
+	pool.scrubCtx, pool.scrubCancel = context.WithCancel(pool.ctx)
 	pool.setIdleCount()
 
 	// The expire worker takes care of removing from the waiter list any clients whose
@@ -397,6 +404,9 @@ func (pool *Pool[C]) CloseWithContext(ctx context.Context) error {
 		// already closed
 		return nil
 	}
+
+	// Abort any in-flight scrub probe so the drain below does not wait on it.
+	pool.scrubCancel()
 
 	// Set capacity to 0 and close all idle connections immediately
 	_ = pool.setCapacity(0)

--- a/go/services/multipooler/internal/pools/connpool/scrub.go
+++ b/go/services/multipooler/internal/pools/connpool/scrub.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connpool
+
+import (
+	"context"
+	"time"
+)
+
+// The session-state scrubber is the safety net for the gateway-authoritative
+// session model: the pool trusts each connection's tracked settings label
+// absolutely (pointer-equal reuse and clean-stack reuse run zero SQL), so any
+// session mutation that escaped tracking — a set_config hidden in a routine
+// body, a tracking bug, an out-of-band DDL — silently leaks to the next
+// borrower. The scrubber periodically probes idle connections through
+// SessionStateVerifier, emits metrics when the real backend state diverges
+// from the label, and closes and replaces divergent connections.
+//
+// It only touches idle connections, so it adds no latency to the query path.
+// It is a sampler: it narrows the leak window and raises an alarm, but the
+// gateway's tracking gates remain the correctness boundary.
+
+// scrubProbeTimeout bounds one verification probe. Kept well under
+// PoolCloseTimeout so an in-flight probe cannot stall pool shutdown.
+const scrubProbeTimeout = 5 * time.Second
+
+// scrubStackCount is the number of idle stacks the scrubber rotates over:
+// the clean stack plus the settings stacks.
+const scrubStackCount = stackMask + 2
+
+// scrubStack maps a rotation index to an idle stack: 0 is the clean stack,
+// 1..stackMask+1 are the settings stacks.
+func (pool *Pool[C]) scrubStack(i int) *connStack[C] {
+	if i == 0 {
+		return &pool.clean
+	}
+	return &pool.states[i-1]
+}
+
+// scrubPop pops an idle connection like pool.pop, but also returns the
+// connection's pre-borrow timeUsed value so the scrubber can restore it: a
+// scrub must not refresh the idle clock, or a small pool would have every
+// connection kept forever-fresh by scrubbing and the idle-timeout worker
+// could never shrink it. The stamp read before borrow is reliable: the only
+// concurrent writer for an in-stack connection is the expirer, and if it won
+// the race the borrow fails and the connection (already closed by the
+// expirer) is skipped.
+func (pool *Pool[C]) scrubPop(stack *connStack[C]) (*Pooled[C], time.Duration) {
+	for conn, ok := stack.Pop(); ok; conn, ok = stack.Pop() {
+		stamp := conn.timeUsed.get()
+		if conn.timeUsed.borrow() {
+			return conn, stamp
+		}
+	}
+	return nil, 0
+}
+
+// scrubOne probes one idle connection for session-state divergence, rotating
+// the starting stack across calls so every bucket gets coverage. A clean
+// connection returns to the pool with its idle clock intact; a divergent one
+// is closed and replaced. Returns false to stop the worker when the pool's
+// connections do not implement SessionStateVerifier (a wiring error).
+func (pool *Pool[C]) scrubOne(cursor *int) bool {
+	if pool.Capacity() == 0 {
+		return true
+	}
+
+	var conn *Pooled[C]
+	var stamp time.Duration
+	for i := range scrubStackCount {
+		idx := (*cursor + i) % scrubStackCount
+		if conn, stamp = pool.scrubPop(pool.scrubStack(idx)); conn != nil {
+			*cursor = (idx + 1) % scrubStackCount
+			break
+		}
+	}
+	if conn == nil {
+		return true
+	}
+
+	verifier, ok := Connection(conn.Conn).(SessionStateVerifier)
+	if !ok {
+		pool.logger.Error("session-state scrubbing enabled on a pool whose connections cannot verify session state; disabling scrubber",
+			"pool", pool.Name)
+		conn.timeUsed.set(stamp)
+		pool.tryReturnConn(conn)
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(pool.ctx, scrubProbeTimeout)
+	div, err := verifier.VerifySessionState(ctx)
+	cancel()
+
+	pool.Metrics.scrubChecked.Add(1)
+	pool.scrubMetrics.RecordCheck(pool.ctx, pool.poolType)
+
+	switch {
+	case err != nil:
+		pool.Metrics.scrubErrors.Add(1)
+		pool.scrubMetrics.RecordError(pool.ctx, pool.poolType)
+		if conn.Conn.IsClosed() {
+			// The probe killed the connection (dead socket); free the slot
+			// and replace it, mirroring closeIdleResources.
+			pool.closedConn()
+			pool.scrubReplace()
+		} else {
+			// The probe failed but the connection is alive (e.g. timeout);
+			// don't punish the connection for a probe problem.
+			pool.logger.Warn("session-state scrub probe failed",
+				"pool", pool.Name, "error", err)
+			conn.timeUsed.set(stamp)
+			pool.tryReturnConn(conn)
+		}
+	case div.IsDiverged():
+		pool.Metrics.scrubDivergent.Add(1)
+		pool.scrubMetrics.RecordDivergence(pool.ctx, pool.poolType, div)
+		// Divergence means tracking was bypassed, and the session GUCs are
+		// only the observable part of what the untracked code did: fail
+		// closed and replace the backend rather than reconcile it.
+		// SessionDivergence carries GUC names only, never values.
+		pool.logger.Warn("session-state divergence detected; replacing backend",
+			"pool", pool.Name,
+			"untracked", div.Untracked,
+			"phantom", div.Phantom,
+			"mismatched", div.Mismatched)
+		conn.Close()
+		pool.closedConn()
+		pool.scrubReplace()
+	default:
+		conn.timeUsed.set(stamp)
+		pool.tryReturnConn(conn)
+	}
+	return true
+}
+
+// scrubReplace opens a replacement connection for a slot the scrubber freed.
+// A failed replacement is not retried here: the freed capacity lets the next
+// Get open a connection on demand.
+func (pool *Pool[C]) scrubReplace() {
+	if conn, err := pool.getNew(pool.ctx); err == nil && conn != nil {
+		pool.tryReturnConn(conn)
+	}
+}

--- a/go/services/multipooler/internal/pools/connpool/scrub.go
+++ b/go/services/multipooler/internal/pools/connpool/scrub.go
@@ -32,8 +32,9 @@ import (
 // It is a sampler: it narrows the leak window and raises an alarm, but the
 // tracking gates remain the correctness boundary.
 
-// scrubProbeTimeout bounds one verification probe. Kept well under
-// PoolCloseTimeout so an in-flight probe cannot stall pool shutdown.
+// scrubProbeTimeout bounds one verification probe. Pool close cancels
+// pool.scrubCtx before draining, so an in-flight probe never stalls
+// shutdown; this timeout only bounds probes against a hung backend.
 const scrubProbeTimeout = 5 * time.Second
 
 // scrubStackCount is the number of idle stacks the scrubber rotates over:
@@ -70,8 +71,8 @@ func (pool *Pool[C]) scrubPop(stack *connStack[C]) (*Pooled[C], time.Duration) {
 // scrubOne runs every registered checker against one idle connection,
 // rotating the starting stack across calls so every bucket gets coverage. A
 // clean connection returns to the pool with its idle clock intact; a
-// divergent one is closed and replaced. The bool return keeps the runWorker
-// signature; it is always true.
+// divergent one, or one whose state could not be verified, is closed and
+// replaced. The bool return keeps the runWorker signature; it is always true.
 func (pool *Pool[C]) scrubOne(cursor *int) bool {
 	if pool.Capacity() == 0 || len(pool.checkers) == 0 {
 		return true
@@ -89,11 +90,14 @@ func (pool *Pool[C]) scrubOne(cursor *int) bool {
 	if conn == nil {
 		return true
 	}
+	// The scrubber holds the connection like a borrower, so Available and
+	// the idle-limit math stay accurate while the probe is in flight.
+	pool.borrowed.Add(1)
 
 	// Run every checker, collecting per-checker findings. A checker error
-	// means no verdict from that checker; findings already collected still
-	// count (fail closed). A dead connection ends the loop — later checkers
-	// cannot produce verdicts on it.
+	// ends the loop: the connection's state is unverified and it is replaced
+	// below (fail closed). A dead connection ends the loop too — later
+	// checkers cannot produce verdicts on it.
 	type finding struct {
 		checker string
 		div     Divergence
@@ -101,7 +105,7 @@ func (pool *Pool[C]) scrubOne(cursor *int) bool {
 	var findings []finding
 	var checkErr error
 	var errChecker string
-	ctx, cancel := context.WithTimeout(pool.ctx, scrubProbeTimeout)
+	ctx, cancel := context.WithTimeout(pool.scrubCtx, scrubProbeTimeout)
 	for _, checker := range pool.checkers {
 		div, err := checker.Check(ctx, conn.Conn)
 		if err != nil {
@@ -123,6 +127,7 @@ func (pool *Pool[C]) scrubOne(cursor *int) bool {
 		pool.Metrics.scrubErrors.Add(1)
 		pool.scrubMetrics.RecordError(pool.ctx, pool.poolType, errChecker)
 	}
+	pool.borrowed.Add(-1)
 
 	switch {
 	case len(findings) > 0:
@@ -143,18 +148,22 @@ func (pool *Pool[C]) scrubOne(cursor *int) bool {
 		conn.Close()
 		pool.closedConn()
 		pool.scrubReplace()
-	case conn.Conn.IsClosed():
-		// A check killed the connection (dead socket); free the slot and
-		// replace it, mirroring closeIdleResources.
+	case checkErr != nil || conn.Conn.IsClosed():
+		// No verdict: either a check killed the connection (dead socket) or a
+		// checker failed (timeout, probe error). An unverified backend may
+		// still carry hidden state, and a client could induce probe failures
+		// deliberately (e.g. a tiny tracked statement_timeout), so fail
+		// closed and replace it. Churn is bounded to one connection per
+		// scrub tick.
+		if checkErr != nil {
+			pool.logger.Warn("connection state check failed; replacing backend",
+				"pool", pool.Name, "checker", errChecker, "error", checkErr)
+		}
+		if !conn.Conn.IsClosed() {
+			conn.Close()
+		}
 		pool.closedConn()
 		pool.scrubReplace()
-	case checkErr != nil:
-		// A checker failed but the connection is alive (e.g. timeout);
-		// don't punish the connection for a probe problem.
-		pool.logger.Warn("connection state check failed",
-			"pool", pool.Name, "checker", errChecker, "error", checkErr)
-		conn.timeUsed.set(stamp)
-		pool.tryReturnConn(conn)
 	default:
 		conn.timeUsed.set(stamp)
 		pool.tryReturnConn(conn)

--- a/go/services/multipooler/internal/pools/connpool/scrub.go
+++ b/go/services/multipooler/internal/pools/connpool/scrub.go
@@ -19,18 +19,18 @@ import (
 	"time"
 )
 
-// The session-state scrubber is the safety net for the gateway-authoritative
-// session model: the pool trusts each connection's tracked settings label
-// absolutely (pointer-equal reuse and clean-stack reuse run zero SQL), so any
-// session mutation that escaped tracking — a set_config hidden in a routine
-// body, a tracking bug, an out-of-band DDL — silently leaks to the next
-// borrower. The scrubber periodically probes idle connections through
-// SessionStateVerifier, emits metrics when the real backend state diverges
-// from the label, and closes and replaces divergent connections.
+// The scrubber is the safety net for state the pool trusts without
+// verification: the gateway-authoritative session model reuses connections
+// with zero SQL (pointer-equal labels, clean-stack reuse), so any backend
+// mutation that escaped tracking — a set_config hidden in a routine body, a
+// tracking bug, an out-of-band DDL — silently leaks to the next borrower.
+// The scrubber periodically runs every registered ConnChecker against idle
+// connections, emits metrics when real backend state diverges from tracked
+// state, and closes and replaces divergent connections.
 //
 // It only touches idle connections, so it adds no latency to the query path.
 // It is a sampler: it narrows the leak window and raises an alarm, but the
-// gateway's tracking gates remain the correctness boundary.
+// tracking gates remain the correctness boundary.
 
 // scrubProbeTimeout bounds one verification probe. Kept well under
 // PoolCloseTimeout so an in-flight probe cannot stall pool shutdown.
@@ -67,13 +67,13 @@ func (pool *Pool[C]) scrubPop(stack *connStack[C]) (*Pooled[C], time.Duration) {
 	return nil, 0
 }
 
-// scrubOne probes one idle connection for session-state divergence, rotating
-// the starting stack across calls so every bucket gets coverage. A clean
-// connection returns to the pool with its idle clock intact; a divergent one
-// is closed and replaced. Returns false to stop the worker when the pool's
-// connections do not implement SessionStateVerifier (a wiring error).
+// scrubOne runs every registered checker against one idle connection,
+// rotating the starting stack across calls so every bucket gets coverage. A
+// clean connection returns to the pool with its idle clock intact; a
+// divergent one is closed and replaced. The bool return keeps the runWorker
+// signature; it is always true.
 func (pool *Pool[C]) scrubOne(cursor *int) bool {
-	if pool.Capacity() == 0 {
+	if pool.Capacity() == 0 || len(pool.checkers) == 0 {
 		return true
 	}
 
@@ -90,54 +90,71 @@ func (pool *Pool[C]) scrubOne(cursor *int) bool {
 		return true
 	}
 
-	verifier, ok := Connection(conn.Conn).(SessionStateVerifier)
-	if !ok {
-		pool.logger.Error("session-state scrubbing enabled on a pool whose connections cannot verify session state; disabling scrubber",
-			"pool", pool.Name)
-		conn.timeUsed.set(stamp)
-		pool.tryReturnConn(conn)
-		return false
+	// Run every checker, collecting per-checker findings. A checker error
+	// means no verdict from that checker; findings already collected still
+	// count (fail closed). A dead connection ends the loop — later checkers
+	// cannot produce verdicts on it.
+	type finding struct {
+		checker string
+		div     Divergence
 	}
-
+	var findings []finding
+	var checkErr error
+	var errChecker string
 	ctx, cancel := context.WithTimeout(pool.ctx, scrubProbeTimeout)
-	div, err := verifier.VerifySessionState(ctx)
+	for _, checker := range pool.checkers {
+		div, err := checker.Check(ctx, conn.Conn)
+		if err != nil {
+			checkErr, errChecker = err, checker.Name()
+			break
+		}
+		if div.IsDiverged() {
+			findings = append(findings, finding{checker: checker.Name(), div: div})
+		}
+		if conn.Conn.IsClosed() {
+			break
+		}
+	}
 	cancel()
 
 	pool.Metrics.scrubChecked.Add(1)
 	pool.scrubMetrics.RecordCheck(pool.ctx, pool.poolType)
+	if checkErr != nil {
+		pool.Metrics.scrubErrors.Add(1)
+		pool.scrubMetrics.RecordError(pool.ctx, pool.poolType, errChecker)
+	}
 
 	switch {
-	case err != nil:
-		pool.Metrics.scrubErrors.Add(1)
-		pool.scrubMetrics.RecordError(pool.ctx, pool.poolType)
-		if conn.Conn.IsClosed() {
-			// The probe killed the connection (dead socket); free the slot
-			// and replace it, mirroring closeIdleResources.
-			pool.closedConn()
-			pool.scrubReplace()
-		} else {
-			// The probe failed but the connection is alive (e.g. timeout);
-			// don't punish the connection for a probe problem.
-			pool.logger.Warn("session-state scrub probe failed",
-				"pool", pool.Name, "error", err)
-			conn.timeUsed.set(stamp)
-			pool.tryReturnConn(conn)
-		}
-	case div.IsDiverged():
+	case len(findings) > 0:
 		pool.Metrics.scrubDivergent.Add(1)
-		pool.scrubMetrics.RecordDivergence(pool.ctx, pool.poolType, div)
-		// Divergence means tracking was bypassed, and the session GUCs are
+		// Divergence means tracking was bypassed, and what a checker sees is
 		// only the observable part of what the untracked code did: fail
 		// closed and replace the backend rather than reconcile it.
-		// SessionDivergence carries GUC names only, never values.
-		pool.logger.Warn("session-state divergence detected; replacing backend",
-			"pool", pool.Name,
-			"untracked", div.Untracked,
-			"phantom", div.Phantom,
-			"mismatched", div.Mismatched)
+		// Divergence carries names only, never values.
+		for _, f := range findings {
+			pool.scrubMetrics.RecordDivergence(pool.ctx, pool.poolType, f.checker, f.div)
+			pool.logger.Warn("session-state divergence detected; replacing backend",
+				"pool", pool.Name,
+				"checker", f.checker,
+				"untracked", f.div.Untracked,
+				"phantom", f.div.Phantom,
+				"mismatched", f.div.Mismatched)
+		}
 		conn.Close()
 		pool.closedConn()
 		pool.scrubReplace()
+	case conn.Conn.IsClosed():
+		// A check killed the connection (dead socket); free the slot and
+		// replace it, mirroring closeIdleResources.
+		pool.closedConn()
+		pool.scrubReplace()
+	case checkErr != nil:
+		// A checker failed but the connection is alive (e.g. timeout);
+		// don't punish the connection for a probe problem.
+		pool.logger.Warn("connection state check failed",
+			"pool", pool.Name, "checker", errChecker, "error", checkErr)
+		conn.timeUsed.set(stamp)
+		pool.tryReturnConn(conn)
 	default:
 		conn.timeUsed.set(stamp)
 		pool.tryReturnConn(conn)

--- a/go/services/multipooler/internal/pools/connpool/scrub_test.go
+++ b/go/services/multipooler/internal/pools/connpool/scrub_test.go
@@ -139,7 +139,9 @@ func TestScrubDivergentConnInSettingsStack(t *testing.T) {
 	assert.EqualValues(t, 1, pool.Active())
 }
 
-func TestScrubProbeErrorKeepsLiveConn(t *testing.T) {
+func TestScrubProbeErrorReplacesLiveConn(t *testing.T) {
+	// A probe failure leaves the backend unverified; a client could induce
+	// one deliberately to hide state, so the scrubber fails closed.
 	pool := newScrubTestPool(t, 2, nil)
 	conn := recycleIdle(t, pool, nil)
 	conn.verifyErr = errors.New("probe timeout")
@@ -147,14 +149,70 @@ func TestScrubProbeErrorKeepsLiveConn(t *testing.T) {
 	cursor := 0
 	assert.True(t, pool.scrubOne(&cursor))
 
-	assert.False(t, conn.IsClosed(), "a live conn is not punished for a probe failure")
+	assert.True(t, conn.IsClosed(), "an unverified conn is replaced")
 	assert.EqualValues(t, 1, pool.Metrics.ScrubErrorCount())
 	assert.EqualValues(t, 0, pool.Metrics.ScrubDivergentCount())
+	assert.EqualValues(t, 1, pool.Active(), "slot freed and replaced")
 
 	pooled, err := pool.Get(context.Background())
 	require.NoError(t, err)
-	assert.Same(t, conn, pooled.Conn)
+	assert.NotSame(t, conn, pooled.Conn)
 	pooled.Recycle()
+}
+
+// funcChecker runs an arbitrary closure as a ConnChecker.
+type funcChecker func(ctx context.Context, m *scrubMockConnection) (Divergence, error)
+
+func (funcChecker) Name() string { return "func" }
+func (f funcChecker) Check(ctx context.Context, m *scrubMockConnection) (Divergence, error) {
+	return f(ctx, m)
+}
+
+func TestScrubCountsHeldConnAsBorrowed(t *testing.T) {
+	// While a probe is in flight the connection is neither idle nor
+	// available; Available and the idle-limit math must reflect that.
+	pool := newScrubTestPool(t, 2, nil)
+	recycleIdle(t, pool, nil)
+
+	var during int64 = -1
+	pool.RegisterChecker(funcChecker(func(context.Context, *scrubMockConnection) (Divergence, error) {
+		during = pool.Available()
+		return Divergence{}, nil
+	}))
+
+	cursor := 0
+	assert.True(t, pool.scrubOne(&cursor))
+	assert.EqualValues(t, 1, during, "held conn is not available mid-probe")
+	assert.EqualValues(t, 2, pool.Available(), "released after the probe")
+	assert.EqualValues(t, 0, pool.InUse())
+}
+
+func TestScrubCloseCancelsInFlightProbe(t *testing.T) {
+	// Close must not wait out a slow probe: cancelling the scrub context
+	// aborts it and the freed connection is closed by the drain.
+	pool := newScrubTestPool(t, 2, nil)
+	recycleIdle(t, pool, nil)
+
+	probing := make(chan struct{})
+	pool.RegisterChecker(funcChecker(func(ctx context.Context, _ *scrubMockConnection) (Divergence, error) {
+		close(probing)
+		<-ctx.Done()
+		return Divergence{}, ctx.Err()
+	}))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		cursor := 0
+		pool.scrubOne(&cursor)
+	}()
+	<-probing
+
+	start := time.Now()
+	pool.Close()
+	assert.Less(t, time.Since(start), time.Second, "close waited on the probe")
+	<-done
+	assert.EqualValues(t, 0, pool.Active())
 }
 
 func TestScrubProbeErrorOnDeadConnReplaces(t *testing.T) {

--- a/go/services/multipooler/internal/pools/connpool/scrub_test.go
+++ b/go/services/multipooler/internal/pools/connpool/scrub_test.go
@@ -1,0 +1,245 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connpool
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/services/multipooler/internal/connstate"
+)
+
+// scrubMockConnection is a mockConnection that also implements
+// SessionStateVerifier with an injectable verdict.
+type scrubMockConnection struct {
+	mockConnection
+	div           SessionDivergence
+	verifyErr     error
+	closeOnVerify bool // simulate the probe killing a dead socket
+	verifyCalls   atomic.Int64
+}
+
+func (m *scrubMockConnection) VerifySessionState(ctx context.Context) (SessionDivergence, error) {
+	m.verifyCalls.Add(1)
+	if m.closeOnVerify {
+		m.closed.Store(true)
+	}
+	return m.div, m.verifyErr
+}
+
+func newScrubTestPool(t *testing.T, capacity int64, connect Connector[*scrubMockConnection]) *Pool[*scrubMockConnection] {
+	t.Helper()
+	pool := NewPool[*scrubMockConnection](context.Background(), &Config{
+		Name:         "scrub-test",
+		Capacity:     capacity,
+		MaxIdleCount: capacity,
+	})
+	if connect == nil {
+		connect = func(ctx context.Context, poolCtx context.Context) (*scrubMockConnection, error) {
+			return &scrubMockConnection{}, nil
+		}
+	}
+	pool.Open(connect, nil)
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// recycleIdle gets one connection and returns it to the idle stacks.
+func recycleIdle(t *testing.T, pool *Pool[*scrubMockConnection], settings *connstate.Settings) *scrubMockConnection {
+	t.Helper()
+	pooled, err := pool.GetWithSettings(context.Background(), settings)
+	require.NoError(t, err)
+	conn := pooled.Conn
+	pooled.Recycle()
+	return conn
+}
+
+func TestScrubCleanConnReturnsToPool(t *testing.T) {
+	pool := newScrubTestPool(t, 2, nil)
+	conn := recycleIdle(t, pool, nil)
+
+	cursor := 0
+	assert.True(t, pool.scrubOne(&cursor))
+
+	assert.EqualValues(t, 1, conn.verifyCalls.Load())
+	assert.EqualValues(t, 1, pool.Metrics.ScrubCheckedCount())
+	assert.EqualValues(t, 0, pool.Metrics.ScrubDivergentCount())
+	assert.False(t, conn.IsClosed())
+
+	// The same connection is handed out again.
+	pooled, err := pool.Get(context.Background())
+	require.NoError(t, err)
+	assert.Same(t, conn, pooled.Conn)
+	pooled.Recycle()
+}
+
+func TestScrubDivergentConnReplaced(t *testing.T) {
+	pool := newScrubTestPool(t, 2, nil)
+	conn := recycleIdle(t, pool, nil)
+	conn.div = SessionDivergence{Untracked: []string{"work_mem"}}
+
+	cursor := 0
+	assert.True(t, pool.scrubOne(&cursor))
+
+	assert.True(t, conn.IsClosed(), "divergent backend must be closed")
+	assert.EqualValues(t, 1, pool.Metrics.ScrubDivergentCount())
+	assert.EqualValues(t, 1, pool.Active(), "replacement must keep the slot accounted")
+
+	// The next borrower gets the replacement, never the divergent backend.
+	pooled, err := pool.Get(context.Background())
+	require.NoError(t, err)
+	assert.NotSame(t, conn, pooled.Conn)
+	assert.False(t, pooled.Conn.IsClosed())
+	pooled.Recycle()
+}
+
+func TestScrubDivergentConnInSettingsStack(t *testing.T) {
+	pool := newScrubTestPool(t, 2, nil)
+	settings := connstate.NewSettings(map[string]string{"work_mem": "64MB"}, 3)
+	conn := recycleIdle(t, pool, settings)
+	conn.div = SessionDivergence{Mismatched: []string{"work_mem"}}
+
+	// One scrub pass finds the connection regardless of which settings
+	// bucket it sits in.
+	cursor := 0
+	assert.True(t, pool.scrubOne(&cursor))
+
+	assert.True(t, conn.IsClosed())
+	assert.EqualValues(t, 1, pool.Metrics.ScrubDivergentCount())
+	assert.EqualValues(t, 1, pool.Active())
+}
+
+func TestScrubProbeErrorKeepsLiveConn(t *testing.T) {
+	pool := newScrubTestPool(t, 2, nil)
+	conn := recycleIdle(t, pool, nil)
+	conn.verifyErr = errors.New("probe timeout")
+
+	cursor := 0
+	assert.True(t, pool.scrubOne(&cursor))
+
+	assert.False(t, conn.IsClosed(), "a live conn is not punished for a probe failure")
+	assert.EqualValues(t, 1, pool.Metrics.ScrubErrorCount())
+	assert.EqualValues(t, 0, pool.Metrics.ScrubDivergentCount())
+
+	pooled, err := pool.Get(context.Background())
+	require.NoError(t, err)
+	assert.Same(t, conn, pooled.Conn)
+	pooled.Recycle()
+}
+
+func TestScrubProbeErrorOnDeadConnReplaces(t *testing.T) {
+	pool := newScrubTestPool(t, 2, nil)
+	conn := recycleIdle(t, pool, nil)
+	conn.verifyErr = errors.New("connection reset")
+	conn.closeOnVerify = true
+
+	cursor := 0
+	assert.True(t, pool.scrubOne(&cursor))
+
+	assert.EqualValues(t, 1, pool.Metrics.ScrubErrorCount())
+	assert.EqualValues(t, 1, pool.Active(), "dead conn's slot must be freed and replaced")
+
+	pooled, err := pool.Get(context.Background())
+	require.NoError(t, err)
+	assert.NotSame(t, conn, pooled.Conn)
+	pooled.Recycle()
+}
+
+func TestScrubPreservesIdleClock(t *testing.T) {
+	pool := newScrubTestPool(t, 2, nil)
+	recycleIdle(t, pool, nil)
+
+	// Read the idle stamp without borrowing it, then put the conn back.
+	pooled, ok := pool.clean.Pop()
+	require.True(t, ok)
+	stamp := pooled.timeUsed.get()
+	pool.clean.Push(pooled)
+
+	cursor := 0
+	assert.True(t, pool.scrubOne(&cursor))
+
+	// Scrubbing must not refresh the idle clock, or small pools would never
+	// shrink via idle timeout.
+	scrubbed, ok := pool.clean.Pop()
+	require.True(t, ok)
+	assert.Same(t, pooled, scrubbed)
+	assert.Equal(t, stamp, scrubbed.timeUsed.get())
+	pool.clean.Push(scrubbed)
+}
+
+func TestScrubEmptyPoolNoop(t *testing.T) {
+	pool := newScrubTestPool(t, 2, nil)
+	cursor := 0
+	assert.True(t, pool.scrubOne(&cursor))
+	assert.EqualValues(t, 0, pool.Metrics.ScrubCheckedCount())
+}
+
+func TestScrubStopsOnNonVerifierConn(t *testing.T) {
+	// newTestPool's mockConnection does not implement SessionStateVerifier;
+	// the scrubber must stop rather than spin, and must not lose the conn.
+	pool := newTestPool(2)
+	defer pool.Close()
+
+	pooled, err := pool.Get(context.Background())
+	require.NoError(t, err)
+	conn := pooled.Conn
+	pooled.Recycle()
+
+	cursor := 0
+	assert.False(t, pool.scrubOne(&cursor))
+	assert.EqualValues(t, 0, pool.Metrics.ScrubCheckedCount())
+
+	got, err := pool.Get(context.Background())
+	require.NoError(t, err)
+	assert.Same(t, conn, got.Conn)
+	got.Recycle()
+}
+
+func TestScrubWorkerReplacesDivergentConn(t *testing.T) {
+	// End-to-end through the background worker: a divergent idle connection
+	// is detected and replaced without any Get/Recycle traffic.
+	var created atomic.Int64
+	pool := NewPool[*scrubMockConnection](context.Background(), &Config{
+		Name:          "scrub-worker-test",
+		Capacity:      2,
+		MaxIdleCount:  2,
+		ScrubInterval: 10 * time.Millisecond,
+	})
+	pool.Open(func(ctx context.Context, poolCtx context.Context) (*scrubMockConnection, error) {
+		conn := &scrubMockConnection{}
+		if created.Add(1) == 1 {
+			// Only the first connection carries hidden session state.
+			conn.div = SessionDivergence{Untracked: []string{"work_mem"}}
+		}
+		return conn, nil
+	}, nil)
+	defer pool.Close()
+
+	first, err := pool.Get(context.Background())
+	require.NoError(t, err)
+	divergent := first.Conn
+	first.Recycle()
+
+	require.Eventually(t, func() bool {
+		return pool.Metrics.ScrubDivergentCount() == 1 && divergent.IsClosed()
+	}, 5*time.Second, 5*time.Millisecond, "scrub worker must replace the divergent backend")
+	assert.EqualValues(t, 1, pool.Active())
+}

--- a/go/services/multipooler/internal/pools/connpool/scrub_test.go
+++ b/go/services/multipooler/internal/pools/connpool/scrub_test.go
@@ -27,17 +27,28 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/internal/connstate"
 )
 
-// scrubMockConnection is a mockConnection that also implements
-// SessionStateVerifier with an injectable verdict.
+// scrubMockConnection is a mockConnection carrying an injectable per-conn
+// verdict that mockChecker reports.
 type scrubMockConnection struct {
 	mockConnection
-	div           SessionDivergence
+	div           Divergence
 	verifyErr     error
 	closeOnVerify bool // simulate the probe killing a dead socket
 	verifyCalls   atomic.Int64
 }
 
-func (m *scrubMockConnection) VerifySessionState(ctx context.Context) (SessionDivergence, error) {
+// mockChecker is a registered ConnChecker that reports whatever verdict the
+// probed connection carries.
+type mockChecker struct{ name string }
+
+func (c mockChecker) Name() string {
+	if c.name == "" {
+		return "mock"
+	}
+	return c.name
+}
+
+func (mockChecker) Check(ctx context.Context, m *scrubMockConnection) (Divergence, error) {
 	m.verifyCalls.Add(1)
 	if m.closeOnVerify {
 		m.closed.Store(true)
@@ -52,6 +63,7 @@ func newScrubTestPool(t *testing.T, capacity int64, connect Connector[*scrubMock
 		Capacity:     capacity,
 		MaxIdleCount: capacity,
 	})
+	pool.RegisterChecker(mockChecker{})
 	if connect == nil {
 		connect = func(ctx context.Context, poolCtx context.Context) (*scrubMockConnection, error) {
 			return &scrubMockConnection{}, nil
@@ -94,7 +106,7 @@ func TestScrubCleanConnReturnsToPool(t *testing.T) {
 func TestScrubDivergentConnReplaced(t *testing.T) {
 	pool := newScrubTestPool(t, 2, nil)
 	conn := recycleIdle(t, pool, nil)
-	conn.div = SessionDivergence{Untracked: []string{"work_mem"}}
+	conn.div = Divergence{Untracked: []string{"work_mem"}}
 
 	cursor := 0
 	assert.True(t, pool.scrubOne(&cursor))
@@ -115,7 +127,7 @@ func TestScrubDivergentConnInSettingsStack(t *testing.T) {
 	pool := newScrubTestPool(t, 2, nil)
 	settings := connstate.NewSettings(map[string]string{"work_mem": "64MB"}, 3)
 	conn := recycleIdle(t, pool, settings)
-	conn.div = SessionDivergence{Mismatched: []string{"work_mem"}}
+	conn.div = Divergence{Mismatched: []string{"work_mem"}}
 
 	// One scrub pass finds the connection regardless of which settings
 	// bucket it sits in.
@@ -192,9 +204,9 @@ func TestScrubEmptyPoolNoop(t *testing.T) {
 	assert.EqualValues(t, 0, pool.Metrics.ScrubCheckedCount())
 }
 
-func TestScrubStopsOnNonVerifierConn(t *testing.T) {
-	// newTestPool's mockConnection does not implement SessionStateVerifier;
-	// the scrubber must stop rather than spin, and must not lose the conn.
+func TestScrubNoopWithoutCheckers(t *testing.T) {
+	// A pool with no registered checkers has nothing to verify: scrubOne
+	// must not touch any connection (and open() never starts the worker).
 	pool := newTestPool(2)
 	defer pool.Close()
 
@@ -204,13 +216,49 @@ func TestScrubStopsOnNonVerifierConn(t *testing.T) {
 	pooled.Recycle()
 
 	cursor := 0
-	assert.False(t, pool.scrubOne(&cursor))
+	assert.True(t, pool.scrubOne(&cursor))
 	assert.EqualValues(t, 0, pool.Metrics.ScrubCheckedCount())
 
 	got, err := pool.Get(context.Background())
 	require.NoError(t, err)
 	assert.Same(t, conn, got.Conn)
 	got.Recycle()
+}
+
+func TestScrubRunsAllRegisteredCheckers(t *testing.T) {
+	// Findings from multiple checkers merge onto one replacement, and a
+	// checker error after an earlier checker's finding still fails closed.
+	pool := NewPool[*scrubMockConnection](context.Background(), &Config{
+		Name:         "scrub-multi-test",
+		Capacity:     2,
+		MaxIdleCount: 2,
+	})
+	pool.RegisterChecker(mockChecker{name: "first"})
+	pool.RegisterChecker(erroringChecker{})
+	pool.Open(func(ctx context.Context, poolCtx context.Context) (*scrubMockConnection, error) {
+		return &scrubMockConnection{}, nil
+	}, nil)
+	defer pool.Close()
+
+	conn := recycleIdle(t, pool, nil)
+	conn.div = Divergence{Untracked: []string{"work_mem"}}
+
+	cursor := 0
+	assert.True(t, pool.scrubOne(&cursor))
+
+	assert.EqualValues(t, 1, conn.verifyCalls.Load(), "first checker ran")
+	assert.True(t, conn.IsClosed(), "finding before the error must still replace the backend")
+	assert.EqualValues(t, 1, pool.Metrics.ScrubDivergentCount())
+	assert.EqualValues(t, 1, pool.Metrics.ScrubErrorCount())
+	assert.EqualValues(t, 1, pool.Active())
+}
+
+// erroringChecker always fails to produce a verdict.
+type erroringChecker struct{}
+
+func (erroringChecker) Name() string { return "erroring" }
+func (erroringChecker) Check(ctx context.Context, m *scrubMockConnection) (Divergence, error) {
+	return Divergence{}, errors.New("no verdict")
 }
 
 func TestScrubWorkerReplacesDivergentConn(t *testing.T) {
@@ -223,11 +271,12 @@ func TestScrubWorkerReplacesDivergentConn(t *testing.T) {
 		MaxIdleCount:  2,
 		ScrubInterval: 10 * time.Millisecond,
 	})
+	pool.RegisterChecker(mockChecker{})
 	pool.Open(func(ctx context.Context, poolCtx context.Context) (*scrubMockConnection, error) {
 		conn := &scrubMockConnection{}
 		if created.Add(1) == 1 {
 			// Only the first connection carries hidden session state.
-			conn.div = SessionDivergence{Untracked: []string{"work_mem"}}
+			conn.div = Divergence{Untracked: []string{"work_mem"}}
 		}
 		return conn, nil
 	}, nil)

--- a/go/services/multipooler/internal/pools/regular/pool.go
+++ b/go/services/multipooler/internal/pools/regular/pool.go
@@ -60,6 +60,7 @@ func NewPool(ctx context.Context, config *PoolConfig) *Pool {
 	}
 
 	pool := connpool.NewPool[*Conn](ctx, config.ConnPoolConfig)
+	pool.RegisterChecker(SessionStateChecker{})
 
 	return &Pool{
 		pool:   pool,

--- a/go/services/multipooler/internal/pools/regular/pool.go
+++ b/go/services/multipooler/internal/pools/regular/pool.go
@@ -71,6 +71,13 @@ func NewPool(ctx context.Context, config *PoolConfig) *Pool {
 // Open opens the pool and starts background workers.
 // Must be called before using the pool.
 func (p *Pool) Open() {
+	// INVARIANT: connection bootstrap must not create session-source GUC
+	// state outside the settings label. Anything set up here must arrive via
+	// startup-packet parameters (source='client') or be reflected in the
+	// label the pool tracks — a bare SET/set_config issued during bootstrap
+	// would register as untracked divergence and make the scrubber replace
+	// every connection each sweep. The e2e scrubber test asserts zero
+	// divergence from normal traffic as the canary for this.
 	connector := func(ctx context.Context, poolCtx context.Context) (*Conn, error) {
 		conn, err := client.Connect(ctx, poolCtx, p.config.ClientConfig)
 		if err != nil {

--- a/go/services/multipooler/internal/pools/regular/session_verify.go
+++ b/go/services/multipooler/internal/pools/regular/session_verify.go
@@ -151,6 +151,12 @@ func (c *Conn) VerifySessionState(ctx context.Context) (connpool.SessionDivergen
 		}
 	}
 
+	// The identity rows are part of the constant probe; their absence means
+	// the result cannot be trusted.
+	if len(identity) != 2 {
+		return div, errors.New("session state probe returned no identity rows")
+	}
+
 	// Ordinary GUCs: compare the session-source rows against the label.
 	var candidates []string
 	for name, realValue := range sessionVars {

--- a/go/services/multipooler/internal/pools/regular/session_verify.go
+++ b/go/services/multipooler/internal/pools/regular/session_verify.go
@@ -20,54 +20,29 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/services/multipooler/internal/connstate"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pools/connpool"
 )
 
-// The session-state probe reads the backend's real session GUC state in one
-// round trip and compares it against the connection's tracked settings label.
-// Three sources are combined, because pg_settings alone cannot see everything
-// (verified on PostgreSQL 17):
-//
-//   - 'session' rows: pg_settings WHERE source = 'session' — every defined
-//     GUC whose current value was installed by this session (SET,
-//     set_config(..., false), including any hidden inside routine bodies).
-//     current_setting() is used instead of pg_settings.setting because it
-//     returns the SHOW-style display form, which is also what set_config
-//     returns in the normalization probe, keeping comparisons
-//     apples-to-apples.
-//   - 'identity' rows: role and session_authorization are GUC_NO_SHOW_ALL —
-//     they NEVER appear in pg_settings — so they are read explicitly.
-//     current_setting('role') reports 'none' when no SET ROLE is in effect;
-//     session_user is the current session authorization.
-//   - 'custom' rows: placeholder GUCs (names with a dot, e.g. 'my.tenant')
-//     are also hidden from pg_settings until an extension defines them, so
-//     every custom name in the tracked label is read explicitly with
-//     current_setting(name, missing_ok := true), which returns NULL when the
-//     session has never seen the GUC.
-//
-// Known blind spot: a custom GUC set behind tracking's back on a connection
-// whose label does not contain it is undetectable — placeholder GUCs cannot
-// be enumerated from SQL. The creation-time rejection gates remain the
-// defense for that class.
-const sessionSourceProbe = "SELECT name, current_setting(name), 'session' FROM pg_settings WHERE source = 'session'" +
-	" UNION ALL SELECT 'role', pg_catalog.current_setting('role'), 'identity'" +
-	" UNION ALL SELECT 'session_authorization', session_user::text, 'identity'"
+// The probe SQL is constants.SessionSourceProbeSQL; see its documentation for
+// the three sources it combines and its known blind spot.
 
 // sessionStateQuery returns the probe SQL, extending the constant part with
 // one 'custom' row per tracked placeholder GUC. customNames must be sorted
-// for deterministic SQL. Single quotes are escaped by doubling, as in
-// Settings.ApplyQuery.
+// for deterministic SQL. Literals are quoted with ast.QuoteStringLiteral so
+// they are safe regardless of the backend's standard_conforming_strings.
 func sessionStateQuery(customNames []string) string {
 	var b strings.Builder
-	b.WriteString(sessionSourceProbe)
+	b.WriteString(constants.SessionSourceProbeSQL)
 	for _, name := range customNames {
-		escaped := strings.ReplaceAll(name, "'", "''")
-		b.WriteString(" UNION ALL SELECT '")
-		b.WriteString(escaped)
-		b.WriteString("', pg_catalog.current_setting('")
-		b.WriteString(escaped)
-		b.WriteString("', true), 'custom'")
+		lit := ast.QuoteStringLiteral(name)
+		b.WriteString(" UNION ALL SELECT ")
+		b.WriteString(lit)
+		b.WriteString(", pg_catalog.current_setting(")
+		b.WriteString(lit)
+		b.WriteString(", true), 'custom'")
 	}
 	return b.String()
 }
@@ -272,18 +247,20 @@ func (c *Conn) confirmValueMismatches(ctx context.Context, candidates []string, 
 
 	// Single autocommit statement: each set_config applies is_local := true,
 	// so every assignment reverts when the statement's implicit transaction
-	// ends. Single quotes are escaped by doubling, as in Settings.ApplyQuery.
+	// ends. Names and values are client-controlled: quote them with
+	// ast.QuoteStringLiteral so a backslash cannot break out of the literal
+	// under standard_conforming_strings=off.
 	var b strings.Builder
 	b.WriteString("SELECT n, pg_catalog.set_config(n, v, true) FROM (VALUES ")
 	for i, name := range candidates {
 		if i > 0 {
 			b.WriteString(", ")
 		}
-		b.WriteString("('")
-		b.WriteString(strings.ReplaceAll(name, "'", "''"))
-		b.WriteString("', '")
-		b.WriteString(strings.ReplaceAll(tracked[name], "'", "''"))
-		b.WriteString("')")
+		b.WriteString("(")
+		b.WriteString(ast.QuoteStringLiteral(name))
+		b.WriteString(", ")
+		b.WriteString(ast.QuoteStringLiteral(tracked[name]))
+		b.WriteString(")")
 	}
 	b.WriteString(") AS t(n, v)")
 

--- a/go/services/multipooler/internal/pools/regular/session_verify.go
+++ b/go/services/multipooler/internal/pools/regular/session_verify.go
@@ -72,6 +72,20 @@ func sessionStateQuery(customNames []string) string {
 	return b.String()
 }
 
+// SessionStateChecker is the connpool.ConnChecker that verifies a
+// connection's session GUC state; it delegates to VerifySessionState. It is
+// registered on every regular pool at construction — the pool's
+// ScrubInterval decides whether the scrub worker actually runs.
+type SessionStateChecker struct{}
+
+// Name implements connpool.ConnChecker.
+func (SessionStateChecker) Name() string { return "session_state" }
+
+// Check implements connpool.ConnChecker.
+func (SessionStateChecker) Check(ctx context.Context, conn *Conn) (connpool.Divergence, error) {
+	return conn.VerifySessionState(ctx)
+}
+
 // VerifySessionState compares this connection's tracked settings label
 // against the backend's real session GUC state and reports any divergence.
 //
@@ -88,8 +102,8 @@ func sessionStateQuery(customNames []string) string {
 // statement's implicit transaction ends.
 //
 // The returned divergence carries GUC names only, never values.
-func (c *Conn) VerifySessionState(ctx context.Context) (connpool.SessionDivergence, error) {
-	var div connpool.SessionDivergence
+func (c *Conn) VerifySessionState(ctx context.Context) (connpool.Divergence, error) {
+	var div connpool.Divergence
 
 	// Idle pool connections are never mid-transaction; refuse to probe one
 	// that is, rather than misread transaction-local state as session state.
@@ -199,7 +213,7 @@ func (c *Conn) VerifySessionState(ctx context.Context) (connpool.SessionDivergen
 	if len(candidates) > 0 {
 		mismatched, err := c.confirmValueMismatches(ctx, candidates, tracked, sessionVars)
 		if err != nil {
-			return connpool.SessionDivergence{}, err
+			return connpool.Divergence{}, err
 		}
 		div.Mismatched = append(div.Mismatched, mismatched...)
 	}
@@ -213,7 +227,7 @@ func (c *Conn) VerifySessionState(ctx context.Context) (connpool.SessionDivergen
 // compareIdentity checks the two GUC_NO_SHOW_ALL identity GUCs against the
 // label. Role names have no display normalization, so value differences are
 // divergence outright.
-func (c *Conn) compareIdentity(div *connpool.SessionDivergence, tracked, identity map[string]string) {
+func (c *Conn) compareIdentity(div *connpool.Divergence, tracked, identity map[string]string) {
 	// current_setting('role') reports 'none' when no SET ROLE is in effect.
 	realRole := identity["role"]
 	trackedRole, hasRole := tracked["role"]

--- a/go/services/multipooler/internal/pools/regular/session_verify.go
+++ b/go/services/multipooler/internal/pools/regular/session_verify.go
@@ -24,14 +24,53 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/internal/pools/connpool"
 )
 
-// sessionSourceQuery reads the backend's real session-level GUC state: every
-// variable whose current value was installed by this session (SET, SET ROLE,
-// SET SESSION AUTHORIZATION, set_config(..., false) — including any hidden
-// inside routine bodies). current_setting() is used instead of
-// pg_settings.setting because it returns the SHOW-style display form, which is
-// also what set_config returns in the normalization probe below, keeping the
-// two comparisons apples-to-apples.
-const sessionSourceQuery = "SELECT name, current_setting(name) FROM pg_settings WHERE source = 'session'"
+// The session-state probe reads the backend's real session GUC state in one
+// round trip and compares it against the connection's tracked settings label.
+// Three sources are combined, because pg_settings alone cannot see everything
+// (verified on PostgreSQL 17):
+//
+//   - 'session' rows: pg_settings WHERE source = 'session' — every defined
+//     GUC whose current value was installed by this session (SET,
+//     set_config(..., false), including any hidden inside routine bodies).
+//     current_setting() is used instead of pg_settings.setting because it
+//     returns the SHOW-style display form, which is also what set_config
+//     returns in the normalization probe, keeping comparisons
+//     apples-to-apples.
+//   - 'identity' rows: role and session_authorization are GUC_NO_SHOW_ALL —
+//     they NEVER appear in pg_settings — so they are read explicitly.
+//     current_setting('role') reports 'none' when no SET ROLE is in effect;
+//     session_user is the current session authorization.
+//   - 'custom' rows: placeholder GUCs (names with a dot, e.g. 'my.tenant')
+//     are also hidden from pg_settings until an extension defines them, so
+//     every custom name in the tracked label is read explicitly with
+//     current_setting(name, missing_ok := true), which returns NULL when the
+//     session has never seen the GUC.
+//
+// Known blind spot: a custom GUC set behind tracking's back on a connection
+// whose label does not contain it is undetectable — placeholder GUCs cannot
+// be enumerated from SQL. The creation-time rejection gates remain the
+// defense for that class.
+const sessionSourceProbe = "SELECT name, current_setting(name), 'session' FROM pg_settings WHERE source = 'session'" +
+	" UNION ALL SELECT 'role', pg_catalog.current_setting('role'), 'identity'" +
+	" UNION ALL SELECT 'session_authorization', session_user::text, 'identity'"
+
+// sessionStateQuery returns the probe SQL, extending the constant part with
+// one 'custom' row per tracked placeholder GUC. customNames must be sorted
+// for deterministic SQL. Single quotes are escaped by doubling, as in
+// Settings.ApplyQuery.
+func sessionStateQuery(customNames []string) string {
+	var b strings.Builder
+	b.WriteString(sessionSourceProbe)
+	for _, name := range customNames {
+		escaped := strings.ReplaceAll(name, "'", "''")
+		b.WriteString(" UNION ALL SELECT '")
+		b.WriteString(escaped)
+		b.WriteString("', pg_catalog.current_setting('")
+		b.WriteString(escaped)
+		b.WriteString("', true), 'custom'")
+	}
+	return b.String()
+}
 
 // VerifySessionState compares this connection's tracked settings label
 // against the backend's real session GUC state and reports any divergence.
@@ -43,7 +82,7 @@ const sessionSourceQuery = "SELECT name, current_setting(name) FROM pg_settings 
 // leaks to the next borrower. This probe is the detection net for that class
 // of failure; it runs on idle pooled connections only.
 //
-// The probe is side-effect-free. The main query only reads pg_settings. The
+// The probe is side-effect-free. The main query only reads state. The
 // secondary normalization probe uses set_config(..., is_local := true) in a
 // single autocommit statement, so every assignment reverts when the
 // statement's implicit transaction ends.
@@ -63,9 +102,20 @@ func (c *Conn) VerifySessionState(ctx context.Context) (connpool.SessionDivergen
 		tracked = s.Vars
 	}
 
+	// Custom (placeholder) GUCs in the label must be probed by name; see the
+	// probe documentation above. Tracked keys are already canonical
+	// (canonicalizeGUCVars at Settings construction).
+	var customNames []string
+	for name := range tracked {
+		if strings.Contains(name, ".") {
+			customNames = append(customNames, name)
+		}
+	}
+	sort.Strings(customNames)
+
 	// Plain Query, never QueryWithRetry: a retry reconnects the socket, which
 	// resets the very session state being inspected and would mask divergence.
-	results, err := c.Query(ctx, sessionSourceQuery)
+	results, err := c.Query(ctx, sessionStateQuery(customNames))
 	if err != nil {
 		return div, err
 	}
@@ -73,18 +123,37 @@ func (c *Conn) VerifySessionState(ctx context.Context) (connpool.SessionDivergen
 		return div, errors.New("session state probe returned unexpected result count")
 	}
 
-	real := make(map[string]string, results[0].RowCount())
+	sessionVars := make(map[string]string)
+	identity := make(map[string]string)
+	customVars := make(map[string]string) // only names the session has a value for
 	for _, row := range results[0].StructuredRows() {
-		if len(row.Values) != 2 || row.Values[0].IsNull() || row.Values[1].IsNull() {
+		if len(row.Values) != 3 || row.Values[0].IsNull() || row.Values[2].IsNull() {
 			return div, errors.New("session state probe returned malformed row")
 		}
-		real[connstate.CanonicalGUCName(string(row.Values[0]))] = string(row.Values[1])
+		name := connstate.CanonicalGUCName(string(row.Values[0]))
+		switch src := string(row.Values[2]); src {
+		case "session", "identity":
+			if row.Values[1].IsNull() {
+				return div, errors.New("session state probe returned malformed row")
+			}
+			if src == "session" {
+				sessionVars[name] = string(row.Values[1])
+			} else {
+				identity[name] = string(row.Values[1])
+			}
+		case "custom":
+			// NULL means the session has never seen this placeholder GUC.
+			if !row.Values[1].IsNull() {
+				customVars[name] = string(row.Values[1])
+			}
+		default:
+			return div, errors.New("session state probe returned unknown source tag")
+		}
 	}
 
-	// Tracked keys are already canonical (canonicalizeGUCVars at Settings
-	// construction), so name comparison is a direct map lookup.
+	// Ordinary GUCs: compare the session-source rows against the label.
 	var candidates []string
-	for name, realValue := range real {
+	for name, realValue := range sessionVars {
 		trackedValue, ok := tracked[name]
 		switch {
 		case !ok:
@@ -93,18 +162,40 @@ func (c *Conn) VerifySessionState(ctx context.Context) (connpool.SessionDivergen
 			candidates = append(candidates, name)
 		}
 	}
-	for name := range tracked {
-		if _, ok := real[name]; !ok {
-			div.Phantom = append(div.Phantom, name)
+	for name, trackedValue := range tracked {
+		switch {
+		case name == "role" || name == "session_authorization":
+			continue // identity, handled below
+		case strings.Contains(name, "."):
+			// Custom GUC: judged via its probed value. A name also present
+			// in sessionVars is extension-defined and already judged above.
+			if _, defined := sessionVars[name]; defined {
+				continue
+			}
+			realValue, set := customVars[name]
+			switch {
+			case !set:
+				div.Phantom = append(div.Phantom, name)
+			case realValue != trackedValue:
+				// Placeholder GUCs are plain strings with no display
+				// normalization, so a value difference is divergence.
+				div.Mismatched = append(div.Mismatched, name)
+			}
+		default:
+			if _, ok := sessionVars[name]; !ok {
+				div.Phantom = append(div.Phantom, name)
+			}
 		}
 	}
 
+	c.compareIdentity(&div, tracked, identity)
+
 	if len(candidates) > 0 {
-		mismatched, err := c.confirmValueMismatches(ctx, candidates, tracked, real)
+		mismatched, err := c.confirmValueMismatches(ctx, candidates, tracked, sessionVars)
 		if err != nil {
 			return connpool.SessionDivergence{}, err
 		}
-		div.Mismatched = mismatched
+		div.Mismatched = append(div.Mismatched, mismatched...)
 	}
 
 	sort.Strings(div.Untracked)
@@ -113,34 +204,58 @@ func (c *Conn) VerifySessionState(ctx context.Context) (connpool.SessionDivergen
 	return div, nil
 }
 
-// confirmValueMismatches filters exact-string value mismatches down to real
-// divergence by asking PostgreSQL to normalize the tracked value: set_config
-// returns the SHOW-style display form, so a tracked '65536' whose backend
-// shows '64MB' compares equal after normalization. Identity GUCs skip the
-// probe (role names have no display normalization, and set_config on them can
-// fail on permissions rather than value), and a failed probe fails closed:
-// its candidates are reported as mismatched rather than silently cleared.
-func (c *Conn) confirmValueMismatches(ctx context.Context, candidates []string, tracked, real map[string]string) ([]string, error) {
-	var mismatched, probeNames []string
-	for _, name := range candidates {
-		switch name {
-		case "role", "session_authorization":
-			mismatched = append(mismatched, name)
+// compareIdentity checks the two GUC_NO_SHOW_ALL identity GUCs against the
+// label. Role names have no display normalization, so value differences are
+// divergence outright.
+func (c *Conn) compareIdentity(div *connpool.SessionDivergence, tracked, identity map[string]string) {
+	// current_setting('role') reports 'none' when no SET ROLE is in effect.
+	realRole := identity["role"]
+	trackedRole, hasRole := tracked["role"]
+	if !hasRole {
+		trackedRole = "none"
+	}
+	if realRole != trackedRole {
+		switch {
+		case !hasRole:
+			div.Untracked = append(div.Untracked, "role")
+		case realRole == "none":
+			div.Phantom = append(div.Phantom, "role")
 		default:
-			probeNames = append(probeNames, name)
+			div.Mismatched = append(div.Mismatched, "role")
 		}
 	}
-	if len(probeNames) == 0 {
-		return mismatched, nil
+
+	// With no tracked session_authorization, session_user must be the user
+	// this connection authenticated as.
+	realAuth := identity["session_authorization"]
+	trackedAuth, hasAuth := tracked["session_authorization"]
+	if !hasAuth {
+		trackedAuth = c.conn.User()
 	}
-	sort.Strings(probeNames)
+	if realAuth != trackedAuth {
+		if !hasAuth {
+			div.Untracked = append(div.Untracked, "session_authorization")
+		} else {
+			div.Mismatched = append(div.Mismatched, "session_authorization")
+		}
+	}
+}
+
+// confirmValueMismatches filters exact-string value mismatches on ordinary
+// GUCs down to real divergence by asking PostgreSQL to normalize the tracked
+// value: set_config returns the SHOW-style display form, so a tracked
+// '65536' whose backend shows '64MB' compares equal after normalization. A
+// failed probe fails closed: its candidates are reported as mismatched
+// rather than silently cleared.
+func (c *Conn) confirmValueMismatches(ctx context.Context, candidates []string, tracked, real map[string]string) ([]string, error) {
+	sort.Strings(candidates)
 
 	// Single autocommit statement: each set_config applies is_local := true,
 	// so every assignment reverts when the statement's implicit transaction
 	// ends. Single quotes are escaped by doubling, as in Settings.ApplyQuery.
 	var b strings.Builder
 	b.WriteString("SELECT n, pg_catalog.set_config(n, v, true) FROM (VALUES ")
-	for i, name := range probeNames {
+	for i, name := range candidates {
 		if i > 0 {
 			b.WriteString(", ")
 		}
@@ -161,7 +276,7 @@ func (c *Conn) confirmValueMismatches(ctx context.Context, candidates []string, 
 		}
 		// The statement itself failed (e.g. a value the backend now rejects):
 		// fail closed and report every probed name as mismatched.
-		return append(mismatched, probeNames...), nil
+		return candidates, nil
 	}
 	if len(results) != 1 {
 		return nil, errors.New("normalization probe returned unexpected result count")
@@ -174,7 +289,8 @@ func (c *Conn) confirmValueMismatches(ctx context.Context, candidates []string, 
 		}
 		normalized[connstate.CanonicalGUCName(string(row.Values[0]))] = string(row.Values[1])
 	}
-	for _, name := range probeNames {
+	var mismatched []string
+	for _, name := range candidates {
 		norm, ok := normalized[name]
 		if !ok || norm != real[name] {
 			mismatched = append(mismatched, name)

--- a/go/services/multipooler/internal/pools/regular/session_verify.go
+++ b/go/services/multipooler/internal/pools/regular/session_verify.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regular
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+
+	"github.com/multigres/multigres/go/services/multipooler/internal/connstate"
+	"github.com/multigres/multigres/go/services/multipooler/internal/pools/connpool"
+)
+
+// sessionSourceQuery reads the backend's real session-level GUC state: every
+// variable whose current value was installed by this session (SET, SET ROLE,
+// SET SESSION AUTHORIZATION, set_config(..., false) — including any hidden
+// inside routine bodies). current_setting() is used instead of
+// pg_settings.setting because it returns the SHOW-style display form, which is
+// also what set_config returns in the normalization probe below, keeping the
+// two comparisons apples-to-apples.
+const sessionSourceQuery = "SELECT name, current_setting(name) FROM pg_settings WHERE source = 'session'"
+
+// VerifySessionState compares this connection's tracked settings label
+// against the backend's real session GUC state and reports any divergence.
+//
+// Under the gateway-authoritative session model the label is trusted
+// absolutely: pooled reuse with a pointer-equal label and clean-stack reuse
+// both run zero SQL. Anything that mutates session state without being
+// tracked (a set_config hidden in a routine body, a tracking bug) therefore
+// leaks to the next borrower. This probe is the detection net for that class
+// of failure; it runs on idle pooled connections only.
+//
+// The probe is side-effect-free. The main query only reads pg_settings. The
+// secondary normalization probe uses set_config(..., is_local := true) in a
+// single autocommit statement, so every assignment reverts when the
+// statement's implicit transaction ends.
+//
+// The returned divergence carries GUC names only, never values.
+func (c *Conn) VerifySessionState(ctx context.Context) (connpool.SessionDivergence, error) {
+	var div connpool.SessionDivergence
+
+	// Idle pool connections are never mid-transaction; refuse to probe one
+	// that is, rather than misread transaction-local state as session state.
+	if !c.IsIdle() {
+		return div, errors.New("connection is not idle")
+	}
+
+	var tracked map[string]string
+	if s := c.State().GetSettings(); s != nil {
+		tracked = s.Vars
+	}
+
+	// Plain Query, never QueryWithRetry: a retry reconnects the socket, which
+	// resets the very session state being inspected and would mask divergence.
+	results, err := c.Query(ctx, sessionSourceQuery)
+	if err != nil {
+		return div, err
+	}
+	if len(results) != 1 {
+		return div, errors.New("session state probe returned unexpected result count")
+	}
+
+	real := make(map[string]string, results[0].RowCount())
+	for _, row := range results[0].StructuredRows() {
+		if len(row.Values) != 2 || row.Values[0].IsNull() || row.Values[1].IsNull() {
+			return div, errors.New("session state probe returned malformed row")
+		}
+		real[connstate.CanonicalGUCName(string(row.Values[0]))] = string(row.Values[1])
+	}
+
+	// Tracked keys are already canonical (canonicalizeGUCVars at Settings
+	// construction), so name comparison is a direct map lookup.
+	var candidates []string
+	for name, realValue := range real {
+		trackedValue, ok := tracked[name]
+		switch {
+		case !ok:
+			div.Untracked = append(div.Untracked, name)
+		case trackedValue != realValue:
+			candidates = append(candidates, name)
+		}
+	}
+	for name := range tracked {
+		if _, ok := real[name]; !ok {
+			div.Phantom = append(div.Phantom, name)
+		}
+	}
+
+	if len(candidates) > 0 {
+		mismatched, err := c.confirmValueMismatches(ctx, candidates, tracked, real)
+		if err != nil {
+			return connpool.SessionDivergence{}, err
+		}
+		div.Mismatched = mismatched
+	}
+
+	sort.Strings(div.Untracked)
+	sort.Strings(div.Phantom)
+	sort.Strings(div.Mismatched)
+	return div, nil
+}
+
+// confirmValueMismatches filters exact-string value mismatches down to real
+// divergence by asking PostgreSQL to normalize the tracked value: set_config
+// returns the SHOW-style display form, so a tracked '65536' whose backend
+// shows '64MB' compares equal after normalization. Identity GUCs skip the
+// probe (role names have no display normalization, and set_config on them can
+// fail on permissions rather than value), and a failed probe fails closed:
+// its candidates are reported as mismatched rather than silently cleared.
+func (c *Conn) confirmValueMismatches(ctx context.Context, candidates []string, tracked, real map[string]string) ([]string, error) {
+	var mismatched, probeNames []string
+	for _, name := range candidates {
+		switch name {
+		case "role", "session_authorization":
+			mismatched = append(mismatched, name)
+		default:
+			probeNames = append(probeNames, name)
+		}
+	}
+	if len(probeNames) == 0 {
+		return mismatched, nil
+	}
+	sort.Strings(probeNames)
+
+	// Single autocommit statement: each set_config applies is_local := true,
+	// so every assignment reverts when the statement's implicit transaction
+	// ends. Single quotes are escaped by doubling, as in Settings.ApplyQuery.
+	var b strings.Builder
+	b.WriteString("SELECT n, pg_catalog.set_config(n, v, true) FROM (VALUES ")
+	for i, name := range probeNames {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString("('")
+		b.WriteString(strings.ReplaceAll(name, "'", "''"))
+		b.WriteString("', '")
+		b.WriteString(strings.ReplaceAll(tracked[name], "'", "''"))
+		b.WriteString("')")
+	}
+	b.WriteString(") AS t(n, v)")
+
+	results, err := c.Query(ctx, b.String())
+	if err != nil {
+		// A dead connection can't be judged; surface the error so the caller
+		// treats this as a probe failure, not divergence.
+		if c.IsClosed() {
+			return nil, err
+		}
+		// The statement itself failed (e.g. a value the backend now rejects):
+		// fail closed and report every probed name as mismatched.
+		return append(mismatched, probeNames...), nil
+	}
+	if len(results) != 1 {
+		return nil, errors.New("normalization probe returned unexpected result count")
+	}
+
+	normalized := make(map[string]string, results[0].RowCount())
+	for _, row := range results[0].StructuredRows() {
+		if len(row.Values) != 2 || row.Values[0].IsNull() || row.Values[1].IsNull() {
+			return nil, errors.New("normalization probe returned malformed row")
+		}
+		normalized[connstate.CanonicalGUCName(string(row.Values[0]))] = string(row.Values[1])
+	}
+	for _, name := range probeNames {
+		norm, ok := normalized[name]
+		if !ok || norm != real[name] {
+			mismatched = append(mismatched, name)
+		}
+	}
+	return mismatched, nil
+}

--- a/go/services/multipooler/internal/pools/regular/session_verify_test.go
+++ b/go/services/multipooler/internal/pools/regular/session_verify_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/fakepgserver"
 	"github.com/multigres/multigres/go/services/multipooler/internal/connstate"
 )
@@ -149,6 +150,38 @@ func TestVerifySessionStateNormalizationEqual(t *testing.T) {
 	div, err := conn.VerifySessionState(context.Background())
 	require.NoError(t, err)
 	assert.False(t, div.IsDiverged())
+}
+
+func TestVerifySessionStateBackslashValueQuotedAsEscapeString(t *testing.T) {
+	// Tracked values are client-controlled. A backslash before a quote would
+	// break out of a quote-only-escaped literal under
+	// standard_conforming_strings=off, so the normalization probe must emit
+	// an E'...' literal with the backslash doubled.
+	server := fakepgserver.New(t)
+	defer server.Close()
+	scriptProbe(server, nil, append([][]any{
+		{"application_name", "x", "session"},
+	}, identityRows()...))
+	server.AddQuery(
+		`SELECT n, pg_catalog.set_config(n, v, true) FROM (VALUES ('application_name', E'a\\''; SELECT 1--')) AS t(n, v)`,
+		fakepgserver.MakeResult([]string{"n", "set_config"}, [][]any{{"application_name", "x"}}),
+	)
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	conn.State().SetSettings(connstate.NewSettings(map[string]string{"application_name": `a\'; SELECT 1--`}, 1))
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.False(t, div.IsDiverged())
+}
+
+func TestSessionStateQueryQuotesCustomNames(t *testing.T) {
+	assert.Equal(t,
+		constants.SessionSourceProbeSQL+
+			` UNION ALL SELECT E'my\\''x', pg_catalog.current_setting(E'my\\''x', true), 'custom'`+
+			` UNION ALL SELECT 'my.tenant', pg_catalog.current_setting('my.tenant', true), 'custom'`,
+		sessionStateQuery([]string{`my\'x`, "my.tenant"}))
 }
 
 func TestVerifySessionStateValueMismatch(t *testing.T) {

--- a/go/services/multipooler/internal/pools/regular/session_verify_test.go
+++ b/go/services/multipooler/internal/pools/regular/session_verify_test.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regular
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/fakepgserver"
+	"github.com/multigres/multigres/go/services/multipooler/internal/connstate"
+)
+
+// addSessionState scripts the session-source probe to report the given
+// name/value pairs as the backend's real session GUC state.
+func addSessionState(server *fakepgserver.Server, vars [][]any) {
+	server.AddQuery(sessionSourceQuery, fakepgserver.MakeResult([]string{"name", "current_setting"}, vars))
+}
+
+func TestVerifySessionStateClean(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	addSessionState(server, nil)
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.False(t, div.IsDiverged())
+}
+
+func TestVerifySessionStateMatchingLabel(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	addSessionState(server, [][]any{{"work_mem", "64MB"}, {"search_path", "app, public"}})
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	conn.State().SetSettings(connstate.NewSettings(map[string]string{
+		"work_mem":    "64MB",
+		"search_path": "app, public",
+	}, 1))
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.False(t, div.IsDiverged())
+}
+
+func TestVerifySessionStateUntracked(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	// A hidden set_config left work_mem session state on a backend whose
+	// label only knows search_path.
+	addSessionState(server, [][]any{{"work_mem", "123MB"}, {"search_path", "app"}})
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	conn.State().SetSettings(connstate.NewSettings(map[string]string{"search_path": "app"}, 1))
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"work_mem"}, div.Untracked)
+	assert.Empty(t, div.Phantom)
+	assert.Empty(t, div.Mismatched)
+}
+
+func TestVerifySessionStateUntrackedOnCleanLabel(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	addSessionState(server, [][]any{{"work_mem", "123MB"}})
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"work_mem"}, div.Untracked)
+}
+
+func TestVerifySessionStatePhantom(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	addSessionState(server, nil)
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	conn.State().SetSettings(connstate.NewSettings(map[string]string{"app.tenant": "acme"}, 1))
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, div.Untracked)
+	assert.Equal(t, []string{"app.tenant"}, div.Phantom)
+	assert.Empty(t, div.Mismatched)
+}
+
+func TestVerifySessionStateNormalizationEqual(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	// Tracked '65536' vs displayed '64MB' is a spelling difference, not
+	// divergence: the normalization probe maps the tracked value to the same
+	// display form.
+	addSessionState(server, [][]any{{"work_mem", "64MB"}})
+	server.AddQuery(
+		"SELECT n, pg_catalog.set_config(n, v, true) FROM (VALUES ('work_mem', '65536')) AS t(n, v)",
+		fakepgserver.MakeResult([]string{"n", "set_config"}, [][]any{{"work_mem", "64MB"}}),
+	)
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	conn.State().SetSettings(connstate.NewSettings(map[string]string{"work_mem": "65536"}, 1))
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.False(t, div.IsDiverged())
+}
+
+func TestVerifySessionStateValueMismatch(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	addSessionState(server, [][]any{{"work_mem", "123MB"}})
+	server.AddQuery(
+		"SELECT n, pg_catalog.set_config(n, v, true) FROM (VALUES ('work_mem', '64MB')) AS t(n, v)",
+		fakepgserver.MakeResult([]string{"n", "set_config"}, [][]any{{"work_mem", "64MB"}}),
+	)
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	conn.State().SetSettings(connstate.NewSettings(map[string]string{"work_mem": "64MB"}, 1))
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, div.Untracked)
+	assert.Empty(t, div.Phantom)
+	assert.Equal(t, []string{"work_mem"}, div.Mismatched)
+}
+
+func TestVerifySessionStateIdentityMismatchSkipsProbe(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	// role/session_authorization never go through the normalization probe:
+	// a differing role name is divergence outright. No set_config query is
+	// scripted, so reaching the probe would fail the test.
+	addSessionState(server, [][]any{{"role", "bob"}})
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	conn.State().SetSettings(connstate.NewSettings(map[string]string{"role": "alice"}, 1))
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"role"}, div.Mismatched)
+}
+
+func TestVerifySessionStateNormalizationProbeFailureFailsClosed(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	addSessionState(server, [][]any{{"temp_buffers", "16MB"}})
+	// The backend rejects re-applying the tracked value (e.g. the
+	// temp_buffers freeze). The probe cannot prove equivalence, so the name
+	// is reported as mismatched rather than silently cleared.
+	server.AddRejectedQuery(
+		"SELECT n, pg_catalog.set_config(n, v, true) FROM (VALUES ('temp_buffers', '8MB')) AS t(n, v)",
+		errors.New("invalid value for parameter"),
+	)
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	conn.State().SetSettings(connstate.NewSettings(map[string]string{"temp_buffers": "8MB"}, 1))
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"temp_buffers"}, div.Mismatched)
+}
+
+func TestVerifySessionStateProbeErrorPropagates(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.AddRejectedQuery(sessionSourceQuery, errors.New("backend on fire"))
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+
+	_, err := conn.VerifySessionState(context.Background())
+	require.Error(t, err)
+}

--- a/go/services/multipooler/internal/pools/regular/session_verify_test.go
+++ b/go/services/multipooler/internal/pools/regular/session_verify_test.go
@@ -26,16 +26,27 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/internal/connstate"
 )
 
-// addSessionState scripts the session-source probe to report the given
-// name/value pairs as the backend's real session GUC state.
-func addSessionState(server *fakepgserver.Server, vars [][]any) {
-	server.AddQuery(sessionSourceQuery, fakepgserver.MakeResult([]string{"name", "current_setting"}, vars))
+// identityRows is the backend's identity state for a connection with no SET
+// ROLE / SET SESSION AUTHORIZATION in effect: role reports 'none' and
+// session_user is the fakepgserver login user ("test").
+func identityRows() [][]any {
+	return [][]any{
+		{"role", "none", "identity"},
+		{"session_authorization", "test", "identity"},
+	}
+}
+
+// scriptProbe scripts the session-state probe for the given tracked custom
+// GUC names, reporting the given (name, value, src) rows.
+func scriptProbe(server *fakepgserver.Server, customNames []string, rows [][]any) {
+	server.AddQuery(sessionStateQuery(customNames),
+		fakepgserver.MakeResult([]string{"name", "current_setting", "src"}, rows))
 }
 
 func TestVerifySessionStateClean(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
-	addSessionState(server, nil)
+	scriptProbe(server, nil, identityRows())
 
 	conn := newTestDirectConn(t, server)
 	defer conn.Close()
@@ -48,7 +59,10 @@ func TestVerifySessionStateClean(t *testing.T) {
 func TestVerifySessionStateMatchingLabel(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
-	addSessionState(server, [][]any{{"work_mem", "64MB"}, {"search_path", "app, public"}})
+	scriptProbe(server, nil, append([][]any{
+		{"work_mem", "64MB", "session"},
+		{"search_path", "app, public", "session"},
+	}, identityRows()...))
 
 	conn := newTestDirectConn(t, server)
 	defer conn.Close()
@@ -67,7 +81,10 @@ func TestVerifySessionStateUntracked(t *testing.T) {
 	defer server.Close()
 	// A hidden set_config left work_mem session state on a backend whose
 	// label only knows search_path.
-	addSessionState(server, [][]any{{"work_mem", "123MB"}, {"search_path", "app"}})
+	scriptProbe(server, nil, append([][]any{
+		{"work_mem", "123MB", "session"},
+		{"search_path", "app", "session"},
+	}, identityRows()...))
 
 	conn := newTestDirectConn(t, server)
 	defer conn.Close()
@@ -83,7 +100,9 @@ func TestVerifySessionStateUntracked(t *testing.T) {
 func TestVerifySessionStateUntrackedOnCleanLabel(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
-	addSessionState(server, [][]any{{"work_mem", "123MB"}})
+	scriptProbe(server, nil, append([][]any{
+		{"work_mem", "123MB", "session"},
+	}, identityRows()...))
 
 	conn := newTestDirectConn(t, server)
 	defer conn.Close()
@@ -96,16 +115,16 @@ func TestVerifySessionStateUntrackedOnCleanLabel(t *testing.T) {
 func TestVerifySessionStatePhantom(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
-	addSessionState(server, nil)
+	scriptProbe(server, nil, identityRows())
 
 	conn := newTestDirectConn(t, server)
 	defer conn.Close()
-	conn.State().SetSettings(connstate.NewSettings(map[string]string{"app.tenant": "acme"}, 1))
+	conn.State().SetSettings(connstate.NewSettings(map[string]string{"work_mem": "64MB"}, 1))
 
 	div, err := conn.VerifySessionState(context.Background())
 	require.NoError(t, err)
 	assert.Empty(t, div.Untracked)
-	assert.Equal(t, []string{"app.tenant"}, div.Phantom)
+	assert.Equal(t, []string{"work_mem"}, div.Phantom)
 	assert.Empty(t, div.Mismatched)
 }
 
@@ -115,7 +134,9 @@ func TestVerifySessionStateNormalizationEqual(t *testing.T) {
 	// Tracked '65536' vs displayed '64MB' is a spelling difference, not
 	// divergence: the normalization probe maps the tracked value to the same
 	// display form.
-	addSessionState(server, [][]any{{"work_mem", "64MB"}})
+	scriptProbe(server, nil, append([][]any{
+		{"work_mem", "64MB", "session"},
+	}, identityRows()...))
 	server.AddQuery(
 		"SELECT n, pg_catalog.set_config(n, v, true) FROM (VALUES ('work_mem', '65536')) AS t(n, v)",
 		fakepgserver.MakeResult([]string{"n", "set_config"}, [][]any{{"work_mem", "64MB"}}),
@@ -133,7 +154,9 @@ func TestVerifySessionStateNormalizationEqual(t *testing.T) {
 func TestVerifySessionStateValueMismatch(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
-	addSessionState(server, [][]any{{"work_mem", "123MB"}})
+	scriptProbe(server, nil, append([][]any{
+		{"work_mem", "123MB", "session"},
+	}, identityRows()...))
 	server.AddQuery(
 		"SELECT n, pg_catalog.set_config(n, v, true) FROM (VALUES ('work_mem', '64MB')) AS t(n, v)",
 		fakepgserver.MakeResult([]string{"n", "set_config"}, [][]any{{"work_mem", "64MB"}}),
@@ -150,27 +173,12 @@ func TestVerifySessionStateValueMismatch(t *testing.T) {
 	assert.Equal(t, []string{"work_mem"}, div.Mismatched)
 }
 
-func TestVerifySessionStateIdentityMismatchSkipsProbe(t *testing.T) {
-	server := fakepgserver.New(t)
-	defer server.Close()
-	// role/session_authorization never go through the normalization probe:
-	// a differing role name is divergence outright. No set_config query is
-	// scripted, so reaching the probe would fail the test.
-	addSessionState(server, [][]any{{"role", "bob"}})
-
-	conn := newTestDirectConn(t, server)
-	defer conn.Close()
-	conn.State().SetSettings(connstate.NewSettings(map[string]string{"role": "alice"}, 1))
-
-	div, err := conn.VerifySessionState(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, []string{"role"}, div.Mismatched)
-}
-
 func TestVerifySessionStateNormalizationProbeFailureFailsClosed(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
-	addSessionState(server, [][]any{{"temp_buffers", "16MB"}})
+	scriptProbe(server, nil, append([][]any{
+		{"temp_buffers", "16MB", "session"},
+	}, identityRows()...))
 	// The backend rejects re-applying the tracked value (e.g. the
 	// temp_buffers freeze). The probe cannot prove equivalence, so the name
 	// is reported as mismatched rather than silently cleared.
@@ -191,11 +199,170 @@ func TestVerifySessionStateNormalizationProbeFailureFailsClosed(t *testing.T) {
 func TestVerifySessionStateProbeErrorPropagates(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
-	server.AddRejectedQuery(sessionSourceQuery, errors.New("backend on fire"))
+	server.AddRejectedQuery(sessionStateQuery(nil), errors.New("backend on fire"))
 
 	conn := newTestDirectConn(t, server)
 	defer conn.Close()
 
 	_, err := conn.VerifySessionState(context.Background())
 	require.Error(t, err)
+}
+
+// --- Identity (role / session_authorization) ---
+//
+// Both are GUC_NO_SHOW_ALL: they never appear in pg_settings, so the probe
+// reads them explicitly and compares them against the label without the
+// phantom logic used for ordinary GUCs.
+
+func TestVerifySessionStateTrackedRoleMatches(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	scriptProbe(server, nil, [][]any{
+		{"role", "alice", "identity"},
+		{"session_authorization", "test", "identity"},
+	})
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	conn.State().SetSettings(connstate.NewSettings(map[string]string{"role": "alice"}, 1))
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.False(t, div.IsDiverged())
+}
+
+func TestVerifySessionStateUntrackedRole(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	// A hidden SET ROLE on a clean-labeled backend.
+	scriptProbe(server, nil, [][]any{
+		{"role", "sneaky", "identity"},
+		{"session_authorization", "test", "identity"},
+	})
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"role"}, div.Untracked)
+}
+
+func TestVerifySessionStatePhantomRole(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	// The label claims a role but the backend has none in effect.
+	scriptProbe(server, nil, identityRows())
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	conn.State().SetSettings(connstate.NewSettings(map[string]string{"role": "alice"}, 1))
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"role"}, div.Phantom)
+}
+
+func TestVerifySessionStateRoleValueMismatch(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	scriptProbe(server, nil, [][]any{
+		{"role", "bob", "identity"},
+		{"session_authorization", "test", "identity"},
+	})
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	conn.State().SetSettings(connstate.NewSettings(map[string]string{"role": "alice"}, 1))
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"role"}, div.Mismatched)
+}
+
+func TestVerifySessionStateSessionAuthDivergence(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	// session_user differs from the login user with nothing tracked: a
+	// hidden SET SESSION AUTHORIZATION.
+	scriptProbe(server, nil, [][]any{
+		{"role", "none", "identity"},
+		{"session_authorization", "other", "identity"},
+	})
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"session_authorization"}, div.Untracked)
+}
+
+func TestVerifySessionStateTrackedSessionAuthMatches(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	scriptProbe(server, nil, [][]any{
+		{"role", "none", "identity"},
+		{"session_authorization", "alice", "identity"},
+	})
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	conn.State().SetSettings(connstate.NewSettings(map[string]string{"session_authorization": "alice"}, 1))
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.False(t, div.IsDiverged())
+}
+
+// --- Custom (placeholder) GUCs ---
+//
+// Placeholder GUCs are hidden from pg_settings until an extension defines
+// them, so tracked custom names are probed explicitly with
+// current_setting(name, missing_ok := true).
+
+func TestVerifySessionStateCustomGucMatches(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	scriptProbe(server, []string{"my.tenant"}, append(identityRows(),
+		[]any{"my.tenant", "acme", "custom"}))
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	conn.State().SetSettings(connstate.NewSettings(map[string]string{"my.tenant": "acme"}, 1))
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.False(t, div.IsDiverged())
+}
+
+func TestVerifySessionStateCustomGucPhantom(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	// NULL from current_setting(name, true): the session never saw the GUC.
+	scriptProbe(server, []string{"my.tenant"}, append(identityRows(),
+		[]any{"my.tenant", nil, "custom"}))
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	conn.State().SetSettings(connstate.NewSettings(map[string]string{"my.tenant": "acme"}, 1))
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"my.tenant"}, div.Phantom)
+}
+
+func TestVerifySessionStateCustomGucMismatch(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	scriptProbe(server, []string{"my.tenant"}, append(identityRows(),
+		[]any{"my.tenant", "evil", "custom"}))
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	conn.State().SetSettings(connstate.NewSettings(map[string]string{"my.tenant": "acme"}, 1))
+
+	div, err := conn.VerifySessionState(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"my.tenant"}, div.Mismatched)
 }

--- a/go/test/endtoend/queryserving/session_state_leak_test.go
+++ b/go/test/endtoend/queryserving/session_state_leak_test.go
@@ -16,6 +16,8 @@ package queryserving
 
 import (
 	"database/sql"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -92,4 +94,77 @@ func TestHiddenFunctionStateDoesNotLeak(t *testing.T) {
 	defer reservedB.Close()
 	require.NoError(t, reservedB.QueryRowContext(ctx, "SHOW work_mem").Scan(&workMem))
 	require.NotEqual(t, "123MB", workMem, "hidden reserved-pool state leaked across logical clients")
+}
+
+// TestSessionScrubberReplacesHiddenState verifies the pool's session-state
+// scrubber: a set_config hidden inside a SQL function body escapes the
+// gateway's session tracking and leaves real session GUC state on a pooled
+// backend whose settings label doesn't know it. The scrubber (default 10s
+// interval) probes idle connections, detects the divergence, and replaces the
+// contaminated backend, so no later client can observe the leaked value.
+//
+// This is the detection net behind the creation-time rejection gates; see
+// TestHiddenFunctionStateDoesNotLeak above for the gate itself.
+func TestSessionScrubberReplacesHiddenState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping session scrubber test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found")
+	}
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, 3*time.Minute)
+
+	gatewayDSN := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	primaryDSN := shardsetup.GetTestUserDSN("localhost", setup.GetPrimary(t).Pgctld.PgPort, "sslmode=disable", "connect_timeout=5")
+	primary, err := sql.Open("postgres", primaryDSN)
+	require.NoError(t, err)
+	defer primary.Close()
+
+	// Install directly so the mutation is absent from the client's top-level SQL.
+	_, err = primary.ExecContext(ctx, `CREATE OR REPLACE FUNCTION hidden_scrub_set()
+		RETURNS text LANGUAGE sql AS $$SELECT set_config('work_mem', '123MB', false)$$`)
+	require.NoError(t, err)
+	defer primary.ExecContext(ctx, "DROP FUNCTION IF EXISTS hidden_scrub_set()") //nolint:errcheck
+
+	// Contaminate one pooled backend and capture its PID in the same
+	// statement so both values come from the same physical connection.
+	connA, err := sql.Open("postgres", gatewayDSN)
+	require.NoError(t, err)
+	connA.SetMaxIdleConns(0)
+	var ignored string
+	var leakedPID int
+	err = connA.QueryRowContext(ctx, "SELECT hidden_scrub_set(), pg_backend_pid()").Scan(&ignored, &leakedPID)
+	require.NoError(t, err)
+	require.NoError(t, connA.Close())
+
+	// The scrubber must find the diverged backend while it sits idle in the
+	// pool and terminate it.
+	require.Eventually(t, func() bool {
+		var alive int
+		if err := primary.QueryRowContext(ctx, "SELECT count(*) FROM pg_stat_activity WHERE pid = $1", leakedPID).Scan(&alive); err != nil {
+			return false
+		}
+		return alive == 0
+	}, 90*time.Second, time.Second, "scrubber should have replaced the contaminated backend (pid %d)", leakedPID)
+
+	// The replacement must have been the scrubber's doing, not routine pool
+	// churn: the multipooler logged the divergence with the leaked GUC name.
+	poolerLog, err := os.ReadFile(setup.PrimaryMultipooler(t).LogFile)
+	require.NoError(t, err)
+	require.Contains(t, string(poolerLog), "session-state divergence detected",
+		"multipooler log should record the scrubber replacing the backend")
+	require.Contains(t, string(poolerLog), "work_mem",
+		"divergence log should name the leaked GUC")
+	require.NotContains(t, strings.ToLower(string(poolerLog)), "123mb",
+		"divergence log must never carry GUC values")
+
+	// And no later client can observe the leaked value.
+	connB, err := sql.Open("postgres", gatewayDSN)
+	require.NoError(t, err)
+	defer connB.Close()
+	var workMem string
+	require.NoError(t, connB.QueryRowContext(ctx, "SHOW work_mem").Scan(&workMem))
+	require.NotEqual(t, "123MB", workMem, "hidden session state leaked past the scrubber")
 }

--- a/go/test/endtoend/queryserving/session_state_leak_test.go
+++ b/go/test/endtoend/queryserving/session_state_leak_test.go
@@ -122,6 +122,26 @@ func TestSessionScrubberReplacesHiddenState(t *testing.T) {
 	require.NoError(t, err)
 	defer primary.Close()
 
+	// Canary: before contaminating anything, normal traffic must produce
+	// ZERO divergence. The untracked rule assumes connection bootstrap
+	// leaves no session-source GUC state outside the settings label (see
+	// the invariant note in regular.Pool.Open); a future bootstrap-time SET
+	// that bypasses the label would make the scrubber replace every backend
+	// each sweep and trip this assertion. Warm the pool, wait for at least
+	// one scrub sweep (default interval 10s), then assert a quiet log. In
+	// full-suite runs this also covers all scrub sweeps during the earlier
+	// tests' traffic.
+	warmup, err := sql.Open("postgres", gatewayDSN)
+	require.NoError(t, err)
+	var one int
+	require.NoError(t, warmup.QueryRowContext(ctx, "SELECT 1").Scan(&one))
+	require.NoError(t, warmup.Close())
+	time.Sleep(15 * time.Second)
+	quietLog, err := os.ReadFile(setup.PrimaryMultipooler(t).LogFile)
+	require.NoError(t, err)
+	require.NotContains(t, string(quietLog), "session-state divergence detected",
+		"normal traffic must not diverge: connection bootstrap created session state outside the settings label")
+
 	// Install directly so the mutation is absent from the client's top-level SQL.
 	_, err = primary.ExecContext(ctx, `CREATE OR REPLACE FUNCTION hidden_scrub_set()
 		RETURNS text LANGUAGE sql AS $$SELECT set_config('work_mem', '123MB', false)$$`)


### PR DESCRIPTION
Builds the connection state consolidator (MUL-1158): a background scrubber that verifies pooled backends' real session state against the state the pool tracks for them, alarms on divergence, and replaces affected connections.

## Why

Under the gateway-authoritative session model (#1306), the pool trusts each connection's settings label absolutely — pointer-equal reuse and clean-stack checkout run zero SQL. Any backend mutation that escapes tracking (a `set_config` hidden in a routine body, a tracking bug, out-of-band DDL) therefore silently leaks to the next borrower. The scrubber is the detection net for that failure class — the "verification sampler" deferred out of scope during the #1306 design. The tracking and rejection gates (#1352) remain the correctness boundary; the scrubber bounds the leak window to roughly one sweep and raises an alarm that tracking was bypassed.

## Design

- **Divergence probe** (`regular.Conn.VerifySessionState`): one round trip comparing the tracked label against real backend state, classifying findings as untracked / phantom / value-mismatch. Verified on PostgreSQL 17 that `role`, `session_authorization`, and custom placeholder GUCs are `GUC_NO_SHOW_ALL` (never visible in `pg_settings`), so identity is probed via `current_setting('role')` + `session_user` (compared against the connection's login user via a new `client.Conn.User()` accessor) and tracked custom GUCs via `current_setting(name, missing_ok)`. Value spellings are normalized through a statement-local `set_config(..., is_local := true)` probe so `'65536'` vs `'64MB'` never counts as divergence. Findings carry GUC names only, never values.
- **Scrubber worker** (`connpool`): pops one idle connection per tick, rotating across the clean and settings stacks; clean connections return with their idle clock intact (scrubbing never defeats idle-timeout shrinking); divergent connections are closed and eagerly replaced into the same slot (a freed slot cannot wake a waitlisted client — same rationale as `closeIdleResources`). Replace, never reconcile: divergence means tracking was bypassed, and what a checker observes is only part of what the untracked code did.
- **Pluggable checkers**: the scrubber runs registered `connpool.ConnChecker`s (`Name` + `Check`); the session-state probe is the first, registered by every regular pool at construction (covering the reserved pool's underlying pool). Future checkers — prepared statements, advisory locks, temp state — plug in the same way and populate the same metrics via their name label.
- **Bootstrap invariant**: the untracked rule requires that connection bootstrap creates no session-source GUC state outside the settings label — bootstrap settings must arrive via startup-packet parameters (`source='client'`) or be reflected in the label, or the scrubber would replace every backend each sweep. Stated at the connector and in the docs, and pinned by an e2e canary (below).
- **Operations**: `--connpool-session-scrub-interval` (default 10s, `0` disables). OTel counters `mg.pooler.session_scrub.{checked,divergence,errors}` with `pool_type`, `checker`, and divergence-`kind` attributes, registered in the generated Prometheus metric catalog; any nonzero divergence warrants investigation. Divergence log lines carry names only.

Known blind spot (documented): an untracked custom placeholder GUC is unenumerable from SQL; the creation-time rejection gates are the defense for that class.

## Testing

- Unit: probe classification (identity, custom GUCs, normalization, fail-closed probe errors) against fakepgserver; scrubber slot accounting, idle-clock preservation, multi-checker merge, worker end-to-end with mock conns. All race-clean.
- E2E (`TestSessionScrubberReplacesHiddenState`): first a canary asserts normal traffic produces zero divergence (pinning the bootstrap invariant); then a `set_config` hidden in a SQL function body installed directly on the primary contaminates a pooled backend; the scrubber detects it, logs the GUC by name (asserted never the value), terminates the backend, and no later client observes the leak.
- Full queryserving suite run with scrubbing default-on: all session/SET/prepared/transaction tests pass; the only divergence event across the run was the e2e test's intentional one (no false positives).
- GUC semantics (`pg_settings` visibility, RESET source restoration, `is_local` autocommit revert, normalization forms) verified against a live PostgreSQL 17.

Docs: scrubber section added to `docs/query_serving/connection_pooling.md`; the hidden-routine-body limitation in `docs/query_serving/session_settings.md` now references it.

