### PR TITLE
fix(pgctld): enable hot_standby_feedback for read replicas

### DIFF
--- a/config/postgres/template.cnf
+++ b/config/postgres/template.cnf
@@ -126,6 +126,9 @@ max_slot_wal_keep_size = {{.MaxSlotWalKeepSize}}   # in megabytes; -1 disables
 # - Standby Servers -
 
 # These settings are ignored on a primary server.
+# Lets a replica report its oldest needed xmin back to the primary so
+# autovacuum does not remove rows a replica query still has open.
+hot_standby_feedback = on
 
 # - Subscribers -
 


### PR DESCRIPTION
## Summary

- Enables `hot_standby_feedback = on` in the pgctld-rendered `postgresql.conf` baseline, so a standby reports its oldest needed xmin back to the primary.
- Without this, autovacuum on the primary can remove a row a replica's in-flight query still needs, and PostgreSQL resolves the conflict by cancelling the query on the replica.
- Relevant because replica reads are a first-class routing target in multigres (a dedicated replica port routes long-lived reads to standbys), not an occasional fallback.
- Applies uniformly to every pod in a shard (primary and replicas alike), since the setting is a no-op on whichever pod currently holds the primary role.