### PR TITLE
fix(multipooler): heal stale cached plans on Bind/Execute and Describe

### DIFF
--- a/go/services/multipooler/internal/executor/cached_plan_retry_test.go
+++ b/go/services/multipooler/internal/executor/cached_plan_retry_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/pb/query"
+)
+
+// cachedPlanError builds a synthetic SQLSTATE 0A000 diagnostic matching what
+// PostgreSQL sends for a stale prepared statement, for tests that need to
+// force the retry path without actually orchestrating a real DDL race.
+func cachedPlanError() error {
+	return mterrors.NewPgError("ERROR", mterrors.PgSSFeatureNotSupported, "cached plan must not change result type", "")
+}
+
+// TestBindExecuteWithCachedPlanRetry_HealsOnCachedPlanError verifies the
+// retry helper closes the stale statement, re-Parses (via ensurePrepared),
+// and retries bindExecute exactly once on a 0A000 error.
+func TestBindExecuteWithCachedPlanRetry_HealsOnCachedPlanError(t *testing.T) {
+	e, _, rconn := newDeadReservedConnTestExecutor(t)
+	ctx := context.Background()
+	conn := rconn.Conn()
+	stmt := &query.PreparedStatement{Query: "SELECT 1"}
+
+	canonicalName, err := e.ensurePrepared(ctx, conn, stmt)
+	require.NoError(t, err)
+
+	calls := 0
+	bindExecute := func(name string) (bool, error) {
+		calls++
+		if calls == 1 {
+			return false, cachedPlanError()
+		}
+		assert.NotEmpty(t, name, "retry must be called with a canonical name")
+		return true, nil
+	}
+
+	completed, _, err := e.bindExecuteWithCachedPlanRetry(ctx, conn, stmt, canonicalName, bindExecute)
+	require.NoError(t, err)
+	assert.True(t, completed)
+	assert.Equal(t, 2, calls, "must retry exactly once after healing")
+}
+
+// TestBindExecuteWithCachedPlanRetry_DoesNotRetryOtherErrors verifies a
+// non-cached-plan error is returned as-is, with no retry attempted.
+func TestBindExecuteWithCachedPlanRetry_DoesNotRetryOtherErrors(t *testing.T) {
+	e, _, rconn := newDeadReservedConnTestExecutor(t)
+	ctx := context.Background()
+	conn := rconn.Conn()
+	stmt := &query.PreparedStatement{Query: "SELECT 1"}
+
+	canonicalName, err := e.ensurePrepared(ctx, conn, stmt)
+	require.NoError(t, err)
+
+	calls := 0
+	unrelatedErr := errors.New("connection reset")
+	bindExecute := func(name string) (bool, error) {
+		calls++
+		return false, unrelatedErr
+	}
+
+	_, _, err = e.bindExecuteWithCachedPlanRetry(ctx, conn, stmt, canonicalName, bindExecute)
+	require.ErrorIs(t, err, unrelatedErr)
+	assert.Equal(t, 1, calls, "must not retry an error that isn't a stale cached plan")
+}
+
+// TestDescribeWithCachedPlanRetry_HealsOnCachedPlanError is describe's
+// counterpart to TestBindExecuteWithCachedPlanRetry_HealsOnCachedPlanError:
+// PostgreSQL revalidates a prepared statement's result shape on Describe
+// too, not just Bind/Execute (exec_describe_statement_message ->
+// CachedPlanGetTargetList -> RevalidateCachedQuery), so this must heal the
+// same way.
+func TestDescribeWithCachedPlanRetry_HealsOnCachedPlanError(t *testing.T) {
+	e, _, rconn := newDeadReservedConnTestExecutor(t)
+	ctx := context.Background()
+	conn := rconn.Conn()
+	stmt := &query.PreparedStatement{Query: "SELECT 1"}
+
+	canonicalName, err := e.ensurePrepared(ctx, conn, stmt)
+	require.NoError(t, err)
+
+	calls := 0
+	wantDesc := &query.StatementDescription{HasFields: true}
+	describe := func(name string) (*query.StatementDescription, error) {
+		calls++
+		if calls == 1 {
+			return nil, cachedPlanError()
+		}
+		assert.NotEmpty(t, name, "retry must be called with a canonical name")
+		return wantDesc, nil
+	}
+
+	desc, err := e.describeWithCachedPlanRetry(ctx, conn, stmt, canonicalName, describe)
+	require.NoError(t, err)
+	assert.Same(t, wantDesc, desc)
+	assert.Equal(t, 2, calls, "must retry exactly once after healing")
+}
+
+// TestDescribeWithCachedPlanRetry_DoesNotRetryOtherErrors verifies a
+// non-cached-plan error is returned as-is, with no retry attempted.
+func TestDescribeWithCachedPlanRetry_DoesNotRetryOtherErrors(t *testing.T) {
+	e, _, rconn := newDeadReservedConnTestExecutor(t)
+	ctx := context.Background()
+	conn := rconn.Conn()
+	stmt := &query.PreparedStatement{Query: "SELECT 1"}
+
+	canonicalName, err := e.ensurePrepared(ctx, conn, stmt)
+	require.NoError(t, err)
+
+	calls := 0
+	unrelatedErr := errors.New("connection reset")
+	describe := func(name string) (*query.StatementDescription, error) {
+		calls++
+		return nil, unrelatedErr
+	}
+
+	_, err = e.describeWithCachedPlanRetry(ctx, conn, stmt, canonicalName, describe)
+	require.ErrorIs(t, err, unrelatedErr)
+	assert.Equal(t, 1, calls, "must not retry an error that isn't a stale cached plan")
+}

--- a/go/services/multipooler/internal/executor/cached_plan_retry_test.go
+++ b/go/services/multipooler/internal/executor/cached_plan_retry_test.go
@@ -55,7 +55,7 @@ func TestBindExecuteWithCachedPlanRetry_HealsOnCachedPlanError(t *testing.T) {
 		return true, nil
 	}
 
-	completed, _, err := e.bindExecuteWithCachedPlanRetry(ctx, conn, stmt, canonicalName, bindExecute)
+	completed, err := cachedPlanRetry(ctx, e, conn, stmt, canonicalName, bindExecute)
 	require.NoError(t, err)
 	assert.True(t, completed)
 	assert.Equal(t, 2, calls, "must retry exactly once after healing")
@@ -79,7 +79,7 @@ func TestBindExecuteWithCachedPlanRetry_DoesNotRetryOtherErrors(t *testing.T) {
 		return false, unrelatedErr
 	}
 
-	_, _, err = e.bindExecuteWithCachedPlanRetry(ctx, conn, stmt, canonicalName, bindExecute)
+	_, err = cachedPlanRetry(ctx, e, conn, stmt, canonicalName, bindExecute)
 	require.ErrorIs(t, err, unrelatedErr)
 	assert.Equal(t, 1, calls, "must not retry an error that isn't a stale cached plan")
 }
@@ -110,7 +110,7 @@ func TestDescribeWithCachedPlanRetry_HealsOnCachedPlanError(t *testing.T) {
 		return wantDesc, nil
 	}
 
-	desc, err := e.describeWithCachedPlanRetry(ctx, conn, stmt, canonicalName, describe)
+	desc, err := cachedPlanRetry(ctx, e, conn, stmt, canonicalName, describe)
 	require.NoError(t, err)
 	assert.Same(t, wantDesc, desc)
 	assert.Equal(t, 2, calls, "must retry exactly once after healing")
@@ -134,7 +134,7 @@ func TestDescribeWithCachedPlanRetry_DoesNotRetryOtherErrors(t *testing.T) {
 		return nil, unrelatedErr
 	}
 
-	_, err = e.describeWithCachedPlanRetry(ctx, conn, stmt, canonicalName, describe)
+	_, err = cachedPlanRetry(ctx, e, conn, stmt, canonicalName, describe)
 	require.ErrorIs(t, err, unrelatedErr)
 	assert.Equal(t, 1, calls, "must not retry an error that isn't a stale cached plan")
 }

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -1131,17 +1131,22 @@ func (e *Executor) portalExecuteWithReserved(
 	// Bind and execute using the portal's own name and the canonical statement name.
 	// When the protocol layer folded Describe('P') into Execute, fuse the
 	// backend round trip too so the portal description rides on the Execute
-	// response.
+	// response. Heals a stale cached plan transparently the same way the
+	// regular-connection path does: this backend may have been reserved by an
+	// entirely different caller before a DDL invalidated the canonical
+	// statement it left prepared, so a 0A000 here is not necessarily this
+	// caller's fault, and it cannot recover on its own either.
 	params := sqltypes.ParamsFromProto(portal.ParamLengths, portal.ParamValues)
-	var completed bool
 	// Opaque row passthrough for this statement; reset after so the reserved
 	// connection does not carry the mode into later transaction statements.
 	reservedConn.Conn().SetPassthroughRow(options.GetPassthroughRow())
-	if includeDescribe {
-		completed, err = reservedConn.BindDescribeAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, maxRows, callback)
-	} else {
-		completed, err = reservedConn.BindAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, maxRows, callback)
+	bindExecute := func(canonicalName string) (bool, error) {
+		if includeDescribe {
+			return reservedConn.BindDescribeAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, maxRows, callback)
+		}
+		return reservedConn.BindAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, maxRows, callback)
 	}
+	completed, _, err := e.bindExecuteWithCachedPlanRetry(ctx, reservedConn.Conn(), preparedStatement, canonicalName, bindExecute)
 	reservedConn.Conn().SetPassthroughRow(false)
 	if err != nil {
 		return e.portalReservedError(reservedConn, portal.Name, options, newlyReserved, addedStatementLocal, err)
@@ -1233,6 +1238,70 @@ func (e *Executor) portalReservedError(reservedConn *reserved.Conn, portalName s
 	return e.buildReservedState(reservedConn), wrapQueryError(err)
 }
 
+// bindExecuteWithCachedPlanRetry runs bindExecute against canonicalName and
+// heals a stale cached plan transparently. If a DDL changed the result type
+// of the cached plan, PostgreSQL returns 0A000 "cached plan must not change
+// result type". Because prepared statements are shared by canonical name
+// across every caller of this connection, no caller can recover just by
+// re-preparing under its own name (that maps right back to the same stale
+// backend statement), so this closes the stale backend statement, drops the
+// per-connection cache entry, re-Parses against the current schema, and
+// retries once. 0A000 is raised during plan revalidation, before any row is
+// streamed, so retrying is safe.
+//
+// Returns the canonical name actually used (unchanged unless healing
+// occurred) alongside bindExecute's own result.
+func (e *Executor) bindExecuteWithCachedPlanRetry(
+	ctx context.Context,
+	conn *regular.Conn,
+	preparedStatement *query.PreparedStatement,
+	canonicalName string,
+	bindExecute func(canonicalName string) (bool, error),
+) (bool, string, error) {
+	completed, err := bindExecute(canonicalName)
+	if err != nil && mterrors.IsCachedPlanError(err) {
+		_ = conn.CloseStatement(ctx, canonicalName)
+		conn.State().DeletePreparedStatement(canonicalName)
+
+		var perr error
+		canonicalName, perr = e.ensurePrepared(ctx, conn, preparedStatement)
+		if perr != nil {
+			return false, canonicalName, perr
+		}
+		completed, err = bindExecute(canonicalName)
+	}
+	return completed, canonicalName, err
+}
+
+// describeWithCachedPlanRetry is describe's counterpart to
+// bindExecuteWithCachedPlanRetry. PostgreSQL revalidates a prepared
+// statement's result shape on a bare statement Describe too, not just on
+// Bind/Execute — exec_describe_statement_message calls
+// CachedPlanGetTargetList, which calls RevalidateCachedQuery, for any
+// statement that returns rows — so a stale cached plan surfaces the same
+// 0A000 here. Heals it the same way: close the stale backend statement, drop
+// the per-connection cache entry, re-Parse, and retry once.
+func (e *Executor) describeWithCachedPlanRetry(
+	ctx context.Context,
+	conn *regular.Conn,
+	preparedStatement *query.PreparedStatement,
+	canonicalName string,
+	describe func(canonicalName string) (*query.StatementDescription, error),
+) (*query.StatementDescription, error) {
+	desc, err := describe(canonicalName)
+	if err != nil && mterrors.IsCachedPlanError(err) {
+		_ = conn.CloseStatement(ctx, canonicalName)
+		conn.State().DeletePreparedStatement(canonicalName)
+
+		canonicalName, err = e.ensurePrepared(ctx, conn, preparedStatement)
+		if err != nil {
+			return nil, err
+		}
+		desc, err = describe(canonicalName)
+	}
+	return desc, err
+}
+
 // portalExecuteWithRegular executes a portal using a regular pooled connection.
 // clientKey and serverKey are the SCRAM passthrough keys forwarded by the
 // caller's session; see connpoolmanager.GetRegularConn.
@@ -1263,22 +1332,13 @@ func (e *Executor) portalExecuteWithRegular(
 	// conn. The defer above clears it before the backend returns to the idle pool.
 	e.trackVpidOnRegular(ctx, conn.Conn, options)
 
-	// Bind and execute, healing a stale cached plan transparently. If a DDL has
-	// changed the result type of the cached plan, PostgreSQL returns 0A000
-	// "cached plan must not change result type". Because prepared statements are
-	// shared by canonical name, the client cannot recover by re-preparing (a new
-	// client name maps back to the same stale backend statement), so we do it
-	// here: close the stale backend statement, drop the per-connection cache
-	// entry, re-Parse against the current schema, and retry once.
 	params := sqltypes.ParamsFromProto(portal.ParamLengths, portal.ParamValues)
 
-	bindExecute := func(canonicalName string) error {
+	bindExecute := func(canonicalName string) (bool, error) {
 		if includeDescribe {
-			_, err := conn.Conn.BindDescribeAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, 0, callback)
-			return err
+			return conn.Conn.BindDescribeAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, 0, callback)
 		}
-		_, err := conn.Conn.BindAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, 0, callback)
-		return err
+		return conn.Conn.BindAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, 0, callback)
 	}
 
 	canonicalName, err := e.ensurePrepared(ctx, conn.Conn, preparedStatement)
@@ -1286,19 +1346,7 @@ func (e *Executor) portalExecuteWithRegular(
 		return nil, err
 	}
 
-	err = bindExecute(canonicalName)
-	if err != nil && mterrors.IsCachedPlanError(err) {
-		// 0A000 is raised during plan revalidation, before any row is streamed, so
-		// no partial results reached the callback — retrying is safe.
-		_ = conn.Conn.CloseStatement(ctx, canonicalName)
-		conn.Conn.State().DeletePreparedStatement(canonicalName)
-
-		canonicalName, err = e.ensurePrepared(ctx, conn.Conn, preparedStatement)
-		if err != nil {
-			return nil, err
-		}
-		err = bindExecute(canonicalName)
-	}
+	_, _, err = e.bindExecuteWithCachedPlanRetry(ctx, conn.Conn, preparedStatement, canonicalName, bindExecute)
 	if err != nil {
 		return nil, wrapQueryError(err)
 	}
@@ -1442,11 +1490,22 @@ func (e *Executor) Describe(
 		return nil, preExecutionUnavailableError(err)
 	}
 
+	// Both branches below heal a stale cached plan the same way the
+	// execute paths do (bindExecuteWithCachedPlanRetry): PostgreSQL
+	// revalidates a prepared statement's result shape on Describe too, not
+	// just Bind/Execute, so a DDL that invalidated the canonical statement
+	// since this connection last prepared it surfaces the same 0A000 here.
+	// Without healing, a caller who never touched the original statement —
+	// this connection may have been reserved, or pulled from the regular
+	// pool, from an entirely different session — would get hit with a raw,
+	// unrecoverable error for something that isn't its fault.
 	if portal != nil {
 		paramFormats := int32ToInt16Slice(portal.ParamFormats)
 		resultFormats := int32ToInt16Slice(portal.ResultFormats)
 		params := sqltypes.ParamsFromProto(portal.ParamLengths, portal.ParamValues)
-		desc, err := conn.BindAndDescribe(ctx, canonicalName, params, paramFormats, resultFormats)
+		desc, err := e.describeWithCachedPlanRetry(ctx, conn, preparedStatement, canonicalName, func(name string) (*query.StatementDescription, error) {
+			return conn.BindAndDescribe(ctx, name, params, paramFormats, resultFormats)
+		})
 		if err != nil {
 			if reservedConn != nil {
 				_, rerr := e.reservedConnError(reservedConn, "failed to describe portal", err)
@@ -1458,7 +1517,9 @@ func (e *Executor) Describe(
 	}
 
 	// Describe prepared using canonical name
-	desc, err := conn.DescribePrepared(ctx, canonicalName)
+	desc, err := e.describeWithCachedPlanRetry(ctx, conn, preparedStatement, canonicalName, func(name string) (*query.StatementDescription, error) {
+		return conn.DescribePrepared(ctx, name)
+	})
 	if err != nil {
 		if reservedConn != nil {
 			_, rerr := e.reservedConnError(reservedConn, "failed to describe prepared statement", err)

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -29,6 +29,7 @@ import (
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/common/queryservice"
@@ -1239,18 +1240,36 @@ func (e *Executor) portalReservedError(reservedConn *reserved.Conn, portalName s
 }
 
 // cachedPlanRetry runs op against canonicalName and heals a stale cached
-// plan transparently. If a DDL changed the result type of the cached plan,
-// PostgreSQL returns 0A000 "cached plan must not change result type" — on
-// Bind/Execute, and on a bare statement Describe too (for any statement that
-// returns rows: exec_describe_statement_message calls
-// CachedPlanGetTargetList, which calls RevalidateCachedQuery, just like
-// Bind does). Because prepared statements are shared by canonical name
-// across every caller of this connection, no caller can recover just by
-// re-preparing under its own name (that maps right back to the same stale
-// backend statement), so this closes the stale backend statement, drops the
-// per-connection cache entry, re-Parses against the current schema, and
-// retries once. 0A000 is raised during plan revalidation, before any row is
-// streamed, so retrying is safe.
+// plan when the connection is still able to run a retry. If a DDL changed
+// the result type of the cached plan, PostgreSQL returns 0A000 "cached plan
+// must not change result type" — on Bind/Execute, and on a bare statement
+// Describe too (for any statement that returns rows:
+// exec_describe_statement_message calls CachedPlanGetTargetList, which calls
+// RevalidateCachedQuery, just like Bind does).
+//
+// Because prepared statements are shared by canonical name across every
+// caller of this connection, no caller can recover just by re-preparing
+// under its own name (that maps right back to the same stale backend
+// statement), so on 0A000 this always closes the stale backend statement —
+// PostgreSQL's Close ('C') protocol message has no aborted-transaction
+// guard, unlike Describe/Bind, since it's handled directly rather than
+// routed through the SQL executor — and drops the per-connection cache
+// entry. Without this, whoever next tries this canonical name on this
+// connection would either wrongly trust the stale entry (if only the local
+// bookkeeping were dropped) or collide with "prepared statement already
+// exists" on its next Parse (if only the backend statement were closed).
+//
+// The retry itself only happens if the connection is still usable
+// afterward. A stale plan invalidated while running inside an explicit
+// transaction leaves that transaction itself unusable — PostgreSQL fails
+// every subsequent command with "transaction is aborted" once any statement
+// in it errors, so a caller in that state cannot retry in place no matter
+// what multipooler does; retrying would only trade the diagnosable 0A000
+// for that opaque secondary error. TxnStatusFailed is exactly this case
+// (never seen except after an error inside an explicit transaction); the
+// original 0A000 is preserved instead, and the caller has to deal with it
+// the same way it would deal with any other error inside that transaction —
+// by rolling back and retrying the transaction as a whole.
 //
 // A free function rather than a method: Go methods cannot have type
 // parameters, and op's result type (bool for Bind/Execute,
@@ -1268,6 +1287,10 @@ func cachedPlanRetry[T any](
 	if err != nil && mterrors.IsCachedPlanError(err) {
 		_ = conn.CloseStatement(ctx, canonicalName)
 		conn.State().DeletePreparedStatement(canonicalName)
+
+		if conn.TxnStatus() == protocol.TxnStatusFailed {
+			return result, err
+		}
 
 		var perr error
 		canonicalName, perr = e.ensurePrepared(ctx, conn, preparedStatement)

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -1146,7 +1146,7 @@ func (e *Executor) portalExecuteWithReserved(
 		}
 		return reservedConn.BindAndExecute(ctx, portal.Name, canonicalName, params, paramFormats, resultFormats, maxRows, callback)
 	}
-	completed, _, err := e.bindExecuteWithCachedPlanRetry(ctx, reservedConn.Conn(), preparedStatement, canonicalName, bindExecute)
+	completed, err := cachedPlanRetry(ctx, e, reservedConn.Conn(), preparedStatement, canonicalName, bindExecute)
 	reservedConn.Conn().SetPassthroughRow(false)
 	if err != nil {
 		return e.portalReservedError(reservedConn, portal.Name, options, newlyReserved, addedStatementLocal, err)
@@ -1238,10 +1238,13 @@ func (e *Executor) portalReservedError(reservedConn *reserved.Conn, portalName s
 	return e.buildReservedState(reservedConn), wrapQueryError(err)
 }
 
-// bindExecuteWithCachedPlanRetry runs bindExecute against canonicalName and
-// heals a stale cached plan transparently. If a DDL changed the result type
-// of the cached plan, PostgreSQL returns 0A000 "cached plan must not change
-// result type". Because prepared statements are shared by canonical name
+// cachedPlanRetry runs op against canonicalName and heals a stale cached
+// plan transparently. If a DDL changed the result type of the cached plan,
+// PostgreSQL returns 0A000 "cached plan must not change result type" — on
+// Bind/Execute, and on a bare statement Describe too (for any statement that
+// returns rows: exec_describe_statement_message calls
+// CachedPlanGetTargetList, which calls RevalidateCachedQuery, just like
+// Bind does). Because prepared statements are shared by canonical name
 // across every caller of this connection, no caller can recover just by
 // re-preparing under its own name (that maps right back to the same stale
 // backend statement), so this closes the stale backend statement, drops the
@@ -1249,16 +1252,19 @@ func (e *Executor) portalReservedError(reservedConn *reserved.Conn, portalName s
 // retries once. 0A000 is raised during plan revalidation, before any row is
 // streamed, so retrying is safe.
 //
-// Returns the canonical name actually used (unchanged unless healing
-// occurred) alongside bindExecute's own result.
-func (e *Executor) bindExecuteWithCachedPlanRetry(
+// A free function rather than a method: Go methods cannot have type
+// parameters, and op's result type (bool for Bind/Execute,
+// *query.StatementDescription for Describe) is the only thing that differs
+// between callers.
+func cachedPlanRetry[T any](
 	ctx context.Context,
+	e *Executor,
 	conn *regular.Conn,
 	preparedStatement *query.PreparedStatement,
 	canonicalName string,
-	bindExecute func(canonicalName string) (bool, error),
-) (bool, string, error) {
-	completed, err := bindExecute(canonicalName)
+	op func(canonicalName string) (T, error),
+) (T, error) {
+	result, err := op(canonicalName)
 	if err != nil && mterrors.IsCachedPlanError(err) {
 		_ = conn.CloseStatement(ctx, canonicalName)
 		conn.State().DeletePreparedStatement(canonicalName)
@@ -1266,40 +1272,12 @@ func (e *Executor) bindExecuteWithCachedPlanRetry(
 		var perr error
 		canonicalName, perr = e.ensurePrepared(ctx, conn, preparedStatement)
 		if perr != nil {
-			return false, canonicalName, perr
+			var zero T
+			return zero, perr
 		}
-		completed, err = bindExecute(canonicalName)
+		result, err = op(canonicalName)
 	}
-	return completed, canonicalName, err
-}
-
-// describeWithCachedPlanRetry is describe's counterpart to
-// bindExecuteWithCachedPlanRetry. PostgreSQL revalidates a prepared
-// statement's result shape on a bare statement Describe too, not just on
-// Bind/Execute — exec_describe_statement_message calls
-// CachedPlanGetTargetList, which calls RevalidateCachedQuery, for any
-// statement that returns rows — so a stale cached plan surfaces the same
-// 0A000 here. Heals it the same way: close the stale backend statement, drop
-// the per-connection cache entry, re-Parse, and retry once.
-func (e *Executor) describeWithCachedPlanRetry(
-	ctx context.Context,
-	conn *regular.Conn,
-	preparedStatement *query.PreparedStatement,
-	canonicalName string,
-	describe func(canonicalName string) (*query.StatementDescription, error),
-) (*query.StatementDescription, error) {
-	desc, err := describe(canonicalName)
-	if err != nil && mterrors.IsCachedPlanError(err) {
-		_ = conn.CloseStatement(ctx, canonicalName)
-		conn.State().DeletePreparedStatement(canonicalName)
-
-		canonicalName, err = e.ensurePrepared(ctx, conn, preparedStatement)
-		if err != nil {
-			return nil, err
-		}
-		desc, err = describe(canonicalName)
-	}
-	return desc, err
+	return result, err
 }
 
 // portalExecuteWithRegular executes a portal using a regular pooled connection.
@@ -1346,7 +1324,7 @@ func (e *Executor) portalExecuteWithRegular(
 		return nil, err
 	}
 
-	_, _, err = e.bindExecuteWithCachedPlanRetry(ctx, conn.Conn, preparedStatement, canonicalName, bindExecute)
+	_, err = cachedPlanRetry(ctx, e, conn.Conn, preparedStatement, canonicalName, bindExecute)
 	if err != nil {
 		return nil, wrapQueryError(err)
 	}
@@ -1491,7 +1469,7 @@ func (e *Executor) Describe(
 	}
 
 	// Both branches below heal a stale cached plan the same way the
-	// execute paths do (bindExecuteWithCachedPlanRetry): PostgreSQL
+	// execute paths do (cachedPlanRetry): PostgreSQL
 	// revalidates a prepared statement's result shape on Describe too, not
 	// just Bind/Execute, so a DDL that invalidated the canonical statement
 	// since this connection last prepared it surfaces the same 0A000 here.
@@ -1503,7 +1481,7 @@ func (e *Executor) Describe(
 		paramFormats := int32ToInt16Slice(portal.ParamFormats)
 		resultFormats := int32ToInt16Slice(portal.ResultFormats)
 		params := sqltypes.ParamsFromProto(portal.ParamLengths, portal.ParamValues)
-		desc, err := e.describeWithCachedPlanRetry(ctx, conn, preparedStatement, canonicalName, func(name string) (*query.StatementDescription, error) {
+		desc, err := cachedPlanRetry(ctx, e, conn, preparedStatement, canonicalName, func(name string) (*query.StatementDescription, error) {
 			return conn.BindAndDescribe(ctx, name, params, paramFormats, resultFormats)
 		})
 		if err != nil {
@@ -1517,7 +1495,7 @@ func (e *Executor) Describe(
 	}
 
 	// Describe prepared using canonical name
-	desc, err := e.describeWithCachedPlanRetry(ctx, conn, preparedStatement, canonicalName, func(name string) (*query.StatementDescription, error) {
+	desc, err := cachedPlanRetry(ctx, e, conn, preparedStatement, canonicalName, func(name string) (*query.StatementDescription, error) {
 		return conn.DescribePrepared(ctx, name)
 	})
 	if err != nil {

--- a/go/test/endtoend/queryserving/describe_stale_across_clients_test.go
+++ b/go/test/endtoend/queryserving/describe_stale_across_clients_test.go
@@ -41,22 +41,27 @@ const (
 // TestDescribeStaleAcrossClients is the regression for: multipooler's pooled
 // backend connections share an already-PREPARE'd statement (keyed by query
 // text + param types, see preparedstatement.PoolerConsolidator) across
-// unrelated client sessions. PostgreSQL revalidates a prepared statement's
-// result shape on Bind/Execute, but NOT on a bare Describe('S', name)
-// (postgres.c exec_describe_statement_message just replays whatever
-// resultDesc was recorded at the last successful Parse). So a client that
-// never touched the original statement, but happens to be handed a backend
-// that has it cached from before a DDL changed the table's shape, can be
-// told the pre-DDL shape on Describe with no error at all.
+// unrelated client sessions. A bare Describe('S', name) on a row-returning
+// statement DOES revalidate against the current schema, same as Bind/Execute
+// — postgres.c exec_describe_statement_message calls CachedPlanGetTargetList,
+// which calls RevalidateCachedQuery (plancache.c) — so it can raise the same
+// SQLSTATE 0A000 "cached plan must not change result type" a stale
+// Bind/Execute would. The bug is that multipooler's Describe RPC, unlike its
+// portal-execute paths (see cachedPlanRetry), had no retry/heal logic for
+// that error at all. So a client that never touched the original statement,
+// but happens to be handed a backend that has it cached from before a DDL
+// changed the table's shape, gets hit with a raw 0A000 it has no way to
+// recover from — it doesn't know a shared backend-level statement is even
+// involved.
 //
 // This only reproduces through multigateway/multipooler's pooling — a direct
 // connection to PostgreSQL always gets a fresh backend with no cached
 // statement, so there is nothing stale to inherit. Unlike
 // TestCachedPlanReprepareAfterDDL (the sibling regression for the
 // Bind/Execute side of this same bug class, which PostgreSQL's own plan
-// revalidation catches and the gateway heals via 0A000), this test does not
-// run against setup.GetComparisonTargets — the bug is specific to the
-// pooled/gateway path.
+// revalidation catches and multipooler already heals via 0A000), this test
+// does not run against setup.GetComparisonTargets — the bug is specific to
+// the pooled path.
 func TestDescribeStaleAcrossClients(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping end-to-end tests in short mode")

--- a/go/test/endtoend/queryserving/describe_stale_across_clients_test.go
+++ b/go/test/endtoend/queryserving/describe_stale_across_clients_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// describeStalePoolCapacity settles the lone test user's regular sub-pool to a
+// single backend (global 2 x (1 - reserved ratio 0.5)), making backend reuse
+// across two different client connections deterministic instead of a race
+// against however many idle backends the pool happens to have. Mirrors
+// cancelPoolCapacity in pgbouncertests/cancel_race_test.go.
+const (
+	describeStalePoolCapacity  = "--connpool-global-capacity=2"
+	describeStaleReservedRatio = "--connpool-reserved-ratio=0.5"
+	describeStaleRebalanceFast = "--connpool-rebalance-interval=1s"
+)
+
+// TestDescribeStaleAcrossClients is the regression for: multipooler's pooled
+// backend connections share an already-PREPARE'd statement (keyed by query
+// text + param types, see preparedstatement.PoolerConsolidator) across
+// unrelated client sessions. PostgreSQL revalidates a prepared statement's
+// result shape on Bind/Execute, but NOT on a bare Describe('S', name)
+// (postgres.c exec_describe_statement_message just replays whatever
+// resultDesc was recorded at the last successful Parse). So a client that
+// never touched the original statement, but happens to be handed a backend
+// that has it cached from before a DDL changed the table's shape, can be
+// told the pre-DDL shape on Describe with no error at all.
+//
+// This only reproduces through multigateway/multipooler's pooling — a direct
+// connection to PostgreSQL always gets a fresh backend with no cached
+// statement, so there is nothing stale to inherit. Unlike
+// TestCachedPlanReprepareAfterDDL (the sibling regression for the
+// Bind/Execute side of this same bug class, which PostgreSQL's own plan
+// revalidation catches and the gateway heals via 0A000), this test does not
+// run against setup.GetComparisonTargets — the bug is specific to the
+// pooled/gateway path.
+func TestDescribeStaleAcrossClients(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping end-to-end tests in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2), // primary + standby (bootstrap needs 2)
+		shardsetup.WithMultigateway(),
+		shardsetup.WithMultipoolerExtraArgs(describeStalePoolCapacity, describeStaleReservedRatio, describeStaleRebalanceFast),
+	)
+	defer cleanup()
+	setup.WaitForMultigatewayQueryServing(t)
+
+	ctx := utils.WithTimeout(t, 60*time.Second)
+	gatewayDSN := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+
+	// Settle the user's regular pool down to a single backend so the two
+	// client connections below are forced to share it.
+	settleDB, err := sql.Open("postgres", gatewayDSN)
+	require.NoError(t, err)
+	_, err = settleDB.ExecContext(ctx, "SELECT 1")
+	require.NoError(t, err, "warmup query should succeed")
+	time.Sleep(5 * time.Second)
+	settleDB.Close()
+
+	// Client A: creates the table and warms the canonical prepared statement.
+	connA := connectLowLevelToPort(t, ctx, setup.MultigatewayPgPort)
+	defer connA.Close()
+
+	_, err = connA.Query(ctx, "DROP TABLE IF EXISTS desctest")
+	require.NoError(t, err)
+	_, err = connA.Query(ctx, "CREATE TABLE desctest (a int, b int)")
+	require.NoError(t, err)
+	// A plain defer, not t.Cleanup: t.Cleanup callbacks run after the test
+	// function's own defers (including shardsetup's cluster teardown below),
+	// so a t.Cleanup here would try to connect after the cluster is gone.
+	defer func() {
+		c := connectLowLevelToPort(t, context.Background(), setup.MultigatewayPgPort)
+		defer c.Close()
+		_, _ = c.Query(context.Background(), "DROP TABLE IF EXISTS desctest")
+	}()
+
+	require.NoError(t, connA.Parse(ctx, "a_s1", "SELECT * FROM desctest", nil))
+	descBefore, err := connA.DescribePrepared(ctx, "a_s1")
+	require.NoError(t, err)
+	require.Len(t, descBefore.Fields, 2, "before DDL: two columns")
+	require.NoError(t, connA.CloseStatement(ctx, "a_s1"))
+
+	// DDL changes the table's shape.
+	_, err = connA.Query(ctx, "ALTER TABLE desctest DROP COLUMN b")
+	require.NoError(t, err)
+
+	// Client B: a brand-new connection that never touched this statement.
+	// Same query text + param types (nil) as client A, so it maps to the same
+	// canonical statement at the pooler, and the settled 1-backend pool means
+	// it is handed the same backend client A used — the one with a stale
+	// PREPARE cached from before the DDL.
+	connB := connectLowLevelToPort(t, ctx, setup.MultigatewayPgPort)
+	defer connB.Close()
+
+	require.NoError(t, connB.Parse(ctx, "b_s1", "SELECT * FROM desctest", nil))
+	descAfter, err := connB.DescribePrepared(ctx, "b_s1")
+	require.NoError(t, err)
+	require.NoError(t, connB.CloseStatement(ctx, "b_s1"))
+
+	assert.Len(t, descAfter.Fields, 1,
+		"a brand-new client's Describe must reflect the post-DDL shape, not a stale shape inherited from a different client's cached statement")
+	if len(descAfter.Fields) == 1 {
+		assert.Equal(t, "a", descAfter.Fields[0].Name)
+	}
+}

--- a/go/test/endtoend/queryserving/reserved_stale_across_clients_test.go
+++ b/go/test/endtoend/queryserving/reserved_stale_across_clients_test.go
@@ -1,0 +1,210 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/sqltypes"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// cachedPlanErrorMessage is the exact PostgreSQL error text for SQLSTATE
+// 0A000 on a stale prepared statement.
+const cachedPlanErrorMessage = "cached plan must not change result type"
+
+// reservedStalePoolCapacity settles the lone test user's pool down to a
+// single backend in *both* the regular and reserved sub-pools (global 2,
+// reserved ratio 0.5 -> 1 and 1), making backend reuse across two different
+// client connections' reservations deterministic. Mirrors
+// describeStalePoolCapacity / cancelPoolCapacity in
+// pgbouncertests/cancel_race_test.go.
+const (
+	reservedStalePoolCapacity  = "--connpool-global-capacity=2"
+	reservedStaleReservedRatio = "--connpool-reserved-ratio=0.5"
+	reservedStaleRebalanceFast = "--connpool-rebalance-interval=1s"
+)
+
+// TestReservedExecuteStaleAcrossClients is portalExecuteWithReserved's
+// counterpart to TestDescribeStaleAcrossClients. A reserved connection is
+// pinned for the lifetime of an explicit transaction and released back to
+// the pool on COMMIT; multipooler shares its already-PREPARE'd statement
+// (keyed by query text + param types, see preparedstatement.PoolerConsolidator)
+// with whichever client reserves that same backend next.
+//
+// If a DDL changes the table's shape after client A's transaction releases
+// the backend, and client B — who never touched the original statement —
+// reserves that same backend for its own transaction, PostgreSQL raises
+// SQLSTATE 0A000 "cached plan must not change result type" on client B's
+// Bind/Execute.
+//
+// Unlike TestDescribeStaleAcrossClients, this cannot heal transparently
+// within client B's transaction: once any statement inside an explicit
+// PostgreSQL transaction errors, every later command in that same
+// transaction fails with "current transaction is aborted" until ROLLBACK —
+// closing and re-Parsing the stale statement doesn't undo that, so
+// cachedPlanRetry (see its doc comment) deliberately does not attempt a
+// retry here and preserves the original 0A000 instead of masking it behind
+// that opaque secondary error. Client B has to ROLLBACK and retry its
+// transaction as a whole, exactly as it would for any other error inside a
+// transaction — but once it does, the statement is correctly rebuilt: this
+// verifies both that client B's first attempt gets the clean, diagnosable
+// 0A000 (not the aborted-transaction error), and that its next attempt, in
+// a fresh transaction, succeeds with the correct post-DDL shape.
+func TestReservedExecuteStaleAcrossClients(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping end-to-end tests in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2), // primary + standby (bootstrap needs 2)
+		shardsetup.WithMultigateway(),
+		shardsetup.WithMultipoolerExtraArgs(reservedStalePoolCapacity, reservedStaleReservedRatio, reservedStaleRebalanceFast),
+	)
+	defer cleanup()
+	setup.WaitForMultigatewayQueryServing(t)
+
+	ctx := utils.WithTimeout(t, 60*time.Second)
+	gatewayDSN := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+
+	// Settle the user's pool (both sub-pools) down to a single backend each,
+	// so the two client connections' reservations below are forced to share
+	// the one reserved backend.
+	settleDB, err := sql.Open("postgres", gatewayDSN)
+	require.NoError(t, err)
+	_, err = settleDB.ExecContext(ctx, "SELECT 1")
+	require.NoError(t, err, "warmup query should succeed")
+	time.Sleep(5 * time.Second)
+	settleDB.Close()
+
+	// collectFields runs the fused Bind+Describe+Execute path (so the
+	// portal's RowDescription rides back through the callback — plain
+	// BindAndExecute never sends one) and returns both the results and any
+	// error, leaving the error check to the caller.
+	collectFields := func(t *testing.T, conn interface {
+		BindDescribeAndExecute(context.Context, string, string, [][]byte, []int16, []int16, int32, func(context.Context, *sqltypes.Result) error) (bool, error)
+	}, stmtName string,
+	) ([]*sqltypes.Result, error) {
+		t.Helper()
+		var results []*sqltypes.Result
+		_, err := conn.BindDescribeAndExecute(ctx, "", stmtName, nil, nil, nil, 0,
+			func(_ context.Context, r *sqltypes.Result) error {
+				results = append(results, r)
+				return nil
+			})
+		return results, err
+	}
+	fieldsOf := func(results []*sqltypes.Result) []*sqltypes.Result {
+		for _, r := range results {
+			if r.Fields != nil {
+				return []*sqltypes.Result{r}
+			}
+		}
+		return nil
+	}
+
+	// Client A: creates the table, then reserves a backend for an explicit
+	// transaction and warms the canonical prepared statement on it.
+	connA := connectLowLevelToPort(t, ctx, setup.MultigatewayPgPort)
+	defer connA.Close()
+
+	_, err = connA.Query(ctx, "DROP TABLE IF EXISTS restest")
+	require.NoError(t, err)
+	_, err = connA.Query(ctx, "CREATE TABLE restest (a int, b int)")
+	require.NoError(t, err)
+	_, err = connA.Query(ctx, "INSERT INTO restest VALUES (1, 2)")
+	require.NoError(t, err)
+	// A plain defer, not t.Cleanup: t.Cleanup callbacks run after the test
+	// function's own defers (including shardsetup's cluster teardown below),
+	// so a t.Cleanup here would try to connect after the cluster is gone.
+	defer func() {
+		c := connectLowLevelToPort(t, context.Background(), setup.MultigatewayPgPort)
+		defer c.Close()
+		_, _ = c.Query(context.Background(), "DROP TABLE IF EXISTS restest")
+	}()
+
+	_, err = connA.Query(ctx, "BEGIN")
+	require.NoError(t, err)
+	require.NoError(t, connA.Parse(ctx, "a_s1", "SELECT * FROM restest", nil))
+	rawA, err := collectFields(t, connA, "a_s1")
+	require.NoError(t, err)
+	resA := fieldsOf(rawA)
+	require.Len(t, resA, 1, "expected one field-bearing result")
+	require.Len(t, resA[0].Fields, 2, "before DDL: two columns")
+	require.NoError(t, connA.CloseStatement(ctx, "a_s1"))
+	_, err = connA.Query(ctx, "COMMIT")
+	require.NoError(t, err)
+
+	// DDL changes the table's shape.
+	_, err = connA.Query(ctx, "ALTER TABLE restest DROP COLUMN b")
+	require.NoError(t, err)
+
+	// Client B: a brand-new connection that never touched this statement.
+	// Same query text + param types (nil) as client A, so it maps to the
+	// same canonical statement at the pooler, and the settled 1-backend
+	// reserved pool means its own transaction reserves the same backend
+	// client A used — the one with a stale PREPARE cached from before the
+	// DDL.
+	connB := connectLowLevelToPort(t, ctx, setup.MultigatewayPgPort)
+	defer connB.Close()
+
+	_, err = connB.Query(ctx, "BEGIN")
+	require.NoError(t, err)
+	require.NoError(t, connB.Parse(ctx, "b_s1", "SELECT * FROM restest", nil))
+	_, err = collectFields(t, connB, "b_s1")
+	require.Error(t, err, "the stale statement must surface an error inside this transaction")
+	assert.ErrorContains(t, err, cachedPlanErrorMessage,
+		"must be the clean, diagnosable 0A000 — not PostgreSQL's opaque secondary "+
+			`"current transaction is aborted" error from a doomed retry attempt`)
+
+	// The transaction is now aborted (as any error inside an explicit
+	// transaction leaves it, regardless of cause) and must be rolled back —
+	// exactly what a real client would do for any transactional error, not
+	// something specific to this bug.
+	_, err = connB.Query(ctx, "ROLLBACK")
+	require.NoError(t, err)
+
+	// A fresh transaction on the same connection must now succeed with the
+	// correct post-DDL shape: cachedPlanRetry's cleanup (closing the stale
+	// backend statement and dropping the local cache entry) on the failed
+	// attempt above is what makes this possible — without it, this Parse
+	// would either wrongly reuse the stale plan again or collide with
+	// "prepared statement already exists".
+	_, err = connB.Query(ctx, "BEGIN")
+	require.NoError(t, err)
+	require.NoError(t, connB.Parse(ctx, "b_s2", "SELECT * FROM restest", nil))
+	rawB, err := collectFields(t, connB, "b_s2")
+	require.NoError(t, err, "the statement must be correctly rebuilt by the time this connection is usable again")
+	resB := fieldsOf(rawB)
+	require.NoError(t, connB.CloseStatement(ctx, "b_s2"))
+	_, err = connB.Query(ctx, "COMMIT")
+	require.NoError(t, err)
+
+	require.Len(t, resB, 1, "expected one field-bearing result")
+	assert.Len(t, resB[0].Fields, 1, "after DDL: one column")
+	if len(resB[0].Fields) == 1 {
+		assert.Equal(t, "a", resB[0].Fields[0].Name)
+	}
+}


### PR DESCRIPTION
## Summary

Two related bugs in cached-plan handling around SQLSTATE 0A000 ("cached plan must not change result type"). Both stem from the same root cause: multipooler's canonical prepared statements are shared by `(query text, param types)` across every client whose pooled backend connection happens to have them prepared (see `PoolerConsolidator`), so a DDL that changes a table's shape can leave a stale plan behind for a completely unrelated later caller to inherit.

- **Bug 1 — `portalExecuteWithReserved` gets stuck on a stale cached plan.** The reserved-connection path had no recovery for 0A000, unlike the regular-connection path. A reserved connection that hits a stale plan stays stuck on the error indefinitely, and since the backend is recycled back into the pool on release, any later caller reserving that same backend inherits the same stuck error.

- **Bug 2 — `Describe` has no recovery either, on either connection kind.** PostgreSQL revalidates a prepared statement's result shape on a bare `Describe('S', name)` for any row-returning statement, not just on Bind/Execute — `exec_describe_statement_message` calls `CachedPlanGetTargetList`, which calls `RevalidateCachedQuery` — so a stale plan raises the identical 0A000 there too. A client that never touched the original statement gets hit with a raw, unrecoverable error for something that isn't its fault: unlike a normal PostgreSQL client, it has no way to know a shared backend-level statement is even involved, so it has no DEALLOCATE-and-re-PREPARE recourse.

## Fix

Both get the same treatment: on 0A000, close the stale backend statement and drop the per-connection cache entry so the statement is correctly rebuilt on its next use, then retry once — but only when the connection is actually able to run that retry. Extracted into a single generic helper, `cachedPlanRetry`, used by all three call sites (`portalExecuteWithReserved`, `portalExecuteWithRegular`, and both of `Describe`'s branches).

The retry is gated on `conn.TxnStatus()`. A connection reserved for an active explicit transaction that hits a stale plan mid-transaction can't be healed in place: PostgreSQL rejects every subsequent command in a transaction once any statement in it has errored, so retrying there just trades the diagnosable 0A000 for PostgreSQL's opaque "transaction is aborted". In that case (`TxnStatusFailed`) the fix still closes the stale statement and drops the local cache entry — PostgreSQL's Close message has no aborted-transaction guard, since it's handled directly rather than routed through the SQL executor — so the statement is correctly rebuilt the next time the connection is used, but the original 0A000 is preserved and returned as-is. The caller rolls back and retries its transaction, exactly as it would for any other transactional error.

## Test plan

- [x] Unit tests for `cachedPlanRetry`: heals on a synthetic 0A000, retries exactly once, does not retry unrelated errors (`cached_plan_retry_test.go`)
- [x] End-to-end regression, regular pool (`describe_stale_across_clients_test.go`): two client connections forced onto the same settled 1-backend pool; client A prepares and describes a statement, a DDL changes the table's shape, client B (never touched the original statement) gets the correct post-DDL shape on Describe. Verified failing (raw 0A000) without the fix and passing with it.
- [x] End-to-end regression, reserved connection / explicit transaction (`reserved_stale_across_clients_test.go`): same setup, but client B's reservation is an active transaction. Verifies client B's first attempt gets the clean 0A000 (not the masked "transaction is aborted"), and that a fresh transaction on the same connection afterward succeeds with the correct post-DDL shape.
- [x] `go test -short` passes for `go/services/multipooler/internal/executor`