### PR TITLE
fix(consensus): restrict MultiCellPolicy to 2 cells

### DIFF
--- a/go/common/consensus/durability.go
+++ b/go/common/consensus/durability.go
@@ -57,7 +57,7 @@ type DurabilityPolicy interface {
 	//
 	// cohort is the full set of poolers participating in the term, including
 	// the primary. The method derives the eligible standby set per policy
-	// (e.g., MultiCellPolicy excludes the primary's cell). Passing the full
+	// (e.g., multiCellPolicy excludes the primary's cell). Passing the full
 	// cohort keeps the caller-side contract simple.
 	//
 	// On success the config is always non-nil — every promotion explicitly
@@ -107,11 +107,12 @@ func NewPolicyFromProto(policy *clustermetadatapb.DurabilityPolicy) (DurabilityP
 		}
 		return AtLeastNPolicy{N: int(policy.RequiredCount)}, nil
 	case clustermetadatapb.QuorumType_QUORUM_TYPE_MULTI_CELL_AT_LEAST_N:
-		// N=0 would make revocation (|uncovered cells| < N) unsatisfiable for any recruitment.
-		if policy.RequiredCount < 1 {
-			return nil, fmt.Errorf("MULTI_CELL_AT_LEAST_N requires RequiredCount >= 1, got %d", policy.RequiredCount)
+		// Only RequiredCount = 2 is currently supported. It's not currently possible to represent any other number in
+		// sync_standby_names. We could expand this in the future.
+		if policy.RequiredCount != 2 {
+			return nil, fmt.Errorf("MULTI_CELL_AT_LEAST_N requires RequiredCount == 2, got %d", policy.RequiredCount)
 		}
-		return MultiCellPolicy{N: int(policy.RequiredCount)}, nil
+		return multiCellPolicy{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported quorum type: %v", policy.QuorumType)
 	}
@@ -200,7 +201,7 @@ func cohortIsSubsetOf(a, b []*clustermetadatapb.ID) bool {
 // the larger N, ensuring the WAL record is acknowledged under the stricter policy.
 // When outgoing and incoming are identical Both matches incoming.
 //
-// Both AtLeastNPolicy and MultiCellPolicy are supported; mixing the two types
+// Both AtLeastNPolicy and multiCellPolicy are supported; mixing the two types
 // returns an error.
 func BuildPolicyTransition(outgoing, incoming PolicyWithCohort) (*PolicyTransition, error) {
 	outN, outFamily := policyFamily(outgoing.Policy)
@@ -241,13 +242,13 @@ func BuildPolicyTransition(outgoing, incoming PolicyWithCohort) (*PolicyTransiti
 }
 
 // policyFamily returns the RequiredCount and a string tag identifying the policy
-// family for AtLeastNPolicy and MultiCellPolicy. Returns (0, "") for unsupported types.
+// family for AtLeastNPolicy and multiCellPolicy. Returns (0, "") for unsupported types.
 func policyFamily(p DurabilityPolicy) (n int, family string) {
 	switch v := p.(type) {
 	case AtLeastNPolicy:
 		return v.N, "at_least_n"
-	case MultiCellPolicy:
-		return v.N, "multi_cell_at_least_n"
+	case multiCellPolicy:
+		return 2, "multi_cell_at_least_n"
 	default:
 		return 0, ""
 	}

--- a/go/common/consensus/durability_test.go
+++ b/go/common/consensus/durability_test.go
@@ -179,7 +179,7 @@ func TestBuildPolicyTransition(t *testing.T) {
 		{
 			name:       "mixed policy families: error",
 			outgoing:   pwc(AtLeastNPolicy{N: 2}, a, b, c),
-			incoming:   pwc(MultiCellPolicy{N: 2}, a, b, c),
+			incoming:   pwc(multiCellPolicy{}, a, b, c),
 			wantErrMsg: "policy types must match",
 		},
 		{
@@ -193,18 +193,11 @@ func TestBuildPolicyTransition(t *testing.T) {
 			wantErrMsg: "policies must be AtLeastN or MultiCellAtLeastN",
 		},
 		{
-			name:         "MultiCell: N increases, same cohort",
-			outgoing:     pwc(MultiCellPolicy{N: 2}, a, b, c),
-			incoming:     pwc(MultiCellPolicy{N: 3}, a, b, c),
-			wantBoth:     pwc(MultiCellPolicy{N: 3}, a, b, c),
-			wantIncoming: pwc(MultiCellPolicy{N: 3}, a, b, c),
-		},
-		{
 			name:         "MultiCell: cohort shrinks, same N",
-			outgoing:     pwc(MultiCellPolicy{N: 2}, a, b, c),
-			incoming:     pwc(MultiCellPolicy{N: 2}, a, b),
-			wantBoth:     pwc(MultiCellPolicy{N: 2}, a, b),
-			wantIncoming: pwc(MultiCellPolicy{N: 2}, a, b),
+			outgoing:     pwc(multiCellPolicy{}, a, b, c),
+			incoming:     pwc(multiCellPolicy{}, a, b),
+			wantBoth:     pwc(multiCellPolicy{}, a, b),
+			wantIncoming: pwc(multiCellPolicy{}, a, b),
 		},
 	}
 
@@ -239,7 +232,7 @@ func TestNewPolicyFromProto(t *testing.T) {
 		{
 			name:   "MULTI_CELL_AT_LEAST_N returns MultiCellPolicy",
 			policy: topoclient.MultiCellAtLeastN(2),
-			wantOK: func(p DurabilityPolicy) bool { _, ok := p.(MultiCellPolicy); return ok },
+			wantOK: func(p DurabilityPolicy) bool { _, ok := p.(multiCellPolicy); return ok },
 		},
 		{
 			name:    "nil policy returns error",
@@ -276,7 +269,7 @@ func TestNewPolicyFromProto(t *testing.T) {
 				QuorumType:    clustermetadatapb.QuorumType_QUORUM_TYPE_MULTI_CELL_AT_LEAST_N,
 				RequiredCount: 0,
 			},
-			wantErr: "MULTI_CELL_AT_LEAST_N requires RequiredCount >= 1",
+			wantErr: "MULTI_CELL_AT_LEAST_N requires RequiredCount == 2, got 0",
 		},
 	}
 

--- a/go/common/consensus/policy_multi_cell.go
+++ b/go/common/consensus/policy_multi_cell.go
@@ -23,23 +23,22 @@ import (
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 )
 
-// MultiCellPolicy requires acknowledgement from poolers spanning at least N
+// multiCellPolicy requires acknowledgement from poolers spanning at least 2
 // distinct cells.
-type MultiCellPolicy struct {
-	N int
-}
+// In future we could expand this to a configurable number of cells
+type multiCellPolicy struct{}
 
-// SatisfiedBy returns nil iff poolers spans at least N distinct cells.
-func (p MultiCellPolicy) SatisfiedBy(poolers []*clustermetadatapb.ID) error {
+// SatisfiedBy returns nil iff poolers spans at least 2 distinct cells.
+func (p multiCellPolicy) SatisfiedBy(poolers []*clustermetadatapb.ID) error {
 	// cellsOf already dedupes by cell, so a duplicate pooler entry can't
 	// inflate the cell count the way it could a raw pooler count — this
 	// normalization is for consistency with AtLeastNPolicy.SatisfiedBy, not
 	// because it changes cellsOf's result here.
 	poolers = normalizeIDs(poolers)
 	cells := cellsOf(poolers)
-	if len(cells) < p.N {
+	if len(cells) < 2 {
 		return fmt.Errorf("durability not satisfied: poolers span %d cells, required %d",
-			len(cells), p.N)
+			len(cells), 2)
 	}
 	return nil
 }
@@ -50,22 +49,10 @@ func (p MultiCellPolicy) SatisfiedBy(poolers []*clustermetadatapb.ID) error {
 //
 // Errors when no eligible different-cell standbys exist or when the eligible
 // set is too small to satisfy num_sync.
-func (p MultiCellPolicy) BuildSyncReplicationConfig(
+func (p multiCellPolicy) BuildSyncReplicationConfig(
 	cohort []*clustermetadatapb.ID,
 	primary *clustermetadatapb.ID,
 ) (*SyncReplicationConfig, error) {
-	// N==1 means the primary alone satisfies durability — return an explicit
-	// "no sync standbys" config so the new primary clears any stale
-	// synchronous_standby_names instead of silently inheriting them.
-	if p.N == 1 {
-		return &SyncReplicationConfig{
-			SyncCommit:     multipoolermanagerdatapb.SynchronousCommitLevel_SYNCHRONOUS_COMMIT_LOCAL,
-			SyncMethod:     multipoolermanagerdatapb.SynchronousMethod_SYNCHRONOUS_METHOD_ANY,
-			NumSync:        1,
-			SyncStandbyIDs: nil,
-		}, nil
-	}
-
 	// Drop cohort members in the primary's own cell so synchronous
 	// acknowledgement always crosses a cell boundary. The primary itself is
 	// naturally excluded (it's in its own cell).
@@ -83,25 +70,17 @@ func (p MultiCellPolicy) BuildSyncReplicationConfig(
 				primaryCell))
 	}
 
-	// num_sync = required_count - 1: primary itself counts as 1 ack.
-	requiredNumSync := p.N - 1
-	if requiredNumSync > len(eligible) {
-		return nil, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION,
-			fmt.Sprintf("cannot establish synchronous replication: insufficient different-cell standbys (required %d standbys, available %d)",
-				requiredNumSync, len(eligible)))
-	}
-
 	return &SyncReplicationConfig{
 		SyncCommit:     multipoolermanagerdatapb.SynchronousCommitLevel_SYNCHRONOUS_COMMIT_ON,
 		SyncMethod:     multipoolermanagerdatapb.SynchronousMethod_SYNCHRONOUS_METHOD_ANY,
-		NumSync:        requiredNumSync,
+		NumSync:        1,
 		SyncStandbyIDs: eligible,
 	}, nil
 }
 
 // Description returns a human-readable summary of the policy.
-func (p MultiCellPolicy) Description() string {
-	return fmt.Sprintf("MULTI_CELL_AT_LEAST_N(N=%d)", p.N)
+func (p multiCellPolicy) Description() string {
+	return "MULTI_CELL_AT_LEAST_N(N=2)"
 }
 
 // cellsOf returns the set of distinct cells covered by poolers.

--- a/go/common/consensus/policy_multi_cell_test.go
+++ b/go/common/consensus/policy_multi_cell_test.go
@@ -26,13 +26,11 @@ import (
 func TestMultiCellPolicy_SatisfiedBy(t *testing.T) {
 	tests := []struct {
 		name           string
-		n              int
 		proposedCohort []*clustermetadatapb.ID
 		wantErrMsg     string
 	}{
 		{
 			name: "MULTI_CELL_2 with poolers in 2 cells is achievable",
-			n:    2,
 			proposedCohort: []*clustermetadatapb.ID{
 				id("pooler-1", "cell1"),
 				id("pooler-2", "cell2"),
@@ -40,7 +38,6 @@ func TestMultiCellPolicy_SatisfiedBy(t *testing.T) {
 		},
 		{
 			name: "MULTI_CELL_2 with poolers in 3 cells is achievable",
-			n:    2,
 			proposedCohort: []*clustermetadatapb.ID{
 				id("pooler-1", "cell1"),
 				id("pooler-2", "cell2"),
@@ -49,7 +46,6 @@ func TestMultiCellPolicy_SatisfiedBy(t *testing.T) {
 		},
 		{
 			name: "MULTI_CELL_2 with 3 poolers all in cell1 is not achievable",
-			n:    2,
 			proposedCohort: []*clustermetadatapb.ID{
 				id("pooler-1", "cell1"),
 				id("pooler-2", "cell1"),
@@ -57,20 +53,11 @@ func TestMultiCellPolicy_SatisfiedBy(t *testing.T) {
 			},
 			wantErrMsg: "durability not satisfied: poolers span 1 cells, required 2",
 		},
-		{
-			name: "MULTI_CELL_3 with poolers in 2 cells is not achievable",
-			n:    3,
-			proposedCohort: []*clustermetadatapb.ID{
-				id("pooler-1", "cell1"),
-				id("pooler-2", "cell2"),
-			},
-			wantErrMsg: "durability not satisfied: poolers span 2 cells, required 3",
-		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			p := MultiCellPolicy{N: tc.n}
+			p := multiCellPolicy{}
 			err := p.SatisfiedBy(tc.proposedCohort)
 			if tc.wantErrMsg == "" {
 				require.NoError(t, err)
@@ -92,7 +79,6 @@ func TestMultiCellPolicy_CheckSufficientRecruitment(t *testing.T) {
 	}{
 		{
 			name: "MULTI_CELL_2 with all 3 cohort cells recruited is sufficient",
-			n:    2,
 			cohort: []*clustermetadatapb.ID{
 				id("pooler-1", "cell1"),
 				id("pooler-2", "cell2"),
@@ -106,7 +92,6 @@ func TestMultiCellPolicy_CheckSufficientRecruitment(t *testing.T) {
 		},
 		{
 			name: "MULTI_CELL_2 with 2 of 3 cohort cells covered is sufficient",
-			n:    2,
 			cohort: []*clustermetadatapb.ID{
 				id("pooler-1", "cell1"),
 				id("pooler-2", "cell2"),
@@ -119,7 +104,6 @@ func TestMultiCellPolicy_CheckSufficientRecruitment(t *testing.T) {
 		},
 		{
 			name: "MULTI_CELL_2 with 3 of 4 cohort poolers (both cell1 poolers plus one cell2) is sufficient",
-			n:    2,
 			cohort: []*clustermetadatapb.ID{
 				id("pooler-1", "cell1"),
 				id("pooler-4", "cell1"),
@@ -134,7 +118,6 @@ func TestMultiCellPolicy_CheckSufficientRecruitment(t *testing.T) {
 		},
 		{
 			name: "MULTI_CELL_2 with 2 of 4 cohort poolers all in cell1 fails majority",
-			n:    2,
 			cohort: []*clustermetadatapb.ID{
 				id("pooler-1", "cell1"),
 				id("pooler-4", "cell1"),
@@ -153,7 +136,6 @@ func TestMultiCellPolicy_CheckSufficientRecruitment(t *testing.T) {
 			// two coordinators could recruit disjoint halves at the same term.
 			// Majority catches this.
 			name: "MULTI_CELL_2 with 3 of 6 cohort poolers (one per cell) fails majority",
-			n:    2,
 			cohort: []*clustermetadatapb.ID{
 				id("pooler-1a", "cell1"),
 				id("pooler-1b", "cell1"),
@@ -175,7 +157,6 @@ func TestMultiCellPolicy_CheckSufficientRecruitment(t *testing.T) {
 			// but leaves un-recruited cells {cell2, cell3} = 2 cells, enough
 			// for a parallel 2-cell quorum. Revocation catches it.
 			name: "MULTI_CELL_2 with 3 of 5 cohort poolers passes majority but fails revocation",
-			n:    2,
 			cohort: []*clustermetadatapb.ID{
 				id("pooler-1a", "cell1"),
 				id("pooler-1b", "cell1"),
@@ -192,7 +173,6 @@ func TestMultiCellPolicy_CheckSufficientRecruitment(t *testing.T) {
 		},
 		{
 			name: "MULTI_CELL_2 with a recruited pooler outside the cohort is rejected",
-			n:    2,
 			cohort: []*clustermetadatapb.ID{
 				id("pooler-1", "cell1"),
 				id("pooler-2", "cell2"),
@@ -208,7 +188,7 @@ func TestMultiCellPolicy_CheckSufficientRecruitment(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			p := MultiCellPolicy{N: tc.n}
+			p := multiCellPolicy{}
 			err := CheckSufficientRecruitment(p, tc.cohort, tc.recruited)
 			if tc.wantErrMsg == "" {
 				require.NoError(t, err)
@@ -221,26 +201,9 @@ func TestMultiCellPolicy_CheckSufficientRecruitment(t *testing.T) {
 }
 
 func TestMultiCellPolicy_BuildSyncReplicationConfig(t *testing.T) {
-	t.Run("N=1 returns local-only config (clears sync standbys)", func(t *testing.T) {
-		leader := id("primary", "cell-a")
-		p := MultiCellPolicy{N: 1}
-		cohort := []*clustermetadatapb.ID{
-			leader,
-			id("mp1", "cell-b"),
-			id("mp2", "cell-c"),
-		}
-		cfg, err := p.BuildSyncReplicationConfig(cohort, leader)
-		require.NoError(t, err)
-		require.NotNil(t, cfg, "N=1 must still return a config so the new primary explicitly clears stale sync settings")
-		require.Equal(t, multipoolermanagerdatapb.SynchronousCommitLevel_SYNCHRONOUS_COMMIT_LOCAL, cfg.SyncCommit)
-		require.Equal(t, multipoolermanagerdatapb.SynchronousMethod_SYNCHRONOUS_METHOD_ANY, cfg.SyncMethod)
-		require.Equal(t, 1, cfg.NumSync, "NumSync must be a valid positive value; the empty standby list is what disables sync")
-		require.Empty(t, cfg.SyncStandbyIDs)
-	})
-
 	t.Run("excludes same-cell standbys", func(t *testing.T) {
 		leader := id("primary", "us-west-1a")
-		p := MultiCellPolicy{N: 2}
+		p := multiCellPolicy{}
 		cohort := []*clustermetadatapb.ID{
 			leader,
 			id("mp1", "us-west-1a"), // same cell — excluded
@@ -259,7 +222,7 @@ func TestMultiCellPolicy_BuildSyncReplicationConfig(t *testing.T) {
 
 	t.Run("only different-cell standbys with mixed cells", func(t *testing.T) {
 		leader := id("primary", "cell-a")
-		p := MultiCellPolicy{N: 3}
+		p := multiCellPolicy{}
 		cohort := []*clustermetadatapb.ID{
 			leader,
 			id("mp1", "cell-a"), // same cell — excluded
@@ -271,7 +234,7 @@ func TestMultiCellPolicy_BuildSyncReplicationConfig(t *testing.T) {
 		cfg, err := p.BuildSyncReplicationConfig(cohort, leader)
 		require.NoError(t, err)
 		require.NotNil(t, cfg)
-		require.Equal(t, 2, cfg.NumSync)
+		require.Equal(t, 1, cfg.NumSync)
 		require.ElementsMatch(t,
 			[]string{"cell-b_mp3", "cell-c_mp4", "cell-d_mp5"},
 			clusterIDStrings(cfg.SyncStandbyIDs),
@@ -280,7 +243,7 @@ func TestMultiCellPolicy_BuildSyncReplicationConfig(t *testing.T) {
 
 	t.Run("all standbys in leader's cell returns error", func(t *testing.T) {
 		leader := id("primary", "us-west-1a")
-		p := MultiCellPolicy{N: 2}
+		p := multiCellPolicy{}
 		cohort := []*clustermetadatapb.ID{
 			leader,
 			id("mp1", "us-west-1a"),
@@ -291,24 +254,9 @@ func TestMultiCellPolicy_BuildSyncReplicationConfig(t *testing.T) {
 		require.Nil(t, cfg)
 		require.EqualError(t, err, "cannot establish synchronous replication: no eligible standbys in different cells (primary_cell=us-west-1a)")
 	})
-
-	t.Run("insufficient different-cell standbys returns error", func(t *testing.T) {
-		leader := id("primary", "cell-a")
-		p := MultiCellPolicy{N: 4} // wants 3 different-cell standbys
-		cohort := []*clustermetadatapb.ID{
-			leader,
-			id("mp1", "cell-a"), // excluded
-			id("mp2", "cell-a"), // excluded
-			id("mp3", "cell-b"),
-		}
-		cfg, err := p.BuildSyncReplicationConfig(cohort, leader)
-		require.Nil(t, cfg)
-		require.EqualError(t, err, "cannot establish synchronous replication: insufficient different-cell standbys (required 3 standbys, available 1)")
-	})
-
 	t.Run("N=2 with 3 different-cell standbys includes all", func(t *testing.T) {
 		leader := id("primary", "cell-primary")
-		p := MultiCellPolicy{N: 2}
+		p := multiCellPolicy{}
 		cohort := []*clustermetadatapb.ID{
 			leader,
 			id("mp1", "us-west-1a"),
@@ -328,7 +276,7 @@ func TestMultiCellPolicy_BuildSyncReplicationConfig(t *testing.T) {
 
 	t.Run("uses ON commit and ANY method", func(t *testing.T) {
 		leader := id("primary", "cell-a")
-		p := MultiCellPolicy{N: 2}
+		p := multiCellPolicy{}
 		cohort := []*clustermetadatapb.ID{
 			leader,
 			id("mp1", "cell-b"),
@@ -342,6 +290,5 @@ func TestMultiCellPolicy_BuildSyncReplicationConfig(t *testing.T) {
 }
 
 func TestMultiCellPolicy_Description(t *testing.T) {
-	require.Equal(t, "MULTI_CELL_AT_LEAST_N(N=2)", MultiCellPolicy{N: 2}.Description())
-	require.Equal(t, "MULTI_CELL_AT_LEAST_N(N=3)", MultiCellPolicy{N: 3}.Description())
+	require.Equal(t, "MULTI_CELL_AT_LEAST_N(N=2)", multiCellPolicy{}.Description())
 }


### PR DESCRIPTION
# Summary

`MultiCellPolicy{N: 3+}` did not correctly require replicas in `sync_standby_names` to be in different cells. For now, simply restrict to `N=2` and make `MultiCellPolicy` require `1+` standby in a different cell to the primary. In the future we could expand support to an arbitrary number of cells.

# Description

Removes `MultiCellPolicy.N` and hard-codes it to 2. Does not make changes at the protobuf layer, instead simply errors if the protobuf tries to construct a `MultiCellPolicy` with `N != 2`.

Makes `multiCellPolicy` private, it was not used outside its package before, and this helps to protect the public API in case we support N cells again.