### PR TITLE
fix(multigateway): handle parameter-bound set_config for gateway-managed variables

### DIFF
--- a/go/services/multigateway/engine/apply_session_state.go
+++ b/go/services/multigateway/engine/apply_session_state.go
@@ -297,20 +297,33 @@ func (s *ApplySessionState) resolveSetConfig(resolver setConfigParamResolver) (r
 				"set_config name argument cannot be NULL")
 		}
 		name = v
-		// A gateway-managed variable must never reach a backend, but a
-		// parameter-bound name is invisible to the planner's rewrite (it only
-		// strips literal gateway-managed names from the routed query), so the
-		// real set_config would execute there. This resolution runs during the
-		// Sequence's prepare phase — before the Route child is sent — so
-		// rejecting here aborts the statement with the backend untouched.
-		if handler.IsGatewayManagedVariable(name) {
+		// A parameter-bound name resolving to a gateway-managed variable is
+		// invisible to the planner's rewrite, so the paired Route runs the
+		// set_config on the backend. That is safe only when it runs
+		// transaction-locally and reverts:
+		//   - is_local=true runs verbatim (transaction-scoped), so it reverts and
+		//     never persists on a pooled backend. Allowed: this resolution falls
+		//     through to the tracker, prepareTrackedSetActionWithExchange applies
+		//     the value to gateway state (so SHOW and the gateway's own deadline
+		//     enforcement stay correct), and PostgreSQL returns the same canonical
+		//     value the client sees. This is PostgREST's role-setting form
+		//     set_config($1, $2, true) with $1='statement_timeout'.
+		//   - is_local=false would, on a *pinned* session, run verbatim on the
+		//     reserved backend and persist there — no cross-client leak (the
+		//     backend is dedicated), but a later gateway-intercepted change would
+		//     not reach it, so it could drift. Forcing the reverted route there
+		//     needs cross-primitive plumbing we don't have yet, so fail closed for
+		//     now; a literal name is the supported spelling for a session-scoped
+		//     change. Relax when session-scoped dynamic-name GMVs are needed.
+		if handler.IsGatewayManagedVariable(name) && !isLocal {
 			return resolvedSetConfig{}, mterrors.NewFeatureNotSupported(
-				fmt.Sprintf("set_config with a parameter-bound name resolving to gateway-managed variable %q is not supported; use a literal name", name))
+				fmt.Sprintf("set_config with a parameter-bound name resolving to gateway-managed variable %q is only supported with is_local=true; use a literal name for a session-scoped change", name))
 		}
-		// A bound name can also resolve to a cluster-restricted GUC
-		// (synchronous_commit): the plan-time guard only sees literal names,
-		// so the resolved name is re-checked here, on the same
-		// before-the-Route prepare pass as the GMV rejection above.
+		// Unlike a gateway-managed variable, a bound name that resolves to a
+		// cluster-restricted GUC (synchronous_commit) IS still rejected: the
+		// plan-time guard only sees literal names, so the resolved name is
+		// re-checked here, during the Sequence's prepare phase — before the paired
+		// Route reaches the backend.
 		if err := pgsettings.RestrictedGUCError(name); err != nil {
 			return resolvedSetConfig{}, err
 		}

--- a/go/services/multigateway/engine/apply_session_state_bind_test.go
+++ b/go/services/multigateway/engine/apply_session_state_bind_test.go
@@ -141,13 +141,49 @@ func TestApplySessionState_BoundNameResolves(t *testing.T) {
 	assert.Equal(t, "public", settings["search_path"])
 }
 
-// TestApplySessionState_BoundNameResolvingToGatewayManagedRejected pins the
-// fail-closed guard: a parameter-bound name is invisible to the planner's
-// gateway-managed rewrite, so the real set_config would execute on the
-// backend. Resolution runs in the Sequence's prepare phase — before the Route
-// child is sent — so the rejection aborts the statement with the backend
-// untouched and no gateway state mutated.
-func TestApplySessionState_BoundNameResolvingToGatewayManagedRejected(t *testing.T) {
+// TestApplySessionState_BoundNameGatewayManagedLocalApplied pins the MUL-1468
+// fix: a parameter-bound name resolving to a gateway-managed variable with
+// is_local=true (PostgREST's role-setting form, inside a transaction) is no
+// longer rejected — the gateway applies it as a transaction-local override. The
+// paired Route runs the real set_config on the backend transaction-locally
+// (reverting, so no pool leak), while this primitive owns the value so SHOW and
+// the gateway's own deadline enforcement stay correct. The value lives in
+// gateway-managed state, never in SessionSettings.
+func TestApplySessionState_BoundNameGatewayManagedLocalApplied(t *testing.T) {
+	const sql = "SELECT set_config($1, $2, true)"
+	portalInfo := buildBoundPortalInfo(t, sql,
+		[]uint32{uint32(ast.TEXTOID), uint32(ast.TEXTOID)},
+		[][]byte{[]byte("statement_timeout"), []byte("5s")}, []int16{0, 0})
+
+	prim := NewApplySessionStateFromBind(sql, syntheticSetLocalForTest("__bind_$1__", "__bind_$2__"),
+		&BoundSetConfigRefs{
+			NameParam:  &ast.ParamRef{Number: 1},
+			ValueParam: &ast.ParamRef{Number: 2},
+		})
+
+	state := &handler.MultigatewayConnectionState{}
+	state.InitStatementTimeout(30 * time.Second)
+	var tags []string
+	err := prim.PortalStreamExecute(context.Background(), nil, txnConn(t), state, portalInfo, 0, false, PlanExecInfo{},
+		func(_ context.Context, r *sqltypes.Result) error {
+			tags = append(tags, r.CommandTag)
+			return nil
+		})
+	require.NoError(t, err)
+	assert.Nil(t, tags, "SilentTracking must suppress the SET CommandComplete; the paired Route owns the response")
+	assert.Equal(t, 5*time.Second, state.GetStatementTimeout(), "transaction-local GMV override must be applied to gateway state")
+	_, exists := state.GetSessionVariable("statement_timeout")
+	assert.False(t, exists, "a gateway-managed variable must never land in SessionSettings")
+}
+
+// TestApplySessionState_BoundNameGatewayManagedSessionRejected pins the
+// deliberate limitation: a parameter-bound name resolving to a gateway-managed
+// variable with is_local=false is rejected. On a pinned session the verbatim
+// call would persist on the reserved backend and could drift from the gateway on
+// a later change, and forcing the reverted route there needs plumbing we don't
+// have yet — so fail closed (a literal name is the supported session-scoped
+// spelling). PostgREST always uses is_local=true, so it is unaffected.
+func TestApplySessionState_BoundNameGatewayManagedSessionRejected(t *testing.T) {
 	const sql = "SELECT set_config($1, '5s', false)"
 	portalInfo := buildBoundPortalInfo(t, sql, []uint32{uint32(ast.TEXTOID)}, [][]byte{[]byte("statement_timeout")}, []int16{0})
 
@@ -158,7 +194,7 @@ func TestApplySessionState_BoundNameResolvingToGatewayManagedRejected(t *testing
 
 	settings, tags, err := runBindExecute(t, prim, portalInfo)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "gateway-managed")
+	assert.Contains(t, err.Error(), "only supported with is_local=true")
 	assert.Empty(t, settings)
 	assert.Nil(t, tags)
 }

--- a/go/test/endtoend/queryserving/statement_timeout_setconfig_test.go
+++ b/go/test/endtoend/queryserving/statement_timeout_setconfig_test.go
@@ -1030,6 +1030,141 @@ func TestCurrentSettingMaterialized(t *testing.T) {
 	}
 }
 
+// TestStatementTimeoutBoundName reproduces MUL-1468.
+//
+// PostgREST applies role-level settings — e.g. a timeout configured with
+// `ALTER ROLE authenticated SET statement_timeout = '3s'` — once per request
+// transaction, using its *dynamic-name* form (setConfigWithDynamicName in
+// PostgREST's SqlFragment.hs):
+//
+//	SELECT set_config($1, $2, true)   -- $1 and $2 bound; is_local literal true
+//
+// The GUC name is a bound parameter, not a literal. When $1 resolves to
+// statement_timeout (a gateway-managed variable), the multigateway rejects the
+// statement at execute time:
+//
+//	set_config with a parameter-bound name resolving to gateway-managed
+//	variable "statement_timeout" is not supported; use a literal name
+//
+// (engine/apply_session_state.go). Because PostgREST issues this on *every*
+// request for a role that has statement_timeout set, every such request fails.
+//
+// Native PostgreSQL accepts the call. This is a dual-target differential test:
+// the postgres subtest passes and the multigateway subtest currently FAILS —
+// that failure IS the reproduction. It will go green once the gateway handles a
+// bound-name set_config that resolves to a gateway-managed variable (routing it
+// through the same gateway-managed apply/rewrite path used for the literal-name
+// form) instead of rejecting it.
+//
+// Note on why PostgREST's imported test suite does not catch this: multigres
+// runs only PostgREST's Haskell hspec `test:spec` suite, whose fixtures
+// (test/spec/fixtures/) contain no `ALTER ROLE ... SET` and no function-level
+// `SET statement_timeout`, so the dynamic-name form is never emitted there. All
+// of PostgREST's statement_timeout coverage lives in its separate Python
+// `test/io/test_io.py` suite (via a helper that runs `ALTER ROLE ... SET
+// statement_timeout`), which multigres does not run.
+func TestStatementTimeoutBoundName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping bound-name statement_timeout test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping bound-name statement_timeout test")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+
+	for _, target := range setup.GetComparisonTargets(t) {
+		t.Run(target.Name, func(t *testing.T) {
+			connStr := shardsetup.GetTestUserDSN("localhost", target.Port, "sslmode=disable", "connect_timeout=5")
+			db, err := sql.Open("postgres", connStr)
+			require.NoError(t, err)
+			defer db.Close()
+
+			// Pin one backend so session/txn GUC state persists across statements.
+			db.SetMaxOpenConns(1)
+
+			ctx := utils.WithTimeout(t, 150*time.Second)
+			require.NoError(t, db.PingContext(ctx))
+
+			show := func(t *testing.T, q querier) string {
+				t.Helper()
+				var v string
+				require.NoError(t, q.QueryRowContext(ctx, "SHOW statement_timeout").Scan(&v))
+				return v
+			}
+
+			// The exact PostgREST role-setting shape: a bound NAME and a bound
+			// VALUE with a literal is_local=true, run inside a transaction (as
+			// PostgREST does). $1 resolves to statement_timeout.
+			t.Run("postgrest role-setting shape set_config($1,$2,true)", func(t *testing.T) {
+				_, err := db.ExecContext(ctx, "SET statement_timeout = 0")
+				require.NoError(t, err)
+
+				tx, err := db.BeginTx(ctx, nil)
+				require.NoError(t, err)
+				defer func() { _ = tx.Rollback() }()
+
+				var ret string
+				err = tx.QueryRowContext(ctx,
+					"SELECT set_config($1, $2, true)", "statement_timeout", "2000").Scan(&ret)
+				require.NoError(t, err,
+					"a bound set_config name resolving to statement_timeout must be handled, not rejected")
+				assert.Equal(t, "2s", ret, "set_config returns the canonical applied value")
+
+				assert.Equal(t, "2s", show(t, tx),
+					"the transaction-local statement_timeout must be the effective value")
+
+				require.NoError(t, tx.Commit())
+			})
+
+			// Ground truth: the bound-name set_config must actually enforce the
+			// timeout on a slow query in the same transaction.
+			t.Run("bound-name set_config enforces the timeout", func(t *testing.T) {
+				_, err := db.ExecContext(ctx, "SET statement_timeout = 0")
+				require.NoError(t, err)
+
+				tx, err := db.BeginTx(ctx, nil)
+				require.NoError(t, err)
+				defer func() { _ = tx.Rollback() }()
+
+				var ret string
+				require.NoError(t, tx.QueryRowContext(ctx,
+					"SELECT set_config($1, $2, true)", "statement_timeout", "300ms").Scan(&ret))
+				require.Equal(t, "300ms", ret)
+
+				start := time.Now()
+				_, err = tx.ExecContext(ctx, "SELECT pg_sleep(3)")
+				elapsed := time.Since(start)
+				assertQueryCanceled(t, err)
+				assert.Less(t, elapsed, 2*time.Second,
+					"timeout should fire well before the 3s sleep completes")
+			})
+
+			// Session-scoped variant of the same bound-name shape
+			// (set_config($1, $2, false)): also currently rejected at execute
+			// time by the gateway. Grounded on postgres, where it persists as a
+			// session value.
+			t.Run("session bound-name set_config($1,$2,false)", func(t *testing.T) {
+				_, err := db.ExecContext(ctx, "SET statement_timeout = 0")
+				require.NoError(t, err)
+
+				var ret string
+				err = db.QueryRowContext(ctx,
+					"SELECT set_config($1, $2, false)", "statement_timeout", "4000").Scan(&ret)
+				require.NoError(t, err,
+					"a session-scoped bound-name set_config resolving to statement_timeout must be handled")
+				assert.Equal(t, "4s", ret, "set_config returns the canonical applied value")
+				assert.Equal(t, "4s", show(t, db), "the session statement_timeout must take effect")
+
+				// Reset so it does not bleed into later subtests.
+				_, err = db.ExecContext(ctx, "SET statement_timeout = 0")
+				require.NoError(t, err)
+			})
+		})
+	}
+}
+
 // querier is the subset of database/sql shared by *sql.DB and *sql.Tx that the
 // SHOW helper needs.
 type querier interface {

--- a/go/test/endtoend/queryserving/statement_timeout_setconfig_test.go
+++ b/go/test/endtoend/queryserving/statement_timeout_setconfig_test.go
@@ -1046,15 +1046,18 @@ func TestCurrentSettingMaterialized(t *testing.T) {
 //	set_config with a parameter-bound name resolving to gateway-managed
 //	variable "statement_timeout" is not supported; use a literal name
 //
-// (engine/apply_session_state.go). Because PostgREST issues this on *every*
-// request for a role that has statement_timeout set, every such request fails.
+// (engine/apply_session_state.go). Because PostgREST issued this on *every*
+// request for a role that had statement_timeout set, every such request failed.
 //
-// Native PostgreSQL accepts the call. This is a dual-target differential test:
-// the postgres subtest passes and the multigateway subtest currently FAILS —
-// that failure IS the reproduction. It will go green once the gateway handles a
-// bound-name set_config that resolves to a gateway-managed variable (routing it
-// through the same gateway-managed apply/rewrite path used for the literal-name
-// form) instead of rejecting it.
+// The fix stops rejecting in engine.resolveSetConfig for the is_local=true case:
+// the gateway applies the value to its own state (via
+// prepareTrackedSetActionWithExchange) instead of failing, and the paired Route
+// runs the set_config on the backend transaction-locally, so it reverts and never
+// persists on a pooled backend. PostgreSQL returns the same canonical value the
+// client sees. A session-scoped (is_local=false) bound-name GMV is still rejected
+// — a deliberate, documented limitation (a pinned session would persist it on the
+// reserved backend); PostgREST always uses is_local=true. This dual-target
+// differential test grounds the behavior in native PostgreSQL.
 //
 // Note on why PostgREST's imported test suite does not catch this: multigres
 // runs only PostgREST's Haskell hspec `test:spec` suite, whose fixtures
@@ -1142,9 +1145,12 @@ func TestStatementTimeoutBoundName(t *testing.T) {
 			})
 
 			// Session-scoped variant of the same bound-name shape
-			// (set_config($1, $2, false)): also currently rejected at execute
-			// time by the gateway. Grounded on postgres, where it persists as a
-			// session value.
+			// (set_config($1, $2, false)): a deliberate, documented divergence.
+			// PostgreSQL applies it as a session value; the multigateway rejects it
+			// because a pinned session would persist a gateway-managed variable on
+			// its reserved backend (see engine.resolveSetConfig). PostgREST always
+			// uses is_local=true, so it is unaffected. Relax when session-scoped
+			// dynamic-name GMVs are needed.
 			t.Run("session bound-name set_config($1,$2,false)", func(t *testing.T) {
 				_, err := db.ExecContext(ctx, "SET statement_timeout = 0")
 				require.NoError(t, err)
@@ -1152,10 +1158,14 @@ func TestStatementTimeoutBoundName(t *testing.T) {
 				var ret string
 				err = db.QueryRowContext(ctx,
 					"SELECT set_config($1, $2, false)", "statement_timeout", "4000").Scan(&ret)
-				require.NoError(t, err,
-					"a session-scoped bound-name set_config resolving to statement_timeout must be handled")
-				assert.Equal(t, "4s", ret, "set_config returns the canonical applied value")
-				assert.Equal(t, "4s", show(t, db), "the session statement_timeout must take effect")
+				if target.Name == "postgres" {
+					require.NoError(t, err, "native PostgreSQL applies it as a session value")
+					assert.Equal(t, "4s", ret)
+				} else {
+					require.Error(t, err, "the multigateway rejects a session-scoped bound-name GMV set_config")
+					assert.Contains(t, err.Error(), "only supported with is_local=true",
+						"the rejection must point at the supported spelling")
+				}
 
 				// Reset so it does not bleed into later subtests.
 				_, err = db.ExecContext(ctx, "SET statement_timeout = 0")


### PR DESCRIPTION
## Summary

- PostgREST applies role-level settings per request via `set_config($1, $2, true)` (dynamic name). When `$1` resolves to a gateway-managed variable like `statement_timeout` (set via `ALTER ROLE`), the gateway rejected the statement, so every request for such a role failed.
- The gateway now accepts the `is_local=true` form: it tracks the value in gateway state and lets the paired Route run the `set_config` transaction-locally on the backend, which reverts and never persists on a pooled connection.

## Problem

A bound `set_config` name is invisible to the planner's gateway-managed rewrite, so `engine.resolveSetConfig` fail-closed on any bound name resolving to a gateway-managed variable — rejecting PostgREST's per-request role-setting query. The upstream PostgREST hspec suite we run never triggers this: its fixtures configure no role-level `statement_timeout`, so the dynamic-name form is never emitted; that coverage lives only in PostgREST's separate Python `test/io` suite, which we don't run.

## Solution

Gate the rejection on `is_local`: allow `is_local=true` (the value runs transaction-locally and reverts, and the gateway owns it for `SHOW`/enforcement), keep rejecting `is_local=false` (a pinned session would persist it on the reserved backend — a documented limitation PostgREST never hits). Adds a dual-target reproduction (`TestStatementTimeoutBoundName`) plus engine unit coverage for the applied and rejected cases.