### PR TITLE
fix(multipooler): enforce 0600 permissions on pgbackrest pgpass file

### DIFF
--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -292,19 +292,9 @@ func NewPgCtldService(
 	// Write a pgpass file and set PGPASSFILE so pgbackrest (archive-push runs as a
 	// postgres subprocess and inherits this process's environment) can authenticate
 	// against PostgreSQL without exposing the password in the process environment.
-	pgpassDir := filepath.Join(poolerDir, "pgbackrest")
-	if err := os.MkdirAll(pgpassDir, 0o755); err != nil {
-		return nil, fmt.Errorf("failed to create pgbackrest directory: %w", err)
-	}
-	pgpassPath := filepath.Join(pgpassDir, "pgbackrest.pgpass")
-	pgpassContent := fmt.Sprintf("*:*:*:%s:%s\n", cfg.User, cfg.Password)
-	if err := os.WriteFile(pgpassPath, []byte(pgpassContent), 0o600); err != nil {
-		return nil, fmt.Errorf("failed to write pgbackrest pgpass file: %w", err)
-	}
-	// enforce 0600 explicitly, as the operator might have changed these permissions
-	// during volume mount.
-	if err := os.Chmod(pgpassPath, 0o600); err != nil {
-		return nil, fmt.Errorf("failed to set pgbackrest pgpass file permissions: %w", err)
+	pgpassPath, err := backup.WritePgpassFile(poolerDir, cfg.User, cfg.Password)
+	if err != nil {
+		return nil, err
 	}
 	if err := os.Setenv("PGPASSFILE", pgpassPath); err != nil {
 		return nil, fmt.Errorf("failed to set PGPASSFILE: %w", err)

--- a/go/common/backup/pgpass.go
+++ b/go/common/backup/pgpass.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/multigres/multigres/go/tools/fileutil"
+)
+
+// WritePgpassFile writes the postgres credentials used by pgbackrest and
+// returns the resulting file path.
+func WritePgpassFile(poolerDir, user, password string) (string, error) {
+	pgpassDir := filepath.Join(poolerDir, "pgbackrest")
+	if err := os.MkdirAll(pgpassDir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create pgbackrest directory: %w", err)
+	}
+
+	pgpassPath := filepath.Join(pgpassDir, "pgbackrest.pgpass")
+	pgpassContent := fmt.Sprintf("*:*:*:%s:%s\n", user, password)
+	if err := fileutil.AtomicWriteFile(pgpassPath, []byte(pgpassContent), 0o600); err != nil {
+		return "", fmt.Errorf("failed to write pgbackrest pgpass file: %w", err)
+	}
+
+	return pgpassPath, nil
+}

--- a/go/common/backup/pgpass_test.go
+++ b/go/common/backup/pgpass_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWritePgpassFile(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupExisting bool
+	}{
+		{name: "creates file and parent directory"},
+		{name: "replaces existing file with secure mode", setupExisting: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			poolerDir := t.TempDir()
+			wantPath := filepath.Join(poolerDir, "pgbackrest", "pgbackrest.pgpass")
+			if tt.setupExisting {
+				if err := os.MkdirAll(filepath.Dir(wantPath), 0o755); err != nil {
+					t.Fatalf("create pgbackrest directory: %v", err)
+				}
+				if err := os.WriteFile(wantPath, []byte("stale"), 0o644); err != nil {
+					t.Fatalf("create existing pgpass file: %v", err)
+				}
+				if err := os.Chmod(wantPath, 0o644); err != nil {
+					t.Fatalf("set existing pgpass mode: %v", err)
+				}
+			}
+
+			gotPath, err := WritePgpassFile(poolerDir, "postgres", "secret")
+			if err != nil {
+				t.Fatalf("WritePgpassFile() error: %v", err)
+			}
+			if gotPath != wantPath {
+				t.Errorf("path = %q, want %q", gotPath, wantPath)
+			}
+
+			content, err := os.ReadFile(wantPath)
+			if err != nil {
+				t.Fatalf("read pgpass file: %v", err)
+			}
+			if got, want := string(content), "*:*:*:postgres:secret\n"; got != want {
+				t.Errorf("content = %q, want %q", got, want)
+			}
+
+			info, err := os.Stat(wantPath)
+			if err != nil {
+				t.Fatalf("stat pgpass file: %v", err)
+			}
+			if got := info.Mode().Perm(); got != 0o600 {
+				t.Errorf("mode = %o, want 600", got)
+			}
+		})
+	}
+}

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -1149,11 +1149,9 @@ func (pm *MultipoolerManager) loadShardConfigFromGlobalTopo() {
 		// with password authentication, and we cannot use a ephemeral file in a
 		// temp directory because pgbackrest needs to be able to read it after
 		// we exec (and the temp file would be cleaned up when closed).
-		pgpassPath := filepath.Join(pm.record.PoolerDir(), "pgbackrest", "pgbackrest.pgpass")
-		pgpassContent := fmt.Sprintf("*:*:*:%s:%s\n", pg1User, pg1Password)
-		// #nosec G703 -- pgpassPath is built from the pooler's own PoolerDir, not external input.
-		if err := os.WriteFile(pgpassPath, []byte(pgpassContent), 0o600); err != nil {
-			pm.setStateError(fmt.Errorf("failed to write pgbackrest pgpass file: %w", err))
+		pgpassPath, err := backup.WritePgpassFile(pm.record.PoolerDir(), pg1User, pg1Password)
+		if err != nil {
+			pm.setStateError(err)
 			return
 		}
 
@@ -1715,13 +1713,13 @@ func (pm *MultipoolerManager) Start(senv *servenv.ServEnv) {
 		}
 		pm.logger.Info("manager reached ready state, will register gRPC services")
 
-		pm.logger.Info("MultipoolerManager started") //nolint:sloglint // message intentionally starts with an operation name or proper noun
+		pm.logger.Info("multipooler manager started")
 		pm.qsc.RegisterGRPCServices()
 		pm.logger.Info("query service controller registered")
 
 		// Register manager gRPC services
 		pm.registerGRPCServices()
-		pm.logger.Info("MultipoolerManager gRPC services registered") //nolint:sloglint // message intentionally starts with an operation name or proper noun
+		pm.logger.Info("multipooler manager gRPC services registered")
 		return nil
 	})
 }
@@ -1794,7 +1792,7 @@ func (pm *MultipoolerManager) startPostgresMonitorPollerLocked() {
 			//   - postgres going down: allows PrimaryIsDeadAnalyzer to detect failure promptly
 			//   - postgres coming back up: allows FixReplication to see IsInitialized=true quickly
 			if !postgresStateEqual(newState, prevState) {
-				pm.logger.InfoContext(ctx, "MonitorPostgres: postgres state changed, broadcasting health", //nolint:sloglint // message intentionally starts with an operation name or proper noun
+				pm.logger.InfoContext(ctx, "monitorPostgres: postgres state changed, broadcasting health",
 					"postgres_running", newState.postgresRunning)
 				pm.broadcastHealth()
 			}

--- a/go/tools/fileutil/atomic_test.go
+++ b/go/tools/fileutil/atomic_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAtomicWriteFileReplacesExistingMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secret")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatalf("create existing file: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("set existing file mode: %v", err)
+	}
+
+	if err := AtomicWriteFile(path, []byte("new"), 0o600); err != nil {
+		t.Fatalf("AtomicWriteFile() error: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat replaced file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("mode = %o, want 600", got)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read replaced file: %v", err)
+	}
+	if got := string(content); got != "new" {
+		t.Errorf("content = %q, want %q", got, "new")
+	}
+}


### PR DESCRIPTION

Replace pgpass through a 0600 temporary file so stale permissions
cannot expose refreshed credentials before chmod.