### PR TITLE
feat(multipooler): per-reason active reserved-connection metric

### DIFF
--- a/docs/query_serving/connection_pooling.md
+++ b/docs/query_serving/connection_pooling.md
@@ -152,6 +152,28 @@ failures for the non-reserved query path.
 - Explicit transactions (`BEGIN`/`COMMIT`/`ROLLBACK`)
 - Cursor operations requiring persistent portal state
 - Any operation requiring connection affinity
+- Unsafe connections (`multigres.unsafe_connection`), pinned to one backend for
+  the session's life via the sticky `ReasonUnsafeConnection` reason
+
+**Active-by-reason metrics:**
+
+Every pin is a reservation _reason_ (`transaction`, `portal`, `temp_table`,
+`copy`, `listen`, `logical_replication`, `session_advisory_lock`, `set_seed`,
+`unsafe_connection`). Two gauges track active reserved connections:
+
+| Metric                                  | Type  | Meaning                                         |
+| --------------------------------------- | ----- | ----------------------------------------------- |
+| `mg.pooler.reserved.active_connections` | Gauge | Total active reserved connections               |
+| `mg.pooler.reserved.active_by_reason`   | Gauge | Active reserved connections holding each reason |
+
+`active_by_reason` carries a `reason` attribute, so e.g. active unsafe
+connections are `mg_pooler_reserved_active_by_reason{reason="unsafe_connection"}`.
+It is an **overlapping** breakdown — a connection holding several reasons at once
+(say `transaction` + `portal`) is counted under each — so the per-reason values
+sum to more than `active_connections`; do not treat it as a partition of the
+total. Both are observable gauges aggregated across all per-user reserved pools
+in the connection-pool manager's callback, so they stay correct regardless of
+how connections are torn down.
 
 **Timeout Handling:**
 

--- a/docs/query_serving/testing_strategy.md
+++ b/docs/query_serving/testing_strategy.md
@@ -315,16 +315,17 @@ and `/image/png` (exactly 8090 NUL-free ASCII bytes, because the expected file
 pins `length_binary=8090`). Live TLS probes to `https://postgis.net` in that
 suite are left unchanged.
 
-### `--unsafe-pooler-mode` for a handful of scaffolding files
+### `multigres.unsafe_connection` for a handful of scaffolding files
 
-A gateway started with `--unsafe-pooler-mode` (default off) skips the
-unsafe-statement rejections. The harness uses it in exactly one place: a second
-gateway that runs a small set of `pg_partman` pgTAP files
-(`UnsafePoolerGlobs`) whose scaffolding opens with a `DO … EXECUTE 'DROP TABLE
-'||to_char(…)` block the enforcing gateway rejects. These files exercise
-`pg_partman` for real; routing them to the unsafe gateway lets them run instead
-of being dropped. It is never used for the core, isolation, or contrib suites,
-and never to inflate a compatibility signal.
+A connection that sets `multigres.unsafe_connection` (default off) skips the
+unsafe-statement rejections. The harness uses it in exactly one place: a small
+set of `pg_partman` pgTAP files (`UnsafeConnectionGlobs`) whose scaffolding
+opens with a `DO … EXECUTE 'DROP TABLE '||to_char(…)` block the enforcing
+gateway rejects. Those files connect to the same enforcing gateway but opt that
+one connection out via `PGOPTIONS=-c multigres.unsafe_connection=on`, so they
+run in full while every other file keeps exercising the rejections. It is never
+used for the core, isolation, or contrib suites, and never to inflate a
+compatibility signal.
 
 ### Virtual PIDs (VPIDs)
 
@@ -401,9 +402,9 @@ patches. Extension-specific instances of the same cause are grouped under
 
 A shared, pooled, multi-tenant fleet cannot safely expose these. The gateway
 rejects them (`unsafe_stmt.go`, `unsafe_funccall.go`, `restricted_guc.go`,
-`execute_unwrap.go`); the resulting rejection line is the recorded divergence. A
-`--unsafe-pooler-mode` flag (default off) disables these rejections for trusted
-single-tenant deployments that accept the risk.
+`execute_unwrap.go`); the resulting rejection line is the recorded divergence.
+The per-connection `multigres.unsafe_connection` GUC (default off) disables
+these rejections for a trusted connection that accepts the risk.
 
 <!-- markdownlint-disable MD013 -->
 

--- a/docs/query_serving/unsafe_statement_rejection.md
+++ b/docs/query_serving/unsafe_statement_rejection.md
@@ -30,9 +30,10 @@ every embedded fragment (see [Tier 1](#tier-1--procedural-code-statements-body-a
 Blocked statements return a PostgreSQL `feature_not_supported` error
 (SQLSTATE `0A000`) with a descriptive message.
 
-An operator opt-out, `--unsafe-pooler-mode` (off by default), disables
-**all** of these rejections for trusted, single-tenant deployments that
-accept the risk; see [Unsafe pooler mode](#unsafe-pooler-mode).
+A per-connection opt-out, the `multigres.unsafe_connection` GUC (off by
+default), disables **all** of these rejections for a single trusted connection
+that accepts the risk; see
+[Per-connection unsafe mode](#per-connection-unsafe-mode-multigresunsafe_connection).
 
 ## Background
 
@@ -151,8 +152,9 @@ variable) it cannot be proven safe and is **rejected** — the same way a
 non-literal `set_config` argument is rejected at the top level.
 
 **Fail closed.** A body that does not parse, or that uses an unsupported
-construct, is rejected rather than passed through. All of this is
-disabled by [`--unsafe-pooler-mode`](#unsafe-pooler-mode).
+construct, is rejected rather than passed through. All of this is disabled for
+a connection that sets
+[`multigres.unsafe_connection`](#per-connection-unsafe-mode-multigresunsafe_connection).
 
 ### Tier 2 — infrastructure operations (blocked at plan time)
 
@@ -328,32 +330,63 @@ restricted-GUC list. Assignments inside PL/pgSQL bodies are now caught by Tier 1
 body analysis, and a dynamic `EXECUTE` with a non-literal argument is rejected
 there.
 
-## Unsafe pooler mode
+## Per-connection unsafe mode (`multigres.unsafe_connection`)
 
-`--unsafe-pooler-mode` (config key `unsafe-pooler-mode`, env
-`MT_UNSAFE_POOLER_MODE`; default **off**) is an operator opt-out for
-trusted, single-tenant deployments that accept the risk. When enabled it
-suppresses **every** rejection layer above:
+`multigres.unsafe_connection` is the opt-out from unsafe-statement rejection.
+It is **per connection**: a client sets it on its own connection, and only that
+connection is affected — every other connection stays fully protected. When
+set, it suppresses all four rejection layers:
 
 - Tier 1 PL/pgSQL / SQL body analysis,
 - the Tier 2 statement blocklist,
 - the restricted-GUC guard, and
 - the expression-level function blocklist (`dblink`, `pg_read_file`, …).
 
-Only the _rejections_ are relaxed. The planning signals the same pass
-gathers — tracked `set_config` calls, advisory-lock pinning,
-`current_setting` rewrites — are still collected, so routing stays
-correct; a blocklisted call or an untrackable `set_config` simply goes
-to PostgreSQL as written instead of being rejected. (The
-non-temporary-replication-slot check is a failover-correctness
-constraint rather than a tenant-isolation rejection, so it stays
-enforced regardless.)
+Only the _rejections_ are relaxed. The planning signals the same pass gathers —
+tracked `set_config` calls, advisory-lock pinning, `current_setting` rewrites —
+are still collected, so routing stays correct; a blocklisted call or an
+untrackable `set_config` simply goes to PostgreSQL as written instead of being
+rejected. Because the setting varies per connection, a statement planned under
+it is never served from the shared plan cache to another connection (the
+executor keeps unsafe-connection sessions off the cache).
 
-The flag is read once at startup and applied to the planner
-(`Planner.SetUnsafePoolerMode`). Because analysis runs on the plan-cache
-miss path, a plan cached while the mode was one value is not
-re-evaluated if the process is restarted with the other — the setting is
-process-static by design.
+### When to use it
+
+Reach for it when a specific session legitimately needs a statement the gateway
+would otherwise reject — a procedural body that changes session state, a `set_config` that eventually resets, or a Tier 2 operation in a trusted context. It scopes the escape hatch
+to the one session that needs it, so the protections stay on for every other
+client.
+
+### How to enable it
+
+| Where           | How                                                                                                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| At connect time | Pass it as a startup GUC: `options='-c multigres.unsafe_connection=on'` in the conninfo/DSN, or `PGOPTIONS='-c multigres.unsafe_connection=on'`. Single-quote it — it has a space. |
+| Mid-session     | `SET multigres.unsafe_connection = on;`                                                                                                                                            |
+
+The deprecated alias `multigres.direct_connection` is still accepted (both at
+connect time and via `SET`) but new clients should use
+`multigres.unsafe_connection`.
+
+### Semantics and cost
+
+- **One-way latch.** Once on, it stays on for the life of the connection.
+  `SET multigres.unsafe_connection = off` and `RESET` both error; a malformed
+  Boolean is a `FATAL` at connect time (an `ERROR` via `SET`).
+- **Not privilege-gated.** Any client can enable it, so it is a
+  deployment-trust decision, not a per-role grant. In an untrusted multi-tenant
+  deployment do not rely on the rejections alone if clients can set arbitrary
+  GUCs.
+- **The backend is pinned and then discarded.** An unsafe connection may change
+  backend session state the gateway does not track, so it is pinned to one
+  PostgreSQL backend for the session's life (the sticky `unsafe_connection`
+  reservation reason) and that backend is **closed at teardown, never
+  recycled** — the state must not leak to the next client. You therefore give
+  up connection pooling for that session and hold a reserved-pool slot until it
+  ends.
+- **Observability.** Active unsafe connections are reported by
+  `mg_pooler_reserved_active_by_reason{reason="unsafe_connection"}` (see the
+  reserved-pool metrics in [connection_pooling.md](./connection_pooling.md)).
 
 ## Other Allowed Statements With Known Risk
 
@@ -549,7 +582,7 @@ deliberately rejects rather than emulates:
   today**. A future connection-reset backstop (`DISCARD ALL` on client
   handoff) could let such statements through safely instead of rejecting
   them, for deployments that want the looser behavior without
-  `--unsafe-pooler-mode`.
+  `multigres.unsafe_connection`.
 - Advisory locks, temp tables, and session state acquired via dynamic
   SQL the parser cannot see remain a pre-existing pooling limitation,
   the same as at the top level.

--- a/go/common/constants/connpool.go
+++ b/go/common/constants/connpool.go
@@ -31,3 +31,7 @@ const (
 	// connection error is due to a restart.
 	ConnPoolRetryBackoff = 100 * time.Millisecond
 )
+
+// ReservedPoolMeterName is the OpenTelemetry meter name (instrumentation scope)
+// for the reserved connection pool's metrics.
+const ReservedPoolMeterName = "github.com/multigres/multigres/go/services/multipooler/internal/pools/reserved"

--- a/go/common/protoutil/reservation.go
+++ b/go/common/protoutil/reservation.go
@@ -225,35 +225,41 @@ func ReasonsString(reasons uint32) string {
 		return "none"
 	}
 	var parts []string
-	if HasTransactionReason(reasons) {
-		parts = append(parts, "transaction")
-	}
-	if HasTempTableReason(reasons) {
-		parts = append(parts, "temp_table")
-	}
-	if HasPortalReason(reasons) {
-		parts = append(parts, "portal")
-	}
-	if HasCopyReason(reasons) {
-		parts = append(parts, "copy")
-	}
-	if HasListenReason(reasons) {
-		parts = append(parts, "listen")
-	}
-	if HasLogicalReplicationReason(reasons) {
-		parts = append(parts, "logical_replication")
-	}
-	if HasSessionAdvisoryLockReason(reasons) {
-		parts = append(parts, "session_advisory_lock")
-	}
-	if HasSetSeedReason(reasons) {
-		parts = append(parts, "set_seed")
-	}
-	if HasUnsafeConnectionReason(reasons) {
-		parts = append(parts, "unsafe_connection")
+	for _, r := range orderedReasonLabels {
+		if HasReason(reasons, r.Bit) {
+			parts = append(parts, r.Name)
+		}
 	}
 	if len(parts) == 0 {
 		return "unknown"
 	}
 	return strings.Join(parts, "|")
+}
+
+// ReasonLabel pairs a single reservation reason bit with its stable label,
+// used both by ReasonsString and by per-reason metrics.
+type ReasonLabel struct {
+	Bit  uint32
+	Name string
+}
+
+// orderedReasonLabels lists every reservation reason with its label, in a
+// stable order. Single source of truth for reason-to-label mapping.
+var orderedReasonLabels = []ReasonLabel{
+	{ReasonTransaction, "transaction"},
+	{ReasonTempTable, "temp_table"},
+	{ReasonPortal, "portal"},
+	{ReasonCopy, "copy"},
+	{ReasonListen, "listen"},
+	{ReasonLogicalReplication, "logical_replication"},
+	{ReasonSessionAdvisoryLock, "session_advisory_lock"},
+	{ReasonSetSeed, "set_seed"},
+	{ReasonUnsafeConnection, "unsafe_connection"},
+}
+
+// ReasonLabels returns every known reservation reason paired with its stable
+// metric label, in a fixed order. Callers building per-reason metrics use it to
+// enumerate reasons (including ones with a zero count) consistently.
+func ReasonLabels() []ReasonLabel {
+	return orderedReasonLabels
 }

--- a/go/observability/metriccatalog/catalog_generated.go
+++ b/go/observability/metriccatalog/catalog_generated.go
@@ -54,7 +54,7 @@ type Metric struct {
 }
 
 // Metrics is the catalog of every metric Multigres defines, sorted by OTel name.
-// There are 139 metrics.
+// There are 140 metrics.
 var Metrics = []Metric{
 	{
 		OTelName:       "db.client.connection.count",
@@ -412,7 +412,7 @@ var Metrics = []Metric{
 		Unit:           "s",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:294",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:312",
 		PrometheusName: "mg_pooler_auth_credential_query_duration_seconds",
 		Series:         []string{"mg_pooler_auth_credential_query_duration_seconds_bucket", "mg_pooler_auth_credential_query_duration_seconds_count", "mg_pooler_auth_credential_query_duration_seconds_sum"},
 	},
@@ -422,7 +422,7 @@ var Metrics = []Metric{
 		Unit:           "{error}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:306",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:324",
 		PrometheusName: "mg_pooler_auth_credential_query_errors_total",
 		Series:         []string{"mg_pooler_auth_credential_query_errors_total"},
 	},
@@ -432,7 +432,7 @@ var Metrics = []Metric{
 		Unit:           "s",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:274",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:292",
 		PrometheusName: "mg_pooler_client_wait_time_seconds_total",
 		Series:         []string{"mg_pooler_client_wait_time_seconds_total"},
 	},
@@ -442,7 +442,7 @@ var Metrics = []Metric{
 		Unit:           "{connection}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:224",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:232",
 		PrometheusName: "mg_pooler_client_waiting_connections",
 		Series:         []string{"mg_pooler_client_waiting_connections"},
 	},
@@ -452,7 +452,7 @@ var Metrics = []Metric{
 		Unit:           "{connection}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:244",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:262",
 		PrometheusName: "mg_pooler_config_max_server_connections",
 		Series:         []string{"mg_pooler_config_max_server_connections"},
 	},
@@ -462,7 +462,7 @@ var Metrics = []Metric{
 		Unit:           "{database}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:204",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:212",
 		PrometheusName: "mg_pooler_databases",
 		Series:         []string{"mg_pooler_databases"},
 	},
@@ -542,7 +542,7 @@ var Metrics = []Metric{
 		Unit:           "{connection}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:254",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:272",
 		PrometheusName: "mg_pooler_pool_capacity",
 		Series:         []string{"mg_pooler_pool_capacity"},
 	},
@@ -552,7 +552,7 @@ var Metrics = []Metric{
 		Unit:           "{connection}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:264",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:282",
 		PrometheusName: "mg_pooler_pool_current_connections",
 		Series:         []string{"mg_pooler_pool_current_connections"},
 	},
@@ -562,7 +562,7 @@ var Metrics = []Metric{
 		Unit:           "{pool}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:184",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:192",
 		PrometheusName: "mg_pooler_pools",
 		Series:         []string{"mg_pooler_pools"},
 	},
@@ -572,7 +572,7 @@ var Metrics = []Metric{
 		Unit:           "{query}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:284",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:302",
 		PrometheusName: "mg_pooler_queries_pooled_total",
 		Series:         []string{"mg_pooler_queries_pooled_total"},
 	},
@@ -757,12 +757,22 @@ var Metrics = []Metric{
 		Series:         []string{"mg_pooler_replication_terminations_total"},
 	},
 	{
+		OTelName:       "mg.pooler.reserved.active_by_reason",
+		Constructor:    "Int64ObservableGauge",
+		Unit:           "{connection}",
+		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
+		Binaries:       []string{"multipooler"},
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:252",
+		PrometheusName: "mg_pooler_reserved_active_by_reason",
+		Series:         []string{"mg_pooler_reserved_active_by_reason"},
+	},
+	{
 		OTelName:       "mg.pooler.reserved.active_connections",
 		Constructor:    "Int64ObservableGauge",
 		Unit:           "{connection}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:234",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:242",
 		PrometheusName: "mg_pooler_reserved_active_connections",
 		Series:         []string{"mg_pooler_reserved_active_connections"},
 	},
@@ -772,7 +782,7 @@ var Metrics = []Metric{
 		Unit:           "{connection}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:214",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:222",
 		PrometheusName: "mg_pooler_server_connections",
 		Series:         []string{"mg_pooler_server_connections"},
 	},
@@ -852,7 +862,7 @@ var Metrics = []Metric{
 		Unit:           "s",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/pools/reserved",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/pools/reserved/metrics.go:49",
+		Source:         "go/services/multipooler/internal/pools/reserved/metrics.go:51",
 		PrometheusName: "mg_pooler_txn_duration_seconds",
 		Series:         []string{"mg_pooler_txn_duration_seconds_bucket", "mg_pooler_txn_duration_seconds_count", "mg_pooler_txn_duration_seconds_sum"},
 	},
@@ -862,7 +872,7 @@ var Metrics = []Metric{
 		Unit:           "{transaction}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/pools/reserved",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/pools/reserved/metrics.go:59",
+		Source:         "go/services/multipooler/internal/pools/reserved/metrics.go:61",
 		PrometheusName: "mg_pooler_txn_outcomes_total",
 		Series:         []string{"mg_pooler_txn_outcomes_total"},
 	},
@@ -872,7 +882,7 @@ var Metrics = []Metric{
 		Unit:           "",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:175",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:183",
 		PrometheusName: "mg_pooler_up",
 		Series:         []string{"mg_pooler_up"},
 	},
@@ -882,7 +892,7 @@ var Metrics = []Metric{
 		Unit:           "{user}",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:194",
+		Source:         "go/services/multipooler/internal/connpoolmanager/metrics.go:202",
 		PrometheusName: "mg_pooler_users",
 		Series:         []string{"mg_pooler_users"},
 	},
@@ -1457,7 +1467,7 @@ var Metrics = []Metric{
 //     action: keep
 //
 // Histogram families collapse to a "<base>_(bucket|count|sum)" group.
-const PrometheusKeepListRegex = `db_client_connection_count|go_config_gogc_percent|go_goroutine_count|go_memory_allocated_bytes_total|go_memory_allocations_total|go_memory_gc_goal_bytes|go_memory_used_bytes|go_processor_limit|mg_gateway_auth_attempts_total|mg_gateway_auth_credential_lookup_duration_seconds_(bucket|count|sum)|mg_gateway_auth_credential_lookup_rate_total|mg_gateway_auth_scram_duration_seconds_(bucket|count|sum)|mg_gateway_client_connections|mg_gateway_notification_streams|mg_gateway_notifications_dropped_total|mg_gateway_query_duration_seconds_(bucket|count|sum)|mg_gateway_query_errors_total|mg_gateway_query_exec_duration_seconds_(bucket|count|sum)|mg_gateway_query_info|mg_gateway_query_log_emits_total|mg_gateway_query_parse_duration_seconds_(bucket|count|sum)|mg_gateway_query_plan_duration_seconds_(bucket|count|sum)|mg_gateway_query_rows_returned_(bucket|count|sum)|mg_gateway_query_table_queries_total|mg_gateway_replication_bytes_total|mg_gateway_replication_chunks_total|mg_gateway_tls_connections_total|mg_gateway_tls_direct_rejected_total|mg_gateway_tls_handshake_duration_seconds_(bucket|count|sum)|mg_gateway_tls_plaintext_rejected_total|mg_gateway_tls_sslrequest_declined_total|mg_gateway_transaction_count_total|mg_gateway_transaction_duration_seconds_(bucket|count|sum)|mg_plancache_hits_total|mg_plancache_misses_total|mg_pooler_auth_credential_query_duration_seconds_(bucket|count|sum)|mg_pooler_auth_credential_query_errors_total|mg_pooler_client_wait_time_seconds_total|mg_pooler_client_waiting_connections|mg_pooler_config_max_server_connections|mg_pooler_databases|mg_pooler_drain_duration_seconds_(bucket|count|sum)|mg_pooler_drain_force_closed_total|mg_pooler_drain_outcome_total|mg_pooler_logical_failover_count_total|mg_pooler_logical_failover_duration_seconds_(bucket|count|sum)|mg_pooler_logical_failover_slots|mg_pooler_logical_failover_slots_dropped_total|mg_pooler_pool_capacity|mg_pooler_pool_current_connections|mg_pooler_pools|mg_pooler_queries_pooled_total|mg_pooler_query_duration_seconds_(bucket|count|sum)|mg_pooler_query_errors_total|mg_pooler_query_pool_acquire_duration_seconds_(bucket|count|sum)|mg_pooler_query_rows_(bucket|count|sum)|mg_pooler_replication_active|mg_pooler_replication_active_connections|mg_pooler_replication_bytes_total|mg_pooler_replication_chunks_total|mg_pooler_replication_duration_seconds_(bucket|count|sum)|mg_pooler_replication_forward_latency_milliseconds_(bucket|count|sum)|mg_pooler_replication_lag_seconds|mg_pooler_replication_last_ack_age_seconds|mg_pooler_replication_last_message_age_seconds|mg_pooler_replication_replay_lag_seconds|mg_pooler_replication_setup_errors_total|mg_pooler_replication_setup_latency_seconds_(bucket|count|sum)|mg_pooler_replication_slot_retained_wal_bytes|mg_pooler_replication_terminations_total|mg_pooler_reserved_active_connections|mg_pooler_server_conn_open_errors_total|mg_pooler_server_conn_opened_total|mg_pooler_server_conn_setup_duration_seconds_(bucket|count|sum)|mg_pooler_server_connections|mg_pooler_serving_transitions_total|mg_pooler_session_scrub_checked_total|mg_pooler_session_scrub_divergence_total|mg_pooler_session_scrub_errors_total|mg_pooler_txn_duration_seconds_(bucket|count|sum)|mg_pooler_txn_outcomes_total|mg_pooler_up|mg_pooler_users|mg_pubsub_channels|mg_pubsub_notifications_dropped_total|mg_pubsub_reconnect_gap_duration_seconds_(bucket|count|sum)|mg_pubsub_reconnects_total|mg_pubsub_subscribers|mg_scatter_execute_duration_seconds_(bucket|count|sum)|mg_scatter_execute_errors_total|mg_servenv_auth_attempts_total|multigateway_buffer_failover_duration_seconds_(bucket|count|sum)|multigateway_buffer_failovers_total|multigateway_buffer_queue_depth|multigateway_buffer_requests_buffered_total|multigateway_buffer_requests_drained_total|multigateway_buffer_requests_evicted_total|multigateway_buffer_requests_failed_unbuffered_total|multigateway_buffer_requests_skipped_total|multigateway_buffer_wait_duration_seconds_(bucket|count|sum)|multiorch_recovery_action_duration_milliseconds_(bucket|count|sum)|multiorch_recovery_detected_problems|multiorch_recovery_errors_total|multiorch_recovery_pooler_store_size|multiorch_recovery_stream_connected|multiorch_recovery_stream_snapshots_received|multipooler_rewind_checkpoint_wait_duration_seconds_(bucket|count|sum)|multipooler_rewind_execution_duration_seconds_(bucket|count|sum)|pgbackrest_backup_attempts_total|pgbackrest_backup_complete_count|pgbackrest_backup_duration_seconds_(bucket|count|sum)|pgbackrest_backup_failures_since_success|pgbackrest_backup_failures_total|pgbackrest_backup_in_progress|pgbackrest_backup_in_progress_duration_seconds|pgbackrest_backup_last_success_age_seconds|pgbackrest_backup_lease_held|pgbackrest_backup_lease_lost_total|pgbackrest_backup_lock_wait_seconds_(bucket|count|sum)|pgbackrest_backup_ready|pgbackrest_backup_successes_total|pgbackrest_backup_verify_duration_seconds_(bucket|count|sum)|pgbackrest_restore_attempts_total|pgbackrest_restore_duration_seconds_(bucket|count|sum)|pgbackrest_restore_failures_total|pgbackrest_restore_successes_total|pgbackrest_server_restart_count|pgbackrest_server_up|pgbackrest_server_uptime|pgbackrest_wal_archive_lag_seconds|process_cpu_time_seconds_total|process_memory_usage_bytes|process_memory_virtual_bytes|rpcclient_connection_cache_size|rpcclient_connection_creates_total|rpcclient_connection_dial_duration_seconds_(bucket|count|sum)|rpcclient_connection_dial_timeouts_total|rpcclient_connection_reuses_total|topoclient_lock_duration_seconds_(bucket|count|sum)`
+const PrometheusKeepListRegex = `db_client_connection_count|go_config_gogc_percent|go_goroutine_count|go_memory_allocated_bytes_total|go_memory_allocations_total|go_memory_gc_goal_bytes|go_memory_used_bytes|go_processor_limit|mg_gateway_auth_attempts_total|mg_gateway_auth_credential_lookup_duration_seconds_(bucket|count|sum)|mg_gateway_auth_credential_lookup_rate_total|mg_gateway_auth_scram_duration_seconds_(bucket|count|sum)|mg_gateway_client_connections|mg_gateway_notification_streams|mg_gateway_notifications_dropped_total|mg_gateway_query_duration_seconds_(bucket|count|sum)|mg_gateway_query_errors_total|mg_gateway_query_exec_duration_seconds_(bucket|count|sum)|mg_gateway_query_info|mg_gateway_query_log_emits_total|mg_gateway_query_parse_duration_seconds_(bucket|count|sum)|mg_gateway_query_plan_duration_seconds_(bucket|count|sum)|mg_gateway_query_rows_returned_(bucket|count|sum)|mg_gateway_query_table_queries_total|mg_gateway_replication_bytes_total|mg_gateway_replication_chunks_total|mg_gateway_tls_connections_total|mg_gateway_tls_direct_rejected_total|mg_gateway_tls_handshake_duration_seconds_(bucket|count|sum)|mg_gateway_tls_plaintext_rejected_total|mg_gateway_tls_sslrequest_declined_total|mg_gateway_transaction_count_total|mg_gateway_transaction_duration_seconds_(bucket|count|sum)|mg_plancache_hits_total|mg_plancache_misses_total|mg_pooler_auth_credential_query_duration_seconds_(bucket|count|sum)|mg_pooler_auth_credential_query_errors_total|mg_pooler_client_wait_time_seconds_total|mg_pooler_client_waiting_connections|mg_pooler_config_max_server_connections|mg_pooler_databases|mg_pooler_drain_duration_seconds_(bucket|count|sum)|mg_pooler_drain_force_closed_total|mg_pooler_drain_outcome_total|mg_pooler_logical_failover_count_total|mg_pooler_logical_failover_duration_seconds_(bucket|count|sum)|mg_pooler_logical_failover_slots|mg_pooler_logical_failover_slots_dropped_total|mg_pooler_pool_capacity|mg_pooler_pool_current_connections|mg_pooler_pools|mg_pooler_queries_pooled_total|mg_pooler_query_duration_seconds_(bucket|count|sum)|mg_pooler_query_errors_total|mg_pooler_query_pool_acquire_duration_seconds_(bucket|count|sum)|mg_pooler_query_rows_(bucket|count|sum)|mg_pooler_replication_active|mg_pooler_replication_active_connections|mg_pooler_replication_bytes_total|mg_pooler_replication_chunks_total|mg_pooler_replication_duration_seconds_(bucket|count|sum)|mg_pooler_replication_forward_latency_milliseconds_(bucket|count|sum)|mg_pooler_replication_lag_seconds|mg_pooler_replication_last_ack_age_seconds|mg_pooler_replication_last_message_age_seconds|mg_pooler_replication_replay_lag_seconds|mg_pooler_replication_setup_errors_total|mg_pooler_replication_setup_latency_seconds_(bucket|count|sum)|mg_pooler_replication_slot_retained_wal_bytes|mg_pooler_replication_terminations_total|mg_pooler_reserved_active_by_reason|mg_pooler_reserved_active_connections|mg_pooler_server_conn_open_errors_total|mg_pooler_server_conn_opened_total|mg_pooler_server_conn_setup_duration_seconds_(bucket|count|sum)|mg_pooler_server_connections|mg_pooler_serving_transitions_total|mg_pooler_session_scrub_checked_total|mg_pooler_session_scrub_divergence_total|mg_pooler_session_scrub_errors_total|mg_pooler_txn_duration_seconds_(bucket|count|sum)|mg_pooler_txn_outcomes_total|mg_pooler_up|mg_pooler_users|mg_pubsub_channels|mg_pubsub_notifications_dropped_total|mg_pubsub_reconnect_gap_duration_seconds_(bucket|count|sum)|mg_pubsub_reconnects_total|mg_pubsub_subscribers|mg_scatter_execute_duration_seconds_(bucket|count|sum)|mg_scatter_execute_errors_total|mg_servenv_auth_attempts_total|multigateway_buffer_failover_duration_seconds_(bucket|count|sum)|multigateway_buffer_failovers_total|multigateway_buffer_queue_depth|multigateway_buffer_requests_buffered_total|multigateway_buffer_requests_drained_total|multigateway_buffer_requests_evicted_total|multigateway_buffer_requests_failed_unbuffered_total|multigateway_buffer_requests_skipped_total|multigateway_buffer_wait_duration_seconds_(bucket|count|sum)|multiorch_recovery_action_duration_milliseconds_(bucket|count|sum)|multiorch_recovery_detected_problems|multiorch_recovery_errors_total|multiorch_recovery_pooler_store_size|multiorch_recovery_stream_connected|multiorch_recovery_stream_snapshots_received|multipooler_rewind_checkpoint_wait_duration_seconds_(bucket|count|sum)|multipooler_rewind_execution_duration_seconds_(bucket|count|sum)|pgbackrest_backup_attempts_total|pgbackrest_backup_complete_count|pgbackrest_backup_duration_seconds_(bucket|count|sum)|pgbackrest_backup_failures_since_success|pgbackrest_backup_failures_total|pgbackrest_backup_in_progress|pgbackrest_backup_in_progress_duration_seconds|pgbackrest_backup_last_success_age_seconds|pgbackrest_backup_lease_held|pgbackrest_backup_lease_lost_total|pgbackrest_backup_lock_wait_seconds_(bucket|count|sum)|pgbackrest_backup_ready|pgbackrest_backup_successes_total|pgbackrest_backup_verify_duration_seconds_(bucket|count|sum)|pgbackrest_restore_attempts_total|pgbackrest_restore_duration_seconds_(bucket|count|sum)|pgbackrest_restore_failures_total|pgbackrest_restore_successes_total|pgbackrest_server_restart_count|pgbackrest_server_up|pgbackrest_server_uptime|pgbackrest_wal_archive_lag_seconds|process_cpu_time_seconds_total|process_memory_usage_bytes|process_memory_virtual_bytes|rpcclient_connection_cache_size|rpcclient_connection_creates_total|rpcclient_connection_dial_duration_seconds_(bucket|count|sum)|rpcclient_connection_dial_timeouts_total|rpcclient_connection_reuses_total|topoclient_lock_duration_seconds_(bucket|count|sum)`
 
 // PrometheusKeepListByBinary maps each binary to a keep-list regex covering only
 // the series that binary exposes, for scoping a keep rule per Prometheus scrape
@@ -1469,7 +1479,7 @@ var PrometheusKeepListByBinary = map[string]string{
 	"multigateway": `go_config_gogc_percent|go_goroutine_count|go_memory_allocated_bytes_total|go_memory_allocations_total|go_memory_gc_goal_bytes|go_memory_used_bytes|go_processor_limit|mg_gateway_auth_attempts_total|mg_gateway_auth_credential_lookup_duration_seconds_(bucket|count|sum)|mg_gateway_auth_credential_lookup_rate_total|mg_gateway_auth_scram_duration_seconds_(bucket|count|sum)|mg_gateway_client_connections|mg_gateway_notification_streams|mg_gateway_notifications_dropped_total|mg_gateway_query_duration_seconds_(bucket|count|sum)|mg_gateway_query_errors_total|mg_gateway_query_exec_duration_seconds_(bucket|count|sum)|mg_gateway_query_info|mg_gateway_query_log_emits_total|mg_gateway_query_parse_duration_seconds_(bucket|count|sum)|mg_gateway_query_plan_duration_seconds_(bucket|count|sum)|mg_gateway_query_rows_returned_(bucket|count|sum)|mg_gateway_query_table_queries_total|mg_gateway_replication_bytes_total|mg_gateway_replication_chunks_total|mg_gateway_tls_connections_total|mg_gateway_tls_direct_rejected_total|mg_gateway_tls_handshake_duration_seconds_(bucket|count|sum)|mg_gateway_tls_plaintext_rejected_total|mg_gateway_tls_sslrequest_declined_total|mg_gateway_transaction_count_total|mg_gateway_transaction_duration_seconds_(bucket|count|sum)|mg_plancache_hits_total|mg_plancache_misses_total|mg_scatter_execute_duration_seconds_(bucket|count|sum)|mg_scatter_execute_errors_total|mg_servenv_auth_attempts_total|multigateway_buffer_failover_duration_seconds_(bucket|count|sum)|multigateway_buffer_failovers_total|multigateway_buffer_queue_depth|multigateway_buffer_requests_buffered_total|multigateway_buffer_requests_drained_total|multigateway_buffer_requests_evicted_total|multigateway_buffer_requests_failed_unbuffered_total|multigateway_buffer_requests_skipped_total|multigateway_buffer_wait_duration_seconds_(bucket|count|sum)|process_cpu_time_seconds_total|process_memory_usage_bytes|process_memory_virtual_bytes|rpcclient_connection_cache_size|rpcclient_connection_creates_total|rpcclient_connection_dial_duration_seconds_(bucket|count|sum)|rpcclient_connection_dial_timeouts_total|rpcclient_connection_reuses_total|topoclient_lock_duration_seconds_(bucket|count|sum)`,
 	"multigres":    `go_config_gogc_percent|go_goroutine_count|go_memory_allocated_bytes_total|go_memory_allocations_total|go_memory_gc_goal_bytes|go_memory_used_bytes|go_processor_limit|mg_servenv_auth_attempts_total|process_cpu_time_seconds_total|process_memory_usage_bytes|process_memory_virtual_bytes|topoclient_lock_duration_seconds_(bucket|count|sum)`,
 	"multiorch":    `go_config_gogc_percent|go_goroutine_count|go_memory_allocated_bytes_total|go_memory_allocations_total|go_memory_gc_goal_bytes|go_memory_used_bytes|go_processor_limit|mg_servenv_auth_attempts_total|multiorch_recovery_action_duration_milliseconds_(bucket|count|sum)|multiorch_recovery_detected_problems|multiorch_recovery_errors_total|multiorch_recovery_pooler_store_size|multiorch_recovery_stream_connected|multiorch_recovery_stream_snapshots_received|process_cpu_time_seconds_total|process_memory_usage_bytes|process_memory_virtual_bytes|rpcclient_connection_cache_size|rpcclient_connection_creates_total|rpcclient_connection_dial_duration_seconds_(bucket|count|sum)|rpcclient_connection_dial_timeouts_total|rpcclient_connection_reuses_total|topoclient_lock_duration_seconds_(bucket|count|sum)`,
-	"multipooler":  `db_client_connection_count|go_config_gogc_percent|go_goroutine_count|go_memory_allocated_bytes_total|go_memory_allocations_total|go_memory_gc_goal_bytes|go_memory_used_bytes|go_processor_limit|mg_pooler_auth_credential_query_duration_seconds_(bucket|count|sum)|mg_pooler_auth_credential_query_errors_total|mg_pooler_client_wait_time_seconds_total|mg_pooler_client_waiting_connections|mg_pooler_config_max_server_connections|mg_pooler_databases|mg_pooler_drain_duration_seconds_(bucket|count|sum)|mg_pooler_drain_force_closed_total|mg_pooler_drain_outcome_total|mg_pooler_logical_failover_count_total|mg_pooler_logical_failover_duration_seconds_(bucket|count|sum)|mg_pooler_logical_failover_slots|mg_pooler_logical_failover_slots_dropped_total|mg_pooler_pool_capacity|mg_pooler_pool_current_connections|mg_pooler_pools|mg_pooler_queries_pooled_total|mg_pooler_query_duration_seconds_(bucket|count|sum)|mg_pooler_query_errors_total|mg_pooler_query_pool_acquire_duration_seconds_(bucket|count|sum)|mg_pooler_query_rows_(bucket|count|sum)|mg_pooler_replication_active|mg_pooler_replication_active_connections|mg_pooler_replication_bytes_total|mg_pooler_replication_chunks_total|mg_pooler_replication_duration_seconds_(bucket|count|sum)|mg_pooler_replication_forward_latency_milliseconds_(bucket|count|sum)|mg_pooler_replication_lag_seconds|mg_pooler_replication_last_ack_age_seconds|mg_pooler_replication_last_message_age_seconds|mg_pooler_replication_replay_lag_seconds|mg_pooler_replication_setup_errors_total|mg_pooler_replication_setup_latency_seconds_(bucket|count|sum)|mg_pooler_replication_slot_retained_wal_bytes|mg_pooler_replication_terminations_total|mg_pooler_reserved_active_connections|mg_pooler_server_conn_open_errors_total|mg_pooler_server_conn_opened_total|mg_pooler_server_conn_setup_duration_seconds_(bucket|count|sum)|mg_pooler_server_connections|mg_pooler_serving_transitions_total|mg_pooler_session_scrub_checked_total|mg_pooler_session_scrub_divergence_total|mg_pooler_session_scrub_errors_total|mg_pooler_txn_duration_seconds_(bucket|count|sum)|mg_pooler_txn_outcomes_total|mg_pooler_up|mg_pooler_users|mg_pubsub_channels|mg_pubsub_notifications_dropped_total|mg_pubsub_reconnect_gap_duration_seconds_(bucket|count|sum)|mg_pubsub_reconnects_total|mg_pubsub_subscribers|mg_servenv_auth_attempts_total|multipooler_rewind_checkpoint_wait_duration_seconds_(bucket|count|sum)|multipooler_rewind_execution_duration_seconds_(bucket|count|sum)|pgbackrest_backup_attempts_total|pgbackrest_backup_complete_count|pgbackrest_backup_duration_seconds_(bucket|count|sum)|pgbackrest_backup_failures_since_success|pgbackrest_backup_failures_total|pgbackrest_backup_in_progress|pgbackrest_backup_in_progress_duration_seconds|pgbackrest_backup_last_success_age_seconds|pgbackrest_backup_lease_held|pgbackrest_backup_lease_lost_total|pgbackrest_backup_lock_wait_seconds_(bucket|count|sum)|pgbackrest_backup_ready|pgbackrest_backup_successes_total|pgbackrest_backup_verify_duration_seconds_(bucket|count|sum)|pgbackrest_restore_attempts_total|pgbackrest_restore_duration_seconds_(bucket|count|sum)|pgbackrest_restore_failures_total|pgbackrest_restore_successes_total|pgbackrest_wal_archive_lag_seconds|process_cpu_time_seconds_total|process_memory_usage_bytes|process_memory_virtual_bytes|topoclient_lock_duration_seconds_(bucket|count|sum)`,
+	"multipooler":  `db_client_connection_count|go_config_gogc_percent|go_goroutine_count|go_memory_allocated_bytes_total|go_memory_allocations_total|go_memory_gc_goal_bytes|go_memory_used_bytes|go_processor_limit|mg_pooler_auth_credential_query_duration_seconds_(bucket|count|sum)|mg_pooler_auth_credential_query_errors_total|mg_pooler_client_wait_time_seconds_total|mg_pooler_client_waiting_connections|mg_pooler_config_max_server_connections|mg_pooler_databases|mg_pooler_drain_duration_seconds_(bucket|count|sum)|mg_pooler_drain_force_closed_total|mg_pooler_drain_outcome_total|mg_pooler_logical_failover_count_total|mg_pooler_logical_failover_duration_seconds_(bucket|count|sum)|mg_pooler_logical_failover_slots|mg_pooler_logical_failover_slots_dropped_total|mg_pooler_pool_capacity|mg_pooler_pool_current_connections|mg_pooler_pools|mg_pooler_queries_pooled_total|mg_pooler_query_duration_seconds_(bucket|count|sum)|mg_pooler_query_errors_total|mg_pooler_query_pool_acquire_duration_seconds_(bucket|count|sum)|mg_pooler_query_rows_(bucket|count|sum)|mg_pooler_replication_active|mg_pooler_replication_active_connections|mg_pooler_replication_bytes_total|mg_pooler_replication_chunks_total|mg_pooler_replication_duration_seconds_(bucket|count|sum)|mg_pooler_replication_forward_latency_milliseconds_(bucket|count|sum)|mg_pooler_replication_lag_seconds|mg_pooler_replication_last_ack_age_seconds|mg_pooler_replication_last_message_age_seconds|mg_pooler_replication_replay_lag_seconds|mg_pooler_replication_setup_errors_total|mg_pooler_replication_setup_latency_seconds_(bucket|count|sum)|mg_pooler_replication_slot_retained_wal_bytes|mg_pooler_replication_terminations_total|mg_pooler_reserved_active_by_reason|mg_pooler_reserved_active_connections|mg_pooler_server_conn_open_errors_total|mg_pooler_server_conn_opened_total|mg_pooler_server_conn_setup_duration_seconds_(bucket|count|sum)|mg_pooler_server_connections|mg_pooler_serving_transitions_total|mg_pooler_session_scrub_checked_total|mg_pooler_session_scrub_divergence_total|mg_pooler_session_scrub_errors_total|mg_pooler_txn_duration_seconds_(bucket|count|sum)|mg_pooler_txn_outcomes_total|mg_pooler_up|mg_pooler_users|mg_pubsub_channels|mg_pubsub_notifications_dropped_total|mg_pubsub_reconnect_gap_duration_seconds_(bucket|count|sum)|mg_pubsub_reconnects_total|mg_pubsub_subscribers|mg_servenv_auth_attempts_total|multipooler_rewind_checkpoint_wait_duration_seconds_(bucket|count|sum)|multipooler_rewind_execution_duration_seconds_(bucket|count|sum)|pgbackrest_backup_attempts_total|pgbackrest_backup_complete_count|pgbackrest_backup_duration_seconds_(bucket|count|sum)|pgbackrest_backup_failures_since_success|pgbackrest_backup_failures_total|pgbackrest_backup_in_progress|pgbackrest_backup_in_progress_duration_seconds|pgbackrest_backup_last_success_age_seconds|pgbackrest_backup_lease_held|pgbackrest_backup_lease_lost_total|pgbackrest_backup_lock_wait_seconds_(bucket|count|sum)|pgbackrest_backup_ready|pgbackrest_backup_successes_total|pgbackrest_backup_verify_duration_seconds_(bucket|count|sum)|pgbackrest_restore_attempts_total|pgbackrest_restore_duration_seconds_(bucket|count|sum)|pgbackrest_restore_failures_total|pgbackrest_restore_successes_total|pgbackrest_wal_archive_lag_seconds|process_cpu_time_seconds_total|process_memory_usage_bytes|process_memory_virtual_bytes|topoclient_lock_duration_seconds_(bucket|count|sum)`,
 	"pgctld":       `go_config_gogc_percent|go_goroutine_count|go_memory_allocated_bytes_total|go_memory_allocations_total|go_memory_gc_goal_bytes|go_memory_used_bytes|go_processor_limit|mg_servenv_auth_attempts_total|pgbackrest_server_restart_count|pgbackrest_server_up|pgbackrest_server_uptime|process_cpu_time_seconds_total|process_memory_usage_bytes|process_memory_virtual_bytes|topoclient_lock_duration_seconds_(bucket|count|sum)`,
 }
 

--- a/go/services/multipooler/internal/connpoolmanager/metrics.go
+++ b/go/services/multipooler/internal/connpoolmanager/metrics.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
 
+	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pools/connpool"
 	"github.com/multigres/multigres/go/services/multipooler/internal/servingstate"
 )
@@ -94,6 +95,13 @@ type Metrics struct {
 
 	// reservedActiveConnections is the number of active reserved connections (in-transaction).
 	reservedActiveConnections metric.Int64ObservableGauge
+
+	// reservedActiveByReason is the number of active reserved connections holding
+	// each reservation reason (transaction, portal, unsafe_connection, etc.),
+	// labeled by reason. Overlapping breakdown of reservedActiveConnections: a
+	// connection with multiple reasons is counted under each, so the per-reason
+	// values sum to more than the total.
+	reservedActiveByReason metric.Int64ObservableGauge
 
 	// configMaxServerConnections is the configured maximum server connections (global capacity).
 	configMaxServerConnections metric.Int64ObservableGauge
@@ -240,6 +248,16 @@ func NewMetrics() (*Metrics, error) {
 		errs = append(errs, fmt.Errorf("mg.pooler.reserved.active_connections gauge: %w", err))
 	}
 
+	// Reserved active connections broken down by reservation reason
+	m.reservedActiveByReason, err = meter.Int64ObservableGauge(
+		"mg.pooler.reserved.active_by_reason",
+		metric.WithDescription("Active reserved connections holding each reservation reason (overlapping; sums to more than the total)"),
+		metric.WithUnit("{connection}"),
+	)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("mg.pooler.reserved.active_by_reason gauge: %w", err))
+	}
+
 	// Config max server connections gauge
 	m.configMaxServerConnections, err = meter.Int64ObservableGauge(
 		"mg.pooler.config.max_server_connections",
@@ -383,6 +401,7 @@ func (m *Metrics) RegisterManagerCallbacks(
 		m.serverConnections,
 		m.clientWaitingConnections,
 		m.reservedActiveConnections,
+		m.reservedActiveByReason,
 		m.configMaxServerConnections,
 		m.poolCapacity,
 		m.poolCurrentConnections,
@@ -442,6 +461,9 @@ func (m *Metrics) RegisterManagerCallbacks(
 			var totalReservedActive int
 			var totalWaitTime float64
 			var totalGetCount int64
+			// Reserved active connections summed per reservation reason across
+			// all user pools. Overlapping breakdown (see reservedActiveByReason).
+			reservedActiveByReason := make(map[string]int64)
 
 			for user, userStats := range stats.UserPools {
 				// Regular pool: server connections
@@ -454,6 +476,11 @@ func (m *Metrics) RegisterManagerCallbacks(
 
 				// Reserved active (clients in transactions)
 				totalReservedActive += userStats.Reserved.Active
+
+				// Per-reason reserved active breakdown.
+				for reason, count := range userStats.Reserved.ActiveByReason {
+					reservedActiveByReason[reason] += int64(count)
+				}
 
 				// Aggregate cumulative metrics
 				totalWaiting += userStats.Waiting
@@ -499,6 +526,18 @@ func (m *Metrics) RegisterManagerCallbacks(
 
 			if m.reservedActiveConnections != nil {
 				o.ObserveInt64(m.reservedActiveConnections, int64(totalReservedActive), routingRoleAttr)
+			}
+
+			// Emit every known reason (0 when none are active) so each series
+			// resets cleanly instead of going stale on its last nonzero value.
+			if m.reservedActiveByReason != nil {
+				for _, r := range protoutil.ReasonLabels() {
+					o.ObserveInt64(m.reservedActiveByReason, reservedActiveByReason[r.Name],
+						metric.WithAttributes(
+							attribute.String("routing_role", routingRole),
+							attribute.String("reason", r.Name),
+						))
+				}
 			}
 
 			if m.clientWaitTimeTotal != nil {

--- a/go/services/multipooler/internal/connpoolmanager/metrics_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/metrics_test.go
@@ -196,6 +196,72 @@ func TestMetrics_RegisterManagerCallbacks_RoutingRoleLabel(t *testing.T) {
 	}
 }
 
+// gaugeValue returns the int64 value of the first data point matching attrs,
+// and whether such a point exists.
+func gaugeValue(t *testing.T, data metricdata.Aggregation, attrs map[string]string) (int64, bool) {
+	t.Helper()
+	g, ok := data.(metricdata.Gauge[int64])
+	require.True(t, ok)
+	for _, dp := range g.DataPoints {
+		if hasAttrs(dp.Attributes, attrs) {
+			return dp.Value, true
+		}
+	}
+	return 0, false
+}
+
+// TestMetrics_ReservedActiveByReason verifies the per-reason reserved gauge sums
+// across user pools, treats reasons as an overlapping breakdown, and emits every
+// known reason (including a zero for reasons with no active connections).
+func TestMetrics_ReservedActiveByReason(t *testing.T) {
+	m, reader := setupPoolerMetrics(t)
+	m.SetRoutingRole(servingstate.RoutingRolePrimary)
+
+	stats := ManagerStats{
+		UserPools: map[string]UserPoolStats{
+			"alice": {Reserved: reserved.PoolStats{
+				Active: 2,
+				ActiveByReason: map[string]int{
+					"unsafe_connection": 1,
+					"transaction":       2,
+					"portal":            1,
+				},
+			}},
+			"bob": {Reserved: reserved.PoolStats{
+				Active: 1,
+				ActiveByReason: map[string]int{
+					"unsafe_connection": 1,
+				},
+			}},
+		},
+	}
+
+	require.NoError(t, m.RegisterManagerCallbacks(
+		func() ManagerStats { return stats },
+		func() int { return len(stats.UserPools) },
+		func() int64 { return 12 },
+		func() bool { return false },
+	))
+
+	data := collectMetric(t, reader, "mg.pooler.reserved.active_by_reason").Data
+
+	// Summed across pools, labeled by reason and routing_role.
+	v, ok := gaugeValue(t, data, map[string]string{"routing_role": "primary", "reason": "unsafe_connection"})
+	require.True(t, ok)
+	require.Equal(t, int64(2), v, "unsafe_connection summed across alice+bob")
+
+	// Overlapping breakdown: transaction and portal counted independently.
+	v, _ = gaugeValue(t, data, map[string]string{"reason": "transaction"})
+	require.Equal(t, int64(2), v)
+	v, _ = gaugeValue(t, data, map[string]string{"reason": "portal"})
+	require.Equal(t, int64(1), v)
+
+	// Every known reason is emitted, including ones with no active conns (0).
+	v, ok = gaugeValue(t, data, map[string]string{"reason": "copy"})
+	require.True(t, ok, "reasons with no active conns must still be emitted")
+	require.Equal(t, int64(0), v)
+}
+
 func TestMetrics_RoutingRoleLabelValues(t *testing.T) {
 	m, _ := setupPoolerMetrics(t)
 

--- a/go/services/multipooler/internal/pools/reserved/metrics.go
+++ b/go/services/multipooler/internal/pools/reserved/metrics.go
@@ -22,6 +22,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/multigres/multigres/go/common/constants"
 )
 
 // Transaction outcome attribute values.
@@ -42,7 +44,7 @@ type txnMetrics struct {
 }
 
 func newTxnMetrics() *txnMetrics {
-	meter := otel.Meter("github.com/multigres/multigres/go/services/multipooler/internal/pools/reserved")
+	meter := otel.Meter(constants.ReservedPoolMeterName)
 	m := &txnMetrics{}
 
 	var err error

--- a/go/services/multipooler/internal/pools/reserved/reserved_pool.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_pool.go
@@ -472,9 +472,22 @@ func (p *Pool) Stats() PoolStats {
 	p.mu.Lock()
 	active := len(p.active)
 	var replActive int
+	// activeByReason is an overlapping breakdown: a connection holding several
+	// reasons at once (e.g. transaction+portal) increments each of its reasons,
+	// so the per-reason counts sum to more than Active. Keyed by the stable
+	// reason label from protoutil.ReasonLabels.
+	activeByReason := make(map[string]int)
 	for _, rc := range p.active {
-		if rc.reservedProps != nil && protoutil.HasLogicalReplicationReason(rc.reservedProps.Reasons) {
+		if rc.reservedProps == nil {
+			continue
+		}
+		if protoutil.HasLogicalReplicationReason(rc.reservedProps.Reasons) {
 			replActive++
+		}
+		for _, r := range protoutil.ReasonLabels() {
+			if protoutil.HasReason(rc.reservedProps.Reasons, r.Bit) {
+				activeByReason[r.Name]++
+			}
 		}
 	}
 	p.mu.Unlock()
@@ -482,6 +495,7 @@ func (p *Pool) Stats() PoolStats {
 	return PoolStats{
 		Active:                   active,
 		LogicalReplicationActive: replActive,
+		ActiveByReason:           activeByReason,
 		ReserveCount:             p.reserveCount.Load(),
 		ReleaseCount:             p.releaseCount.Load(),
 		KillCount:                p.killCount.Load(),
@@ -533,6 +547,13 @@ type PoolStats struct {
 	// LogicalReplicationActive is the number of active reserved conns that
 	// have ReasonLogicalReplication set. Sub-count of Active.
 	LogicalReplicationActive int
+
+	// ActiveByReason counts active reserved conns holding each reservation
+	// reason, keyed by the stable reason label (protoutil.ReasonLabels). It is
+	// an overlapping breakdown — a connection with multiple reasons is counted
+	// under each — so the values sum to more than Active. Reasons with no active
+	// connections are absent from the map.
+	ActiveByReason map[string]int
 
 	// ReserveCount is the total number of reservations.
 	ReserveCount int64

--- a/go/services/multipooler/internal/pools/reserved/reserved_pool_test.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_pool_test.go
@@ -87,6 +87,43 @@ func TestPool_NewConn(t *testing.T) {
 	conn.Release(ReleaseCommit, nil)
 }
 
+func TestPool_StatsActiveByReason(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+	ctx := context.Background()
+
+	// c1 holds two reasons at once (overlapping breakdown).
+	c1, err := pool.NewConn(ctx, nil)
+	require.NoError(t, err)
+	c1.AddReservationReason(protoutil.ReasonTransaction)
+	c1.AddReservationReason(protoutil.ReasonUnsafeConnection)
+
+	// c2 holds only the unsafe reason.
+	c2, err := pool.NewConn(ctx, nil)
+	require.NoError(t, err)
+	c2.AddReservationReason(protoutil.ReasonUnsafeConnection)
+
+	stats := pool.Stats()
+	assert.Equal(t, 2, stats.Active)
+	assert.Equal(t, 2, stats.ActiveByReason["unsafe_connection"], "both conns are unsafe")
+	assert.Equal(t, 1, stats.ActiveByReason["transaction"], "only c1 is in a transaction")
+	// Overlap: per-reason counts sum to more than Active.
+	assert.Equal(t, 0, stats.ActiveByReason["portal"], "no reason absent-key returns zero")
+
+	// Releasing c1 drops its reasons from the breakdown.
+	c1.Release(ReleaseError, nil)
+	stats = pool.Stats()
+	assert.Equal(t, 1, stats.Active)
+	assert.Equal(t, 1, stats.ActiveByReason["unsafe_connection"])
+	assert.Equal(t, 0, stats.ActiveByReason["transaction"])
+
+	c2.Release(ReleaseError, nil)
+}
+
 func TestPool_ReleaseCleanupRunsOnCleanRelease(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()

--- a/go/test/endtoend/metrics/metrics_test.go
+++ b/go/test/endtoend/metrics/metrics_test.go
@@ -274,6 +274,112 @@ func TestQueryPathMetricsExposed(t *testing.T) {
 	}
 }
 
+// TestReservedActiveByReasonMetric verifies mg_pooler_reserved_active_by_reason
+// tracks live reserved connections per reservation reason. It drives one gateway
+// connection into unsafe mode inside a transaction — so the backend is reserved
+// on the primary under two overlapping reasons at once (unsafe_connection and
+// transaction) — scrapes the primary pooler, then checks the gauge falls
+// correctly as the transaction concludes and the connection closes.
+func TestReservedActiveByReasonMetric(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("skipping: PostgreSQL binaries not found")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	primary := setup.GetPrimary(t)
+	poolerPort, ok := setup.MetricsPorts[primary.Name]
+	require.True(t, ok, "no metrics port for primary %s", primary.Name)
+
+	const (
+		byReason  = "mg_pooler_reserved_active_by_reason"
+		totalName = "mg_pooler_reserved_active_connections"
+	)
+	unsafeLabels := map[string]string{"reason": "unsafe_connection"}
+	txnLabels := map[string]string{"reason": "transaction"}
+
+	reason := func(s []utils.MetricSample, labels map[string]string) float64 {
+		v, _ := utils.FindMetric(s, byReason, labels)
+		return v
+	}
+	scrape := func() []utils.MetricSample {
+		return utils.ParseMetrics(utils.ScrapeMetrics(t, poolerPort))
+	}
+	// poll scrapes the primary pooler until pred holds or the deadline passes.
+	// It runs on the test goroutine (ScrapeMetrics may call FailNow), so it
+	// cannot use require.Eventually, which runs its condition in a goroutine.
+	poll := func(pred func(s []utils.MetricSample) bool, msg string) {
+		t.Helper()
+		deadline := time.Now().Add(10 * time.Second)
+		for {
+			s := scrape()
+			if pred(s) {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("%s (last: unsafe=%v transaction=%v)", msg, reason(s, unsafeLabels), reason(s, txnLabels))
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+
+	// Baselines: whatever these reasons already report (0 on a clean cluster,
+	// but captured as deltas so the test is robust to any residue).
+	base := scrape()
+	unsafeBase := reason(base, unsafeLabels)
+	txnBase := reason(base, txnLabels)
+
+	conn, err := client.Connect(ctx, ctx, &client.Config{
+		Host:        "localhost",
+		Port:        setup.MultigatewayPgPort,
+		User:        shardsetup.DefaultTestUser,
+		Password:    shardsetup.TestPostgresPassword,
+		Database:    "postgres",
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	// Latch unsafe mode, then open a transaction so the backend is reserved on
+	// the primary (transactions route there) and held while we scrape. The
+	// connection now holds two reasons at once — the overlapping breakdown the
+	// metric is meant to report.
+	_, err = conn.Query(ctx, "SET multigres.unsafe_connection = on")
+	require.NoError(t, err)
+	_, err = conn.Query(ctx, "BEGIN")
+	require.NoError(t, err)
+	_, err = conn.Query(ctx, "SELECT 1")
+	require.NoError(t, err)
+
+	poll(func(s []utils.MetricSample) bool {
+		total, _ := utils.FindMetric(s, totalName, nil)
+		return reason(s, unsafeLabels) >= unsafeBase+1 &&
+			reason(s, txnLabels) >= txnBase+1 &&
+			total >= 1
+	}, "unsafe_connection and transaction reasons should both be counted while the connection is pinned")
+
+	// COMMIT removes the transaction reason; unsafe_connection is sticky, so the
+	// backend stays reserved and only the transaction sub-count drops.
+	_, err = conn.Query(ctx, "COMMIT")
+	require.NoError(t, err)
+	poll(func(s []utils.MetricSample) bool {
+		return reason(s, unsafeLabels) >= unsafeBase+1 && reason(s, txnLabels) <= txnBase
+	}, "after COMMIT the transaction sub-count should drop while unsafe_connection stays pinned")
+
+	// Closing the connection releases the reserved backend; unsafe returns to base.
+	require.NoError(t, conn.Close())
+	poll(func(s []utils.MetricSample) bool {
+		return reason(s, unsafeLabels) <= unsafeBase
+	}, "closing the unsafe connection should drop the unsafe_connection gauge back to baseline")
+}
+
 // resourceMetricSeries are the process- and Go-runtime-level series that every
 // Multigres component exports by virtue of going through telemetry.InitTelemetry
 // (see go/tools/telemetry/processmetrics.go). The process.* gauges are the


### PR DESCRIPTION
## Summary

- Add `mg.pooler.reserved.active_by_reason`, an observable gauge that breaks active reserved connections down by reservation reason (`transaction`, `portal`, `unsafe_connection`, etc.), so operators can see how many unsafe connections — or connections held for any other reason — are currently live.
- Document the `multigres.unsafe_connection` GUC for users, and fix stale references to the removed `--unsafe-pooler-mode` operator flag across the query-serving docs.
- Add unit tests (reserved pool + connpoolmanager) and an end-to-end test that scrapes the metric from a running cluster.

## Description

We recently added the `multigres.unsafe_connection` GUC but shipped no metrics or user docs for it. Rather than a bespoke unsafe-only metric, this adds a single `reason`-labeled gauge that covers unsafe connections and every other reservation reason at once.

**Metric.** `mg.pooler.reserved.active_by_reason{reason, routing_role}` is emitted from the connpoolmanager callback, aggregated across all per-user reserved pools, with every known reason reported each collection (0 when none are active). It lives there — not as a per-pool gauge — because reserved pools are per-user, so a per-pool observable gauge would register duplicate callbacks that don't sum. The breakdown is **overlapping**: a connection holding several reasons at once is counted under each, so the per-reason values sum to more than `reserved.active_connections`; it is not a partition of the total.

`reserved.PoolStats` gains `ActiveByReason`, and `protoutil` exposes `ReasonLabels` as the single source of truth for reason-to-label mapping (`ReasonsString` now uses it too). The generated metric catalog is regenerated to include the new series.

**Docs.** Documents `multigres.unsafe_connection` for users — what it is, when to use it, how to enable it (connect-time via `options=-c ...` and mid-session via `SET`), and its one-way-latch / backend-pinning semantics. Also corrects the query-serving docs, which still described the operator-wide `--unsafe-pooler-mode` flag that was removed in #1424 in favor of the per-connection GUC (now the only opt-out from unsafe-statement rejection).

## Testing

- Unit: reserved `Stats().ActiveByReason` (overlap + drop-on-release), and the connpoolmanager gauge (sum across pools, overlap, zero-emission for inactive reasons).
- End-to-end (`go/test/endtoend/metrics`): drives one gateway connection into unsafe mode inside a transaction, scrapes the primary pooler's Prometheus endpoint, and verifies both `unsafe_connection` and `transaction` are counted while held, the transaction sub-count drops after `COMMIT` while `unsafe_connection` stays pinned (sticky), and `unsafe_connection` returns to baseline on close. Passes under `-count=3`; full metrics suite green.
