### PR TITLE
refactor(query-serving): rename direct-connection to unsafe-connection

### DIFF
--- a/go/common/constants/gateway.go
+++ b/go/common/constants/gateway.go
@@ -21,10 +21,17 @@ const (
 	// and never forwards it to a backend.
 	MultigresServerVersionVariable = "multigres.server_version"
 
-	// DirectConnectionParam is the connect-time option / GUC name that requests a
-	// direct connection for a client connection (e.g. options=-c
-	// multigres.direct_connection=on, or `SET multigres.direct_connection = on`).
+	// UnsafeConnectionParam is the connect-time option / GUC name that requests an
+	// unsafe connection for a client connection (e.g. options=-c
+	// multigres.unsafe_connection=on, or `SET multigres.unsafe_connection = on`).
 	// It is a gateway-only property, never forwarded to a backend.
+	UnsafeConnectionParam = "multigres.unsafe_connection"
+
+	// DirectConnectionParam is the deprecated former name for
+	// UnsafeConnectionParam. It is still recognized (at connect time and via SET)
+	// so existing clients keep working, but new code and docs should use
+	// UnsafeConnectionParam. Remove once all clients have migrated off
+	// multigres.direct_connection.
 	DirectConnectionParam = "multigres.direct_connection"
 
 	// MultigresSchema is the schema used to namespace gateway-provided functions

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -193,15 +193,16 @@ type Conn struct {
 	// authenticated role; the post-auth verifier enforces that.
 	replicationMode ReplicationMode
 
-	// directConnection is the per-connection direct-connection opt-out. When true
+	// unsafeConnection is the per-connection unsafe-connection opt-out. When true
 	// the planner suppresses the unsafe-statement rejections for this connection
-	// and the backend is pinned and quarantined (ReasonDirectConnection). It is a
+	// and the backend is pinned and quarantined (ReasonUnsafeConnection). It is a
 	// one-way latch: it can be turned on — at connect time via the
-	// `multigres.direct_connection` option, or mid-session via
-	// `SET multigres.direct_connection = on` — but never off, since a connection
-	// that has run under it may hold untracked backend state. The backend is
-	// discarded at teardown.
-	directConnection bool
+	// `multigres.unsafe_connection` option, or mid-session via
+	// `SET multigres.unsafe_connection = on` (the deprecated alias
+	// `multigres.direct_connection` is also accepted) — but never off, since a
+	// connection that has run under it may hold untracked backend state. The
+	// backend is discarded at teardown.
+	unsafeConnection bool
 
 	// SCRAM-SHA-256 keys extracted during the client handshake, used for
 	// passthrough authentication to the backing PostgreSQL. Nil for non-SCRAM
@@ -479,17 +480,17 @@ func (c *Conn) ReplicationMode() ReplicationMode {
 	return c.replicationMode
 }
 
-// DirectConnection reports whether this connection is running in unsafe-pooler
-// mode (see Conn.directConnection). Once latched on it never turns off.
-func (c *Conn) DirectConnection() bool {
-	return c.directConnection
+// UnsafeConnection reports whether this connection is running in unsafe-pooler
+// mode (see Conn.unsafeConnection). Once latched on it never turns off.
+func (c *Conn) UnsafeConnection() bool {
+	return c.unsafeConnection
 }
 
-// LatchDirectConnection turns direct connection on for this connection. It is a
+// LatchUnsafeConnection turns unsafe connection on for this connection. It is a
 // one-way latch (never turned off). Idempotent. Called from the connect-time
-// option handling and the `SET multigres.direct_connection` primitive.
-func (c *Conn) LatchDirectConnection() {
-	c.directConnection = true
+// option handling and the `SET multigres.unsafe_connection` primitive.
+func (c *Conn) LatchUnsafeConnection() {
+	c.unsafeConnection = true
 }
 
 // ScramClientKey returns the SCRAM-SHA-256 ClientKey extracted during the

--- a/go/common/pgprotocol/server/startup.go
+++ b/go/common/pgprotocol/server/startup.go
@@ -508,11 +508,12 @@ func (c *Conn) handleStartupMessage(protocolVersion uint32, reader *MessageReade
 	delete(c.params, "replication")
 	c.replicationMode = replicationMode
 
-	// multigres.direct_connection is a gateway-only connect-time property, not a
+	// multigres.unsafe_connection is a gateway-only connect-time property, not a
 	// backend GUC. Extract and strip it here so it never reaches a backend (it
 	// would be rejected as unrecognized) and does not trip the restricted-GUC
-	// vetting below. A truthy value latches direct connection for the connection.
-	if err := c.extractDirectConnectionParam(); err != nil {
+	// vetting below. A truthy value latches unsafe connection for the connection.
+	// The deprecated alias multigres.direct_connection is handled the same way.
+	if err := c.extractUnsafeConnectionParam(); err != nil {
 		return err
 	}
 
@@ -550,26 +551,31 @@ func (c *Conn) handleStartupMessage(protocolVersion uint32, reader *MessageReade
 	return c.authenticate()
 }
 
-// extractDirectConnectionParam pulls multigres.direct_connection
-// (constants.DirectConnectionParam) out of the startup parameters and, if
-// truthy, latches direct connection for the connection. It removes the key so it
-// never flows to a backend or trips the restricted-GUC vetting. A malformed
-// Boolean value is a FATAL startup error, matching how PostgreSQL rejects a bad
-// Boolean GUC. Enabling direct connection is not gated on a role privilege — see
-// Conn.directConnection.
-func (c *Conn) extractDirectConnectionParam() error {
-	value, ok := c.params[constants.DirectConnectionParam]
-	if !ok {
-		return nil
-	}
-	delete(c.params, constants.DirectConnectionParam)
-	on, valid := sqltypes.ParseBool(value)
-	if !valid {
-		return mterrors.NewPgError("FATAL", mterrors.PgSSInvalidParameterValue,
-			fmt.Sprintf("parameter %q requires a Boolean value", constants.DirectConnectionParam), "")
-	}
-	if on {
-		c.directConnection = true
+// extractUnsafeConnectionParam pulls multigres.unsafe_connection
+// (constants.UnsafeConnectionParam) — and its deprecated alias
+// multigres.direct_connection (constants.DirectConnectionParam) — out of the
+// startup parameters and, if truthy, latches unsafe connection for the
+// connection. It removes the keys so they never flow to a backend or trip the
+// restricted-GUC vetting. A malformed Boolean value is a FATAL startup error,
+// matching how PostgreSQL rejects a bad Boolean GUC. Enabling unsafe connection
+// is not gated on a role privilege — see Conn.unsafeConnection.
+func (c *Conn) extractUnsafeConnectionParam() error {
+	// Recognize the current name and the deprecated alias. Both are stripped so
+	// neither reaches a backend; either being truthy latches the connection.
+	for _, name := range []string{constants.UnsafeConnectionParam, constants.DirectConnectionParam} {
+		value, ok := c.params[name]
+		if !ok {
+			continue
+		}
+		delete(c.params, name)
+		on, valid := sqltypes.ParseBool(value)
+		if !valid {
+			return mterrors.NewPgError("FATAL", mterrors.PgSSInvalidParameterValue,
+				fmt.Sprintf("parameter %q requires a Boolean value", name), "")
+		}
+		if on {
+			c.unsafeConnection = true
+		}
 	}
 	return nil
 }

--- a/go/common/pgprotocol/server/test_helpers.go
+++ b/go/common/pgprotocol/server/test_helpers.go
@@ -76,9 +76,9 @@ func WithTestUser(user string) TestConnOption {
 	return func(c *Conn) { c.user = user }
 }
 
-// WithTestDirectConnection latches direct connection on a test connection.
-func WithTestDirectConnection() TestConnOption {
-	return func(c *Conn) { c.directConnection = true }
+// WithTestUnsafeConnection latches unsafe connection on a test connection.
+func WithTestUnsafeConnection() TestConnOption {
+	return func(c *Conn) { c.unsafeConnection = true }
 }
 
 // WithTestScramKeys sets the SCRAM passthrough keys on a test connection.

--- a/go/common/pgprotocol/server/unsafe_connection_test.go
+++ b/go/common/pgprotocol/server/unsafe_connection_test.go
@@ -23,11 +23,12 @@ import (
 	"github.com/multigres/multigres/go/common/constants"
 )
 
-// TestExtractDirectConnectionParam covers the connect-time parse: the parameter
+// TestExtractUnsafeConnectionParam covers the connect-time parse: the parameter
 // is stripped from the params map (so it never reaches a backend), a truthy value
-// latches direct connection on the connection, a falsy value does not, and a
-// malformed value is a FATAL.
-func TestExtractDirectConnectionParam(t *testing.T) {
+// latches unsafe connection on the connection, a falsy value does not, and a
+// malformed value is a FATAL. It runs against both the current parameter name and
+// the deprecated multigres.direct_connection alias, which must behave identically.
+func TestExtractUnsafeConnectionParam(t *testing.T) {
 	tests := []struct {
 		name      string
 		value     string
@@ -43,24 +44,30 @@ func TestExtractDirectConnectionParam(t *testing.T) {
 		{name: "false", value: "false", present: true, wantLatch: false},
 		{name: "garbage", value: "maybe", present: true, wantErr: true},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &Conn{params: map[string]string{}}
-			if tt.present {
-				c.params[constants.DirectConnectionParam] = tt.value
-			}
+	params := map[string]string{
+		"unsafe_connection":        constants.UnsafeConnectionParam,
+		"direct_connection(alias)": constants.DirectConnectionParam,
+	}
+	for paramLabel, paramName := range params {
+		for _, tt := range tests {
+			t.Run(paramLabel+"/"+tt.name, func(t *testing.T) {
+				c := &Conn{params: map[string]string{}}
+				if tt.present {
+					c.params[paramName] = tt.value
+				}
 
-			err := c.extractDirectConnectionParam()
+				err := c.extractUnsafeConnectionParam()
 
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantLatch, c.DirectConnection())
-			// Always stripped, whatever the value, so it never flows to a backend.
-			_, stillPresent := c.params[constants.DirectConnectionParam]
-			assert.False(t, stillPresent, "param must be stripped from c.params")
-		})
+				if tt.wantErr {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantLatch, c.UnsafeConnection())
+				// Always stripped, whatever the value, so it never flows to a backend.
+				_, stillPresent := c.params[paramName]
+				assert.False(t, stillPresent, "param must be stripped from c.params")
+			})
+		}
 	}
 }

--- a/go/common/protoutil/reservation.go
+++ b/go/common/protoutil/reservation.go
@@ -23,14 +23,14 @@ import (
 )
 
 // validReasonsMask is the bitmask of all known reservation reasons.
-const validReasonsMask = ReasonTransaction | ReasonTempTable | ReasonPortal | ReasonCopy | ReasonListen | ReasonLogicalReplication | ReasonSessionAdvisoryLock | ReasonSetSeed | ReasonDirectConnection
+const validReasonsMask = ReasonTransaction | ReasonTempTable | ReasonPortal | ReasonCopy | ReasonListen | ReasonLogicalReplication | ReasonSessionAdvisoryLock | ReasonSetSeed | ReasonUnsafeConnection
 
 // StickyReasons are the reasons that survive DISCARD ALL and hold the backend
 // pinned until the connection's real teardown, because PostgreSQL has no command
 // that undoes their effect. Unlike every other reason, they are not cleared by
 // DISCARD ALL; the release path keeps the connection reserved while any of them
 // remains (see ReleaseReservedConnection's keepStickyReservations handling).
-const StickyReasons = ReasonSetSeed | ReasonDirectConnection
+const StickyReasons = ReasonSetSeed | ReasonUnsafeConnection
 
 // Reason constants as uint32 for bitmask operations.
 // These match the ReservationReason enum values.
@@ -79,7 +79,7 @@ const (
 	// reproducible sequence silently changing mid-use).
 	ReasonSetSeed = uint32(multipoolerpb.ReservationReason_RESERVATION_REASON_SET_SEED) // 128
 
-	// ReasonDirectConnection indicates the connection is running in direct connection
+	// ReasonUnsafeConnection indicates the connection is running as an unsafe connection
 	// (the per-connection opt-out that suppresses the unsafe-statement
 	// rejections). Such a connection may run statements that change untracked
 	// backend session state, so its backend must never be returned to the shared
@@ -88,7 +88,7 @@ const (
 	// survives DISCARD ALL and is released only at the connection's real
 	// teardown, where — unlike setseed — the tainted backend is discarded rather
 	// than returned to the pool.
-	ReasonDirectConnection = uint32(multipoolerpb.ReservationReason_RESERVATION_REASON_DIRECT_CONNECTION) // 256
+	ReasonUnsafeConnection = uint32(multipoolerpb.ReservationReason_RESERVATION_REASON_UNSAFE_CONNECTION) // 256
 )
 
 // StatementLocalReasons are the reasons a single statement adds for its own
@@ -150,10 +150,10 @@ func HasSetSeedReason(reasons uint32) bool {
 	return HasReason(reasons, ReasonSetSeed)
 }
 
-// HasDirectConnectionReason returns true if the reasons bitmask includes an
-// direct-connection pin.
-func HasDirectConnectionReason(reasons uint32) bool {
-	return HasReason(reasons, ReasonDirectConnection)
+// HasUnsafeConnectionReason returns true if the reasons bitmask includes an
+// unsafe-connection pin.
+func HasUnsafeConnectionReason(reasons uint32) bool {
+	return HasReason(reasons, ReasonUnsafeConnection)
 }
 
 // HasStickyReason returns true if the reasons bitmask includes any reason that
@@ -249,8 +249,8 @@ func ReasonsString(reasons uint32) string {
 	if HasSetSeedReason(reasons) {
 		parts = append(parts, "set_seed")
 	}
-	if HasDirectConnectionReason(reasons) {
-		parts = append(parts, "direct_connection")
+	if HasUnsafeConnectionReason(reasons) {
+		parts = append(parts, "unsafe_connection")
 	}
 	if len(parts) == 0 {
 		return "unknown"

--- a/go/pb/multipoolerservice/multipoolerservice.pb.go
+++ b/go/pb/multipoolerservice/multipoolerservice.pb.go
@@ -126,7 +126,7 @@ const (
 	// residual-state gap is accepted since it only affects the statistical
 	// freshness of an unrelated session's random() sequence.
 	ReservationReason_RESERVATION_REASON_SET_SEED ReservationReason = 128 // 0b10000000
-	// Connection is a direct connection (the per-connection mode that gives the
+	// Connection is an unsafe connection (the per-connection mode that gives the
 	// client its own dedicated backend and suppresses the unsafe-statement
 	// rejections). Such a connection may run statements that change untracked
 	// backend session state, so its backend must never be returned to the shared
@@ -134,7 +134,7 @@ const (
 	// backend for the session's lifetime and, like SET_SEED, sticky: it survives
 	// DISCARD ALL and is released only at the connection's real teardown, when the
 	// tainted backend is discarded.
-	ReservationReason_RESERVATION_REASON_DIRECT_CONNECTION ReservationReason = 256 // 0b100000000
+	ReservationReason_RESERVATION_REASON_UNSAFE_CONNECTION ReservationReason = 256 // 0b100000000
 )
 
 // Enum value maps for ReservationReason.
@@ -149,7 +149,7 @@ var (
 		32:  "RESERVATION_REASON_LOGICAL_REPLICATION",
 		64:  "RESERVATION_REASON_SESSION_ADVISORY_LOCK",
 		128: "RESERVATION_REASON_SET_SEED",
-		256: "RESERVATION_REASON_DIRECT_CONNECTION",
+		256: "RESERVATION_REASON_UNSAFE_CONNECTION",
 	}
 	ReservationReason_value = map[string]int32{
 		"RESERVATION_REASON_UNSPECIFIED":           0,
@@ -161,7 +161,7 @@ var (
 		"RESERVATION_REASON_LOGICAL_REPLICATION":   32,
 		"RESERVATION_REASON_SESSION_ADVISORY_LOCK": 64,
 		"RESERVATION_REASON_SET_SEED":              128,
-		"RESERVATION_REASON_DIRECT_CONNECTION":     256,
+		"RESERVATION_REASON_UNSAFE_CONNECTION":     256,
 	}
 )
 
@@ -2110,7 +2110,7 @@ type ReleaseReservedConnectionRequest struct {
 	// remains after the usual cleanup (rollback, COPY abort, temp table
 	// discard, advisory unlock). A sticky reason has no PostgreSQL command
 	// that undoes it (RESERVATION_REASON_SET_SEED or
-	// RESERVATION_REASON_DIRECT_CONNECTION), so it can only be cleared by the
+	// RESERVATION_REASON_UNSAFE_CONNECTION), so it can only be cleared by the
 	// connection's real teardown. Real client-disconnect
 	// cleanup always leaves this false, so a sticky reason never blocks a
 	// connection's actual teardown.
@@ -2651,7 +2651,7 @@ const file_multipoolerservice_proto_rawDesc = "" +
 	"&RESERVATION_REASON_LOGICAL_REPLICATION\x10 \x12,\n" +
 	"(RESERVATION_REASON_SESSION_ADVISORY_LOCK\x10@\x12 \n" +
 	"\x1bRESERVATION_REASON_SET_SEED\x10\x80\x01\x12)\n" +
-	"$RESERVATION_REASON_DIRECT_CONNECTION\x10\x80\x02*\x87\x01\n" +
+	"$RESERVATION_REASON_UNSAFE_CONNECTION\x10\x80\x02*\x87\x01\n" +
 	"\x15TransactionConclusion\x12&\n" +
 	"\"TRANSACTION_CONCLUSION_UNSPECIFIED\x10\x00\x12!\n" +
 	"\x1dTRANSACTION_CONCLUSION_COMMIT\x10\x01\x12#\n" +

--- a/go/services/multigateway/engine/enable_unsafe_connection.go
+++ b/go/services/multigateway/engine/enable_unsafe_connection.go
@@ -24,25 +24,25 @@ import (
 	"github.com/multigres/multigres/go/services/multigateway/handler"
 )
 
-// EnableDirectConnection is the gateway-local primitive for
-// `SET multigres.direct_connection = on`. It latches the connection into
-// direct connection (a one-way switch — see server.Conn.LatchDirectConnection)
+// EnableUnsafeConnection is the gateway-local primitive for
+// `SET multigres.unsafe_connection = on`. It latches the connection into
+// unsafe connection (a one-way switch — see server.Conn.LatchUnsafeConnection)
 // and replies with a bare "SET" CommandComplete. It never touches a backend: the
 // flag is a gateway control, and every subsequent statement reads it to suppress
 // the unsafe-statement rejections and pin+quarantine the backend.
-type EnableDirectConnection struct {
+type EnableUnsafeConnection struct {
 	sql string
 }
 
-// NewEnableDirectConnection creates the latch primitive for a validated
-// `SET multigres.direct_connection = on`.
-func NewEnableDirectConnection(sql string) *EnableDirectConnection {
-	return &EnableDirectConnection{sql: sql}
+// NewEnableUnsafeConnection creates the latch primitive for a validated
+// `SET multigres.unsafe_connection = on`.
+func NewEnableUnsafeConnection(sql string) *EnableUnsafeConnection {
+	return &EnableUnsafeConnection{sql: sql}
 }
 
-// StreamExecute latches direct connection on the connection and sends the
+// StreamExecute latches unsafe connection on the connection and sends the
 // CommandComplete.
-func (e *EnableDirectConnection) StreamExecute(
+func (e *EnableUnsafeConnection) StreamExecute(
 	ctx context.Context,
 	_ IExecute,
 	conn *server.Conn,
@@ -51,13 +51,13 @@ func (e *EnableDirectConnection) StreamExecute(
 	_ PlanExecInfo,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	conn.LatchDirectConnection()
+	conn.LatchUnsafeConnection()
 	return callback(ctx, &sqltypes.Result{CommandTag: "SET"})
 }
 
 // PortalStreamExecute satisfies the Primitive interface for the extended
 // protocol; the statement carries no binds, so it delegates to StreamExecute.
-func (e *EnableDirectConnection) PortalStreamExecute(
+func (e *EnableUnsafeConnection) PortalStreamExecute(
 	ctx context.Context,
 	exec IExecute,
 	conn *server.Conn,
@@ -72,12 +72,12 @@ func (e *EnableDirectConnection) PortalStreamExecute(
 }
 
 // GetTableGroup returns empty: this primitive targets no backend.
-func (e *EnableDirectConnection) GetTableGroup() string { return "" }
+func (e *EnableUnsafeConnection) GetTableGroup() string { return "" }
 
 // GetQuery returns empty: this primitive executes no backend query.
-func (e *EnableDirectConnection) GetQuery() string { return "" }
+func (e *EnableUnsafeConnection) GetQuery() string { return "" }
 
 // String returns a description for logging/debugging.
-func (e *EnableDirectConnection) String() string {
-	return "EnableDirectConnection(" + e.sql + ")"
+func (e *EnableUnsafeConnection) String() string {
+	return "EnableUnsafeConnection(" + e.sql + ")"
 }

--- a/go/services/multigateway/engine/enable_unsafe_connection_test.go
+++ b/go/services/multigateway/engine/enable_unsafe_connection_test.go
@@ -26,13 +26,13 @@ import (
 	"github.com/multigres/multigres/go/common/sqltypes"
 )
 
-// TestEnableDirectConnection confirms the primitive latches direct connection on
+// TestEnableUnsafeConnection confirms the primitive latches unsafe connection on
 // the connection and replies with a bare "SET" CommandComplete, touching no backend.
-func TestEnableDirectConnection(t *testing.T) {
+func TestEnableUnsafeConnection(t *testing.T) {
 	conn := server.NewTestConn(&bytes.Buffer{}).Conn
-	require.False(t, conn.DirectConnection())
+	require.False(t, conn.UnsafeConnection())
 
-	prim := NewEnableDirectConnection("SET multigres.direct_connection = on")
+	prim := NewEnableUnsafeConnection("SET multigres.unsafe_connection = on")
 
 	var got []*sqltypes.Result
 	err := prim.StreamExecute(context.Background(), nil, conn, nil, nil, PlanExecInfo{},
@@ -42,7 +42,7 @@ func TestEnableDirectConnection(t *testing.T) {
 		})
 	require.NoError(t, err)
 
-	assert.True(t, conn.DirectConnection(), "connection must be latched into direct connection")
+	assert.True(t, conn.UnsafeConnection(), "connection must be latched into unsafe connection")
 	require.Len(t, got, 1)
 	assert.Equal(t, "SET", got[0].CommandTag)
 }

--- a/go/services/multigateway/engine/session_state_branch.go
+++ b/go/services/multigateway/engine/session_state_branch.go
@@ -40,10 +40,10 @@ func SessionPinned(conn *server.Conn, state *handler.MultigatewayConnectionState
 	if conn != nil && conn.IsInTransaction() {
 		return true
 	}
-	// A direct connection pins (and quarantines) its backend on
+	// A unsafe connection pins (and quarantines) its backend on
 	// every statement, so its session is always pinned — a set_config on it
 	// persists for real rather than reverting via pool replay.
-	if conn != nil && conn.DirectConnection() {
+	if conn != nil && conn.UnsafeConnection() {
 		return true
 	}
 	return state != nil && state.HasReservedConnectionFor(tableGroup, shard)

--- a/go/services/multigateway/engine/session_state_branch_test.go
+++ b/go/services/multigateway/engine/session_state_branch_test.go
@@ -23,15 +23,15 @@ import (
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 )
 
-// TestSessionPinned_DirectConnection confirms a direct connection is always
+// TestSessionPinned_UnsafeConnection confirms an unsafe connection is always
 // treated as pinned (its backend is reserved+quarantined per statement), while a
 // plain connection with no transaction/reservation is not.
-func TestSessionPinned_DirectConnection(t *testing.T) {
+func TestSessionPinned_UnsafeConnection(t *testing.T) {
 	plain := server.NewTestConn(&bytes.Buffer{}).Conn
 	assert.False(t, SessionPinned(plain, nil, "tg", "0"),
 		"a plain idle connection is not pinned")
 
-	direct := server.NewTestConn(&bytes.Buffer{}, server.WithTestDirectConnection()).Conn
+	direct := server.NewTestConn(&bytes.Buffer{}, server.WithTestUnsafeConnection()).Conn
 	assert.True(t, SessionPinned(direct, nil, "tg", "0"),
-		"a direct connection is always pinned")
+		"an unsafe connection is always pinned")
 }

--- a/go/services/multigateway/executor/executor.go
+++ b/go/services/multigateway/executor/executor.go
@@ -136,12 +136,12 @@ func (e *Executor) resolvePlan(
 	conn *server.Conn,
 	state *handler.MultigatewayConnectionState,
 ) (*engine.Plan, []*ast.A_Const, bool, string, string, error) {
-	// A direct connection is kept off the shared plan cache: its
+	// A unsafe connection is kept off the shared plan cache: its
 	// planning depends on the per-connection opt-out (accept/reject decisions and
-	// the ReasonDirectConnection pin), so a plan built for it must never be served to
+	// the ReasonUnsafeConnection pin), so a plan built for it must never be served to
 	// another connection. Route it through the non-cacheable path with State, like
 	// any other statement whose plan depends on live connection state.
-	if !isCacheable(astStmt) || conn.DirectConnection() {
+	if !isCacheable(astStmt) || conn.UnsafeConnection() {
 		plan, err := e.planner.Plan(queryStr, astStmt, conn, planner.PlanOptions{State: state})
 		if err != nil {
 			return nil, nil, false, "", "", err
@@ -290,12 +290,12 @@ func (e *Executor) resolvePortalPlan(
 	// is always correct to serve to the other. The protocol difference lives in
 	// the plan's PortalStreamExecute vs StreamExecute, never in its content.
 	//
-	// A direct connection is also forced down this path (mirroring resolvePlan):
+	// A unsafe connection is also forced down this path (mirroring resolvePlan):
 	// its plan is built with the unsafe-statement rejections suppressed, so it
 	// must never enter the shared cache where a normal connection could receive it
 	// as a database-wide hit — that would bypass analyzeStatement's function
 	// blocklist (e.g. a cached SELECT dblink(...) served to another client).
-	if !isCacheable(astStmt) || conn.DirectConnection() {
+	if !isCacheable(astStmt) || conn.UnsafeConnection() {
 		plan, err := e.planner.Plan(portalInfo.PreparedStatementInfo.Query, astStmt, conn, planner.PlanOptions{IsPortal: true, State: state})
 		if err != nil {
 			return nil, false, "", "", err

--- a/go/services/multigateway/executor/executor_test.go
+++ b/go/services/multigateway/executor/executor_test.go
@@ -280,17 +280,17 @@ func TestPortalStreamExecute_CacheHitOnRepeatedPortal(t *testing.T) {
 	assert.Equal(t, int32(2), mock.portalStreamExecuteCalls.Load())
 }
 
-// TestPortalStreamExecute_DirectConnectionNotCached is the regression guard for
-// the cross-protocol plan-cache poisoning vector. A direct connection's plan is
+// TestPortalStreamExecute_UnsafeConnectionNotCached is the regression guard for
+// the cross-protocol plan-cache poisoning vector. A unsafe connection's plan is
 // built with the unsafe-statement rejections suppressed, so it must never enter
 // the shared, database-wide plan cache: otherwise a normal connection could
 // receive it as a cache hit and run a blocklisted call the planner would reject
 // (SELECT pg_read_file(...) — an LFI/SSRF bypass). The extended-protocol
-// resolvePortalPlan must exclude direct connections just as resolvePlan does.
+// resolvePortalPlan must exclude unsafe connections just as resolvePlan does.
 //
 // Uses the doorkeeper-disabled test cache (newTestExecutor) so admission is
 // deterministic — the same reason this cannot be verified reliably end-to-end.
-func TestPortalStreamExecute_DirectConnectionNotCached(t *testing.T) {
+func TestPortalStreamExecute_UnsafeConnectionNotCached(t *testing.T) {
 	mock := &mockExec{}
 	exec := newTestExecutor(mock)
 	defer exec.planCache.Close()
@@ -305,21 +305,21 @@ func TestPortalStreamExecute_DirectConnectionNotCached(t *testing.T) {
 	_, err := exec.PortalStreamExecute(ctx, testConn(), nil, makePortalInfo(t, sql), 0, false, noopCallback)
 	require.Error(t, err, "blocklisted call must be rejected on an enforcing connection")
 
-	// A direct connection accepts and executes it. Absent the guard, its plan is
+	// A unsafe connection accepts and executes it. Absent the guard, its plan is
 	// put into the shared cache here.
-	direct := server.NewTestConn(&bytes.Buffer{}, server.WithTestDirectConnection()).Conn
+	direct := server.NewTestConn(&bytes.Buffer{}, server.WithTestUnsafeConnection()).Conn
 	res, err := exec.PortalStreamExecute(ctx, direct, nil, makePortalInfo(t, sql), 0, false, noopCallback)
-	require.NoError(t, err, "direct connection must accept the blocklisted call")
-	assert.False(t, res.CacheHit, "a direct connection must never serve from or populate the shared cache")
+	require.NoError(t, err, "unsafe connection must accept the blocklisted call")
+	assert.False(t, res.CacheHit, "an unsafe connection must never serve from or populate the shared cache")
 
 	// theine processes writes asynchronously; give any (erroneous) write time to land.
 	time.Sleep(50 * time.Millisecond)
 
 	// The crux: a normal connection running the same statement must STILL be
-	// rejected — the direct connection's accepted plan must not have poisoned the
+	// rejected — the unsafe connection's accepted plan must not have poisoned the
 	// shared cache.
 	_, err = exec.PortalStreamExecute(ctx, testConn(), nil, makePortalInfo(t, sql), 0, false, noopCallback)
-	require.Error(t, err, "direct-connection plan must not be cached for a normal connection")
+	require.Error(t, err, "unsafe-connection plan must not be cached for a normal connection")
 	assert.Contains(t, err.Error(), "pg_read_file is not supported")
 }
 

--- a/go/services/multigateway/planner/planner.go
+++ b/go/services/multigateway/planner/planner.go
@@ -155,13 +155,13 @@ func (p *Planner) Plan(
 		"default_tablegroup", p.defaultTableGroup,
 		"statement_type", stmt.NodeTag())
 
-	// directConnection is the per-connection opt-out. It suppresses the
+	// unsafeConnection is the per-connection opt-out. It suppresses the
 	// unsafe-statement rejections and pins+quarantines the backend. Because it
 	// varies per connection, a statement planned under it must never be served
 	// from the shared plan cache to another connection — the executor keeps
-	// direct-connection sessions off the cache (see resolvePlan), so reading it
+	// unsafe-connection sessions off the cache (see resolvePlan), so reading it
 	// here stays sound.
-	directConnection := conn != nil && conn.DirectConnection()
+	unsafeConnection := conn != nil && conn.UnsafeConnection()
 
 	// Analyze the statement before dispatch: reject unsupported constructs
 	// (Tier 2 statement types and blocklisted/misplaced FuncCalls) and gather
@@ -171,7 +171,7 @@ func (p *Planner) Plan(
 	// construction already analyzed and safe. The normalizer is configured to
 	// preserve literals inside set_config calls so its args remain A_Const at
 	// this point.
-	analysis, err := analyzeStatement(stmt, directConnection)
+	analysis, err := analyzeStatement(stmt, unsafeConnection)
 	if err != nil {
 		return nil, err
 	}

--- a/go/services/multigateway/planner/prepared_stmt.go
+++ b/go/services/multigateway/planner/prepared_stmt.go
@@ -60,9 +60,9 @@ func (p *Planner) planExecuteStmt(sql string, stmt *ast.ExecuteStmt, conn *serve
 	var execInfo engine.PlanExecInfo
 	var setConfigs []engine.SQLPreparedSetConfig
 	var bodyOverride *query.PreparedStatement
-	directConnection := conn != nil && conn.DirectConnection()
+	unsafeConnection := conn != nil && conn.UnsafeConnection()
 	if psi := conn.Handler().GetPreparedStatementInfo(conn.ConnectionID(), stmt.Name); psi != nil {
-		analysis, err := analyzeSQLPreparedBody(psi.AstStmt(), directConnection)
+		analysis, err := analyzeSQLPreparedBody(psi.AstStmt(), unsafeConnection)
 		if err != nil {
 			return nil, err
 		}

--- a/go/services/multigateway/planner/unsafe_connection_test.go
+++ b/go/services/multigateway/planner/unsafe_connection_test.go
@@ -27,10 +27,12 @@ import (
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 )
 
-// TestPlanDirectConnectionSet covers the `SET multigres.direct_connection`
+// TestPlanUnsafeConnectionSet covers the `SET multigres.unsafe_connection`
 // path: `= on` plans the latch primitive, while turning it off / resetting it /
-// a non-boolean value are rejected (the latch is one-way).
-func TestPlanDirectConnectionSet(t *testing.T) {
+// a non-boolean value are rejected (the latch is one-way). Each case runs against
+// both the current name and the deprecated multigres.direct_connection alias,
+// which must be planned identically.
+func TestPlanUnsafeConnectionSet(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
 	p := NewPlanner("default", logger, nil)
 	conn := server.NewTestConn(&bytes.Buffer{})
@@ -43,36 +45,41 @@ func TestPlanDirectConnectionSet(t *testing.T) {
 		assert.Equal(t, code, diag.Code)
 	}
 
-	t.Run("enables", func(t *testing.T) {
-		sql := "SET multigres.direct_connection = on"
-		plan, err := p.Plan(sql, parseOne(t, sql), conn.Conn, PlanOptions{})
-		require.NoError(t, err)
-		require.NotNil(t, plan)
-	})
+	// The current name and its deprecated alias must behave identically.
+	for _, param := range []string{"multigres.unsafe_connection", "multigres.direct_connection"} {
+		t.Run(param, func(t *testing.T) {
+			t.Run("enables", func(t *testing.T) {
+				sql := "SET " + param + " = on"
+				plan, err := p.Plan(sql, parseOne(t, sql), conn.Conn, PlanOptions{})
+				require.NoError(t, err)
+				require.NotNil(t, plan)
+			})
 
-	t.Run("turning off rejected (one-way latch)", func(t *testing.T) {
-		sql := "SET multigres.direct_connection = off"
-		_, err := p.Plan(sql, parseOne(t, sql), conn.Conn, PlanOptions{})
-		assertErrCode(t, err, mterrors.PgSSFeatureNotSupported)
-	})
+			t.Run("turning off rejected (one-way latch)", func(t *testing.T) {
+				sql := "SET " + param + " = off"
+				_, err := p.Plan(sql, parseOne(t, sql), conn.Conn, PlanOptions{})
+				assertErrCode(t, err, mterrors.PgSSFeatureNotSupported)
+			})
 
-	t.Run("reset rejected (one-way latch)", func(t *testing.T) {
-		sql := "RESET multigres.direct_connection"
-		_, err := p.Plan(sql, parseOne(t, sql), conn.Conn, PlanOptions{})
-		assertErrCode(t, err, mterrors.PgSSFeatureNotSupported)
-	})
+			t.Run("reset rejected (one-way latch)", func(t *testing.T) {
+				sql := "RESET " + param
+				_, err := p.Plan(sql, parseOne(t, sql), conn.Conn, PlanOptions{})
+				assertErrCode(t, err, mterrors.PgSSFeatureNotSupported)
+			})
 
-	t.Run("non-boolean value rejected", func(t *testing.T) {
-		sql := "SET multigres.direct_connection = maybe"
-		_, err := p.Plan(sql, parseOne(t, sql), conn.Conn, PlanOptions{})
-		assertErrCode(t, err, mterrors.PgSSInvalidParameterValue)
-	})
+			t.Run("non-boolean value rejected", func(t *testing.T) {
+				sql := "SET " + param + " = maybe"
+				_, err := p.Plan(sql, parseOne(t, sql), conn.Conn, PlanOptions{})
+				assertErrCode(t, err, mterrors.PgSSInvalidParameterValue)
+			})
+		})
+	}
 }
 
-// TestPlanDirectConnectionSuppressesRejections confirms that a statement the
+// TestPlanUnsafeConnectionSuppressesRejections confirms that a statement the
 // enforcing path rejects (a blocklisted expression call) is accepted when the
-// connection is a direct connection — i.e. Plan reads the per-connection flag.
-func TestPlanDirectConnectionSuppressesRejections(t *testing.T) {
+// connection is an unsafe connection — i.e. Plan reads the per-connection flag.
+func TestPlanUnsafeConnectionSuppressesRejections(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
 	p := NewPlanner("default", logger, nil)
 	sql := "SELECT dblink('host=x', 'SELECT 1')"
@@ -82,8 +89,8 @@ func TestPlanDirectConnectionSuppressesRejections(t *testing.T) {
 	_, err := p.Plan(sql, parseOne(t, sql), enforcing.Conn, PlanOptions{})
 	require.Error(t, err)
 
-	// Direct connection: accepted.
-	direct := server.NewTestConn(&bytes.Buffer{}, server.WithTestDirectConnection())
+	// Unsafe connection: accepted.
+	direct := server.NewTestConn(&bytes.Buffer{}, server.WithTestUnsafeConnection())
 	plan, err := p.Plan(sql, parseOne(t, sql), direct.Conn, PlanOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, plan)

--- a/go/services/multigateway/planner/unsafe_funccall.go
+++ b/go/services/multigateway/planner/unsafe_funccall.go
@@ -345,15 +345,15 @@ type statementAnalysis struct {
 // statement-type rejection on the extended-protocol path and silently let
 // blocklisted function calls through on non-cacheable portal queries.
 //
-// directConnection is the per-connection opt-out: when set, every unsafe-statement
+// unsafeConnection is the per-connection opt-out: when set, every unsafe-statement
 // rejection layer (Tier 1 body analysis, the Tier 2 statement blocklist, the
 // restricted-GUC guard, and the expression-level function blocklist) is
 // suppressed, because the connection has its own dedicated, quarantined backend.
 // The planning signals — tracked set_config calls, advisory-lock pinning,
 // current_setting rewrites — are still gathered, so routing stays correct; only
 // the "reject this statement" behavior is relaxed.
-func analyzeStatement(stmt ast.Stmt, directConnection bool) (*statementAnalysis, error) {
-	if !directConnection {
+func analyzeStatement(stmt ast.Stmt, unsafeConnection bool) (*statementAnalysis, error) {
+	if !unsafeConnection {
 		if err := rejectUnsupportedStatement(stmt); err != nil {
 			return nil, err
 		}
@@ -368,22 +368,22 @@ func analyzeStatement(stmt ast.Stmt, directConnection bool) (*statementAnalysis,
 		return nil, err
 	}
 	if ps, ok := stmt.(*ast.PrepareStmt); ok {
-		if _, err := analyzeSQLPreparedBody(ps.Query, directConnection); err != nil {
+		if _, err := analyzeSQLPreparedBody(ps.Query, unsafeConnection); err != nil {
 			return nil, err
 		}
 		// PREPARE analyzes but does not execute the body, so advisory/temp/set_config
 		// effects are applied later by SQL EXECUTE.
 		return &statementAnalysis{}, nil
 	}
-	return analyzeFunctionCalls(stmt, !directConnection)
+	return analyzeFunctionCalls(stmt, !unsafeConnection)
 }
 
-func analyzeSQLPreparedBody(query ast.Node, directConnection bool) (*statementAnalysis, error) {
+func analyzeSQLPreparedBody(query ast.Node, unsafeConnection bool) (*statementAnalysis, error) {
 	stmt, ok := query.(ast.Stmt)
 	if !ok || stmt == nil {
 		return &statementAnalysis{}, nil
 	}
-	if !directConnection {
+	if !unsafeConnection {
 		if err := rejectUnsupportedStatement(stmt); err != nil {
 			return nil, err
 		}
@@ -397,7 +397,7 @@ func analyzeSQLPreparedBody(query ast.Node, directConnection bool) (*statementAn
 	if err := checkTempSchemaQualifiedCreate(stmt); err != nil {
 		return nil, err
 	}
-	analysis, err := analyzeFunctionCalls(stmt, !directConnection)
+	analysis, err := analyzeFunctionCalls(stmt, !unsafeConnection)
 	if err != nil {
 		return nil, err
 	}
@@ -465,7 +465,7 @@ func validateSQLPreparedSetConfigs(analysis *statementAnalysis) error {
 //
 // reject controls the safety rejections (blocklisted call, set_config in a
 // disallowed position, cluster-managed GUC via set_config). When false — the
-// direct-connection opt-out — those are skipped and the offending call simply
+// unsafe-connection opt-out — those are skipped and the offending call simply
 // goes untracked, while the planning signals (accepted set_config, advisory
 // locks, current_setting) are still gathered so routing stays correct.
 func analyzeFunctionCalls(stmt ast.Stmt, reject bool) (*statementAnalysis, error) {
@@ -501,7 +501,7 @@ func analyzeFunctionCalls(stmt ast.Stmt, reject bool) (*statementAnalysis, error
 				walkErr = mterrors.NewFeatureNotSupported(msg)
 				return false
 			}
-			// direct-connection: operator accepts the risk; leave the call
+			// unsafe-connection: operator accepts the risk; leave the call
 			// alone (it goes to PG untracked) and keep walking.
 			return true
 		}
@@ -564,7 +564,7 @@ func analyzeFunctionCalls(stmt ast.Stmt, reject bool) (*statementAnalysis, error
 			// the pooler to track, so it may pass straight through to the backend
 			// untracked — this unblocks PostgREST's mutation row-count trick, which
 			// calls set_config('pgrst.inserted', …, true) inside an INSERT ... WHERE;
-			// other shapes are rejected. In direct-connection (reject=false)
+			// other shapes are rejected. In unsafe-connection (reject=false)
 			// nothing is rejected: it all goes to PG as written.
 			if reject {
 				if err := allowTransactionLocalSetConfig(fc); err != nil {
@@ -599,7 +599,7 @@ func analyzeFunctionCalls(stmt ast.Stmt, reject bool) (*statementAnalysis, error
 		if err == nil {
 			// A cluster-managed GUC is still rejected when the name is a literal;
 			// the only supported dynamic name is pg_settings.name. Suppressed in
-			// direct-connection.
+			// unsafe-connection.
 			if reject {
 				for _, fc := range accepted {
 					if name, ok := constStringArg(fc.Args.Items[0]); ok {
@@ -612,7 +612,7 @@ func analyzeFunctionCalls(stmt ast.Stmt, reject bool) (*statementAnalysis, error
 			result.DynamicSetConfig = true
 			return result, nil
 		}
-		// direct-connection with an unsupported dynamic shape: don't reject and
+		// unsafe-connection with an unsupported dynamic shape: don't reject and
 		// don't synthesize the resolve-and-apply plan. Fall through to the
 		// per-call loop, which lets each set_config pass to PG untracked.
 	}
@@ -623,7 +623,7 @@ func analyzeFunctionCalls(stmt ast.Stmt, reject bool) (*statementAnalysis, error
 			if reject {
 				return nil, err
 			}
-			// direct-connection: an untrackable set_config is not rejected; it
+			// unsafe-connection: an untrackable set_config is not rejected; it
 			// goes to PG as written, just untracked.
 			continue
 		}
@@ -1059,7 +1059,7 @@ func validateAcceptedSetConfig(fc *ast.FuncCall, reject bool) (*setConfigCall, e
 	// checkRestrictedGUCChange. The normalizer keeps the name literal (see
 	// normalizer.go) so we can read it here on the cached and is_local=true
 	// paths too. A bound or otherwise non-literal name is a documented gap: we
-	// let it through rather than reject blindly. Suppressed in direct-connection.
+	// let it through rather than reject blindly. Suppressed in unsafe-connection.
 	if reject {
 		if name, ok := constStringArg(fc.Args.Items[0]); ok {
 			if err := restrictedGUCError(name); err != nil {

--- a/go/services/multigateway/planner/unsafe_funccall_test.go
+++ b/go/services/multigateway/planner/unsafe_funccall_test.go
@@ -872,13 +872,13 @@ func TestInspectExpressionFuncCalls_DynamicSetConfigRejected(t *testing.T) {
 	}
 }
 
-// TestInspectExpressionFuncCalls_SetConfigDirectConnection confirms the operator
+// TestInspectExpressionFuncCalls_SetConfigUnsafeConnection confirms the operator
 // opt-out actually lets every untrackable set_config shape through: the same
 // statements the enforced path rejects (dynamic-shape and per-call shape errors)
 // must analyze without error and produce no tracking (empty SetConfigs, no
 // DynamicSetConfig), so they route to PostgreSQL as written and untracked. This
 // is the contract in docs/query_serving/unsafe_statement_rejection.md.
-func TestInspectExpressionFuncCalls_SetConfigDirectConnection(t *testing.T) {
+func TestInspectExpressionFuncCalls_SetConfigUnsafeConnection(t *testing.T) {
 	sqls := []string{
 		// Dynamic-shape rejections (reach validateDynamicSetConfigShape).
 		"SELECT set_config(name, '256MB', false) FROM gucs",
@@ -899,9 +899,9 @@ func TestInspectExpressionFuncCalls_SetConfigDirectConnection(t *testing.T) {
 			// Enforced: rejected.
 			_, err := analyzeFunctionCalls(stmt, true)
 			require.Error(t, err, "expected rejection when enforced")
-			// direct-connection: accepted and untracked.
+			// unsafe-connection: accepted and untracked.
 			result, err := analyzeFunctionCalls(parseOne(t, sql), false)
-			require.NoError(t, err, "direct-connection must not reject")
+			require.NoError(t, err, "unsafe-connection must not reject")
 			require.NotNil(t, result)
 			assert.False(t, result.DynamicSetConfig, "must not synthesize a dynamic set_config plan")
 			assert.Empty(t, result.SetConfigs, "untrackable set_config must not be tracked")

--- a/go/services/multigateway/planner/unsafe_plpgsql_test.go
+++ b/go/services/multigateway/planner/unsafe_plpgsql_test.go
@@ -296,9 +296,9 @@ func TestAnalyzeProceduralBody_Allow(t *testing.T) {
 	}
 }
 
-// TestAnalyzeProceduralBody_DirectConnection confirms the operator opt-out disables
+// TestAnalyzeProceduralBody_UnsafeConnection confirms the operator opt-out disables
 // the body analysis: a body that would otherwise be rejected is allowed.
-func TestAnalyzeProceduralBody_DirectConnection(t *testing.T) {
+func TestAnalyzeProceduralBody_UnsafeConnection(t *testing.T) {
 	unsafe := []string{
 		"DO $$ BEGIN PERFORM set_config('work_mem','10GB',false); END $$",
 		"DO $$ BEGIN SET work_mem = '10GB'; END $$",
@@ -310,7 +310,7 @@ func TestAnalyzeProceduralBody_DirectConnection(t *testing.T) {
 			// Enforced: rejected.
 			_, err := analyzeStatement(parseOne(t, sql), false)
 			require.Error(t, err)
-			// direct-connection: allowed.
+			// unsafe-connection: allowed.
 			_, err = analyzeStatement(parseOne(t, sql), true)
 			require.NoError(t, err)
 		})

--- a/go/services/multigateway/planner/variable_set_stmt.go
+++ b/go/services/multigateway/planner/variable_set_stmt.go
@@ -68,10 +68,12 @@ func (p *Planner) planVariableSetStmt(
 	conn *server.Conn,
 	state *handler.MultigatewayConnectionState,
 ) (*engine.Plan, error) {
-	// multigres.direct_connection is a gateway control, not a backend GUC: a
+	// multigres.unsafe_connection (and its deprecated alias
+	// multigres.direct_connection) is a gateway control, not a backend GUC: a
 	// one-way latch handled entirely here.
-	if strings.EqualFold(stmt.Name, constants.DirectConnectionParam) {
-		return p.planDirectConnectionSet(sql, stmt)
+	if strings.EqualFold(stmt.Name, constants.UnsafeConnectionParam) ||
+		strings.EqualFold(stmt.Name, constants.DirectConnectionParam) {
+		return p.planUnsafeConnectionSet(sql, stmt)
 	}
 
 	// Transaction-only variables are backend state, not replayable session GUCs.
@@ -171,7 +173,7 @@ func (p *Planner) planVariableSetStmt(
 		// routes unchanged. For a GUC the client set in its startup packet the
 		// raw RESET would diverge: pooled backends receive startup params via
 		// replayed SET (never a real startup packet), so PostgreSQL's reset
-		// value there is the server default — while on a direct connection
+		// value there is the server default — while on an unsafe connection
 		// startup-packet GUCs are the session baseline (PGC_S_CLIENT) and
 		// RESET restores them. The merged gateway map (GetSessionSettings)
 		// already implements the correct semantics, so the backend is brought
@@ -358,29 +360,31 @@ func isGatewayManagedVariable(name string) bool {
 // planGatewayManagedVariable creates a GatewaySessionState primitive for a
 // gateway-managed variable. All parsing and validation happens here at plan
 // time so the primitive's execute path is a simple assignment.
-// planDirectConnectionSet handles `SET multigres.direct_connection = on`. It is
-// a one-way latch: only turning it on is supported (RESET or a falsy value
-// errors), because a connection that has run under direct connection may hold
+// planUnsafeConnectionSet handles `SET multigres.unsafe_connection = on` (and
+// the deprecated alias `SET multigres.direct_connection = on`). It is a one-way
+// latch: only turning it on is supported (RESET or a falsy value errors),
+// because a connection that has run under an unsafe connection may hold
 // untracked backend state and its backend is discarded at teardown. Enabling it
-// is intentionally not gated on a role privilege (see Conn.directConnection). The
+// is intentionally not gated on a role privilege (see Conn.unsafeConnection). The
 // returned primitive latches the flag on the connection at execute time; every
 // later statement then reads it to suppress the rejections and pin+quarantine the
-// backend.
-func (p *Planner) planDirectConnectionSet(sql string, stmt *ast.VariableSetStmt) (*engine.Plan, error) {
+// backend. Error messages echo stmt.Name so a client using the deprecated alias
+// sees the name it supplied.
+func (p *Planner) planUnsafeConnectionSet(sql string, stmt *ast.VariableSetStmt) (*engine.Plan, error) {
 	if stmt.Kind != ast.VAR_SET_VALUE {
 		return nil, mterrors.NewPgError("ERROR", mterrors.PgSSFeatureNotSupported,
-			constants.DirectConnectionParam+" cannot be reset once set", "")
+			stmt.Name+" cannot be reset once set", "")
 	}
 	on, valid := sqltypes.ParseBool(extractVariableValue(stmt.Args))
 	if !valid {
 		return nil, mterrors.NewPgError("ERROR", mterrors.PgSSInvalidParameterValue,
-			"parameter "+constants.DirectConnectionParam+" requires a Boolean value", "")
+			"parameter "+stmt.Name+" requires a Boolean value", "")
 	}
 	if !on {
 		return nil, mterrors.NewPgError("ERROR", mterrors.PgSSFeatureNotSupported,
-			constants.DirectConnectionParam+" cannot be turned off once set", "")
+			stmt.Name+" cannot be turned off once set", "")
 	}
-	return engine.NewPlan(sql, engine.NewEnableDirectConnection(sql)), nil
+	return engine.NewPlan(sql, engine.NewEnableUnsafeConnection(sql)), nil
 }
 
 func (p *Planner) planGatewayManagedVariable(

--- a/go/services/multigateway/scatterconn/scatter_conn.go
+++ b/go/services/multigateway/scatterconn/scatter_conn.go
@@ -302,11 +302,11 @@ func (sc *ScatterConn) StreamExecute(
 		// a logical replication slot, add the corresponding reason(s) so the
 		// multipooler keeps the backend pinned accordingly. Promotes an existing
 		// reservation (e.g. an open transaction) to also hold these reasons. A
-		// direct connection ORs in its reason too, so an already-reserved backend
+		// unsafe connection ORs in its reason too, so an already-reserved backend
 		// stays pinned+quarantined once the other reason (e.g. the transaction) ends.
 		reasons := reservationReasonsForExecInfo(info)
-		if conn.DirectConnection() {
-			reasons |= protoutil.ReasonDirectConnection
+		if conn.UnsafeConnection() {
+			reasons |= protoutil.ReasonUnsafeConnection
 		}
 		if reasons != 0 {
 			if reservationOpts == nil {
@@ -380,15 +380,15 @@ func (sc *ScatterConn) StreamExecute(
 	// Case 2: Need a new reserved connection — for transaction, temp table,
 	// portal pin (DECLARE WITH HOLD), or any combination.
 	pinPortalNames := info.PinPortals
-	if conn.IsInTransaction() || conn.DirectConnection() || info.TempTable || info.AdvisoryLock || info.LogicalReplicationSlot || info.SetSeed || len(pinPortalNames) > 0 {
+	if conn.IsInTransaction() || conn.UnsafeConnection() || info.TempTable || info.AdvisoryLock || info.LogicalReplicationSlot || info.SetSeed || len(pinPortalNames) > 0 {
 		reasons := reservationReasonsForExecInfo(info)
 		if conn.IsInTransaction() {
 			reasons |= protoutil.ReasonTransaction
 		}
-		// A direct connection reserves (and quarantines) its own backend on every
+		// A unsafe connection reserves (and quarantines) its own backend on every
 		// statement — including plain ones that would otherwise skip reservation.
-		if conn.DirectConnection() {
-			reasons |= protoutil.ReasonDirectConnection
+		if conn.UnsafeConnection() {
+			reasons |= protoutil.ReasonUnsafeConnection
 		}
 		// If the session already has a temp table reservation on another shard,
 		// include the temp table reason so the connection survives COMMIT.
@@ -565,27 +565,27 @@ func (sc *ScatterConn) PortalStreamExecute(
 		if info.SetSeed {
 			reasons |= protoutil.ReasonSetSeed
 		}
-		// A direct connection keeps its reason on the already-reserved backend so
+		// A unsafe connection keeps its reason on the already-reserved backend so
 		// it stays pinned+quarantined after the other reason ends.
-		if conn.DirectConnection() {
-			reasons |= protoutil.ReasonDirectConnection
+		if conn.UnsafeConnection() {
+			reasons |= protoutil.ReasonUnsafeConnection
 		}
 		if reasons != 0 {
 			reservationOpts = &querypb.ReservationOptions{Reasons: reasons}
 		}
-	} else if conn.IsInTransaction() || conn.DirectConnection() || info.TempTable || info.AdvisoryLock || info.LogicalReplicationSlot || info.SetSeed {
+	} else if conn.IsInTransaction() || conn.UnsafeConnection() || info.TempTable || info.AdvisoryLock || info.LogicalReplicationSlot || info.SetSeed {
 		// Case 2: Need a new reserved connection — for transaction, temp table,
-		// advisory lock, direct connection, or a combination. Build reservation
+		// advisory lock, unsafe connection, or a combination. Build reservation
 		// options the same way the simple StreamExecute path does and pass them on
 		// the portal RPC; the multipooler reserves-and-runs atomically.
 		reasons := reservationReasonsForExecInfo(info)
 		if conn.IsInTransaction() {
 			reasons |= protoutil.ReasonTransaction
 		}
-		// A direct connection reserves (and quarantines) its own backend on every
+		// A unsafe connection reserves (and quarantines) its own backend on every
 		// statement — including plain ones that would otherwise skip reservation.
-		if conn.DirectConnection() {
-			reasons |= protoutil.ReasonDirectConnection
+		if conn.UnsafeConnection() {
+			reasons |= protoutil.ReasonUnsafeConnection
 		}
 		if state.HasTempTableReservation() {
 			reasons |= protoutil.ReasonTempTable
@@ -1040,17 +1040,17 @@ func (sc *ScatterConn) CopyOutInitiate(
 		// AND CHAIN signal that the new transaction has not run a statement
 		// yet; clear it now that one has.
 		state.PendingBeginQuery = ""
-	} else if conn.IsInTransaction() || conn.DirectConnection() {
+	} else if conn.IsInTransaction() || conn.UnsafeConnection() {
 		// A transaction needs a reserved connection (with a possibly deferred
-		// BEGIN); a direct connection needs its backend pinned and quarantined even
+		// BEGIN); an unsafe connection needs its backend pinned and quarantined even
 		// for a first COPY, so untracked session state a trigger or function changes
 		// mid-COPY is never recycled to another client. Either — or both — reserves.
 		reservationOpts = &querypb.ReservationOptions{}
 		if conn.IsInTransaction() {
 			reservationOpts.Reasons |= protoutil.ReasonTransaction
 		}
-		if conn.DirectConnection() {
-			reservationOpts.Reasons |= protoutil.ReasonDirectConnection
+		if conn.UnsafeConnection() {
+			reservationOpts.Reasons |= protoutil.ReasonUnsafeConnection
 		}
 		if state.HasTempTableReservation() {
 			reservationOpts.Reasons |= protoutil.ReasonTempTable
@@ -1207,9 +1207,9 @@ func (sc *ScatterConn) CopyInitiate(
 		// AND CHAIN signal that the new transaction has not run a statement
 		// yet; clear it now that one has.
 		state.PendingBeginQuery = ""
-	} else if conn.IsInTransaction() || conn.DirectConnection() {
+	} else if conn.IsInTransaction() || conn.UnsafeConnection() {
 		// A transaction needs a reserved connection with a (possibly deferred)
-		// BEGIN executed before COPY; a direct connection needs its backend pinned
+		// BEGIN executed before COPY; an unsafe connection needs its backend pinned
 		// and quarantined even for a first COPY, so untracked session state a
 		// trigger or function changes mid-COPY is never recycled to another client.
 		// Either — or both — reserves here.
@@ -1217,8 +1217,8 @@ func (sc *ScatterConn) CopyInitiate(
 		if conn.IsInTransaction() {
 			reservationOpts.Reasons |= protoutil.ReasonTransaction
 		}
-		if conn.DirectConnection() {
-			reservationOpts.Reasons |= protoutil.ReasonDirectConnection
+		if conn.UnsafeConnection() {
+			reservationOpts.Reasons |= protoutil.ReasonUnsafeConnection
 		}
 		if state.HasTempTableReservation() {
 			reservationOpts.Reasons |= protoutil.ReasonTempTable

--- a/go/services/multigateway/scatterconn/scatter_conn_test.go
+++ b/go/services/multigateway/scatterconn/scatter_conn_test.go
@@ -455,24 +455,24 @@ func TestScatterConn_Case2_SetSeedReservesNewConn(t *testing.T) {
 	require.Equal(t, uint64(89), ss.ReservedState.GetReservedConnectionId())
 }
 
-// TestScatterConn_DirectConnection_PlainStatementReserves guards the crux of
-// direct connection: even a plain statement (no transaction/temp/lock — what
+// TestScatterConn_UnsafeConnection_PlainStatementReserves guards the crux of
+// unsafe connection: even a plain statement (no transaction/temp/lock — what
 // would otherwise take the unreserved Case 3 path) must reserve+quarantine its
-// own backend, carrying ReasonDirectConnection. Without the gate including
-// conn.DirectConnection(), such a statement would run on a shared pooled backend
+// own backend, carrying ReasonUnsafeConnection. Without the gate including
+// conn.UnsafeConnection(), such a statement would run on a shared pooled backend
 // and leak any untracked state it changed.
-func TestScatterConn_DirectConnection_PlainStatementReserves(t *testing.T) {
+func TestScatterConn_UnsafeConnection_PlainStatementReserves(t *testing.T) {
 	gw := &mockGateway{
 		streamExecuteReturnState: &querypb.ReservedState{
 			ReservedConnectionId: 91,
 			PoolerId:             &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"},
-			ReservationReasons:   protoutil.ReasonDirectConnection,
+			ReservationReasons:   protoutil.ReasonUnsafeConnection,
 		},
 		callbackResult: &sqltypes.Result{CommandTag: "SELECT 1"},
 	}
 	sc := NewScatterConn(gw, slog.Default())
 	state := handler.NewMultigatewayConnectionState()
-	conn := server.NewTestConn(&bytes.Buffer{}, server.WithTestDirectConnection()).Conn // direct, not in a txn
+	conn := server.NewTestConn(&bytes.Buffer{}, server.WithTestUnsafeConnection()).Conn // direct, not in a txn
 
 	// A plain SELECT: no transaction, no temp table, no lock — the one that used
 	// to take the unreserved path.
@@ -482,24 +482,24 @@ func TestScatterConn_DirectConnection_PlainStatementReserves(t *testing.T) {
 
 	require.NoError(t, err)
 	require.True(t, gw.streamExecuteCalled)
-	require.NotNil(t, gw.streamExecuteReservationOps, "a direct connection must reserve even for a plain statement")
-	require.True(t, protoutil.HasDirectConnectionReason(gw.streamExecuteReservationOps.GetReasons()))
+	require.NotNil(t, gw.streamExecuteReservationOps, "an unsafe connection must reserve even for a plain statement")
+	require.True(t, protoutil.HasUnsafeConnectionReason(gw.streamExecuteReservationOps.GetReasons()))
 }
 
-// TestScatterConn_DirectConnection_CopyReserves guards that a first COPY
-// FROM/TO STDIN on a direct connection (no transaction, no prior reservation)
-// still reserves and quarantines its backend with ReasonDirectConnection.
+// TestScatterConn_UnsafeConnection_CopyReserves guards that a first COPY
+// FROM/TO STDIN on an unsafe connection (no transaction, no prior reservation)
+// still reserves and quarantines its backend with ReasonUnsafeConnection.
 // Without it, a trigger or function that changes untracked session state during
 // COPY would run on a pooled backend that is then recycled to another client.
-func TestScatterConn_DirectConnection_CopyReserves(t *testing.T) {
+func TestScatterConn_UnsafeConnection_CopyReserves(t *testing.T) {
 	newDirectConn := func() *server.Conn {
-		return server.NewTestConn(&bytes.Buffer{}, server.WithTestDirectConnection()).Conn // direct, not in a txn
+		return server.NewTestConn(&bytes.Buffer{}, server.WithTestUnsafeConnection()).Conn // direct, not in a txn
 	}
 	reservedState := func() *querypb.ReservedState {
 		return &querypb.ReservedState{
 			ReservedConnectionId: 77,
 			PoolerId:             &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"},
-			ReservationReasons:   protoutil.ReasonDirectConnection,
+			ReservationReasons:   protoutil.ReasonUnsafeConnection,
 		}
 	}
 
@@ -512,8 +512,8 @@ func TestScatterConn_DirectConnection_CopyReserves(t *testing.T) {
 			func(_ context.Context, _ *sqltypes.Result) error { return nil })
 
 		require.NoError(t, err)
-		require.NotNil(t, gw.copyReadyReservationOps, "a direct connection must reserve for a first COPY FROM STDIN")
-		require.True(t, protoutil.HasDirectConnectionReason(gw.copyReadyReservationOps.GetReasons()))
+		require.NotNil(t, gw.copyReadyReservationOps, "an unsafe connection must reserve for a first COPY FROM STDIN")
+		require.True(t, protoutil.HasUnsafeConnectionReason(gw.copyReadyReservationOps.GetReasons()))
 	})
 
 	t.Run("COPY TO STDOUT", func(t *testing.T) {
@@ -524,8 +524,8 @@ func TestScatterConn_DirectConnection_CopyReserves(t *testing.T) {
 		_, _, _, err := sc.CopyOutInitiate(context.Background(), newDirectConn(), "tg1", "", "COPY t TO STDOUT", state)
 
 		require.NoError(t, err)
-		require.NotNil(t, gw.copyOutReadyReservationOps, "a direct connection must reserve for a first COPY TO STDOUT")
-		require.True(t, protoutil.HasDirectConnectionReason(gw.copyOutReadyReservationOps.GetReasons()))
+		require.NotNil(t, gw.copyOutReadyReservationOps, "an unsafe connection must reserve for a first COPY TO STDOUT")
+		require.True(t, protoutil.HasUnsafeConnectionReason(gw.copyOutReadyReservationOps.GetReasons()))
 	})
 }
 

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -2335,7 +2335,7 @@ func (e *Executor) DiscardTempTables(
 //
 // keepStickyReservations, when true, leaves the connection reserved instead
 // of returning it to the pool if a sticky reason (ReasonSetSeed or
-// ReasonDirectConnection) remains after the above cleanup — a sticky reason has
+// ReasonUnsafeConnection) remains after the above cleanup — a sticky reason has
 // no PostgreSQL command that undoes it, so it must survive until the
 // connection's real teardown. Real client-disconnect cleanup always passes
 // false, so a sticky reason never blocks the connection's actual teardown.

--- a/go/services/multipooler/internal/pools/reserved/properties_test.go
+++ b/go/services/multipooler/internal/pools/reserved/properties_test.go
@@ -252,21 +252,21 @@ func TestRemoveReservationReason_DrainsOnEmpty(t *testing.T) {
 		"sole reason drains on removal")
 }
 
-// TestAddReservationReason_DirectConnectionTaintsAtAcquire pins that adding the
-// direct-connection reason immediately marks the backend closeOnRelease, so it
+// TestAddReservationReason_UnsafeConnectionTaintsAtAcquire pins that adding the
+// unsafe-connection reason immediately marks the backend closeOnRelease, so it
 // is discarded on every release path rather than recycled with untracked state.
 // Other reasons (here temp) do not taint at add time.
-func TestAddReservationReason_DirectConnectionTaintsAtAcquire(t *testing.T) {
+func TestAddReservationReason_UnsafeConnectionTaintsAtAcquire(t *testing.T) {
 	clean := &Conn{}
 	clean.AddReservationReason(protoutil.ReasonTempTable)
 	assert.False(t, clean.closeOnRelease.Load(), "temp reason must not taint at add time")
 
 	direct := &Conn{}
-	direct.AddReservationReason(protoutil.ReasonDirectConnection)
-	assert.True(t, direct.closeOnRelease.Load(), "direct-connection reason must taint at add time")
+	direct.AddReservationReason(protoutil.ReasonUnsafeConnection)
+	assert.True(t, direct.closeOnRelease.Load(), "unsafe-connection reason must taint at add time")
 
-	// Also set when direct connection rides alongside other reasons.
+	// Also set when unsafe connection rides alongside other reasons.
 	mixed := &Conn{}
-	mixed.AddReservationReason(protoutil.ReasonTransaction | protoutil.ReasonDirectConnection)
+	mixed.AddReservationReason(protoutil.ReasonTransaction | protoutil.ReasonUnsafeConnection)
 	assert.True(t, mixed.closeOnRelease.Load())
 }

--- a/go/services/multipooler/internal/pools/reserved/reserved_conn.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_conn.go
@@ -429,7 +429,7 @@ func (c *Conn) ReservedProps() *ReservationProperties {
 // PostgreSQL rejects it — the taint is applied separately by MarkTempTainted
 // on the success path.
 //
-// The direct-connection reason IS tainted here, unconditionally: such a
+// The unsafe-connection reason IS tainted here, unconditionally: such a
 // connection may change backend session state the gateway does not track, so
 // once used this way the backend is forever suspect — the gateway's settings
 // label can no longer describe it and recycling would leak that state. Unlike
@@ -442,7 +442,7 @@ func (c *Conn) AddReservationReason(reason uint32) {
 	} else {
 		c.reservedProps.AddReason(reason)
 	}
-	if reason&protoutil.ReasonDirectConnection != 0 {
+	if reason&protoutil.ReasonUnsafeConnection != 0 {
 		c.closeOnRelease.Store(true)
 	}
 }

--- a/go/test/endtoend/pgregresstest/extensions.go
+++ b/go/test/endtoend/pgregresstest/extensions.go
@@ -234,9 +234,9 @@ type ExternalExtension struct {
 	// fixture files (see the pgtap spec below).
 	ExcludeGlobs []string
 
-	// DirectConnectionGlobs (pgTAP) names test files, matched against the path
+	// UnsafeConnectionGlobs (pgTAP) names test files, matched against the path
 	// relative to TestSubdir, that must run with the connection opted into
-	// direct connection (a per-connection opt-out) instead of
+	// unsafe connection (a per-connection opt-out) instead of
 	// under the enforcing default. Unlike ExcludeGlobs (a test dropped because it
 	// isn't a reliable signal), these tests DO pass on stock postgres and DO
 	// exercise the extension for real; they only fail through the enforcing
@@ -249,9 +249,9 @@ type ExternalExtension struct {
 	// mismatch). Real pg_partman usage is unaffected — create_parent /
 	// run_maintenance are installed at CREATE EXTENSION time and their internal
 	// dynamic SQL never passes through the gateway's body analysis. Running just
-	// these files with direct connection lets them run in full while every other
+	// these files with unsafe connection lets them run in full while every other
 	// file keeps exercising the rejections. See runExternalPgTAP.
-	DirectConnectionGlobs []string
+	UnsafeConnectionGlobs []string
 
 	// PreseedFile, when non-empty, names a SQL file (its key in externalPreseeds,
 	// backed by an embed under testdata/pg<major>/external/) run directly on the
@@ -577,8 +577,8 @@ var externalSpecs = map[string]ExternalExtension{
 		// analysis, and ON_ERROR_STOP then aborts the whole file mid-plan (they
 		// pass 221/221 on stock postgres but stop at 167/221 through the enforcing
 		// gateway). They exercise pg_partman for real, so run them on a direct
-		// connection rather than dropping them — see DirectConnectionGlobs.
-		DirectConnectionGlobs: []string{
+		// connection rather than dropping them — see UnsafeConnectionGlobs.
+		UnsafeConnectionGlobs: []string{
 			"test-time-daily.sql",
 			"test-text-time-daily.sql",
 			"test-time-gap-fill.sql",

--- a/go/test/endtoend/pgregresstest/pg_regress.go
+++ b/go/test/endtoend/pgregresstest/pg_regress.go
@@ -52,7 +52,7 @@ func (pb *PostgresBuilder) RunRegressionTests(t *testing.T, ctx context.Context,
 	t.Logf("Running PostgreSQL regression tests against multigateway on port %d...", multigatewayPort)
 
 	// Pre-seed benign scaffolding helper functions (EXPLAIN wrappers, etc.)
-	// through a gateway direct connection before the suite. Their runtime CREATE
+	// through a gateway unsafe connection before the suite. Their runtime CREATE
 	// is rejected by the enforcing gateway's PL/pgSQL body analysis; seeding them
 	// keeps a single test from cascading into thousands of "function does not
 	// exist" errors and lets the substantive tests run. See preseedRegressHelpers.

--- a/go/test/endtoend/pgregresstest/pg_tap.go
+++ b/go/test/endtoend/pgregresstest/pg_tap.go
@@ -122,17 +122,17 @@ func (pb *PostgresBuilder) runExternalPgTAP(t *testing.T, ctx context.Context, e
 		}
 		name := strings.TrimSuffix(rel, ".sql")
 
-		// Most files run against the enforcing gateway. A few (DirectConnectionGlobs)
+		// Most files run against the enforcing gateway. A few (UnsafeConnectionGlobs)
 		// have scaffolding the enforcing gateway rejects by design — e.g. a
 		// runtime-built EXECUTE inside a DO block — which, under ON_ERROR_STOP,
 		// aborts the whole file mid-plan. Those connect to the same gateway but opt
-		// into direct connection per-connection (PGOPTIONS below), so they run in full while
+		// into unsafe connection per-connection (PGOPTIONS below), so they run in full while
 		// every other file keeps exercising the rejections. See
-		// ExternalExtension.DirectConnectionGlobs.
+		// ExternalExtension.UnsafeConnectionGlobs.
 		gatewayLabel := "multigateway"
-		directConnection := matchesAnyGlob(rel, ext.DirectConnectionGlobs)
-		if directConnection {
-			gatewayLabel = "multigateway(direct-connection)"
+		unsafeConnection := matchesAnyGlob(rel, ext.UnsafeConnectionGlobs)
+		if unsafeConnection {
+			gatewayLabel = "multigateway(unsafe-connection)"
 		}
 
 		// Drop the throwaway schemas a pg_partman test file creates, on the primary,
@@ -163,10 +163,10 @@ func (pb *PostgresBuilder) runExternalPgTAP(t *testing.T, ctx context.Context, e
 			"PGDATABASE=postgres",
 			"PGCONNECT_TIMEOUT=10",
 		)
-		// Opt this connection into direct connection for the
+		// Opt this connection into unsafe connection for the
 		// files whose scaffolding the enforcing gateway rejects by design.
-		if directConnection {
-			cmd.AddEnv("PGOPTIONS=-c " + constants.DirectConnectionParam + "=on")
+		if unsafeConnection {
+			cmd.AddEnv("PGOPTIONS=-c " + constants.UnsafeConnectionParam + "=on")
 		}
 		cmd.SetWaitDelay(10 * time.Second)
 

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -387,7 +387,7 @@ func (pb *PostgresBuilder) RunExternalTests(t *testing.T, ctx context.Context, e
 		}
 
 		// Seed any test-helper the gateway rejects by design (a dynamic EXECUTE in
-		// the helper body) through a gateway direct connection, after the
+		// the helper body) through a gateway unsafe connection, after the
 		// public-schema reset so it isn't wiped. The suite's own CREATE is still
 		// rejected under the enforcing default and recorded as a divergence; the
 		// seed just lets the helper's callers resolve. See ExternalExtension.PreseedFile.
@@ -396,10 +396,10 @@ func (pb *PostgresBuilder) RunExternalTests(t *testing.T, ctx context.Context, e
 			if !ok {
 				return merged, fmt.Errorf("external/%s: unknown PreseedFile %q (add it to externalPreseeds)", ext.Name, ext.PreseedFile)
 			}
-			if err := execViaGatewayDirectConnection(ctx, multigatewayPort, password, seed); err != nil {
+			if err := execViaGatewayUnsafeConnection(ctx, multigatewayPort, password, seed); err != nil {
 				t.Logf("external/%s: warning: preseed %q failed: %v", ext.Name, ext.PreseedFile, err)
 			} else {
-				t.Logf("external/%s: pre-seeded %s via gateway direct connection", ext.Name, ext.PreseedFile)
+				t.Logf("external/%s: pre-seeded %s via gateway unsafe connection", ext.Name, ext.PreseedFile)
 			}
 		}
 
@@ -706,16 +706,16 @@ func (pb *PostgresBuilder) runPostGISTests(t *testing.T, ctx context.Context, ex
 		"POSTGIS_TOP_BUILD_DIR="+cloneDir,
 		"PGIS_REG_TMPDIR="+tmpDir,
 		// Per-test helper re-seed: the patched run_test.pl runs this SQL before each
-		// test through a gateway direct connection (options=-c
-		// multigres.direct_connection=on), so the helpers the enforcing gateway
+		// test through a gateway unsafe connection (options=-c
+		// multigres.unsafe_connection=on), so the helpers the enforcing gateway
 		// rejects install via the pooled path (PGPASSWORD above authenticates it).
 		// The options value is single-quoted: it contains a space, and libpq's
 		// conninfo parser otherwise treats that space as a pair separator — reading
-		// only `options=-c` and then rejecting `multigres.direct_connection=on` as an
+		// only `options=-c` and then rejecting `multigres.unsafe_connection=on` as an
 		// unknown connection keyword, so psql never connects and the seed is skipped.
 		"MG_POSTGIS_PRESEED_FILE="+preseedPath,
 		fmt.Sprintf("MG_POSTGIS_PRESEED_CONNINFO=host=localhost port=%d user=postgres dbname=postgres options='-c %s=on'",
-			multigatewayPort, constants.DirectConnectionParam),
+			multigatewayPort, constants.UnsafeConnectionParam),
 		// Normalize planner GUCs to PostgreSQL defaults so index scan-type checks
 		// (qnodes) match PostGIS's expected output despite pgctld's tuned GUCs.
 		"PGOPTIONS=-c work_mem=4MB -c random_page_cost=4.0 -c effective_cache_size=4GB -c max_parallel_workers_per_gather=2",
@@ -1300,15 +1300,15 @@ func execOnPrimary(directPgPort int, password, stmt string) error {
 	return nil
 }
 
-// execViaGatewayDirectConnection runs stmt through multigateway on a direct
-// connection: it opens one pinned connection, enables direct connection with
-// `SET multigres.direct_connection = on`, then runs stmt. This installs
+// execViaGatewayUnsafeConnection runs stmt through multigateway on an unsafe
+// connection: it opens one pinned connection, enables unsafe connection with
+// `SET multigres.unsafe_connection = on`, then runs stmt. This installs
 // scaffolding the enforcing gateway would reject by design — e.g. a plpgsql body
 // with a dynamic EXECUTE — through the same pooled path the tests use, with no
 // direct-postgres access. The CREATE routes to the primary, commits, and
 // replicates via WAL like any DDL; the connection's backend is quarantined and
 // discarded at teardown, but the committed objects persist for every backend.
-func execViaGatewayDirectConnection(ctx context.Context, gatewayPort int, password, stmt string) error {
+func execViaGatewayUnsafeConnection(ctx context.Context, gatewayPort int, password, stmt string) error {
 	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
 		gatewayPort, password)
 	db, err := sql.Open("postgres", connStr)
@@ -1317,7 +1317,7 @@ func execViaGatewayDirectConnection(ctx context.Context, gatewayPort int, passwo
 	}
 	defer db.Close()
 
-	// Pin one connection so the direct-connection latch (per gateway connection)
+	// Pin one connection so the unsafe-connection latch (per gateway connection)
 	// applies to stmt below.
 	conn, err := db.Conn(ctx)
 	if err != nil {
@@ -1325,8 +1325,8 @@ func execViaGatewayDirectConnection(ctx context.Context, gatewayPort int, passwo
 	}
 	defer conn.Close()
 
-	if _, err := conn.ExecContext(ctx, "SET "+constants.DirectConnectionParam+" = on"); err != nil {
-		return fmt.Errorf("enable direct connection: %w", err)
+	if _, err := conn.ExecContext(ctx, "SET "+constants.UnsafeConnectionParam+" = on"); err != nil {
+		return fmt.Errorf("enable unsafe connection: %w", err)
 	}
 	if _, err := conn.ExecContext(ctx, stmt); err != nil {
 		return fmt.Errorf("exec [%s]: %w", stmt, err)

--- a/go/test/endtoend/pgregresstest/regress_preseed.go
+++ b/go/test/endtoend/pgregresstest/regress_preseed.go
@@ -30,7 +30,7 @@ var regressPreseedSQL string
 
 // postgisPreseedSQL holds the PostGIS core test-helper functions re-seeded
 // before each PostGIS test (the patched run_test.pl runs it via psql on a gateway
-// direct connection — see MG_POSTGIS_PRESEED_CONNINFO). PostGIS test files
+// unsafe connection — see MG_POSTGIS_PRESEED_CONNINFO). PostGIS test files
 // CREATE OR REPLACE their own helpers — which the enforcing gateway rejects — and
 // DROP them at the end, so they must be re-seeded per test. Extracted from
 // postgis 3.6.3 test sources.
@@ -45,7 +45,7 @@ var postgisPreseedSQL string
 var hypopgPreseedSQL string
 
 // externalPreseeds maps an ExternalExtension.PreseedFile name to the embedded
-// SQL run through a gateway direct connection before that extension's suite. Add
+// SQL run through a gateway unsafe connection before that extension's suite. Add
 // an embed var and an entry here for each extension whose test helpers the
 // enforcing gateway rejects by design (a dynamic EXECUTE in a helper body) but
 // which the suite then depends on. Keyed by the PreseedFile value in the spec.
@@ -54,7 +54,7 @@ var externalPreseeds = map[string]string{
 }
 
 // preseedRegressHelpers installs a small set of benign scaffolding helper
-// functions through a gateway direct connection before the regression suite
+// functions through a gateway unsafe connection before the regression suite
 // runs — the same pooled path the tests use, with no direct-postgres access.
 //
 // Almost every function in regress_preseed.sql — EXPLAIN wrappers,
@@ -77,9 +77,9 @@ var externalPreseeds = map[string]string{
 // backend sees the helper.
 func (pb *PostgresBuilder) preseedRegressHelpers(t *testing.T, ctx context.Context, gatewayPort int, password string) error {
 	t.Helper()
-	if err := execViaGatewayDirectConnection(ctx, gatewayPort, password, regressPreseedSQL); err != nil {
+	if err := execViaGatewayUnsafeConnection(ctx, gatewayPort, password, regressPreseedSQL); err != nil {
 		return fmt.Errorf("exec preseed: %w", err)
 	}
-	t.Logf("pre-seeded regression helper functions via gateway direct connection")
+	t.Logf("pre-seeded regression helper functions via gateway unsafe connection")
 	return nil
 }

--- a/go/test/endtoend/queryserving/unsafe_connection_test.go
+++ b/go/test/endtoend/queryserving/unsafe_connection_test.go
@@ -32,7 +32,7 @@ import (
 // is cluster-managed) but PostgreSQL itself accepts.
 const restrictedProbeSet = "SET synchronous_commit = off"
 
-// TestDirectConnection covers multigres.direct_connection, the per-connection
+// TestUnsafeConnection covers multigres.unsafe_connection, the per-connection
 // opt-out that suppresses the gateway's unsafe-statement rejections and, in
 // exchange, pins and quarantines the connection's backend so any untracked
 // session state it changes can never leak to another client through the shared
@@ -41,7 +41,7 @@ const restrictedProbeSet = "SET synchronous_commit = off"
 //   - the connect-time option and the SET latch both enable it;
 //   - it is a one-way latch (off / RESET / bad value are rejected);
 //   - a bad Boolean at connect time is a FATAL startup error;
-//   - untracked backend state set on a direct connection does not leak to a
+//   - untracked backend state set on an unsafe connection does not leak to a
 //     later pooled client (the quarantine-and-discard guarantee).
 //
 // They share one cluster fixture: the subtests each open their own connections
@@ -50,7 +50,7 @@ const restrictedProbeSet = "SET synchronous_commit = off"
 // cluster-restricted GUC the enforcing gateway rejects, yet a valid USERSET GUC
 // PostgreSQL applies per session and the gateway does not track — so it doubles
 // as both the "rejection suppressed" signal and a genuine untracked-state probe.
-func TestDirectConnection(t *testing.T) {
+func TestUnsafeConnection(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping end-to-end test (short mode)")
 	}
@@ -61,7 +61,7 @@ func TestDirectConnection(t *testing.T) {
 	setup.SetupTest(t)
 
 	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
-	param := constants.DirectConnectionParam
+	param := constants.UnsafeConnectionParam
 
 	// Baseline: the probe really is rejected on an ordinary (enforcing)
 	// connection — otherwise the suppression subtests below would prove nothing.
@@ -81,11 +81,11 @@ func TestDirectConnection(t *testing.T) {
 		assert.Equal(t, 1, one)
 	})
 
-	// The connect-time option (options=-c multigres.direct_connection=on, sent
+	// The connect-time option (options=-c multigres.unsafe_connection=on, sent
 	// here as a startup RuntimeParam) latches the connection so the otherwise
 	// rejected probe is accepted, and the gateway-only param is stripped (never
 	// forwarded to the backend, which would reject an unknown GUC).
-	t.Run("connect-time option enables direct connection", func(t *testing.T) {
+	t.Run("connect-time option enables unsafe connection", func(t *testing.T) {
 		ctx := utils.WithTimeout(t, 60*time.Second)
 		cfg, err := pgx.ParseConfig(connStr)
 		require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestDirectConnection(t *testing.T) {
 
 		// The restricted SET the enforcing path rejects now goes through to postgres.
 		_, err = conn.Exec(ctx, restrictedProbeSet)
-		require.NoError(t, err, "restricted SET must be accepted on a direct connection")
+		require.NoError(t, err, "restricted SET must be accepted on an unsafe connection")
 
 		var sc string
 		require.NoError(t, conn.QueryRow(ctx, "SHOW synchronous_commit").Scan(&sc))
@@ -127,10 +127,10 @@ func TestDirectConnection(t *testing.T) {
 		assert.Contains(t, pgErr.Message, param)
 	})
 
-	// `SET multigres.direct_connection = on` latches the connection mid-session:
+	// `SET multigres.unsafe_connection = on` latches the connection mid-session:
 	// it replies like a normal SET, and a probe rejected before the latch is
 	// accepted after it.
-	t.Run("SET latch enables direct connection mid-session", func(t *testing.T) {
+	t.Run("SET latch enables unsafe connection mid-session", func(t *testing.T) {
 		ctx := utils.WithTimeout(t, 60*time.Second)
 		conn, err := pgx.Connect(ctx, connStr)
 		require.NoError(t, err)
@@ -152,6 +152,38 @@ func TestDirectConnection(t *testing.T) {
 		var sc string
 		require.NoError(t, conn.QueryRow(ctx, "SHOW synchronous_commit").Scan(&sc))
 		assert.Equal(t, "off", sc)
+	})
+
+	// The deprecated multigres.direct_connection alias must keep working — both at
+	// connect time and via SET — until all clients migrate to the new name.
+	t.Run("deprecated direct_connection alias still enables", func(t *testing.T) {
+		ctx := utils.WithTimeout(t, 60*time.Second)
+
+		t.Run("connect-time option", func(t *testing.T) {
+			cfg, err := pgx.ParseConfig(connStr)
+			require.NoError(t, err)
+			cfg.RuntimeParams[constants.DirectConnectionParam] = "on"
+
+			conn, err := pgx.ConnectConfig(ctx, cfg)
+			require.NoError(t, err)
+			defer conn.Close(ctx)
+
+			_, err = conn.Exec(ctx, restrictedProbeSet)
+			require.NoError(t, err, "deprecated alias must enable unsafe connection at connect time")
+		})
+
+		t.Run("SET latch", func(t *testing.T) {
+			conn, err := pgx.Connect(ctx, connStr)
+			require.NoError(t, err)
+			defer conn.Close(ctx)
+
+			tag, err := conn.Exec(ctx, "SET "+constants.DirectConnectionParam+" = on")
+			require.NoError(t, err)
+			assert.Equal(t, "SET", tag.String())
+
+			_, err = conn.Exec(ctx, restrictedProbeSet)
+			require.NoError(t, err, "deprecated alias must enable unsafe connection mid-session")
+		})
 	})
 
 	// The latch can only be turned on: turning it off, resetting it, and a
@@ -198,27 +230,27 @@ func TestDirectConnection(t *testing.T) {
 			require.NoError(t, err)
 
 			// The latch is one-way: attempting to turn it off is still an error, and
-			// the connection remains a direct connection (probe still accepted).
+			// the connection remains an unsafe connection (probe still accepted).
 			_, err = conn.Exec(ctx, "SET "+param+" = off")
 			_ = utils.RequirePgError(t, err, "0A000")
 
 			_, err = conn.Exec(ctx, restrictedProbeSet)
-			require.NoError(t, err, "connection must remain a direct connection after a failed off attempt")
+			require.NoError(t, err, "connection must remain an unsafe connection after a failed off attempt")
 		})
 	})
 
-	// Quarantine, observed directly by backend PID. A direct connection draws a
+	// Quarantine, observed directly by backend PID. A unsafe connection draws a
 	// dedicated *reserved* backend; when it closes, that backend must be closed
 	// (quarantined), not recycled. Since the reserved pool otherwise recycles a
 	// released backend to the next reserved borrower, the check is: the direct
 	// connection's PID must never reappear on a later reserved borrow. The probe
 	// is a plain transaction (BEGIN … pg_backend_pid() … ROLLBACK), a reserved
 	// connection drawing from the same pool. Removing the quarantine (the
-	// closeOnRelease taint on the direct-connection reason) makes this fail.
+	// closeOnRelease taint on the unsafe-connection reason) makes this fail.
 	t.Run("backend is discarded on teardown", func(t *testing.T) {
 		ctx := utils.WithTimeout(t, 90*time.Second)
 
-		// The direct connection's dedicated reserved backend PID.
+		// The unsafe connection's dedicated reserved backend PID.
 		var directPID int
 		func() {
 			cfg, err := pgx.ParseConfig(connStr)
@@ -236,7 +268,7 @@ func TestDirectConnection(t *testing.T) {
 		for i := range 12 {
 			pid := reservedBackendPID(t, ctx, connStr)
 			require.NotEqualf(t, directPID, pid,
-				"probe %d reused the direct connection's backend PID %d; it must have been discarded, not recycled",
+				"probe %d reused the unsafe connection's backend PID %d; it must have been discarded, not recycled",
 				i, directPID)
 		}
 	})
@@ -259,7 +291,7 @@ func TestDirectConnection(t *testing.T) {
 		require.NotEmpty(t, baseline)
 		require.NotEqual(t, leakValue, baseline, "baseline unexpectedly equals the leak probe value")
 
-		// Direct connection: create + run a function whose body hides an
+		// Unsafe connection: create + run a function whose body hides an
 		// is_local=false set_config the gateway cannot track, mutating work_mem on
 		// this backend only.
 		func() {
@@ -271,17 +303,17 @@ func TestDirectConnection(t *testing.T) {
 			defer conn.Close(ctx)
 
 			// The CREATE (an is_local=false set_config in the body) is rejected on an
-			// enforcing connection by body analysis; a direct connection accepts it.
+			// enforcing connection by body analysis; an unsafe connection accepts it.
 			_, err = conn.Exec(ctx, `CREATE OR REPLACE FUNCTION mg_dc_hidden_leak() RETURNS text
 				LANGUAGE sql AS $$SELECT set_config('work_mem', '`+leakValue+`', false)$$`)
-			require.NoError(t, err, "hidden-set_config function must be creatable on a direct connection")
+			require.NoError(t, err, "hidden-set_config function must be creatable on an unsafe connection")
 
 			_, err = conn.Exec(ctx, "SELECT mg_dc_hidden_leak()")
 			require.NoError(t, err)
 
 			var got string
 			require.NoError(t, conn.QueryRow(ctx, "SHOW work_mem").Scan(&got))
-			require.Equal(t, leakValue, got, "the untracked value must apply on the direct connection's own backend")
+			require.Equal(t, leakValue, got, "the untracked value must apply on the unsafe connection's own backend")
 		}()
 		// DROP is allowed on an enforcing connection; clean up the catalog object.
 		defer func() {
@@ -298,7 +330,7 @@ func TestDirectConnection(t *testing.T) {
 		for i := range 12 {
 			got := reservedWorkMem(t, ctx, connStr)
 			require.Equalf(t, baseline, got,
-				"probe %d saw work_mem=%q; the direct connection's untracked work_mem=%q leaked through the pool",
+				"probe %d saw work_mem=%q; the unsafe connection's untracked work_mem=%q leaked through the pool",
 				i, got, leakValue)
 		}
 	})

--- a/proto/multipoolerservice.proto
+++ b/proto/multipoolerservice.proto
@@ -443,7 +443,7 @@ enum ReservationReason {
   // residual-state gap is accepted since it only affects the statistical
   // freshness of an unrelated session's random() sequence.
   RESERVATION_REASON_SET_SEED = 128;  // 0b10000000
-  // Connection is a direct connection (the per-connection mode that gives the
+  // Connection is an unsafe connection (the per-connection mode that gives the
   // client its own dedicated backend and suppresses the unsafe-statement
   // rejections). Such a connection may run statements that change untracked
   // backend session state, so its backend must never be returned to the shared
@@ -451,7 +451,7 @@ enum ReservationReason {
   // backend for the session's lifetime and, like SET_SEED, sticky: it survives
   // DISCARD ALL and is released only at the connection's real teardown, when the
   // tainted backend is discarded.
-  RESERVATION_REASON_DIRECT_CONNECTION = 256;  // 0b100000000
+  RESERVATION_REASON_UNSAFE_CONNECTION = 256;  // 0b100000000
 }
 
 // TransactionConclusion specifies how to conclude a transaction.
@@ -576,7 +576,7 @@ message ReleaseReservedConnectionRequest {
   // remains after the usual cleanup (rollback, COPY abort, temp table
   // discard, advisory unlock). A sticky reason has no PostgreSQL command
   // that undoes it (RESERVATION_REASON_SET_SEED or
-  // RESERVATION_REASON_DIRECT_CONNECTION), so it can only be cleared by the
+  // RESERVATION_REASON_UNSAFE_CONNECTION), so it can only be cleared by the
   // connection's real teardown. Real client-disconnect
   // cleanup always leaves this false, so a sticky reason never blocks a
   // connection's actual teardown.


### PR DESCRIPTION
## Summary

- Rename the per-connection direct-connection mode to unsafe-connection across the codebase, aligning it with the existing "unsafe" family (unsafe-pooler-mode, unsafe_funccall).
- The user-facing option/GUC is now `multigres.unsafe_connection`; the former `multigres.direct_connection` is kept as a deprecated alias, recognized at connect time and via `SET`, until all clients migrate off it.
- Internal identifiers, files, tests, and the reservation-reason proto enum (`RESERVATION_REASON_UNSAFE_CONNECTION`, numeric value unchanged at 256, so wire-compatible) are all renamed.

## Description

`SET` error messages now echo the name the client actually supplied, so a client using the deprecated alias sees the name it typed rather than the canonical one. Both recognition points (connect-time in `startup.go` and `SET` in `variable_set_stmt.go`) accept either name.

Unit tests for both recognition points are parametrized over the primary name and the deprecated alias, and an end-to-end subtest proves the alias still enables the mode at connect time and via `SET`. Unrelated "direct connection" usages (direct TLS, the raw-write path, pgregress `isolation.go`, pgbench docs) were left untouched.