### PR TITLE
fix(pgctld): detect a stale postmaster.pid whose PID was reused

### DIFF
--- a/go/cmd/pgctld/command/crash_recovery.go
+++ b/go/cmd/pgctld/command/crash_recovery.go
@@ -111,7 +111,11 @@ func (s *PgCtldService) runCrashRecoveryInDir(
 	// Callers gate this path on a stopped node; this is the last-line guard for
 	// the residual race where a postmaster appears between that check and here.
 	// A running node needs no crash recovery, so skipping is also the correct no-op.
-	if isPostgreSQLRunning(dataDir) {
+	running, err := checkPostgreSQLRunning(ctx, logger, s.pgConfig)
+	if err != nil {
+		return fmt.Errorf("failed to check if PostgreSQL is running: %w", err)
+	}
+	if running {
 		logger.InfoContext(ctx, "skipping crash recovery: postgres is running", "data_dir", dataDir)
 		return nil
 	}

--- a/go/cmd/pgctld/command/crash_recovery_test.go
+++ b/go/cmd/pgctld/command/crash_recovery_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/services/pgctld"
 	"github.com/multigres/multigres/go/tools/retry"
@@ -275,16 +276,19 @@ func TestRunCrashRecoveryInDir_RemoveFailureSkipsRecovery(t *testing.T) {
 
 // TestRunCrashRecoveryInDir_SkipsWhenPostgresRunning verifies the guard that
 // crash recovery never disturbs a live postmaster: it must not touch
-// standby.signal and must not run recovery. A live postmaster is simulated by a
-// postmaster.pid pointing at this test process (which is, by definition, running).
+// standby.signal and must not run recovery. A live postmaster is simulated by
+// a postmaster.pid plus a pg_isready mock reporting the server as accepting
+// connections, which is what checkPostgreSQLRunning now checks.
 func TestRunCrashRecoveryInDir_SkipsWhenPostgresRunning(t *testing.T) {
 	dir := t.TempDir()
 	s := testPgCtldService(dir)
 	signalPath, err1 := s.createStandbySignal()
 	require.NoError(t, err1)
 
-	// postmaster.pid's first line is the PID; point it at ourselves so
-	// isPostgreSQLRunning sees a live process.
+	binDir := t.TempDir()
+	testutil.MockBinary(t, binDir, "pg_isready", "exit 0")
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
 	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, "postmaster.pid"),
 		[]byte(strconv.Itoa(os.Getpid())+"\n"),

--- a/go/cmd/pgctld/command/reload.go
+++ b/go/cmd/pgctld/command/reload.go
@@ -15,6 +15,7 @@
 package command
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -72,18 +73,22 @@ Examples:
 }
 
 // ReloadPostgreSQLConfigWithResult reloads PostgreSQL configuration and returns detailed result information
-func ReloadPostgreSQLConfigWithResult(logger *slog.Logger, config *pgctld.PostgresCtlConfig) (*ReloadResult, error) {
+func ReloadPostgreSQLConfigWithResult(ctx context.Context, logger *slog.Logger, config *pgctld.PostgresCtlConfig) (*ReloadResult, error) {
 	result := &ReloadResult{}
 
 	// Check if PostgreSQL is running
-	if !isPostgreSQLRunning(config.PostgresDataDir) {
+	running, err := checkPostgreSQLRunning(ctx, logger, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if PostgreSQL is running: %w", err)
+	}
+	if !running {
 		result.WasRunning = false
 		result.Message = "PostgreSQL is not running"
 		return result, errors.New("PostgreSQL is not running")
 	}
 
 	result.WasRunning = true
-	logger.Info("reloading Postgres configuration", "data_dir", config.PostgresDataDir)
+	logger.InfoContext(ctx, "reloading Postgres configuration", "data_dir", config.PostgresDataDir)
 
 	if err := reloadPostgreSQLConfig(logger, config.PostgresDataDir); err != nil {
 		return nil, fmt.Errorf("failed to reload PostgreSQL configuration: %w", err)
@@ -100,7 +105,7 @@ func (r *PgCtlReloadCmd) runReload(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	result, err := ReloadPostgreSQLConfigWithResult(r.pgCtlCmd.lg.GetLogger(), config)
+	result, err := ReloadPostgreSQLConfigWithResult(cmd.Context(), r.pgCtlCmd.lg.GetLogger(), config)
 	if err != nil {
 		return err
 	}

--- a/go/cmd/pgctld/command/restart.go
+++ b/go/cmd/pgctld/command/restart.go
@@ -15,6 +15,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/multigres/multigres/go/tools/viperutil"
@@ -93,29 +94,23 @@ Examples:
 }
 
 // RestartPostgreSQLWithResult restarts PostgreSQL with the given configuration and returns detailed result information
-func (s *PgCtldService) RestartPostgreSQLWithResult(mode string, asStandby bool) (*RestartResult, error) {
+func (s *PgCtldService) RestartPostgreSQLWithResult(ctx context.Context, mode string, asStandby bool) (*RestartResult, error) {
 	result := &RestartResult{}
 	logger := s.logger
 	config := s.pgConfig
 
 	if asStandby {
-		logger.Info("restarting Postgres server as standby", "data_dir", config.PostgresDataDir, "mode", mode)
+		logger.InfoContext(ctx, "restarting Postgres server as standby", "data_dir", config.PostgresDataDir, "mode", mode)
 	} else {
-		logger.Info("restarting Postgres server", "data_dir", config.PostgresDataDir, "mode", mode)
+		logger.InfoContext(ctx, "restarting Postgres server", "data_dir", config.PostgresDataDir, "mode", mode)
 	}
 
 	// Stop the server if it's running
-	if isPostgreSQLRunning(config.PostgresDataDir) {
-		logger.Info("stopping Postgres server")
-		stopResult, err := s.StopPostgreSQLWithResult(mode)
-		if err != nil {
-			return nil, fmt.Errorf("failed to stop PostgreSQL during restart: %w", err)
-		}
-		result.StoppedFirst = stopResult.WasRunning
-	} else {
-		logger.Info("Postgres is not running, proceeding with start") //nolint:sloglint // message intentionally starts with an operation name or proper noun
-		result.StoppedFirst = false
+	stopResult, err := s.StopPostgreSQLWithResult(ctx, mode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stop PostgreSQL during restart: %w", err)
 	}
+	result.StoppedFirst = stopResult.WasRunning
 
 	// Create standby.signal if restarting as standby
 	if asStandby {
@@ -126,20 +121,20 @@ func (s *PgCtldService) RestartPostgreSQLWithResult(mode string, asStandby bool)
 
 	// Start the server with detailed context
 	if asStandby {
-		logger.Info("starting Postgres server as standby",
+		logger.InfoContext(ctx, "starting Postgres server as standby",
 			"data_dir", config.PostgresDataDir,
 			"port", config.Port,
 			"timeout", config.Timeout,
 		)
 	} else {
-		logger.Info("starting Postgres server")
+		logger.InfoContext(ctx, "starting Postgres server")
 	}
 
-	startResult, err := s.StartPostgreSQLWithResult()
+	startResult, err := s.StartPostgreSQLWithResult(ctx)
 	if err != nil {
 		// Enhanced error logging for standby mode
 		if asStandby {
-			logger.Error("failed to start Postgres as standby",
+			logger.ErrorContext(ctx, "failed to start Postgres as standby",
 				"error", err,
 				"data_dir", config.PostgresDataDir,
 				"port", config.Port,
@@ -166,7 +161,7 @@ func (r *PgCtlRestartCmd) runRestart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	svc := &PgCtldService{logger: r.pgCtlCmd.lg.GetLogger(), pgConfig: config}
-	result, err := svc.RestartPostgreSQLWithResult(r.mode.Get(), r.asStandby.Get())
+	result, err := svc.RestartPostgreSQLWithResult(cmd.Context(), r.mode.Get(), r.asStandby.Get())
 	if err != nil {
 		return err
 	}

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -589,45 +589,51 @@ func (s *PgCtldService) Start(ctx context.Context, req *pb.StartRequest) (*pb.St
 	// is instead crash-recovered by the postmaster on the normal start below and
 	// does not set it.
 	var crashRecoveryRan bool
-	if req.GetAllowCrashRecovery() && isPostgreSQLRunning(s.pgConfig.PostgresDataDir) {
-		// Never crash-recover a running postmaster: runCrashRecovery removes
-		// standby.signal for single-user recovery, and doing that to a postmaster
-		// that is up — or still starting after a Start whose success was misreported
-		// — can bring it up read-write on a timeline it must not claim. A Start
-		// against an already-running node is an idempotent no-op via
-		// StartPostgreSQLWithResult below.
-		s.logger.InfoContext(ctx, "skipping crash recovery before start: postgres is already running")
-	} else if req.GetAllowCrashRecovery() {
-		needed, nErr := s.crashRecoveryNeeded(ctx)
-		if nErr != nil {
-			s.logger.WarnContext(ctx, "could not determine clean-shutdown state before start (continuing)", "error", nErr)
-		} else if needed && s.hasStandbySignal() && req.GetSuspectedDivergence() {
-			// A not-cleanly-stopped standby that the caller suspects may have
-			// diverged (a former primary being demoted, or a node already flagged
-			// for rewind) is force-recovered in single-user mode. runCrashRecovery
-			// removes standby.signal first — postgres --single refuses to run with
-			// it — and recreates it afterwards; this reaches the clean-shutdown
-			// state pg_rewind needs (e.g. to unwedge a node whose earlier pg_rewind
-			// stamped minRecoveryPoint onto the wrong timeline).
-			//
-			// A clean follower is deliberately NOT sent here: single-user
-			// recovery runs in primary mode and does not follow timeline-history
-			// switches, so it would finalize the node on its old timeline past the
-			// leader's fork and wedge the standby start ("requested timeline N is not
-			// a child"). Its crash recovery — and that of a node without
-			// standby.signal — is handled by the postmaster on the normal start
-			// below, which in standby mode follows the timeline switch. crashRecoveryRan
-			// therefore reports specifically whether single-user recovery ran.
-			crashRecoveryRan = true
-			if rcErr := s.runCrashRecovery(ctx); rcErr != nil {
-				// Best effort: the start below may still surface a clearer error.
-				s.logger.WarnContext(ctx, "standby crash recovery before start failed (continuing)", "error", rcErr)
+	if req.GetAllowCrashRecovery() {
+		running, err := checkPostgreSQLRunning(ctx, s.logger, s.pgConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check if PostgreSQL is running: %w", err)
+		}
+		if running {
+			// Never crash-recover a running postmaster: runCrashRecovery removes
+			// standby.signal for single-user recovery, and doing that to a postmaster
+			// that is up — or still starting after a Start whose success was misreported
+			// — can bring it up read-write on a timeline it must not claim. A Start
+			// against an already-running node is an idempotent no-op via
+			// StartPostgreSQLWithResult below.
+			s.logger.InfoContext(ctx, "skipping crash recovery before start: postgres is already running")
+		} else {
+			needed, nErr := s.crashRecoveryNeeded(ctx)
+			if nErr != nil {
+				s.logger.WarnContext(ctx, "could not determine clean-shutdown state before start (continuing)", "error", nErr)
+			} else if needed && s.hasStandbySignal() && req.GetSuspectedDivergence() {
+				// A not-cleanly-stopped standby that the caller suspects may have
+				// diverged (a former primary being demoted, or a node already flagged
+				// for rewind) is force-recovered in single-user mode. runCrashRecovery
+				// removes standby.signal first — postgres --single refuses to run with
+				// it — and recreates it afterwards; this reaches the clean-shutdown
+				// state pg_rewind needs (e.g. to unwedge a node whose earlier pg_rewind
+				// stamped minRecoveryPoint onto the wrong timeline).
+				//
+				// A clean follower is deliberately NOT sent here: single-user
+				// recovery runs in primary mode and does not follow timeline-history
+				// switches, so it would finalize the node on its old timeline past the
+				// leader's fork and wedge the standby start ("requested timeline N is not
+				// a child"). Its crash recovery — and that of a node without
+				// standby.signal — is handled by the postmaster on the normal start
+				// below, which in standby mode follows the timeline switch. crashRecoveryRan
+				// therefore reports specifically whether single-user recovery ran.
+				crashRecoveryRan = true
+				if rcErr := s.runCrashRecovery(ctx); rcErr != nil {
+					// Best effort: the start below may still surface a clearer error.
+					s.logger.WarnContext(ctx, "standby crash recovery before start failed (continuing)", "error", rcErr)
+				}
 			}
 		}
 	}
 
 	// Use the pre-configured PostgreSQL config for start operation
-	result, err := s.StartPostgreSQLWithResult()
+	result, err := s.StartPostgreSQLWithResult(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start PostgreSQL: %w", err)
 	}
@@ -657,7 +663,7 @@ func (s *PgCtldService) Stop(ctx context.Context, req *pb.StopRequest) (*pb.Stop
 	}
 
 	// Use the pre-configured PostgreSQL config for stop operation
-	result, err := s.StopPostgreSQLWithResult(req.Mode)
+	result, err := s.StopPostgreSQLWithResult(ctx, req.Mode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to stop PostgreSQL: %w", err)
 	}
@@ -677,7 +683,7 @@ func (s *PgCtldService) Restart(ctx context.Context, req *pb.RestartRequest) (*p
 	}
 
 	// Use the pre-configured PostgreSQL config for restart operation
-	result, err := s.RestartPostgreSQLWithResult(req.Mode, req.AsStandby)
+	result, err := s.RestartPostgreSQLWithResult(ctx, req.Mode, req.AsStandby)
 	if err != nil {
 		return nil, fmt.Errorf("failed to restart PostgreSQL: %w", err)
 	}
@@ -706,7 +712,7 @@ func (s *PgCtldService) ReloadConfig(ctx context.Context, req *pb.ReloadConfigRe
 	}
 
 	// Use the pre-configured PostgreSQL config for reload operation
-	result, err := ReloadPostgreSQLConfigWithResult(s.logger, s.pgConfig)
+	result, err := ReloadPostgreSQLConfigWithResult(ctx, s.logger, s.pgConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to reload PostgreSQL configuration: %w", err)
 	}

--- a/go/cmd/pgctld/command/start.go
+++ b/go/cmd/pgctld/command/start.go
@@ -15,7 +15,7 @@
 package command
 
 import (
-	"errors"
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -28,6 +28,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/servenv"
 	"github.com/multigres/multigres/go/services/pgctld"
 )
@@ -113,7 +114,7 @@ func (s *PgCtlStartCmd) runStart(cmd *cobra.Command, args []string) error {
 	config.Password = password
 
 	svc := &PgCtldService{logger: s.pgCtlCmd.lg.GetLogger(), pgConfig: config}
-	result, err := svc.StartPostgreSQLWithResult()
+	result, err := svc.StartPostgreSQLWithResult(cmd.Context())
 	if err != nil {
 		return err
 	}
@@ -129,16 +130,18 @@ func (s *PgCtlStartCmd) runStart(cmd *cobra.Command, args []string) error {
 }
 
 // StartPostgreSQLWithResult starts PostgreSQL with the given configuration and returns detailed result information
-func (s *PgCtldService) StartPostgreSQLWithResult() (*StartResult, error) {
-	result := &StartResult{}
+func (s *PgCtldService) StartPostgreSQLWithResult(ctx context.Context) (*StartResult, error) {
 	logger := s.logger
 	config := s.pgConfig
 
 	// Check if PostgreSQL is already running
-	if isPostgreSQLRunning(config.PostgresDataDir) {
+	running, err := checkPostgreSQLRunning(ctx, logger, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if PostgreSQL is running: %w", err)
+	}
+	if running {
 		logger.Info("Postgres is already running") //nolint:sloglint // message intentionally starts with an operation name or proper noun
-		result.AlreadyRunning = true
-		result.Message = "PostgreSQL is already running"
+		result := &StartResult{AlreadyRunning: true, Message: "PostgreSQL is already running"}
 
 		// Get PID of running instance
 		if pid, err := readPostmasterPID(config.PostgresDataDir); err == nil {
@@ -148,6 +151,8 @@ func (s *PgCtldService) StartPostgreSQLWithResult() (*StartResult, error) {
 		return result, nil
 	}
 
+	result := &StartResult{}
+
 	// Ensure Unix socket directory exists before starting PostgreSQL
 	// This is necessary for restarts after restores, where pgBackRest only restores pg_data
 	// but not external directories like pg_sockets
@@ -155,7 +160,7 @@ func (s *PgCtldService) StartPostgreSQLWithResult() (*StartResult, error) {
 		if err := os.MkdirAll(config.UnixSocketDirectories, 0o755); err != nil {
 			return nil, fmt.Errorf("failed to create Unix socket directory %s: %w", config.UnixSocketDirectories, err)
 		}
-		logger.Info("ensured Unix socket directory exists", "socket_dir", config.UnixSocketDirectories)
+		logger.InfoContext(ctx, "ensured Unix socket directory exists", "socket_dir", config.UnixSocketDirectories)
 	}
 
 	// Enforce PGDATA permission invariant before pg_ctl start
@@ -164,13 +169,13 @@ func (s *PgCtldService) StartPostgreSQLWithResult() (*StartResult, error) {
 	}
 
 	// Start PostgreSQL
-	logger.Info("starting Postgres server", "data_dir", config.PostgresDataDir)
+	logger.InfoContext(ctx, "starting Postgres server", "data_dir", config.PostgresDataDir)
 	if err := startPostgreSQLWithConfig(logger, config); err != nil {
 		return nil, fmt.Errorf("failed to start PostgreSQL: %w", err)
 	}
 
 	// Wait for server to be ready
-	logger.Info("waiting for Postgres to be ready")
+	logger.InfoContext(ctx, "waiting for Postgres to be ready")
 	if err := waitForPostgreSQLWithConfig(logger, config); err != nil {
 		return nil, fmt.Errorf("PostgreSQL failed to become ready: %w", err)
 	}
@@ -186,16 +191,16 @@ func (s *PgCtldService) StartPostgreSQLWithResult() (*StartResult, error) {
 }
 
 // StartPostgreSQLWithConfig starts PostgreSQL with the given configuration
-func (s *PgCtldService) StartPostgreSQLWithConfig() error {
+func (s *PgCtldService) StartPostgreSQLWithConfig(ctx context.Context) error {
 	logger := s.logger
-	result, err := s.StartPostgreSQLWithResult()
+	result, err := s.StartPostgreSQLWithResult(ctx)
 	if err != nil {
 		return err
 	}
 
 	// For backward compatibility, log the message if provided
 	if result.Message != "" && !result.AlreadyRunning {
-		logger.Info(result.Message)
+		logger.InfoContext(ctx, result.Message)
 	}
 
 	return nil
@@ -241,20 +246,81 @@ func ensurePGDATAPermissions(logger *slog.Logger, dataDir string) error {
 	return nil
 }
 
-func isPostgreSQLRunning(dataDir string) bool {
-	// Check if postmaster.pid file exists and process is running
-	pidFile := filepath.Join(dataDir, "postmaster.pid")
-	if _, err := os.Stat(pidFile); err != nil {
-		return false
-	}
-
-	// Read PID from file and check if process is actually running
-	pid, err := readPostmasterPID(dataDir)
+// checkPostgreSQLRunning wraps probePostgreSQLRunningAndReady with one added
+// side effect: a lock file the probe finds stale is removed (see
+// removeStalePostmasterPID) so pg_ctl/postgres don't inherit the same false
+// positive. For callers about to act on the result — Start, Stop, Restart,
+// ReloadConfig, crash recovery. Status polls the probe directly instead; see
+// its doc comment for why.
+//
+// Returns an error when pg_isready itself can't answer the question — see
+// classifyPgIsReady — rather than guessing either way; running is false
+// whenever err is non-nil.
+func checkPostgreSQLRunning(ctx context.Context, logger *slog.Logger, config *pgctld.PostgresCtlConfig) (running bool, err error) {
+	running, _, err = probePostgreSQLRunningAndReady(ctx, config)
 	if err != nil {
-		return false
+		return false, err
+	} else if running {
+		return true, nil
 	}
 
-	return isProcessRunning(pid)
+	dataDir := config.PostgresDataDir
+	pidFile := filepath.Join(dataDir, constants.PostmasterPIDFile)
+	if _, statErr := os.Stat(pidFile); statErr != nil {
+		// No lock file to begin with — e.g. a normal start against a freshly
+		// initialized data directory — so there is nothing stale to report or
+		// remove.
+		return false, nil //nolint:nilerr
+	}
+
+	pid, _ := readPostmasterPID(dataDir) // best effort, for the log line below only
+	removeStalePostmasterPID(logger, pidFile, pid)
+	return false, nil
+}
+
+// probePostgreSQLRunningAndReady reports whether postmaster.pid records a
+// postmaster that is genuinely still running for this data directory, and
+// whether it is fully accepting connections — without touching the lock
+// file. Safe to call repeatedly and concurrently with anything else holding
+// that lock file.
+//
+// A bare "does a process with this PID exist" check is not enough: after a
+// pod reschedule onto a different node, postmaster.pid survives on the
+// reattached volume holding a PID from the old container, and the new
+// container has its own fresh PID namespace. If an unrelated process there
+// happens to hold that PID number, a liveness check alone reports a false
+// positive forever. Probing the actual connection endpoint via pg_isready
+// rules that out: an unrelated process holding the recorded PID is not
+// listening as postgres, whatever its identity.
+//
+// Status uses this directly, not checkPostgreSQLRunning: Status is a
+// read-only query polled continuously in the background and must not have
+// the side effect of mutating state on a bad probe. The actual stale-lock
+// cleanup still happens the next time something calls checkPostgreSQLRunning
+// (i.e. Start).
+func probePostgreSQLRunningAndReady(ctx context.Context, config *pgctld.PostgresCtlConfig) (running, ready bool, err error) {
+	dataDir := config.PostgresDataDir
+	pidFile := filepath.Join(dataDir, constants.PostmasterPIDFile)
+	if _, statErr := os.Stat(pidFile); statErr != nil {
+		// No lock file (or one we can't even stat) means nothing to corroborate
+		// against — that's "not running", not the control-plane error
+		// classifyPgIsReady's own error return is for.
+		return false, false, nil //nolint:nilerr
+	}
+
+	exitCode, runErr := runPgIsReady(ctx, config, pgIsReadyTimeoutSecs(ctx))
+	return classifyPgIsReady(exitCode, runErr)
+}
+
+// removeStalePostmasterPID deletes a postmaster.pid file whose postmaster is
+// no longer responding, logging the action so operators have visibility into
+// this self-healing step.
+func removeStalePostmasterPID(logger *slog.Logger, pidFile string, pid int) {
+	logger.Warn("removing stale postmaster.pid: postgres is not responding",
+		"pid", pid, "path", pidFile)
+	if err := os.Remove(pidFile); err != nil && !os.IsNotExist(err) {
+		logger.Warn("failed to remove stale postmaster.pid", "error", err, "path", pidFile)
+	}
 }
 
 func startPostgreSQLWithConfig(logger *slog.Logger, config *pgctld.PostgresCtlConfig) error {
@@ -409,18 +475,20 @@ func waitForPostgreSQLWithConfig(logger *slog.Logger, config *pgctld.PostgresCtl
 	}
 }
 
+// readPostmasterPID returns just the PID recorded in postmaster.pid (line
+// 1). Only that line is required: postgres writes the lock file in one
+// non-atomic write(), so a torn read that yields a good first line and
+// nothing else must still succeed for callers that need nothing but the PID.
 func readPostmasterPID(dataDir string) (int, error) {
-	pidFile := filepath.Join(dataDir, "postmaster.pid")
+	pidFile := filepath.Join(dataDir, constants.PostmasterPIDFile)
 	content, err := os.ReadFile(pidFile)
 	if err != nil {
 		return 0, err
 	}
 
-	// First line contains the PID
+	// strings.Split always returns at least one element, even for empty
+	// input, so lines[0] below is never an out-of-range access.
 	lines := strings.Split(string(content), "\n")
-	if len(lines) == 0 {
-		return 0, errors.New("empty postmaster.pid file")
-	}
 
 	pid, err := strconv.Atoi(strings.TrimSpace(lines[0]))
 	if err != nil {

--- a/go/cmd/pgctld/command/start_test.go
+++ b/go/cmd/pgctld/command/start_test.go
@@ -158,11 +158,59 @@ func TestIsDataDirInitialized(t *testing.T) {
 	}
 }
 
+// TestReadPostmasterPID_ToleratesTruncatedFile pins the contract that
+// reloadWithSignal, status reporting, and the startup readiness loop depend
+// on: a torn lock file with a readable first line must not fail them, no
+// matter what (if anything) follows it.
+func TestReadPostmasterPID_ToleratesTruncatedFile(t *testing.T) {
+	baseDir, cleanup := testutil.TempDir(t, "pgctld_pid_contract_test")
+	defer cleanup()
+
+	dataDir := testutil.CreateDataDir(t, baseDir, true)
+	pidFile := filepath.Join(dataDir, "postmaster.pid")
+	// Only the PID made it to disk.
+	require.NoError(t, os.WriteFile(pidFile, []byte("4242\n"), 0o644))
+
+	pid, err := readPostmasterPID(dataDir)
+	require.NoError(t, err)
+	assert.Equal(t, 4242, pid)
+}
+
+// TestReadPostmasterPID_UnparseablePIDIsAnError covers the other half of
+// readPostmasterPID's contract: unlike a missing start-time line, a PID line
+// that isn't a number leaves nothing for PID-only callers to act on, so it
+// must be a real error rather than silently reporting PID 0.
+func TestReadPostmasterPID_UnparseablePIDIsAnError(t *testing.T) {
+	baseDir, cleanup := testutil.TempDir(t, "pgctld_pid_contract_test")
+	defer cleanup()
+
+	dataDir := testutil.CreateDataDir(t, baseDir, true)
+	pidFile := filepath.Join(dataDir, "postmaster.pid")
+	require.NoError(t, os.WriteFile(pidFile, []byte("not-a-pid\n"+dataDir+"\n"), 0o644))
+
+	pid, err := readPostmasterPID(dataDir)
+	require.Error(t, err)
+	assert.Equal(t, 0, pid)
+}
+
+// checkPostgreSQLRunningTestConfig builds the config checkPostgreSQLRunning
+// needs to reach pg_isready, pointed at dataDir under poolerDir.
+func checkPostgreSQLRunningTestConfig(t *testing.T, poolerDir, dataDir string) *pgctld.PostgresCtlConfig {
+	t.Helper()
+	config, err := pgctld.NewPostgresCtlConfig(
+		5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, 30,
+		dataDir, pgctld.PostgresConfigFile(), poolerDir, "localhost", pgctld.PostgresSocketDir(poolerDir),
+	)
+	require.NoError(t, err)
+	return config
+}
+
 func TestIsPostgreSQLRunning(t *testing.T) {
 	tests := []struct {
-		name      string
-		setupDir  func(string) string
-		isRunning bool
+		name          string
+		setupDir      func(string) string
+		setupBinaries bool
+		isRunning     bool
 	}{
 		{
 			name: "server running with PID file",
@@ -171,14 +219,15 @@ func TestIsPostgreSQLRunning(t *testing.T) {
 				testutil.CreatePIDFile(t, dataDir, 12345)
 				return dataDir
 			},
-			isRunning: true,
+			setupBinaries: true, // mock pg_isready defaults to exit 0
+			isRunning:     true,
 		},
 		{
 			name: "server not running",
 			setupDir: func(baseDir string) string {
 				return testutil.CreateDataDir(t, baseDir, true)
 			},
-			isRunning: false,
+			isRunning: false, // no postmaster.pid: pg_isready is never even invoked
 		},
 		{
 			name: "uninitialized directory",
@@ -194,11 +243,172 @@ func TestIsPostgreSQLRunning(t *testing.T) {
 			baseDir, cleanup := testutil.TempDir(t, "pgctld_running_test")
 			defer cleanup()
 
+			if tt.setupBinaries {
+				binDir := filepath.Join(baseDir, "bin")
+				require.NoError(t, os.MkdirAll(binDir, 0o755))
+				testutil.CreateMockPostgreSQLBinaries(t, binDir)
+
+				originalPath := os.Getenv("PATH")
+				os.Setenv("PATH", binDir+":"+originalPath)
+				defer os.Setenv("PATH", originalPath)
+			}
+
 			dataDir := tt.setupDir(baseDir)
-			result := isPostgreSQLRunning(dataDir)
+			config := checkPostgreSQLRunningTestConfig(t, baseDir, dataDir)
+
+			logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+			result, err := checkPostgreSQLRunning(t.Context(), logger, config)
+			require.NoError(t, err)
 			assert.Equal(t, tt.isRunning, result)
 		})
 	}
+}
+
+// TestCheckPostgreSQLRunning_StaleLockRemovedWhenPostgresNotResponding
+// covers a stale postmaster.pid: it records a PID that some unrelated
+// process now holds, as happens when a reschedule lands on a fresh PID
+// namespace. Nothing is actually listening as postgres, so pg_isready
+// reports "no response" (exit 2) regardless of who (if anyone) holds the
+// recorded PID.
+func TestCheckPostgreSQLRunning_StaleLockRemovedWhenPostgresNotResponding(t *testing.T) {
+	baseDir, cleanup := testutil.TempDir(t, "pgctld_stale_pid_test")
+	defer cleanup()
+
+	dataDir := testutil.CreateDataDir(t, baseDir, true)
+	testutil.CreateDeadPIDFile(t, dataDir, 424242)
+
+	binDir := filepath.Join(baseDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	testutil.MockBinary(t, binDir, "pg_isready", "exit 2")
+	originalPath := os.Getenv("PATH")
+	os.Setenv("PATH", binDir+":"+originalPath)
+	defer os.Setenv("PATH", originalPath)
+
+	config := checkPostgreSQLRunningTestConfig(t, baseDir, dataDir)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	result, err := checkPostgreSQLRunning(t.Context(), logger, config)
+	require.NoError(t, err)
+	assert.False(t, result, "a postmaster.pid pg_isready cannot reach must not read as running")
+
+	_, statErr := os.Stat(filepath.Join(dataDir, "postmaster.pid"))
+	assert.True(t, os.IsNotExist(statErr), "the stale postmaster.pid should have been removed")
+}
+
+// TestProbePostgreSQLRunningAndReady_DoesNotRemoveStaleLock covers the
+// side-effect-free probe used by Status: unlike checkPostgreSQLRunning, a
+// pg_isready exit 2 must NOT delete postmaster.pid. Status is polled
+// continuously and concurrently by multipooler's readiness checks, and doing
+// the removal there could race a postgres pgctld itself started transiently
+// (e.g. init's post-initdb SQL-dir setup) and orphan it.
+func TestProbePostgreSQLRunningAndReady_DoesNotRemoveStaleLock(t *testing.T) {
+	baseDir, cleanup := testutil.TempDir(t, "pgctld_probe_stale_pid_test")
+	defer cleanup()
+
+	dataDir := testutil.CreateDataDir(t, baseDir, true)
+	testutil.CreateDeadPIDFile(t, dataDir, 424242)
+
+	binDir := filepath.Join(baseDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	testutil.MockBinary(t, binDir, "pg_isready", "exit 2")
+	originalPath := os.Getenv("PATH")
+	os.Setenv("PATH", binDir+":"+originalPath)
+	defer os.Setenv("PATH", originalPath)
+
+	config := checkPostgreSQLRunningTestConfig(t, baseDir, dataDir)
+	running, ready, err := probePostgreSQLRunningAndReady(t.Context(), config)
+	require.NoError(t, err)
+	assert.False(t, running)
+	assert.False(t, ready)
+
+	_, statErr := os.Stat(filepath.Join(dataDir, "postmaster.pid"))
+	assert.NoError(t, statErr, "probing must never remove postmaster.pid, stale or not")
+}
+
+// TestCheckPostgreSQLRunning_RejectingConnectionsStillCountsAsRunning covers
+// a postmaster mid-startup or crash recovery: pg_isready's exit 1 ("rejecting
+// connections") means it is alive but not ready yet, which must not be
+// mistaken for stale.
+func TestCheckPostgreSQLRunning_RejectingConnectionsStillCountsAsRunning(t *testing.T) {
+	baseDir, cleanup := testutil.TempDir(t, "pgctld_starting_test")
+	defer cleanup()
+
+	dataDir := testutil.CreateDataDir(t, baseDir, true)
+	testutil.CreateDeadPIDFile(t, dataDir, 424242)
+
+	binDir := filepath.Join(baseDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	testutil.MockBinary(t, binDir, "pg_isready", "exit 1")
+	originalPath := os.Getenv("PATH")
+	os.Setenv("PATH", binDir+":"+originalPath)
+	defer os.Setenv("PATH", originalPath)
+
+	config := checkPostgreSQLRunningTestConfig(t, baseDir, dataDir)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	result, err := checkPostgreSQLRunning(t.Context(), logger, config)
+	require.NoError(t, err)
+	assert.True(t, result, "a postmaster rejecting connections is still running")
+
+	_, statErr := os.Stat(filepath.Join(dataDir, "postmaster.pid"))
+	assert.NoError(t, statErr, "postmaster.pid must be preserved")
+}
+
+// TestCheckPostgreSQLRunning_UnreachablePgIsReadyReturnsError covers
+// pg_isready itself failing to run at all (e.g. missing from PATH, as
+// opposed to running and reporting an exit code): with no definitive signal
+// either way, checkPostgreSQLRunning must not guess — it returns an error
+// and must not delete a lock file it can't disprove.
+func TestCheckPostgreSQLRunning_UnreachablePgIsReadyReturnsError(t *testing.T) {
+	baseDir, cleanup := testutil.TempDir(t, "pgctld_pgisready_missing_test")
+	defer cleanup()
+
+	dataDir := testutil.CreateDataDir(t, baseDir, true)
+	testutil.CreateDeadPIDFile(t, dataDir, 424242)
+
+	// Deliberately no pg_isready anywhere on PATH — not even the real system
+	// one, which a test machine with PostgreSQL installed might otherwise pick up.
+	binDir := filepath.Join(baseDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	originalPath := os.Getenv("PATH")
+	os.Setenv("PATH", binDir)
+	defer os.Setenv("PATH", originalPath)
+
+	config := checkPostgreSQLRunningTestConfig(t, baseDir, dataDir)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	result, err := checkPostgreSQLRunning(t.Context(), logger, config)
+	assert.Error(t, err, "an unreachable pg_isready must surface as an error, not a guess")
+	assert.False(t, result)
+
+	_, statErr := os.Stat(filepath.Join(dataDir, "postmaster.pid"))
+	assert.NoError(t, statErr, "postmaster.pid must be preserved")
+}
+
+// TestCheckPostgreSQLRunning_BrokenExitCodeReturnsError covers pg_isready's
+// exit 3 ("no attempt made", e.g. invalid connection parameters): per
+// review, this means something is broken in the control plane itself, not
+// in postgres, and must be flagged as an error rather than guessed either
+// way.
+func TestCheckPostgreSQLRunning_BrokenExitCodeReturnsError(t *testing.T) {
+	baseDir, cleanup := testutil.TempDir(t, "pgctld_pgisready_broken_test")
+	defer cleanup()
+
+	dataDir := testutil.CreateDataDir(t, baseDir, true)
+	testutil.CreateDeadPIDFile(t, dataDir, 424242)
+
+	binDir := filepath.Join(baseDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	testutil.MockBinary(t, binDir, "pg_isready", "exit 3")
+	originalPath := os.Getenv("PATH")
+	os.Setenv("PATH", binDir+":"+originalPath)
+	defer os.Setenv("PATH", originalPath)
+
+	config := checkPostgreSQLRunningTestConfig(t, baseDir, dataDir)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	result, err := checkPostgreSQLRunning(t.Context(), logger, config)
+	assert.Error(t, err, "pg_isready exit 3 must surface as an error, not a guess")
+	assert.False(t, result)
+
+	_, statErr := os.Stat(filepath.Join(dataDir, "postmaster.pid"))
+	assert.NoError(t, statErr, "postmaster.pid must be preserved")
 }
 
 func TestInitializeDataDir(t *testing.T) {

--- a/go/cmd/pgctld/command/status.go
+++ b/go/cmd/pgctld/command/status.go
@@ -16,13 +16,16 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"time"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/services/pgctld"
 	"github.com/multigres/multigres/go/tools/executil"
 
@@ -114,18 +117,24 @@ func GetStatusWithResult(ctx context.Context, logger *slog.Logger, config *pgctl
 		Port:    config.Port,
 	}
 
-	// Check if PostgreSQL is running
-	if !isPostgreSQLRunning(config.PostgresDataDir) {
+	// Check if PostgreSQL is running and, from the same probe, whether it is
+	// actually accepting connections — a process that exists but cannot
+	// respond (e.g. SIGSTOP, cgroup freeze) is treated as not running so that
+	// multipooler and multiorch can detect the failure and trigger recovery
+	// rather than waiting indefinitely. The side-effect-free probe, not
+	// checkPostgreSQLRunning — see probePostgreSQLRunningAndReady's doc
+	// comment for why Status must not remove a lock file it finds stale.
+	running, ready, err := probePostgreSQLRunningAndReady(ctx, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if PostgreSQL is running: %w", err)
+	}
+	if !running {
 		result.Status = statusStopped
 		result.Message = "PostgreSQL server is stopped"
 		return result, nil
 	}
-
-	// Process exists — verify it is actually accepting connections.
-	// A process that exists but cannot respond (e.g. SIGSTOP, cgroup freeze)
-	// is treated as not running so that multipooler and multiorch can detect
-	// the failure and trigger recovery rather than waiting indefinitely.
-	if result.Ready = isServerReadyWithConfig(ctx, config); !result.Ready {
+	result.Ready = ready
+	if !ready {
 		result.Status = statusStopped
 		result.Message = "PostgreSQL process exists but is not accepting connections"
 		return result, nil
@@ -146,7 +155,7 @@ func GetStatusWithResult(ctx context.Context, logger *slog.Logger, config *pgctl
 	result.Version = getServerVersionWithConfig(ctx, config)
 
 	// Get uptime (approximate based on pidfile mtime)
-	pidFile := filepath.Join(config.PostgresDataDir, "postmaster.pid")
+	pidFile := filepath.Join(config.PostgresDataDir, constants.PostmasterPIDFile)
 	if stat, err := os.Stat(pidFile); err == nil {
 		result.UptimeSeconds = int64(time.Since(stat.ModTime()).Seconds())
 	}
@@ -243,19 +252,55 @@ func pgIsReadyTimeoutSecs(ctx context.Context) int {
 	return max(1, int(timeout.Seconds()))
 }
 
-func isServerReadyWithConfig(ctx context.Context, config *pgctld.PostgresCtlConfig) bool {
-	// Use Unix socket connection for pg_isready
+// runPgIsReady invokes pg_isready against config's connection parameters and
+// reports its exit code: 0 accepting, 1 rejecting (e.g. still starting up),
+// 2 no response, 3 no attempt made (see `man pg_isready`). err is non-nil
+// only if pg_isready itself could not be run at all (e.g. binary missing),
+// as opposed to running and reporting an exit code.
+func runPgIsReady(ctx context.Context, config *pgctld.PostgresCtlConfig, timeoutSecs int) (exitCode int, err error) {
 	socketDir := pgctld.PostgresSocketDir(config.PoolerDir)
 
-	timeoutSecs := pgIsReadyTimeoutSecs(ctx)
-
-	return executil.Command(ctx, "pg_isready",
+	runErr := executil.Command(ctx, "pg_isready",
 		"-h", socketDir,
 		"-p", strconv.Itoa(config.Port), // Need port even for socket connections
 		"-U", config.User,
 		"-d", config.Database,
 		"-t", strconv.Itoa(timeoutSecs),
-	).WithClientSpan().Run() == nil
+	).WithClientSpan().Run()
+	if runErr == nil {
+		return 0, nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		return exitErr.ExitCode(), nil
+	}
+
+	return 0, runErr
+}
+
+// classifyPgIsReady interprets a pg_isready exit code (or the error from
+// failing to run it at all) into running (exit 0 or 1: postgres is alive,
+// whether or not it's accepting queries yet) and ready (exit 0 only: fully
+// accepting connections). err is non-nil only for exit 3 ("no attempt made",
+// e.g. invalid connection parameters) or a failure to execute pg_isready at
+// all — both mean the control plane itself can't answer the question, not
+// that postgres is down, so callers must surface the error rather than
+// guess either way.
+func classifyPgIsReady(exitCode int, runErr error) (running, ready bool, err error) {
+	if runErr != nil {
+		return false, false, fmt.Errorf("could not run pg_isready: %w", runErr)
+	}
+	switch exitCode {
+	case 0:
+		return true, true, nil
+	case 1:
+		return true, false, nil
+	case 2:
+		return false, false, nil
+	default:
+		return false, false, fmt.Errorf("pg_isready returned unexpected exit code %d", exitCode)
+	}
 }
 
 func getServerVersionWithConfig(ctx context.Context, config *pgctld.PostgresCtlConfig) string {
@@ -277,7 +322,7 @@ func getServerVersionWithConfig(ctx context.Context, config *pgctld.PostgresCtlC
 }
 
 func getServerUptime(dataDir string) string {
-	pidFile := filepath.Join(dataDir, "postmaster.pid")
+	pidFile := filepath.Join(dataDir, constants.PostmasterPIDFile)
 	stat, err := os.Stat(pidFile)
 	if err != nil {
 		return ""

--- a/go/cmd/pgctld/command/status_test.go
+++ b/go/cmd/pgctld/command/status_test.go
@@ -17,6 +17,7 @@ package command
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -188,61 +189,32 @@ func TestRunStatus(t *testing.T) {
 	})
 }
 
-func TestIsServerReady(t *testing.T) {
+func TestClassifyPgIsReady(t *testing.T) {
 	tests := []struct {
 		name        string
-		setupBinary func(string)
-		isReady     bool
+		exitCode    int
+		runErr      error
+		wantRunning bool
+		wantReady   bool
+		wantErr     bool
 	}{
-		{
-			name: "server is ready",
-			setupBinary: func(binDir string) {
-				testutil.CreateMockPostgreSQLBinaries(t, binDir)
-			},
-			isReady: true,
-		},
-		{
-			name: "server not ready",
-			setupBinary: func(binDir string) {
-				// Create pg_isready that fails
-				testutil.MockBinary(t, binDir, "pg_isready", "exit 1")
-			},
-			isReady: false,
-		},
+		{name: "exit 0: accepting", exitCode: 0, wantRunning: true, wantReady: true},
+		{name: "exit 1: rejecting", exitCode: 1, wantRunning: true, wantReady: false},
+		{name: "exit 2: no response", exitCode: 2, wantRunning: false, wantReady: false},
+		{name: "exit 3: no attempt made", exitCode: 3, wantErr: true},
+		{name: "pg_isready could not be run at all", runErr: errors.New("exec: not found"), wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			baseDir, cleanup := testutil.TempDir(t, "pgctld_ready_test")
-			defer cleanup()
-
-			binDir := filepath.Join(baseDir, "bin")
-			require.NoError(t, os.MkdirAll(binDir, 0o755))
-			tt.setupBinary(binDir)
-
-			originalPath := os.Getenv("PATH")
-			os.Setenv("PATH", binDir+":"+originalPath)
-			defer os.Setenv("PATH", originalPath)
-
-			// Create initialized data directory with postgresql.conf
-			testutil.CreateDataDir(t, baseDir, true)
-
-			// Create config directly for the test
-			config, err := pgctld.NewPostgresCtlConfig(
-				5432,
-				"postgres",
-				"postgres",
-				30,
-				pgctld.PostgresDataDir(),
-				pgctld.PostgresConfigFile(),
-				baseDir,
-				"localhost",
-				pgctld.PostgresSocketDir(baseDir),
-			)
-			require.NoError(t, err)
-
-			result := isServerReadyWithConfig(t.Context(), config)
-			assert.Equal(t, tt.isReady, result)
+			running, ready, err := classifyPgIsReady(tt.exitCode, tt.runErr)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantRunning, running)
+			assert.Equal(t, tt.wantReady, ready)
 		})
 	}
 }

--- a/go/cmd/pgctld/command/stop.go
+++ b/go/cmd/pgctld/command/stop.go
@@ -15,6 +15,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -109,7 +110,7 @@ func (s *PgCtlStopCmd) runStop(cmd *cobra.Command, args []string) error {
 	// it's not strictly necessary and adds complexity (requires password, can
 	// fail if PostgreSQL is already in a bad state, etc.)
 	svc := &PgCtldService{logger: s.pgCtlCmd.lg.GetLogger(), pgConfig: config}
-	result, err := svc.StopPostgreSQLWithResult(s.mode.Get())
+	result, err := svc.StopPostgreSQLWithResult(cmd.Context(), s.mode.Get())
 	if err != nil {
 		return err
 	}
@@ -124,9 +125,18 @@ func (s *PgCtlStopCmd) runStop(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// StopPostgreSQLWithResult stops PostgreSQL with the given configuration and returns detailed result information
-func (s *PgCtldService) StopPostgreSQLWithResult(mode string) (*StopResult, error) {
-	result := &StopResult{}
+// StopPostgreSQLWithResult stops PostgreSQL with the given configuration and
+// returns detailed result information.
+//
+// Deliberately does not pre-check checkPostgreSQLRunning before attempting
+// the stop: that check's stale-lock removal is meant for callers about to
+// start postgres back up, and running it here first could delete the lock
+// file out from under a postmaster that is, in fact, still running (a
+// slow/timed-out probe misreading it as stale) — orphaning it with nothing
+// left to signal. Instead this attempts the stop directly, and only on
+// failure falls back to the side-effect-free probe to tell an already-down
+// postgres (an idempotent success) from a genuine stop failure.
+func (s *PgCtldService) StopPostgreSQLWithResult(ctx context.Context, mode string) (*StopResult, error) {
 	config := s.pgConfig
 	logger := s.logger
 
@@ -135,37 +145,36 @@ func (s *PgCtldService) StopPostgreSQLWithResult(mode string) (*StopResult, erro
 		mode = "fast"
 	}
 
-	// Check if PostgreSQL is running
-	if !isPostgreSQLRunning(config.PostgresDataDir) {
-		logger.Info("Postgres is not running") //nolint:sloglint // message intentionally starts with an operation name or proper noun
-		result.WasRunning = false
-		result.Message = "PostgreSQL is not running"
-		return result, nil
-	}
-
-	result.WasRunning = true
-	logger.Info("stopping Postgres server", "data_dir", config.PostgresDataDir, "mode", mode)
+	logger.InfoContext(ctx, "stopping Postgres server", "data_dir", config.PostgresDataDir, "mode", mode)
 
 	if err := s.stopPostgreSQLWithConfig(mode); err != nil {
-		return nil, fmt.Errorf("failed to stop PostgreSQL: %w", err)
+		running, _, probeErr := probePostgreSQLRunningAndReady(ctx, config)
+		if probeErr != nil {
+			return nil, fmt.Errorf("failed to stop PostgreSQL: %w (and could not confirm whether it was already stopped: %w)", err, probeErr)
+		}
+		if running {
+			return nil, fmt.Errorf("failed to stop PostgreSQL: %w", err)
+		}
+
+		logger.Info("Postgres is not running") //nolint:sloglint // message intentionally starts with an operation name or proper noun
+		return &StopResult{WasRunning: false, Message: "PostgreSQL is not running"}, nil
 	}
 
-	result.Message = "PostgreSQL server stopped successfully\n"
 	logger.Info("Postgres server stopped successfully") //nolint:sloglint // message intentionally starts with an operation name or proper noun
-	return result, nil
+	return &StopResult{WasRunning: true, Message: "PostgreSQL server stopped successfully\n"}, nil
 }
 
 // StopPostgreSQLWithConfig stops PostgreSQL with the given configuration and mode
-func (s *PgCtldService) StopPostgreSQLWithConfig(mode string) error {
+func (s *PgCtldService) StopPostgreSQLWithConfig(ctx context.Context, mode string) error {
 	logger := s.logger
-	result, err := s.StopPostgreSQLWithResult(mode)
+	result, err := s.StopPostgreSQLWithResult(ctx, mode)
 	if err != nil {
 		return err
 	}
 
 	// For backward compatibility, log the message if PostgreSQL was actually stopped
 	if result.WasRunning && result.Message != "" {
-		logger.Info(result.Message)
+		logger.InfoContext(ctx, result.Message)
 	}
 
 	return nil

--- a/go/cmd/pgctld/command/stop_test.go
+++ b/go/cmd/pgctld/command/stop_test.go
@@ -126,7 +126,7 @@ func TestStopPostgreSQLWithResult(t *testing.T) {
 
 			logger := slog.New(slog.DiscardHandler)
 			svc := &PgCtldService{logger: logger, pgConfig: config}
-			result, err := svc.StopPostgreSQLWithResult(tt.mode)
+			result, err := svc.StopPostgreSQLWithResult(t.Context(), tt.mode)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -143,6 +143,49 @@ func TestStopPostgreSQLWithResult(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestStopPostgreSQLWithResult_PgCtlFailsButAlreadyStopped covers the actual
+// pg_ctl failure path (as opposed to pg_ctl being entirely missing from
+// PATH): pg_ctl stop reports failure because postgres was already down, and
+// the probe run afterward confirms that — treated as an idempotent success,
+// not an error, without ever pre-checking (and risking removing a lock file
+// out from under a still-running postmaster) before attempting the stop.
+func TestStopPostgreSQLWithResult_PgCtlFailsButAlreadyStopped(t *testing.T) {
+	baseDir, cleanup := testutil.TempDir(t, "pgctld_stop_already_down_test")
+	defer cleanup()
+
+	binDir := filepath.Join(baseDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	testutil.CreateMockPostgreSQLBinaries(t, binDir)
+	// Override pg_ctl's mock "stop" to fail like the real binary does when
+	// there is no postmaster.pid, and pg_isready to confirm "not responding".
+	testutil.MockBinary(t, binDir, "pg_ctl", `
+case "$1" in
+    stop)
+        echo "pg_ctl: PID file does not exist" >&2
+        exit 1
+        ;;
+esac
+`)
+	testutil.MockBinary(t, binDir, "pg_isready", "exit 2")
+
+	originalPath := os.Getenv("PATH")
+	os.Setenv("PATH", binDir+":"+originalPath)
+	defer os.Setenv("PATH", originalPath)
+
+	testutil.CreateDataDir(t, baseDir, true) // no postmaster.pid: nothing was ever running
+
+	poolerDir := baseDir
+	config, err := pgctld.NewPostgresCtlConfig(5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, 30, pgctld.PostgresDataDir(), pgctld.PostgresConfigFile(), poolerDir, "localhost", pgctld.PostgresSocketDir(poolerDir))
+	require.NoError(t, err)
+
+	logger := slog.New(slog.DiscardHandler)
+	svc := &PgCtldService{logger: logger, pgConfig: config}
+	result, err := svc.StopPostgreSQLWithResult(t.Context(), "fast")
+	require.NoError(t, err)
+	assert.False(t, result.WasRunning)
+	assert.Equal(t, "PostgreSQL is not running", result.Message)
 }
 
 func TestStopPostgreSQLWithResult_EmptyPoolerDir(t *testing.T) {
@@ -306,7 +349,7 @@ func TestStopPostgreSQLWithConfig(t *testing.T) {
 
 			logger := slog.New(slog.DiscardHandler)
 			svc := &PgCtldService{logger: logger, pgConfig: config}
-			err = svc.StopPostgreSQLWithConfig(tt.mode)
+			err = svc.StopPostgreSQLWithConfig(t.Context(), tt.mode)
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/go/cmd/pgctld/testutil/mock_postgres.go
+++ b/go/cmd/pgctld/testutil/mock_postgres.go
@@ -194,7 +194,9 @@ case "$1" in
         done
         
         if [ -n "$DATADIR" ]; then
-            # Start a background process to pass isProcessRunning check
+            # Background a real process so PID-liveness checks see something
+            # running; its identity is irrelevant since the "is postgres
+            # actually running" check is now a pg_isready probe.
             sleep 3600 >/dev/null 2>&1 &
             MOCK_PID=$!
             echo "$MOCK_PID" > "$DATADIR/postmaster.pid"
@@ -238,7 +240,7 @@ case "$1" in
             echo "waiting for server to shut down.... done"
             echo "server stopped"
 
-            # Start a new background process
+            # Start a new background process; see the "start" case above.
             sleep 3600 >/dev/null 2>&1 &
             MOCK_PID=$!
             echo "$MOCK_PID" > "$DATADIR/postmaster.pid"

--- a/go/cmd/pgctld/testutil/mock_postgres.go
+++ b/go/cmd/pgctld/testutil/mock_postgres.go
@@ -195,7 +195,7 @@ case "$1" in
         
         if [ -n "$DATADIR" ]; then
             # Start a background process to pass isProcessRunning check
-            sleep 3600 &
+            sleep 3600 >/dev/null 2>&1 &
             MOCK_PID=$!
             echo "$MOCK_PID" > "$DATADIR/postmaster.pid"
             echo "$DATADIR" >> "$DATADIR/postmaster.pid"
@@ -239,7 +239,7 @@ case "$1" in
             echo "server stopped"
 
             # Start a new background process
-            sleep 3600 &
+            sleep 3600 >/dev/null 2>&1 &
             MOCK_PID=$!
             echo "$MOCK_PID" > "$DATADIR/postmaster.pid"
             echo "$DATADIR" >> "$DATADIR/postmaster.pid"

--- a/go/cmd/pgctld/testutil/temp_dirs.go
+++ b/go/cmd/pgctld/testutil/temp_dirs.go
@@ -111,7 +111,7 @@ func CreatePIDFile(t *testing.T, dataDir string, pid int) {
 	content := []string{
 		strconv.Itoa(realPID),
 		dataDir,
-		"1234567890",
+		strconv.FormatInt(time.Now().Unix(), 10),
 		"5432",
 		"/tmp",
 		"localhost",

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -187,4 +187,9 @@ const (
 	// survives restore_command being cleared and PGDATA being wiped by a
 	// subsequent restore.
 	RestoreCommandPIDFile = "restore_command.pid"
+
+	// PostmasterPIDFile is the filename (joined onto PGDATA) postgres itself
+	// writes its lock file to, recording the postmaster's PID and start time
+	// among other fields. Fixed by PostgreSQL itself, not configurable.
+	PostmasterPIDFile = "postmaster.pid"
 )


### PR DESCRIPTION
## Problem

After a pod reschedule onto a different node (node drain, RWO volume reattach), `postmaster.pid` survives on the reattached data volume holding a PID from the *old* container, while the new container starts with its own fresh PID namespace.

The running check only asked whether *some* process held that PID (`Signal(0)`), which proves a process exists but not that it is our postmaster. When an unrelated process in the new namespace happened to be assigned the same PID number, the check reported a false positive and the node wedged:

1. `StartPostgreSQLWithResult` returned `AlreadyRunning=true` and never called `pg_ctl`, so postgres was never started.
2. Every subsequent `MonitorPostgres` tick reached the same conclusion, so there was no self-correction.
3. The readiness gate reports on gRPC rather than postgres (deliberately), so the pod stayed `Ready` the whole time and the shard controller saw nothing wrong.

Recovery required manually deleting `postmaster.pid`. Credit to @mkindahl, whose review on #1410 walked through this sequence precisely — and who also suggested the pg_isready-based approach this PR uses.

## Solution

Rather than trying to corroborate the recorded PID's OS-level identity (start time, process name), `checkPostgreSQLRunning` now probes the actual connection endpoint with `pg_isready` and trusts its exit code:

- **0 (accepting) or 1 (rejecting, e.g. still starting up or in crash recovery)** — postgres is alive; keep the lock file.
- **2 (no response)** — nothing is listening as postgres, whatever the recorded PID currently belongs to; remove the stale lock file so `pg_ctl`/postgres don't inherit the same false positive.
- **3 (no attempt made, e.g. invalid connection parameters), or pg_isready itself couldn't be run at all** — something is broken in the control plane, not in postgres. This is flagged as a hard error and bubbled up rather than guessed either way — every caller (`Start`, `Stop`, `Restart`, `ReloadConfig`, crash recovery, and status reporting) surfaces it instead of silently deciding the node is up or down.

`pg_isready`'s `-t` timeout is derived from the request's context deadline rather than relying on libpq's default, so the subprocess's own connection timeout fires before the context cancels it mid-wait.

This sidesteps OS process-identity entirely — no interface for injecting a fake process reader, no dependency on a real process happening to be named `postgres`, no start-time tolerance window to reason about.

### Status must be read-only

`checkPostgreSQLRunning` is split into a side-effect-free `probePostgreSQLRunningAndReady` (used only by `Status`) and `checkPostgreSQLRunning` itself, which layers the stale-lock cleanup on top for callers that act on the result (`Start`, `Stop`, `Restart`, `ReloadConfig`, crash recovery). `Status` is polled continuously and concurrently in the background, so it must not carry the side effect of deleting a lock file on a single bad probe — doing so raced a postgres instance pgctld was legitimately still managing and caused several integration tests to fail deterministically in CI.

`Restart` also now calls `StopPostgreSQLWithResult`/`StartPostgreSQLWithResult` directly rather than through separate "skip the recheck" variants, trading one extra `pg_isready` probe per restart for a simpler call graph.

## Relationship to #1410

#1410 retries `pg_ctl start` through the orphan-cleanup lock window. That is a different failure (same node, unclean kill, transient) from the reused-PID scenario this PR fixes, and it does not touch the running-check false positive that actually wedges a rescheduled pod. This change is independent of it and does not conflict.

## Commits

1. **test(pgctld): stop mock pg_ctl's background sleep from holding test stdio** — a pre-existing, unrelated bug in the mock `pg_ctl`: its backgrounded `sleep 3600 &` inherited the shell's stdout/stderr, which is the pipe `CombinedOutput` reads from, so the pipe kept a live writer after `pg_ctl` exited and never reached EOF. Same fix as in #1410, kept as its own commit so it's independently reviewable and green.
2. **fix(pgctld): detect a stale postmaster.pid whose PID was reused** — everything else described above.

## Testing

- `go test -short ./go/cmd/pgctld/...` — green.
- `make build && go test ./go/test/endtoend/pgctld/...` (full package, real compiled binary) — green.
- `golangci-lint run ./...` — 0 issues, full repo.