### PR TITLE
fix(multigateway): return 3D000 for a nonexistent database

### DIFF
--- a/go/common/mterrors/code.go
+++ b/go/common/mterrors/code.go
@@ -36,6 +36,7 @@ const (
 	PgSSAuthFailed              = "28P01" // invalid_password
 	PgSSInvalidAuthSpec         = "28000" // invalid_authorization_specification
 	PgSSInvalidCursorName       = "34000" // invalid_cursor_name
+	PgSSInvalidCatalogName      = "3D000" // invalid_catalog_name
 	PgSSDuplicatePreparedStmt   = "42P05" // duplicate_prepared_statement
 	PgSSInsufficientPrivilege   = "42501" // insufficient_privilege
 	PgSSSyntaxError             = "42601" // syntax_error

--- a/go/common/topoclient/poolerwatch/cache.go
+++ b/go/common/topoclient/poolerwatch/cache.go
@@ -451,6 +451,22 @@ func (c *PoolerCache[T]) GetByShard(database, tableGroup, shard string) []Entry[
 	return out
 }
 
+// HasDatabase reports whether any read-visible entry belongs to the named
+// database. It answers "does this database exist as far as discovery is
+// concerned", which callers use to tell an unknown database from a known one
+// whose poolers are momentarily unroutable. Scans the byShard index keys, so
+// the cost is the number of tracked shards, not the number of poolers.
+func (c *PoolerCache[T]) HasDatabase(database string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for key := range c.byShard {
+		if key.database == database {
+			return true
+		}
+	}
+	return false
+}
+
 // All returns every read-visible entry (Live or MissingFromTopo). Tombstones are not
 // included. Intended for cross-shard scans like metric collection or
 // bookkeeping; for ordinary lookups prefer Get / GetByShard.

--- a/go/common/topoclient/poolerwatch/cache_test.go
+++ b/go/common/topoclient/poolerwatch/cache_test.go
@@ -363,6 +363,30 @@ func TestCache_GetByShardAndCellExcludeShutdownPoolers(t *testing.T) {
 	assert.Equal(t, "alive", shard[0].Pooler.Id.Name)
 }
 
+// TestCache_HasDatabaseTracksShardIndex covers the read used to tell an unknown
+// database from a known one whose poolers are unroutable. It follows the same
+// read-visibility rule as GetByShard: a SHUTDOWN pooler leaves the index, and
+// with it the database it was the last member of.
+func TestCache_HasDatabaseTracksShardIndex(t *testing.T) {
+	clk := newFakeClock()
+	c, _ := newTestCache(t, clk, time.Hour, time.Hour)
+	defer c.Shutdown()
+
+	assert.False(t, c.HasDatabase("db"), "an empty cache knows no database")
+
+	c.applyUpsert(pool("zone1", "p1", "db", "tg", "0", clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE))
+	assert.True(t, c.HasDatabase("db"))
+	assert.False(t, c.HasDatabase("other_db"))
+
+	// A second shard of the same database keeps it known once the first goes.
+	c.applyUpsert(pool("zone1", "p2", "db", "tg", "1", clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE))
+	c.applyUpsert(pool("zone1", "p1", "db", "tg", "0", clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN))
+	assert.True(t, c.HasDatabase("db"), "the database still has a shard with a live pooler")
+
+	c.applyUpsert(pool("zone1", "p2", "db", "tg", "1", clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN))
+	assert.False(t, c.HasDatabase("db"), "the last read-visible pooler left the database")
+}
+
 func TestCache_ShutdownDisposesEverythingRemaining(t *testing.T) {
 	clk := newFakeClock()
 	c, rec := newTestCache(t, clk, time.Hour, time.Hour)

--- a/go/services/multigateway/poolergateway/availability_errors.go
+++ b/go/services/multigateway/poolergateway/availability_errors.go
@@ -16,6 +16,7 @@ package poolergateway
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/multigres/multigres/go/common/mterrors"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
@@ -43,6 +44,33 @@ func newNoWritablePrimaryError(internalFormat string, args ...any) error {
 		internalFormat,
 		args...,
 	)}
+}
+
+// newUnknownDatabaseError rejects a database that discovery has never seen —
+// no pooler is registered for it anywhere in the cache. PostgreSQL and
+// pgbouncer both answer 3D000 (invalid_catalog_name) here, and the
+// distinction matters: 57P03 is conventionally retryable, so a client asking
+// for a database that will never exist would otherwise retry forever.
+//
+// The RPC code is INVALID_ARGUMENT by elimination. UNAVAILABLE would be
+// swallowed by isCredentialSourceUnavailable and reported as a transient
+// credential-source failure, and NOT_FOUND is how the credential provider
+// recognises "this role does not exist" (scram.ErrUserNotFound).
+//
+// On the connect path this answers before authentication and therefore
+// reveals whether a database exists. That matches pgbouncer and is
+// intentional for compatibility.
+func newUnknownDatabaseError(database string) error {
+	diagnostic := mterrors.NewPgError(
+		"ERROR",
+		mterrors.PgSSInvalidCatalogName,
+		fmt.Sprintf("database %q does not exist", database),
+		"",
+	)
+	return mterrors.WithCode(
+		mterrors.Wrapf(diagnostic, "no pooler is registered for database %q", database),
+		mtrpcpb.Code_INVALID_ARGUMENT,
+	)
 }
 
 func isNoWritablePrimaryError(err error) bool {

--- a/go/services/multigateway/poolergateway/load_balancer.go
+++ b/go/services/multigateway/poolergateway/load_balancer.go
@@ -333,6 +333,30 @@ func (lb *loadBalancer) notifyLeaderServingFromSummary(summary *shardSummary, co
 	lb.onLeaderServing(summary.shardKey)
 }
 
+// unknownDatabaseError returns a terminal 3D000 error when the target names a
+// database discovery has never seen, and nil when the database is known — or
+// when we cannot tell. Every routing failure otherwise looks alike from the
+// client's side ("no writable primary", conventionally retryable), which is
+// the wrong answer for a database that will never appear.
+//
+// An empty cache means discovery has not populated yet — startup, or a
+// topology outage — so every database is equally unseen and none can be
+// declared nonexistent. Those callers keep the retryable 57P03.
+//
+// HasDatabase scans shard keys, but only failed routing reaches here, and a
+// known database returns on the first key that matches it. A full scan
+// happens only for a database that really is absent, which is terminal: the
+// client stops retrying rather than coming back.
+func (lb *loadBalancer) unknownDatabaseError(sk *clustermetadatapb.ShardKey) error {
+	if lb.cache == nil || lb.cache.Len() == 0 {
+		return nil
+	}
+	if lb.cache.HasDatabase(sk.GetDatabase()) {
+		return nil
+	}
+	return newUnknownDatabaseError(sk.GetDatabase())
+}
+
 // getConnection returns a poolerConnection matching the target specification.
 // Returns an error immediately if no suitable connection is available.
 //
@@ -374,6 +398,9 @@ func (lb *loadBalancer) getConnection(target *query.Target) (*poolerConnection, 
 	routesToLeader := mode == query.Mode_MODE_WRITABLE || mode == query.Mode_MODE_CONSISTENT
 	if routesToLeader {
 		if !haveLeader {
+			if err := lb.unknownDatabaseError(sk); err != nil {
+				return nil, err
+			}
 			return nil, newNoWritablePrimaryError(
 				"no leader observed yet for database=%s, tablegroup=%s, shard=%s",
 				sk.GetDatabase(), sk.GetTableGroup(), sk.GetShard())
@@ -420,6 +447,9 @@ func (lb *loadBalancer) getConnection(target *query.Target) (*poolerConnection, 
 	}
 
 	if len(candidates) == 0 {
+		if err := lb.unknownDatabaseError(sk); err != nil {
+			return nil, err
+		}
 		return nil, mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
 			"no pooler found for target: database=%s, tablegroup=%s, shard=%s, mode=%s",
 			sk.GetDatabase(), sk.GetTableGroup(), sk.GetShard(), mode.String())

--- a/go/services/multigateway/poolergateway/load_balancer_test.go
+++ b/go/services/multigateway/poolergateway/load_balancer_test.go
@@ -1032,3 +1032,105 @@ func TestLoadBalancer_DrainingPrimaryStaysRoutable(t *testing.T) {
 		"a cleanly-draining primary must stay routable so MTF01 buffering can engage")
 	assert.Equal(t, poolerID(primary), got.ID())
 }
+
+// withDatabase overrides the pooler's database, so a test can populate the
+// cache with a database other than the default one it is routing to.
+func withDatabase(p *clustermetadatapb.Multipooler, database string) *clustermetadatapb.Multipooler {
+	p.ShardKey.Database = database
+	return p
+}
+
+// TestLoadBalancer_UnknownDatabaseIsTerminal covers the distinction between a
+// database that does not exist and one that is momentarily unroutable. Both
+// used to answer 57P03, which clients treat as retryable — so a connection to
+// a database that will never appear retried forever. An unknown database now
+// answers 3D000 (invalid_catalog_name), the same code PostgreSQL and pgbouncer
+// return, on both the leader and the replica routing path.
+func TestLoadBalancer_UnknownDatabaseIsTerminal(t *testing.T) {
+	const unknownDB = "no_such_db_xyz"
+
+	modes := []query.Mode{query.Mode_MODE_WRITABLE, query.Mode_MODE_CONSISTENT, query.Mode_MODE_INCONSISTENT}
+	for _, mode := range modes {
+		t.Run(mode.String(), func(t *testing.T) {
+			lb := newTestLB(t, "zone1")
+
+			// Discovery has seen a different database, so the cache is
+			// populated and the unknown database is genuinely absent rather
+			// than merely undiscovered.
+			known := createTestMultipooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+			addPoolerForTest(t, lb, known)
+
+			target := protoutil.NewTarget(unknownDB, constants.DefaultTableGroup, "0", mode)
+			_, err := lb.getConnection(target)
+			require.Error(t, err)
+			assert.Equal(t, mtrpcpb.Code_INVALID_ARGUMENT, mterrors.Code(err),
+				"an unknown database must not be classified as UNAVAILABLE — that is what makes it retryable")
+
+			var diagnostic *mterrors.PgDiagnostic
+			require.True(t, errors.As(err, &diagnostic), "the error must carry a PostgreSQL diagnostic")
+			assert.Equal(t, mterrors.PgSSInvalidCatalogName, diagnostic.Code)
+			assert.Equal(t, `database "no_such_db_xyz" does not exist`, diagnostic.Message)
+		})
+	}
+}
+
+// TestLoadBalancer_KnownDatabaseStaysRetryable is the other half of the
+// distinction: a database whose poolers are registered but currently offer no
+// writable primary — a failover in progress — must keep the retryable 57P03.
+func TestLoadBalancer_KnownDatabaseStaysRetryable(t *testing.T) {
+	lb := newTestLB(t, "zone1")
+
+	// A pooler exists for the database, but never attests leadership, so the
+	// shard has no writable primary.
+	replica := createTestMultipooler("replica1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
+	addPoolerForTest(t, lb, replica)
+
+	target := protoutil.NewTarget(constants.DefaultPostgresDatabase, constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
+	_, err := lb.getConnection(target)
+	require.Error(t, err)
+	assert.Equal(t, mtrpcpb.Code_UNAVAILABLE, mterrors.Code(err))
+
+	var diagnostic *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diagnostic))
+	assert.Equal(t, mterrors.PgSSCannotConnectNow, diagnostic.Code,
+		"a registered database awaiting a primary must stay retryable")
+}
+
+// TestLoadBalancer_UndiscoveredDatabaseStaysRetryable guards the startup and
+// topology-outage case: with nothing in the cache, every database is equally
+// unseen, so none can be declared nonexistent.
+func TestLoadBalancer_UndiscoveredDatabaseStaysRetryable(t *testing.T) {
+	lb := newTestLB(t, "zone1")
+	require.Equal(t, 0, lb.cache.Len(), "precondition: discovery has not populated the cache")
+
+	target := protoutil.NewTarget("any_db", constants.DefaultTableGroup, "0", query.Mode_MODE_WRITABLE)
+	_, err := lb.getConnection(target)
+	require.Error(t, err)
+
+	var diagnostic *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diagnostic))
+	assert.Equal(t, mterrors.PgSSCannotConnectNow, diagnostic.Code,
+		"an empty cache cannot distinguish an unknown database from an undiscovered one")
+}
+
+// TestLoadBalancer_DatabaseKnownFromAnotherShard checks the verdict is made at
+// database granularity, not shard granularity: routing to a shard that has no
+// poolers, in a database that has poolers elsewhere, is a routing failure and
+// not a nonexistent database.
+func TestLoadBalancer_DatabaseKnownFromAnotherShard(t *testing.T) {
+	lb := newTestLB(t, "zone1")
+
+	other := withDatabase(
+		createTestMultipooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY),
+		"tenant_db")
+	addPoolerForTest(t, lb, other)
+
+	target := protoutil.NewTarget("tenant_db", constants.DefaultTableGroup, "99", query.Mode_MODE_WRITABLE)
+	_, err := lb.getConnection(target)
+	require.Error(t, err)
+
+	var diagnostic *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diagnostic))
+	assert.Equal(t, mterrors.PgSSCannotConnectNow, diagnostic.Code,
+		"the database exists; only this shard is unroutable")
+}

--- a/go/test/endtoend/queryserving/pgbouncertests/README.md
+++ b/go/test/endtoend/queryserving/pgbouncertests/README.md
@@ -52,9 +52,11 @@ first); don't run `go test` directly.
 
 ## Known divergences from PostgreSQL
 
-- **Nonexistent connection database:** the gateway authenticates the client and
-  serves its backend database instead of rejecting with `3D000`
-  (guarded by `nonexistent_db_test.go`).
+- **Auth-vs-database error ordering:** for a wrong password on a nonexistent
+  database, PostgreSQL reports the bad password (`28P01`) and the gateway
+  reports the unknown database (`3D000`) — it has nowhere to route the
+  credential lookup, so the database check necessarily comes first. Both reject
+  a nonexistent database with `3D000` (guarded by `nonexistent_db_test.go`).
 - **`DISCARD ALL`** does not run `pg_advisory_unlock_all()` on the backend, so
   session-level advisory locks are not released (a pre-existing pooling
   limitation).

--- a/go/test/endtoend/queryserving/pgbouncertests/nonexistent_db_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/nonexistent_db_test.go
@@ -40,28 +40,26 @@ import (
 // GetComparisonTargets). The two cases are connecting to a nonexistent database
 // and the auth-vs-database error ordering.
 //
-// **Known divergence**: the multigateway rejects a nonexistent connection
-// database with 57P03 (cannot_connect_now) instead of 3D000 / "no such
-// database", which is what both PostgreSQL and pgbouncer return. See
-// TestNonexistentDatabaseConnectBehavior; the eventual fix is to align with
-// pgbouncer.
+// The multigateway agrees with both on the SQLSTATE for a nonexistent database
+// (3D000) and diverges only on ordering: it rejects the unknown database
+// before checking the password, where PostgreSQL checks the password first.
+// See TestAuthAndDatabaseErrorPrecedence.
 
 // nonexistentDB is a database name that is not registered in the test topology
 // nor created in postgres.
 const nonexistentDB = "no_such_db_xyz"
 
-// TestNonexistentDatabaseConnectBehavior documents how the two targets reject a
-// nonexistent connection database with different SQLSTATEs:
+// TestNonexistentDatabaseConnectBehavior pins both targets to the same
+// SQLSTATE for a nonexistent connection database:
 //   - Direct PostgreSQL validates the catalog during startup and returns 3D000
 //     (invalid_catalog_name) at connect time.
-//   - The multigateway routes the credential lookup to the requested database;
-//     no pooler is registered for an unknown database, so the credential
-//     provider's error path surfaces as 57P03 (cannot_connect_now) at connect
-//     time.
+//   - The multigateway routes the credential lookup to the requested database
+//     and finds no pooler registered for it anywhere, which it reports as the
+//     same 3D000 rather than a routing failure.
 //
-// The multigateway still diverges from PostgreSQL and pgbouncer, but does not
-// misreport the routing failure as bad credentials. The eventual fix is to
-// translate "no pooler for database" into 3D000.
+// The SQLSTATE is what matters to clients here: 57P03 (the multigateway's
+// previous answer) is conventionally retryable, so a connection to a database
+// that will never exist retried forever.
 func TestNonexistentDatabaseConnectBehavior(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping in short mode")
@@ -82,21 +80,23 @@ func TestNonexistentDatabaseConnectBehavior(t *testing.T) {
 	assert.Equal(t, "3D000", code, "direct postgres should reject a nonexistent database with invalid_catalog_name")
 	assert.Equal(t, "connect", stage, "direct postgres rejects the database at connect time")
 
-	// Multigateway (DIVERGENCE): the credential lookup is routed to the
-	// requested database and fails because no pooler is registered for it.
-	// The lookup fails before credentials can be inspected, so the gateway
-	// reports 57P03. A future change can translate an unknown database to 3D000.
+	// Multigateway: the credential lookup is routed to the requested database,
+	// which has no pooler registered anywhere in the topology. That is
+	// reported as an unknown database, not as an unavailable credential
+	// source.
 	code, stage, err = probeConnect(t, ctx, targetPort(t, targets, "multigateway"), nonexistentDB, shardsetup.TestPostgresPassword)
 	require.Error(t, err, "multigateway must reject a nonexistent database")
 	t.Logf("multigateway: failed at %s stage with SQLSTATE %q", stage, code)
-	assert.Equal(t, "57P03", code,
-		"multigateway should report that the credential source is unavailable")
+	assert.Equal(t, "3D000", code,
+		"multigateway should reject a nonexistent database with invalid_catalog_name")
 	assert.Equal(t, "connect", stage, "multigateway rejects the database at connect time")
 }
 
 // TestAuthAndDatabaseErrorPrecedence documents how each target handles a wrong
-// password for a nonexistent database. PostgreSQL checks the password first;
-// multigateway cannot route the credential lookup and never inspects it.
+// password for a nonexistent database. The targets agree the connection must
+// fail and disagree on which reason wins: PostgreSQL checks the password first
+// (28P01), while multigateway rejects the unknown database (3D000) before it
+// has anywhere to send the credential lookup.
 func TestAuthAndDatabaseErrorPrecedence(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping in short mode")
@@ -115,7 +115,7 @@ func TestAuthAndDatabaseErrorPrecedence(t *testing.T) {
 			t.Logf("%s: failed at %s stage with SQLSTATE %q", target.Name, stage, code)
 			expectedCode := "28P01"
 			if target.Name == "multigateway" {
-				expectedCode = "57P03"
+				expectedCode = "3D000"
 			}
 			assert.Equal(t, expectedCode, code)
 			assert.Equalf(t, "connect", stage,


### PR DESCRIPTION
## Summary

Connecting to a database that exists nowhere in the topology answered `57P03`
(`cannot_connect_now`) — the same code the gateway uses for a real database whose
primary is momentarily unavailable. Clients treat `57P03` as retryable, so a
connection to a database that will never appear retried forever.

PostgreSQL and PgBouncer both answer `3D000` (`invalid_catalog_name`) here. This
makes the gateway agree with them.

Fixes #1290.

## Description

`loadBalancer.getConnection` now distinguishes the two cases before reporting a
routing failure: if no pooler is registered anywhere for the target's database,
it returns a terminal `3D000` carrying PostgreSQL's wording (`database "x" does
not exist`); otherwise the retryable `57P03` stands. Both the leader path
(`WRITABLE` / `CONSISTENT`) and the replica path (`INCONSISTENT`) are covered.

Two guards keep a real database from being mislabelled:

- **An empty cache never yields a verdict.** At startup, or during a topology
  outage, every database is equally unseen — so none can be declared
  nonexistent, and the retryable error stands.
- **The verdict is made at database granularity.** A shard awaiting a leader
  during a failover keeps its retryable error as long as the database has a
  pooler registered somewhere.

The RPC code is `INVALID_ARGUMENT` by elimination: `UNAVAILABLE` would be
swallowed by `isCredentialSourceUnavailable` and reported as a transient
credential-source failure, and `NOT_FOUND` is how the credential provider
recognises "this role does not exist".

### Intentional divergence

This answers before authentication and therefore reveals whether a database
exists. That matches PgBouncer and is intentional for compatibility. For a wrong
password on a nonexistent database, PostgreSQL reports the bad password
(`28P01`) while the gateway reports the unknown database (`3D000`) — it has
nowhere to route the credential lookup, so the database check necessarily comes
first. `pgbouncertests/README.md` records this under "Known divergences".

### Changed files

| File | Change |
| --- | --- |
| `go/common/mterrors/code.go` | add `PgSSInvalidCatalogName = "3D000"` |
| `go/common/topoclient/poolerwatch/cache.go` | `HasDatabase()` — scans the `byShard` index keys |
| `poolergateway/availability_errors.go` | `newUnknownDatabaseError()` |
| `poolergateway/load_balancer.go` | apply it on both `getConnection` paths |
| `pgbouncertests/nonexistent_db_test.go` | expect `3D000` |
| `pgbouncertests/README.md` | rewrite the known-divergence note to the error ordering that remains |

## Testing

New unit tests:

- `TestLoadBalancer_UnknownDatabaseIsTerminal` — `3D000` across `WRITABLE` /
  `CONSISTENT` / `INCONSISTENT`
- `TestLoadBalancer_KnownDatabaseStaysRetryable` — `57P03` during a failover of a
  registered database
- `TestLoadBalancer_UndiscoveredDatabaseStaysRetryable` — `57P03` on an empty cache
- `TestLoadBalancer_DatabaseKnownFromAnotherShard` — the verdict is per-database
- `TestCache_HasDatabaseTracksShardIndex` — including removal from the index on `SHUTDOWN`

Runs:

```
go test -count=1 ./go/common/topoclient/poolerwatch/... ./go/services/multigateway/poolergateway/...
ok  github.com/multigres/multigres/go/common/topoclient/poolerwatch          0.344s
ok  github.com/multigres/multigres/go/services/multigateway/poolergateway    4.458s
```

End-to-end, against a real cluster (PostgreSQL 17.11):

```
go test -count=1 -run 'TestNonexistentDatabaseConnectBehavior|TestAuthAndDatabaseErrorPrecedence' \
  ./go/test/endtoend/queryserving/pgbouncertests/...
--- PASS: TestNonexistentDatabaseConnectBehavior (19.79s)
--- PASS: TestAuthAndDatabaseErrorPrecedence (0.00s)
ok  github.com/multigres/multigres/go/test/endtoend/queryserving/pgbouncertests  20.992s
```

`TestAuthAndDatabaseErrorPrecedence` runs both the `postgres` and `multigateway`
subtests, so the differential comparison against real PostgreSQL is exercised
rather than skipped.
