### PR TITLE
test(pgregress): accept patched expected variants

### DIFF
--- a/go/test/endtoend/pgregresstest/patch_verify_test.go
+++ b/go/test/endtoend/pgregresstest/patch_verify_test.go
@@ -64,6 +64,30 @@ func fixture(t *testing.T, name, expected, actual, patch string) VerifyInput {
 	}
 }
 
+func patchedVariantFixture(t *testing.T) (VerifyInput, []string) {
+	t.Helper()
+	const (
+		name      = "patched_variant"
+		canonical = "header\nplan: index only\ncommon\nfooter\n"
+		alternate = "header\nplan: bitmap\ncommon\nfooter\n"
+		actual    = "header\nplan: bitmap\ncommon\nmultigres warning\nfooter\n"
+		patch     = `--- a
++++ b
+@@ -3,2 +3,3 @@
+ common
++multigres warning
+ footer
+`
+	)
+
+	in := fixture(t, name, canonical, actual, patch)
+	alternatePath := filepath.Join(filepath.Dir(in.ExpectedPath), name+"_1.out")
+	if err := os.WriteFile(alternatePath, []byte(alternate), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return in, []string{in.ExpectedPath, alternatePath}
+}
+
 func requirePatchTool(t *testing.T) {
 	t.Helper()
 	if _, err := exec.LookPath("patch"); err != nil {
@@ -380,41 +404,9 @@ func TestVerifyWithPatchesAcceptsCoreAlternateExpected(t *testing.T) {
 
 func TestVerifyPatchedVariantsAppliesCommonPatchToNumberedAlternative(t *testing.T) {
 	requirePatchTool(t)
-	root := t.TempDir()
-	regressDir := filepath.Join(root, "regress")
-	patchDir := filepath.Join(root, "patches")
-	expectedDir := filepath.Join(regressDir, "expected")
-	for _, dir := range []string{expectedDir, patchDir} {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatal(err)
-		}
-	}
+	in, variants := patchedVariantFixture(t)
 
-	const name = "patched_variant"
-	canonical := filepath.Join(expectedDir, name+".out")
-	alternate := filepath.Join(expectedDir, name+"_1.out")
-	actual := filepath.Join(root, name+".out")
-	for path, contents := range map[string]string{
-		canonical: "header\nplan: index only\ncommon\nfooter\n",
-		alternate: "header\nplan: bitmap\ncommon\nfooter\n",
-		actual:    "header\nplan: bitmap\ncommon\nmultigres warning\nfooter\n",
-	} {
-		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	patch := `--- a
-+++ b
-@@ -3,2 +3,3 @@
- common
-+multigres warning
- footer
-`
-	if err := os.WriteFile(filepath.Join(patchDir, name+".patch"), []byte(patch), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	outcome, err := verifyPatchedVariants(t.Context(), name, actual, regressDir, patchDir, root, []string{canonical, alternate}, PatchModeVerify)
+	outcome, err := verifyPatchedVariants(t.Context(), in.Name, in.ActualPath, in.RepoRoot, in.PatchDir, in.RepoRoot, variants, PatchModeVerify)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/test/endtoend/pgregresstest/patch_verify_test.go
+++ b/go/test/endtoend/pgregresstest/patch_verify_test.go
@@ -378,7 +378,7 @@ func TestVerifyWithPatchesAcceptsCoreAlternateExpected(t *testing.T) {
 	}
 }
 
-func TestVerifyPatchedVariantsAcceptsPatchedAlternate(t *testing.T) {
+func TestVerifyPatchedVariantsAppliesCommonPatchToNumberedAlternative(t *testing.T) {
 	requirePatchTool(t)
 	root := t.TempDir()
 	regressDir := filepath.Join(root, "regress")

--- a/go/test/endtoend/pgregresstest/patch_verify_test.go
+++ b/go/test/endtoend/pgregresstest/patch_verify_test.go
@@ -378,6 +378,51 @@ func TestVerifyWithPatchesAcceptsCoreAlternateExpected(t *testing.T) {
 	}
 }
 
+func TestVerifyPatchedVariantsAcceptsPatchedAlternate(t *testing.T) {
+	requirePatchTool(t)
+	root := t.TempDir()
+	regressDir := filepath.Join(root, "regress")
+	patchDir := filepath.Join(root, "patches")
+	expectedDir := filepath.Join(regressDir, "expected")
+	for _, dir := range []string{expectedDir, patchDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const name = "patched_variant"
+	canonical := filepath.Join(expectedDir, name+".out")
+	alternate := filepath.Join(expectedDir, name+"_1.out")
+	actual := filepath.Join(root, name+".out")
+	for path, contents := range map[string]string{
+		canonical: "header\nplan: index only\ncommon\nfooter\n",
+		alternate: "header\nplan: bitmap\ncommon\nfooter\n",
+		actual:    "header\nplan: bitmap\ncommon\nmultigres warning\nfooter\n",
+	} {
+		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	patch := `--- a
++++ b
+@@ -3,2 +3,3 @@
+ common
++multigres warning
+ footer
+`
+	if err := os.WriteFile(filepath.Join(patchDir, name+".patch"), []byte(patch), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outcome, err := verifyPatchedVariants(t.Context(), name, actual, regressDir, patchDir, root, []string{canonical, alternate}, PatchModeVerify)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.Status != "pass" || !outcome.PatchApplied {
+		t.Fatalf("patched alternate was not accepted: %+v", outcome)
+	}
+}
+
 func TestMarkdownSummaryClassifiesCompatibilityResults(t *testing.T) {
 	pb := &PostgresBuilder{Builder: &pgbuilder.Builder{OutputDir: t.TempDir()}}
 	results := &TestResults{

--- a/go/test/endtoend/pgregresstest/patch_verify_test.go
+++ b/go/test/endtoend/pgregresstest/patch_verify_test.go
@@ -402,7 +402,7 @@ func TestVerifyWithPatchesAcceptsCoreAlternateExpected(t *testing.T) {
 	}
 }
 
-func TestVerifyPatchedVariantsAppliesCommonPatchToNumberedAlternative(t *testing.T) {
+func TestVerifyPatchedVariants_Alternate(t *testing.T) {
 	requirePatchTool(t)
 	in, variants := patchedVariantFixture(t)
 

--- a/go/test/endtoend/pgregresstest/pg_regress.go
+++ b/go/test/endtoend/pgregresstest/pg_regress.go
@@ -467,22 +467,10 @@ func (pb *PostgresBuilder) verifyModuleResults(ctx context.Context, expectedDir,
 			continue
 		}
 
-		// No stock output matches: apply the reviewed Multigres patch against its
-		// declared upstream base (canonical unless the patch preamble says
-		// otherwise).
-		expPath, err := expectedFileForPatch(expectedDir, test.Name, patchDir, variants)
-		if err != nil {
-			test.Status = "fail"
-			test.FailReason = err.Error()
-			continue
-		}
-		outcome, err := VerifyTest(ctx, VerifyInput{
-			Name:         test.Name,
-			ExpectedPath: expPath,
-			ActualPath:   actPath,
-			PatchDir:     patchDir,
-			RepoRoot:     repoRoot,
-		}, mode)
+		// No stock output matches: apply the reviewed Multigres patch to every
+		// expected variant. A common divergence can then be layered on top of
+		// any output PostgreSQL itself considers valid.
+		outcome, err := verifyPatchedVariants(ctx, test.Name, actPath, expectedDir, patchDir, repoRoot, variants, mode)
 		if err != nil {
 			test.Status = "fail"
 			test.FailReason = err.Error()
@@ -513,6 +501,56 @@ func expectedVariants(regressDir, name string) []string {
 		}
 	}
 	return out
+}
+
+// verifyPatchedVariants applies a test's common Multigres patch to every
+// PostgreSQL expected-output variant and accepts the first match. The optional
+// pgregress-expected-file directive chooses the preferred base for diagnostics
+// and patch generation; it does not prevent other variants from matching.
+func verifyPatchedVariants(ctx context.Context, name, actualPath, regressDir, patchDir, repoRoot string, variants []string, mode PatchMode) (*VerifyOutcome, error) {
+	preferred, err := expectedFileForPatch(regressDir, name, patchDir, variants)
+	if err != nil {
+		return nil, err
+	}
+
+	ordered := make([]string, 0, len(variants))
+	ordered = append(ordered, preferred)
+	for _, variant := range variants {
+		if variant != preferred {
+			ordered = append(ordered, variant)
+		}
+	}
+
+	var preferredFailure *VerifyOutcome
+	for _, expectedPath := range ordered {
+		outcome, err := VerifyTest(ctx, VerifyInput{
+			Name:         name,
+			ExpectedPath: expectedPath,
+			ActualPath:   actualPath,
+			PatchDir:     patchDir,
+			RepoRoot:     repoRoot,
+		}, PatchModeVerify)
+		if err != nil {
+			return nil, err
+		}
+		if outcome.Status == "pass" {
+			return outcome, nil
+		}
+		if expectedPath == preferred {
+			preferredFailure = outcome
+		}
+	}
+
+	if mode == PatchModeGenerate {
+		return VerifyTest(ctx, VerifyInput{
+			Name:         name,
+			ExpectedPath: preferred,
+			ActualPath:   actualPath,
+			PatchDir:     patchDir,
+			RepoRoot:     repoRoot,
+		}, PatchModeGenerate)
+	}
+	return preferredFailure, nil
 }
 
 const expectedFileDirective = "# pgregress-expected-file:"
@@ -713,17 +751,7 @@ func (pb *PostgresBuilder) VerifyWithPatches(t *testing.T, ctx context.Context, 
 			continue
 		}
 
-		expPath, err := expectedFileForPatch(sourceRegressDir, test.Name, patchDir, variants)
-		if err != nil {
-			return fmt.Errorf("select expected output for %s: %w", test.Name, err)
-		}
-		outcome, err := VerifyTest(ctx, VerifyInput{
-			Name:         test.Name,
-			ExpectedPath: expPath,
-			ActualPath:   actPath,
-			PatchDir:     patchDir,
-			RepoRoot:     repoRoot,
-		}, mode)
+		outcome, err := verifyPatchedVariants(ctx, test.Name, actPath, sourceRegressDir, patchDir, repoRoot, variants, mode)
 		if err != nil {
 			return fmt.Errorf("verify %s: %w", test.Name, err)
 		}

--- a/go/test/endtoend/pgregresstest/pgregress_test.go
+++ b/go/test/endtoend/pgregresstest/pgregress_test.go
@@ -151,6 +151,11 @@ func TestPostgreSQLRegression(t *testing.T) {
 	if err := builder.EnsureSource(t, buildCtx); err != nil {
 		t.Fatalf("Failed to setup PostgreSQL source: %v", err)
 	}
+	if runRegress {
+		if err := builder.PrepareExpectedVariants(buildCtx); err != nil {
+			t.Fatalf("Failed to prepare PostgreSQL expected-output variants: %v", err)
+		}
+	}
 
 	// Phase 2: Build PostgreSQL
 	t.Logf("Phase 2: Building PostgreSQL...")

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -1470,6 +1470,43 @@ func PatchesDir() string {
 	return filepath.Join(pkgDir, "testdata", pgMajorDir(), "patches")
 }
 
+// ExpectedVariantsDir contains compact patches that derive additional valid
+// pg_regress expected .out files from PostgreSQL's canonical output.
+func ExpectedVariantsDir() string {
+	return filepath.Join(filepath.Dir(PatchesDir()), "expected_variants")
+}
+
+// PrepareExpectedVariants materializes numbered pg_regress alternatives such
+// as create_index_1.out from compact, reviewed patches. PostgreSQL then sees
+// them exactly like its own numbered expected-output variants.
+func (pb *PostgresBuilder) PrepareExpectedVariants(ctx context.Context) error {
+	variantPatches, err := filepath.Glob(filepath.Join(ExpectedVariantsDir(), "*_?.patch"))
+	if err != nil {
+		return fmt.Errorf("find expected-output variant patches: %w", err)
+	}
+	expectedDir := filepath.Join(pb.SourceDir, "src", "test", "regress", "expected")
+	for _, patchPath := range variantPatches {
+		variantName := strings.TrimSuffix(filepath.Base(patchPath), ".patch")
+		separator := strings.LastIndexByte(variantName, '_')
+		if separator <= 0 {
+			return fmt.Errorf("invalid expected-output variant patch name %q", filepath.Base(patchPath))
+		}
+		canonicalPath := filepath.Join(expectedDir, variantName[:separator]+".out")
+		canonical, err := os.ReadFile(canonicalPath)
+		if err != nil {
+			return fmt.Errorf("read canonical expected output for %s: %w", variantName, err)
+		}
+		variant, err := suiteutil.ApplyPatch(ctx, canonical, patchPath)
+		if err != nil {
+			return fmt.Errorf("generate expected output %s: %w", variantName, err)
+		}
+		if err := os.WriteFile(filepath.Join(expectedDir, variantName+".out"), variant, 0o644); err != nil {
+			return fmt.Errorf("write expected output %s: %w", variantName, err)
+		}
+	}
+	return nil
+}
+
 // pgMajorDir returns the directory name under testdata/ that holds patches for
 // the PostgreSQL version this test targets. Pinned to pg17 today; add a case
 // when PostgresVersion advances.

--- a/go/test/endtoend/pgregresstest/testdata/pg17/expected_variants/create_index_1.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/expected_variants/create_index_1.patch
@@ -1,0 +1,92 @@
+# Valid alternative under physical replication with hot_standby_feedback=on.
+# A freshly loaded table may not be all-visible when VACUUM first runs, making
+# PostgreSQL choose bitmap heap scans instead of index-only scans.
+--- a
++++ b
+@@ -1922,11 +1922,15 @@
+ SELECT unique1 FROM tenk1
+ WHERE unique1 IN (1,42,7)
+ ORDER BY unique1;
+-                      QUERY PLAN                       
+--------------------------------------------------------
+- Index Only Scan using tenk1_unique1 on tenk1
+-   Index Cond: (unique1 = ANY ('{1,42,7}'::integer[]))
+-(2 rows)
++                            QUERY PLAN                             
++-------------------------------------------------------------------
++ Sort
++   Sort Key: unique1
++   ->  Bitmap Heap Scan on tenk1
++         Recheck Cond: (unique1 = ANY ('{1,42,7}'::integer[]))
++         ->  Bitmap Index Scan on tenk1_unique1
++               Index Cond: (unique1 = ANY ('{1,42,7}'::integer[]))
++(6 rows)
+ 
+ SELECT unique1 FROM tenk1
+ WHERE unique1 IN (1,42,7)
+@@ -2037,11 +2041,13 @@
+ 
+ explain (costs off)
+ SELECT unique1 FROM tenk1 WHERE unique1 IN (1, 42, 7) and unique1 >= 42;
+-                                 QUERY PLAN                                  
+------------------------------------------------------------------------------
+- Index Only Scan using tenk1_unique1 on tenk1
+-   Index Cond: ((unique1 = ANY ('{1,42,7}'::integer[])) AND (unique1 >= 42))
+-(2 rows)
++                                    QUERY PLAN                                     
++-----------------------------------------------------------------------------------
++ Bitmap Heap Scan on tenk1
++   Recheck Cond: ((unique1 = ANY ('{1,42,7}'::integer[])) AND (unique1 >= 42))
++   ->  Bitmap Index Scan on tenk1_unique1
++         Index Cond: ((unique1 = ANY ('{1,42,7}'::integer[])) AND (unique1 >= 42))
++(4 rows)
+ 
+ SELECT unique1 FROM tenk1 WHERE unique1 IN (1, 42, 7) and unique1 >= 42;
+  unique1 
+@@ -2051,11 +2057,13 @@
+ 
+ explain (costs off)
+ SELECT unique1 FROM tenk1 WHERE unique1 IN (1, 42, 7) and unique1 > 42;
+-                                 QUERY PLAN                                 
+-----------------------------------------------------------------------------
+- Index Only Scan using tenk1_unique1 on tenk1
+-   Index Cond: ((unique1 = ANY ('{1,42,7}'::integer[])) AND (unique1 > 42))
+-(2 rows)
++                                    QUERY PLAN                                    
++----------------------------------------------------------------------------------
++ Bitmap Heap Scan on tenk1
++   Recheck Cond: ((unique1 = ANY ('{1,42,7}'::integer[])) AND (unique1 > 42))
++   ->  Bitmap Index Scan on tenk1_unique1
++         Index Cond: ((unique1 = ANY ('{1,42,7}'::integer[])) AND (unique1 > 42))
++(4 rows)
+ 
+ SELECT unique1 FROM tenk1 WHERE unique1 IN (1, 42, 7) and unique1 > 42;
+  unique1 
+@@ -2078,18 +2086,20 @@
+ 
+ explain (costs off)
+ SELECT unique1 FROM tenk1 WHERE unique1 < 3 and unique1 <= 3;
+-                    QUERY PLAN                    
+---------------------------------------------------
+- Index Only Scan using tenk1_unique1 on tenk1
+-   Index Cond: ((unique1 < 3) AND (unique1 <= 3))
+-(2 rows)
++                       QUERY PLAN                       
++--------------------------------------------------------
++ Bitmap Heap Scan on tenk1
++   Recheck Cond: ((unique1 < 3) AND (unique1 <= 3))
++   ->  Bitmap Index Scan on tenk1_unique1
++         Index Cond: ((unique1 < 3) AND (unique1 <= 3))
++(4 rows)
+ 
+ SELECT unique1 FROM tenk1 WHERE unique1 < 3 and unique1 <= 3;
+  unique1 
+ ---------
+-       0
++       2
+        1
+-       2
++       0
+ (3 rows)
+ 
+ explain (costs off)


### PR DESCRIPTION
## Why

With physical replication and `hot_standby_feedback`, PostgreSQL can validly choose a bitmap heap scan where the upstream `create_index` regression output expects an index-only scan. Multigres also applies its own accepted-output patch, but the verifier previously applied that patch to only one expected file.

## What changed

- Generate `create_index_1.out` from a small reviewed patch instead of committing a full duplicate output file.
- Apply the common Multigres patch to each PostgreSQL expected variant and pass on the first match.
- Keep the preferred variant as the base for failure reporting and patch generation.

## Flow

`create_index.out` + `create_index_1.patch` → generated numbered alternative → apply common `create_index.patch` to each variant → accept the first exact match.


## Testing

- `go test ./go/test/endtoend/pgregresstest -count=1`
- `PGREGRESS_TESTS='test_setup create_index' RUN_PGREGRESS=1 go test -count=1 -run '^TestPostgreSQLRegression$' -v -timeout 60m ./go/test/endtoend/pgregresstest`
- `make test` was run; unrelated timezone-sensitive consensus tests fail when parsing `Asia/Kolkata` timestamps. The focused regression and package tests pass.
