### PR TITLE
fix(pgprotocol): preserve File/Line/Routine on ErrorResponse

### DIFF
--- a/go/common/mterrors/grpc_test.go
+++ b/go/common/mterrors/grpc_test.go
@@ -156,7 +156,7 @@ func TestFromGRPCNonStatusError(t *testing.T) {
 }
 
 func TestPgErrorGRPCRoundTrip(t *testing.T) {
-	// Test that all 14 PostgreSQL fields are preserved through gRPC round-trip
+	// Test that all PostgreSQL diagnostic fields are preserved through gRPC round-trip
 	originalDiag := &PgDiagnostic{
 		MessageType:      protocol.MsgErrorResponse,
 		Severity:         "ERROR",
@@ -173,6 +173,9 @@ func TestPgErrorGRPCRoundTrip(t *testing.T) {
 		Column:           "id",
 		DataType:         "integer",
 		Constraint:       "users_pkey",
+		File:             "nbtinsert.c",
+		Line:             670,
+		Routine:          "_bt_check_unique",
 	}
 
 	// Convert to gRPC
@@ -186,7 +189,7 @@ func TestPgErrorGRPCRoundTrip(t *testing.T) {
 	var diag *PgDiagnostic
 	require.True(t, errors.As(recovered, &diag))
 
-	// Verify all 14 fields are preserved
+	// Verify all fields are preserved, including source location (F/L/R)
 	assert.Equal(t, byte(protocol.MsgErrorResponse), diag.MessageType)
 	assert.Equal(t, "ERROR", diag.Severity)
 	assert.Equal(t, "23505", diag.Code)
@@ -202,6 +205,9 @@ func TestPgErrorGRPCRoundTrip(t *testing.T) {
 	assert.Equal(t, "id", diag.Column)
 	assert.Equal(t, "integer", diag.DataType)
 	assert.Equal(t, "users_pkey", diag.Constraint)
+	assert.Equal(t, "nbtinsert.c", diag.File)
+	assert.Equal(t, int32(670), diag.Line)
+	assert.Equal(t, "_bt_check_unique", diag.Routine)
 
 	// Verify Error() message is preserved
 	assert.Equal(t, "ERROR: duplicate key value violates unique constraint", diag.Error())

--- a/go/common/mterrors/pgdiagnostic.go
+++ b/go/common/mterrors/pgdiagnostic.go
@@ -43,6 +43,9 @@ type PgDiagnostic struct {
 	Column           string
 	DataType         string
 	Constraint       string
+	File             string
+	Line             int32
+	Routine          string
 }
 
 // IsError returns true if this diagnostic represents an error (MessageType == 'E').
@@ -247,6 +250,9 @@ func PgDiagnosticToProto(d *PgDiagnostic) *query.PgDiagnostic {
 		ColumnName:       d.Column,
 		DataTypeName:     d.DataType,
 		ConstraintName:   d.Constraint,
+		File:             d.File,
+		Line:             d.Line,
+		Routine:          d.Routine,
 	}
 }
 
@@ -271,5 +277,8 @@ func PgDiagnosticFromProto(pd *query.PgDiagnostic) *PgDiagnostic {
 		Column:           pd.ColumnName,
 		DataType:         pd.DataTypeName,
 		Constraint:       pd.ConstraintName,
+		File:             pd.File,
+		Line:             pd.Line,
+		Routine:          pd.Routine,
 	}
 }

--- a/go/common/pgprotocol/client/diagnostic_test.go
+++ b/go/common/pgprotocol/client/diagnostic_test.go
@@ -91,9 +91,9 @@ func TestParseDiagnosticFieldsMissingRequiredFields(t *testing.T) {
 	}
 }
 
-// TestParseDiagnosticFieldsAllFieldsPopulated tests parsing diagnostics with all 14 fields.
+// TestParseDiagnosticFieldsAllFieldsPopulated tests parsing diagnostics with all fields.
 func TestParseDiagnosticFieldsAllFieldsPopulated(t *testing.T) {
-	// Build wire format message with all 14 fields
+	// Build wire format message with all diagnostic fields, including F/L/R.
 	w := NewMessageWriter()
 	w.AppendByte(protocol.FieldSeverity)
 	w.WriteString("ERROR")
@@ -123,12 +123,18 @@ func TestParseDiagnosticFieldsAllFieldsPopulated(t *testing.T) {
 	w.WriteString("text")
 	w.AppendByte(protocol.FieldConstraint)
 	w.WriteString("users_email_key")
+	w.AppendByte(protocol.FieldFile)
+	w.WriteString("nbtinsert.c")
+	w.AppendByte(protocol.FieldLine)
+	w.WriteString("670")
+	w.AppendByte(protocol.FieldRoutine)
+	w.WriteString("_bt_check_unique")
 	w.AppendByte(0) // Terminator
 
 	diag := parseDiagnosticFields(protocol.MsgErrorResponse, w.Bytes())
 	require.NotNil(t, diag)
 
-	// Verify all 14 fields
+	// Verify all fields, including source location (F/L/R).
 	assert.Equal(t, byte(protocol.MsgErrorResponse), diag.MessageType)
 	assert.Equal(t, "ERROR", diag.Severity)
 	assert.Equal(t, "23505", diag.Code)
@@ -144,6 +150,9 @@ func TestParseDiagnosticFieldsAllFieldsPopulated(t *testing.T) {
 	assert.Equal(t, "email", diag.Column)
 	assert.Equal(t, "text", diag.DataType)
 	assert.Equal(t, "users_email_key", diag.Constraint)
+	assert.Equal(t, "nbtinsert.c", diag.File)
+	assert.Equal(t, int32(670), diag.Line)
+	assert.Equal(t, "_bt_check_unique", diag.Routine)
 
 	// Validate should pass
 	err := diag.Validate()
@@ -181,6 +190,9 @@ func TestParseDiagnosticFieldsOnlyRequiredFields(t *testing.T) {
 	assert.Empty(t, diag.Column)
 	assert.Empty(t, diag.DataType)
 	assert.Empty(t, diag.Constraint)
+	assert.Empty(t, diag.File)
+	assert.Equal(t, int32(0), diag.Line)
+	assert.Empty(t, diag.Routine)
 
 	// Validate should pass
 	err := diag.Validate()
@@ -274,6 +286,21 @@ func TestDiagnosticRoundTripParseProtoWriteParse(t *testing.T) {
 				Column:           "email",
 				DataType:         "text",
 				Constraint:       "users_email_key",
+				File:             "nbtinsert.c",
+				Line:             670,
+				Routine:          "_bt_check_unique",
+			},
+		},
+		{
+			name: "error with source location only",
+			diag: &mterrors.PgDiagnostic{
+				MessageType: protocol.MsgErrorResponse,
+				Severity:    "ERROR",
+				Code:        "22012",
+				Message:     "division by zero",
+				File:        "int.c",
+				Line:        870,
+				Routine:     "int4div",
 			},
 		},
 		{
@@ -643,6 +670,9 @@ func assertDiagnosticsEqual(t *testing.T, expected, actual *mterrors.PgDiagnosti
 	assert.Equal(t, expected.Column, actual.Column, "Column mismatch")
 	assert.Equal(t, expected.DataType, actual.DataType, "DataType mismatch")
 	assert.Equal(t, expected.Constraint, actual.Constraint, "Constraint mismatch")
+	assert.Equal(t, expected.File, actual.File, "File mismatch")
+	assert.Equal(t, expected.Line, actual.Line, "Line mismatch")
+	assert.Equal(t, expected.Routine, actual.Routine, "Routine mismatch")
 }
 
 // Helper function to build wire format from PgDiagnostic
@@ -704,6 +734,18 @@ func buildDiagnosticWireFormat(diag *mterrors.PgDiagnostic) []byte {
 	if diag.Constraint != "" {
 		w.AppendByte(protocol.FieldConstraint)
 		w.WriteString(diag.Constraint)
+	}
+	if diag.File != "" {
+		w.AppendByte(protocol.FieldFile)
+		w.WriteString(diag.File)
+	}
+	if diag.Line != 0 {
+		w.AppendByte(protocol.FieldLine)
+		w.WriteString(positionToString(diag.Line))
+	}
+	if diag.Routine != "" {
+		w.AppendByte(protocol.FieldRoutine)
+		w.WriteString(diag.Routine)
 	}
 
 	w.AppendByte(0) // Terminator

--- a/go/common/pgprotocol/client/query.go
+++ b/go/common/pgprotocol/client/query.go
@@ -730,7 +730,8 @@ func parseRowsAffected(tag string) uint64 {
 	return 0
 }
 
-// parseDiagnosticFields parses all 14 PostgreSQL diagnostic fields from the wire format.
+// parseDiagnosticFields parses PostgreSQL diagnostic fields from the wire format,
+// including source location (file, line, routine).
 // This is a shared helper used by both parseError() and parseNotice() since PostgreSQL
 // uses the same field format for ErrorResponse ('E') and NoticeResponse ('N') messages.
 // The msgType parameter should be protocol.MsgErrorResponse or protocol.MsgNoticeResponse.
@@ -797,6 +798,14 @@ func parseDiagnosticFields(msgType byte, body []byte) *mterrors.PgDiagnostic {
 			diag.DataType = value
 		case protocol.FieldConstraint:
 			diag.Constraint = value
+		case protocol.FieldFile:
+			diag.File = value
+		case protocol.FieldLine:
+			if line, err := strconv.ParseInt(value, 10, 32); err == nil {
+				diag.Line = int32(line)
+			}
+		case protocol.FieldRoutine:
+			diag.Routine = value
 		}
 	}
 
@@ -818,7 +827,7 @@ func parseDiagnosticFields(msgType byte, body []byte) *mterrors.PgDiagnostic {
 // parseError parses an ErrorResponse message into a *mterrors.PgDiagnostic.
 // Since mterrors.PgDiagnostic implements the error interface, it can be returned
 // directly as an error. This eliminates the need for a separate wrapper type.
-// It captures all 14 PostgreSQL error fields defined in the protocol.
+// It captures the PostgreSQL diagnostic fields, including source location.
 func (c *Conn) parseError(body []byte) error {
 	return parseDiagnosticFields(protocol.MsgErrorResponse, body)
 }

--- a/go/common/pgprotocol/client/query_test.go
+++ b/go/common/pgprotocol/client/query_test.go
@@ -163,7 +163,7 @@ func TestParseError(t *testing.T) {
 }
 
 func TestParseErrorAllFields(t *testing.T) {
-	// Build an ErrorResponse message body with all 14 fields.
+	// Build an ErrorResponse message body with all diagnostic fields, including F/L/R.
 	w := NewMessageWriter()
 	w.AppendByte(protocol.FieldSeverity)
 	w.WriteString("ERROR")
@@ -193,6 +193,12 @@ func TestParseErrorAllFields(t *testing.T) {
 	w.WriteString("text")
 	w.AppendByte(protocol.FieldConstraint)
 	w.WriteString("users_email_key")
+	w.AppendByte(protocol.FieldFile)
+	w.WriteString("nbtinsert.c")
+	w.AppendByte(protocol.FieldLine)
+	w.WriteString("670")
+	w.AppendByte(protocol.FieldRoutine)
+	w.WriteString("_bt_check_unique")
 	w.AppendByte(0) // Terminator
 
 	conn := &Conn{}
@@ -202,7 +208,7 @@ func TestParseErrorAllFields(t *testing.T) {
 	var diag *mterrors.PgDiagnostic
 	require.True(t, errors.As(err, &diag))
 
-	// Verify all 14 fields.
+	// Verify all fields, including source location (F/L/R).
 	require.NotNil(t, diag)
 	assert.Equal(t, "ERROR", diag.Severity)
 	assert.Equal(t, "23505", diag.Code)
@@ -218,10 +224,13 @@ func TestParseErrorAllFields(t *testing.T) {
 	assert.Equal(t, "email", diag.Column)
 	assert.Equal(t, "text", diag.DataType)
 	assert.Equal(t, "users_email_key", diag.Constraint)
+	assert.Equal(t, "nbtinsert.c", diag.File)
+	assert.Equal(t, int32(670), diag.Line)
+	assert.Equal(t, "_bt_check_unique", diag.Routine)
 }
 
 func TestPgDiagnosticFields(t *testing.T) {
-	// Build an ErrorResponse message body with all 14 fields.
+	// Build an ErrorResponse message body with all diagnostic fields, including F/L/R.
 	w := NewMessageWriter()
 	w.AppendByte(protocol.FieldSeverity)
 	w.WriteString("ERROR")
@@ -251,6 +260,12 @@ func TestPgDiagnosticFields(t *testing.T) {
 	w.WriteString("boolean")
 	w.AppendByte(protocol.FieldConstraint)
 	w.WriteString("myconstraint")
+	w.AppendByte(protocol.FieldFile)
+	w.WriteString("bool.c")
+	w.AppendByte(protocol.FieldLine)
+	w.WriteString("123")
+	w.AppendByte(protocol.FieldRoutine)
+	w.WriteString("boolin")
 	w.AppendByte(0) // Terminator
 
 	conn := &Conn{}
@@ -280,6 +295,9 @@ func TestPgDiagnosticFields(t *testing.T) {
 	assert.Equal(t, "mycolumn", diag.Column)
 	assert.Equal(t, "boolean", diag.DataType)
 	assert.Equal(t, "myconstraint", diag.Constraint)
+	assert.Equal(t, "bool.c", diag.File)
+	assert.Equal(t, int32(123), diag.Line)
+	assert.Equal(t, "boolin", diag.Routine)
 }
 
 func TestPgDiagnosticErrorString(t *testing.T) {

--- a/go/common/pgprotocol/server/query.go
+++ b/go/common/pgprotocol/server/query.go
@@ -302,7 +302,8 @@ func (c *Conn) WriteNotice(diag *mterrors.PgDiagnostic) error {
 
 // writePgDiagnosticResponse writes a PostgreSQL diagnostic response (error or notice).
 // The msgType should be MsgErrorResponse ('E') or MsgNoticeResponse ('N').
-// This unified function handles all 14 PostgreSQL diagnostic fields.
+// This unified function handles the PostgreSQL diagnostic fields, including
+// source location (file, line, routine).
 func (c *Conn) writePgDiagnosticResponse(msgType byte, diag *mterrors.PgDiagnostic) error {
 	fields := make(map[byte]string)
 	fields[protocol.FieldSeverity] = diag.Severity
@@ -341,6 +342,15 @@ func (c *Conn) writePgDiagnosticResponse(msgType byte, diag *mterrors.PgDiagnost
 	}
 	if diag.Constraint != "" {
 		fields[protocol.FieldConstraint] = diag.Constraint
+	}
+	if diag.File != "" {
+		fields[protocol.FieldFile] = diag.File
+	}
+	if diag.Line != 0 {
+		fields[protocol.FieldLine] = strconv.Itoa(int(diag.Line))
+	}
+	if diag.Routine != "" {
+		fields[protocol.FieldRoutine] = diag.Routine
 	}
 
 	return c.writeErrorOrNotice(msgType, fields)

--- a/go/common/pgprotocol/server/query_test.go
+++ b/go/common/pgprotocol/server/query_test.go
@@ -402,6 +402,9 @@ func TestWriteError(t *testing.T) {
 		message  string
 		detail   string
 		hint     string
+		file     string
+		line     string
+		routine  string
 	}{
 		{
 			name:     "PgDiagnostic error",
@@ -425,6 +428,24 @@ func TestWriteError(t *testing.T) {
 			message:  "duplicate key value violates unique constraint",
 			detail:   "Key (id)=(1) already exists.",
 			hint:     "Use a different value for the id column.",
+		},
+		{
+			name: "PgDiagnostic with source location",
+			err: &mterrors.PgDiagnostic{
+				MessageType: 'E',
+				Severity:    "ERROR",
+				Code:        "22012",
+				Message:     "division by zero",
+				File:        "int.c",
+				Line:        870,
+				Routine:     "int4div",
+			},
+			severity: "ERROR",
+			sqlState: "22012",
+			message:  "division by zero",
+			file:     "int.c",
+			line:     "870",
+			routine:  "int4div",
 		},
 		{
 			name:     "MT error",
@@ -499,6 +520,15 @@ func TestWriteError(t *testing.T) {
 			}
 			if tt.hint != "" {
 				assert.Equal(t, tt.hint, fields[protocol.FieldHint])
+			}
+			if tt.file != "" {
+				assert.Equal(t, tt.file, fields[protocol.FieldFile])
+			}
+			if tt.line != "" {
+				assert.Equal(t, tt.line, fields[protocol.FieldLine])
+			}
+			if tt.routine != "" {
+				assert.Equal(t, tt.routine, fields[protocol.FieldRoutine])
 			}
 		})
 	}

--- a/go/common/sqltypes/sqltypes.go
+++ b/go/common/sqltypes/sqltypes.go
@@ -34,7 +34,7 @@
 //
 //	PostgreSQL ErrorResponse/NoticeResponse
 //	        ↓
-//	*PgDiagnostic (parse all 14 fields, implements error)
+//	*PgDiagnostic (parse wire fields including F/L/R, implements error)
 //	        ↓
 //	mterrors.PgError (wraps PgDiagnostic for system-level handling)
 //	        ↓
@@ -42,7 +42,7 @@
 //	        ↓
 //	mterrors.PgError (reconstructed from gRPC)
 //	        ↓
-//	server.writePgDiagnosticResponse (write all 14 fields)
+//	server.writePgDiagnosticResponse (write wire fields including F/L/R)
 //	        ↓
 //	Client sees native PostgreSQL error format
 //
@@ -64,7 +64,7 @@
 //
 // # PostgreSQL Protocol Fields
 //
-// PgDiagnostic captures all 14 PostgreSQL diagnostic fields:
+// PgDiagnostic captures the PostgreSQL diagnostic fields:
 //
 //	Field             Code  Description
 //	─────────────────────────────────────────────────────────
@@ -82,6 +82,9 @@
 //	Column            c     Column name (constraint errors)
 //	DataType          d     Data type name
 //	Constraint        n     Constraint name
+//	File              F     PostgreSQL source file
+//	Line              L     Source line number
+//	Routine           R     Source routine name
 //
 // See: https://www.postgresql.org/docs/current/protocol-error-fields.html
 package sqltypes

--- a/go/common/sqltypes/sqltypes_test.go
+++ b/go/common/sqltypes/sqltypes_test.go
@@ -427,6 +427,21 @@ func TestPgDiagnosticToProtoAndBack(t *testing.T) {
 				Column:           "email",
 				DataType:         "character varying",
 				Constraint:       "users_email_key",
+				File:             "nbtinsert.c",
+				Line:             670,
+				Routine:          "_bt_check_unique",
+			},
+		},
+		{
+			name: "source location fields",
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType: 'E',
+				Severity:    "ERROR",
+				Code:        "22012",
+				Message:     "division by zero",
+				File:        "int.c",
+				Line:        870,
+				Routine:     "int4div",
 			},
 		},
 		{
@@ -566,6 +581,9 @@ func TestPgDiagnosticToProtoAndBack(t *testing.T) {
 			assert.Equal(t, tc.diagnostic.Column, protoDiag.ColumnName)
 			assert.Equal(t, tc.diagnostic.DataType, protoDiag.DataTypeName)
 			assert.Equal(t, tc.diagnostic.Constraint, protoDiag.ConstraintName)
+			assert.Equal(t, tc.diagnostic.File, protoDiag.File)
+			assert.Equal(t, tc.diagnostic.Line, protoDiag.Line)
+			assert.Equal(t, tc.diagnostic.Routine, protoDiag.Routine)
 
 			// Convert back
 			recovered := mterrors.PgDiagnosticFromProto(protoDiag)
@@ -587,6 +605,9 @@ func TestPgDiagnosticToProtoAndBack(t *testing.T) {
 			assert.Equal(t, tc.diagnostic.Column, recovered.Column)
 			assert.Equal(t, tc.diagnostic.DataType, recovered.DataType)
 			assert.Equal(t, tc.diagnostic.Constraint, recovered.Constraint)
+			assert.Equal(t, tc.diagnostic.File, recovered.File)
+			assert.Equal(t, tc.diagnostic.Line, recovered.Line)
+			assert.Equal(t, tc.diagnostic.Routine, recovered.Routine)
 		})
 	}
 }

--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -24,12 +24,13 @@
 package query
 
 import (
-	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -531,8 +532,9 @@ func (x *Row) GetValues() []byte {
 
 // PgDiagnostic represents a PostgreSQL diagnostic message (error or notice).
 // PostgreSQL uses the same wire format for both ErrorResponse ('E') and NoticeResponse ('N'),
-// differentiated by the message_type field. This unified structure captures all 14 fields
-// defined in the PostgreSQL protocol for diagnostic messages.
+// differentiated by the message_type field. This unified structure captures the
+// PostgreSQL protocol diagnostic fields, including source location (file, line,
+// routine) used by psql \errverbose and by libpq / pgx / pgJDBC.
 //
 // Error severities: ERROR, FATAL, PANIC
 // Notice severities: WARNING, NOTICE, DEBUG, INFO, LOG
@@ -572,8 +574,17 @@ type PgDiagnostic struct {
 	DataTypeName string `protobuf:"bytes,13,opt,name=data_type_name,json=dataTypeName,proto3" json:"data_type_name,omitempty"`
 	// constraint_name is the name of the constraint associated with the diagnostic (optional)
 	ConstraintName string `protobuf:"bytes,14,opt,name=constraint_name,json=constraintName,proto3" json:"constraint_name,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// file is the PostgreSQL source file that raised the diagnostic (optional).
+	// Wire field 'F'. Used by psql LOCATION and libpq PG_DIAG_SOURCE_FILE.
+	File string `protobuf:"bytes,16,opt,name=file,proto3" json:"file,omitempty"`
+	// line is the source line number in file (1-indexed, 0 if not available).
+	// Wire field 'L'. Used by psql LOCATION and libpq PG_DIAG_SOURCE_LINE.
+	Line int32 `protobuf:"varint,17,opt,name=line,proto3" json:"line,omitempty"`
+	// routine is the PostgreSQL source routine that raised the diagnostic (optional).
+	// Wire field 'R'. Used by psql LOCATION and libpq PG_DIAG_SOURCE_FUNCTION.
+	Routine       string `protobuf:"bytes,18,opt,name=routine,proto3" json:"routine,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PgDiagnostic) Reset() {
@@ -707,6 +718,27 @@ func (x *PgDiagnostic) GetDataTypeName() string {
 func (x *PgDiagnostic) GetConstraintName() string {
 	if x != nil {
 		return x.ConstraintName
+	}
+	return ""
+}
+
+func (x *PgDiagnostic) GetFile() string {
+	if x != nil {
+		return x.File
+	}
+	return ""
+}
+
+func (x *PgDiagnostic) GetLine() int32 {
+	if x != nil {
+		return x.Line
+	}
+	return 0
+}
+
+func (x *PgDiagnostic) GetRoutine() string {
+	if x != nil {
+		return x.Routine
 	}
 	return ""
 }
@@ -1652,7 +1684,7 @@ const file_query_proto_rawDesc = "" +
 	"\x06format\x18\b \x01(\x05R\x06format\"7\n" +
 	"\x03Row\x12\x18\n" +
 	"\alengths\x18\x01 \x03(\x12R\alengths\x12\x16\n" +
-	"\x06values\x18\x02 \x01(\fR\x06values\"\xdd\x03\n" +
+	"\x06values\x18\x02 \x01(\fR\x06values\"\x9f\x04\n" +
 	"\fPgDiagnostic\x12!\n" +
 	"\fmessage_type\x18\x0f \x01(\x05R\vmessageType\x12\x1a\n" +
 	"\bseverity\x18\x01 \x01(\tR\bseverity\x12\x12\n" +
@@ -1672,7 +1704,10 @@ const file_query_proto_rawDesc = "" +
 	"\vcolumn_name\x18\f \x01(\tR\n" +
 	"columnName\x12$\n" +
 	"\x0edata_type_name\x18\r \x01(\tR\fdataTypeName\x12'\n" +
-	"\x0fconstraint_name\x18\x0e \x01(\tR\x0econstraintName\"V\n" +
+	"\x0fconstraint_name\x18\x0e \x01(\tR\x0econstraintName\x12\x12\n" +
+	"\x04file\x18\x10 \x01(\tR\x04file\x12\x12\n" +
+	"\x04line\x18\x11 \x01(\x05R\x04line\x12\x18\n" +
+	"\aroutine\x18\x12 \x01(\tR\aroutine\"V\n" +
 	"\x0ePgNotification\x12\x10\n" +
 	"\x03pid\x18\x01 \x01(\x05R\x03pid\x12\x18\n" +
 	"\achannel\x18\x02 \x01(\tR\achannel\x12\x18\n" +

--- a/go/test/endtoend/queryserving/error_format_test.go
+++ b/go/test/endtoend/queryserving/error_format_test.go
@@ -343,6 +343,54 @@ func TestErrorFormat_HintAndDetail(t *testing.T) {
 	}
 }
 
+// TestErrorFormat_SourceLocation tests that backend ErrorResponse fields
+// F (file), L (line), and R (routine) survive the gateway. These populate
+// psql's LOCATION line and the equivalent fields on libpq / pgx / pgJDBC.
+// Regression for GitHub issue #1387.
+//
+// Each subtest runs against both direct PostgreSQL and multigateway so the
+// proxy must surface the same source location native PostgreSQL does.
+func TestErrorFormat_SourceLocation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping error format test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping error format tests")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	for _, target := range setup.GetComparisonTargets(t) {
+		t.Run(target.Name, func(t *testing.T) {
+			connStr := shardsetup.GetTestUserDSN("localhost", target.Port, "sslmode=disable")
+			conn, err := pgx.Connect(ctx, connStr)
+			require.NoError(t, err)
+			defer conn.Close(ctx)
+
+			_, err = conn.Exec(ctx, "SELECT 1/0")
+			require.Error(t, err)
+
+			var pgErr *pgconn.PgError
+			require.True(t, errors.As(err, &pgErr), "expected pgconn.PgError, got %T", err)
+
+			assert.Equal(t, "ERROR", pgErr.Severity)
+			assert.Equal(t, "22012", pgErr.Code)
+			assert.Contains(t, pgErr.Message, "division by zero")
+			// File/Line/Routine are the whole point of #1387. Direct
+			// PostgreSQL always populates them for 1/0; the gateway must
+			// not drop them. Line is version-dependent so only require it
+			// to be set.
+			assert.NotEmpty(t, pgErr.File, "File (F) should carry the PostgreSQL source file")
+			assert.Contains(t, pgErr.File, ".c")
+			assert.Greater(t, pgErr.Line, int32(0), "Line (L) should carry the PostgreSQL source line")
+			assert.NotEmpty(t, pgErr.Routine, "Routine (R) should carry the PostgreSQL source routine")
+			t.Logf("division by zero: File=%s Line=%d Routine=%s", pgErr.File, pgErr.Line, pgErr.Routine)
+		})
+	}
+}
+
 // TestErrorFormat_CopyFromStdinContext tests that errors raised during
 // COPY FROM STDIN preserve PostgreSQL's COPY context (the Where field, e.g.
 // "COPY t, line 1, column id: ...") instead of being wrapped into a flat

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -133,8 +133,9 @@ message Row {
 
 // PgDiagnostic represents a PostgreSQL diagnostic message (error or notice).
 // PostgreSQL uses the same wire format for both ErrorResponse ('E') and NoticeResponse ('N'),
-// differentiated by the message_type field. This unified structure captures all 14 fields
-// defined in the PostgreSQL protocol for diagnostic messages.
+// differentiated by the message_type field. This unified structure captures the
+// PostgreSQL protocol diagnostic fields, including source location (file, line,
+// routine) used by psql \errverbose and by libpq / pgx / pgJDBC.
 //
 // Error severities: ERROR, FATAL, PANIC
 // Notice severities: WARNING, NOTICE, DEBUG, INFO, LOG
@@ -187,6 +188,18 @@ message PgDiagnostic {
 
   // constraint_name is the name of the constraint associated with the diagnostic (optional)
   string constraint_name = 14;
+
+  // file is the PostgreSQL source file that raised the diagnostic (optional).
+  // Wire field 'F'. Used by psql LOCATION and libpq PG_DIAG_SOURCE_FILE.
+  string file = 16;
+
+  // line is the source line number in file (1-indexed, 0 if not available).
+  // Wire field 'L'. Used by psql LOCATION and libpq PG_DIAG_SOURCE_LINE.
+  int32 line = 17;
+
+  // routine is the PostgreSQL source routine that raised the diagnostic (optional).
+  // Wire field 'R'. Used by psql LOCATION and libpq PG_DIAG_SOURCE_FUNCTION.
+  string routine = 18;
 }
 
 // PgNotification represents a PostgreSQL asynchronous notification.


### PR DESCRIPTION
## Summary

Errors relayed through multigateway dropped the `F` (file), `L` (line), and `R` (routine) fields of `ErrorResponse`. Every other diagnostic field already passed through.

That meant `psql \errverbose` had no `LOCATION` line, and drivers (libpq `PG_DIAG_SOURCE_*`, pgJDBC `ServerErrorMessage`, pgx `PgError`) saw empty source-location fields.

The server-side writer already knew how to emit these fields. They were never parsed, stored, or converted.

Fixes #1387.

## Description

- Add `file`, `line`, and `routine` to proto `query.PgDiagnostic` and `mterrors.PgDiagnostic`.
- Parse wire fields `F`/`L`/`R` in `parseDiagnosticFields`.
- Round-trip them through `PgDiagnosticToProto` / `PgDiagnosticFromProto`.
- Emit them from `writePgDiagnosticResponse`.
- Gateway-synthesized errors still leave the fields empty.

## Testing

- Unit tests cover parse, write, proto conversion, and a full parse → proto → write → parse round-trip, including a `SELECT 1/0`-shaped source-location case.
- Added `TestErrorFormat_SourceLocation` e2e: `SELECT 1/0` through both direct PostgreSQL and multigateway must expose File/Line/Routine.

I could not run the e2e suite locally (no PostgreSQL server binaries on this machine). Unit tests for the touched packages passed.