### PR TITLE
fix(multipooler): skip user pools with checked-out conns in inactive-pool GC

### DIFF
--- a/go/services/multipooler/internal/connpoolmanager/rebalancer.go
+++ b/go/services/multipooler/internal/connpoolmanager/rebalancer.go
@@ -116,7 +116,7 @@ func (m *Manager) garbageCollectInactivePools(ctx context.Context) {
 	// Find inactive pools
 	var inactiveUsers []string
 	for user, pool := range *pools {
-		if pool.LastActivity() < cutoff {
+		if pool.LastActivity() < cutoff && !pool.HasCheckedOutConns() {
 			inactiveUsers = append(inactiveUsers, user)
 		}
 	}
@@ -146,8 +146,11 @@ func (m *Manager) garbageCollectInactivePools(ctx context.Context) {
 			continue
 		}
 
-		// Double-check activity timestamp (may have been updated since first check)
-		if pool.LastActivity() >= cutoff {
+		// Double-check activity and checked-out conns (may have changed since
+		// first check). Closing a pool hard-closes its reserved conns and blocks
+		// up to PoolCloseTimeout on borrowed regular conns, so never close a
+		// pool that is in use.
+		if pool.LastActivity() >= cutoff || pool.HasCheckedOutConns() {
 			continue
 		}
 

--- a/go/services/multipooler/internal/connpoolmanager/rebalancer_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/rebalancer_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/fakepgserver"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pools/connpool"
+	"github.com/multigres/multigres/go/services/multipooler/internal/pools/reserved"
 	"github.com/multigres/multigres/go/tools/viperutil"
 )
 
@@ -317,4 +318,62 @@ func TestUserPool_StatsIncludesDemand(t *testing.T) {
 	assert.GreaterOrEqual(t, stats.RegularDemand, int64(0))
 	assert.GreaterOrEqual(t, stats.ReservedDemand, int64(0))
 	assert.Greater(t, stats.LastActivity, int64(0))
+}
+
+// A pool holding a checked-out reserved conn (e.g. the pubsub LISTEN conn,
+// which never touches lastActivity) must survive GC until the conn is released.
+func TestManager_GarbageCollectSkipsPoolWithHeldReservedConn(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManagerForRebalancer(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	rc, err := manager.NewReservedConn(ctx, nil, "listener", nil, nil)
+	require.NoError(t, err)
+	rc.SetInactivityTimeout(0)
+
+	pool := (*manager.userPoolsSnapshot.Load())["listener"]
+	pool.lastActivity.Store(time.Now().Add(-10 * time.Minute).UnixNano())
+
+	manager.garbageCollectInactivePools(ctx)
+	assert.True(t, manager.HasUserPool("listener"), "pool with held reserved conn must not be GC'd")
+	assert.False(t, rc.IsClosed(), "held reserved conn must not be closed by GC")
+
+	rc.Release(reserved.ReleaseRollback, nil)
+	pool.lastActivity.Store(time.Now().Add(-10 * time.Minute).UnixNano())
+
+	manager.garbageCollectInactivePools(ctx)
+	assert.False(t, manager.HasUserPool("listener"), "idle pool must be GC'd once the conn is released")
+}
+
+// A pool with a borrowed regular conn (statement in flight) must survive GC:
+// closing it would block the rebalancer on PoolCloseTimeout waiting for drain.
+func TestManager_GarbageCollectSkipsPoolWithBorrowedRegularConn(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManagerForRebalancer(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	conn, err := manager.GetRegularConn(ctx, "busy", nil, nil)
+	require.NoError(t, err)
+
+	pool := (*manager.userPoolsSnapshot.Load())["busy"]
+	pool.lastActivity.Store(time.Now().Add(-10 * time.Minute).UnixNano())
+
+	manager.garbageCollectInactivePools(ctx)
+	assert.True(t, manager.HasUserPool("busy"))
+
+	conn.Recycle()
+	pool.lastActivity.Store(time.Now().Add(-10 * time.Minute).UnixNano())
+
+	manager.garbageCollectInactivePools(ctx)
+	assert.False(t, manager.HasUserPool("busy"))
 }

--- a/go/services/multipooler/internal/connpoolmanager/user_pool.go
+++ b/go/services/multipooler/internal/connpoolmanager/user_pool.go
@@ -218,6 +218,14 @@ func (p *UserPool) LastActivity() int64 {
 	return p.lastActivity.Load()
 }
 
+// HasCheckedOutConns reports whether any connection is currently lent out:
+// a regular conn mid-statement or a reserved conn held by a client. Such a
+// pool is in use regardless of lastActivity, which is touched only on
+// acquire — a long-lived holder (e.g. the pubsub LISTEN conn) never touches it.
+func (p *UserPool) HasCheckedOutConns() bool {
+	return p.regularPool.Stats().Borrowed > 0 || p.reservedPool.Stats().Active > 0
+}
+
 // RegularDemand returns the peak demand for regular connections over the sliding window.
 // It also rotates the demand tracker to the next bucket, aging out old data.
 // This should be called once per rebalance cycle. Returns 0 if demand tracking is disabled.

--- a/go/services/multipooler/internal/pools/reserved/logical_replication.go
+++ b/go/services/multipooler/internal/pools/reserved/logical_replication.go
@@ -16,7 +16,6 @@ package reserved
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"strconv"
@@ -24,6 +23,7 @@ import (
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/protoutil"
+	"github.com/multigres/multigres/go/services/multipooler/internal/pools/connpool"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pools/regular"
 )
 
@@ -92,7 +92,7 @@ func (p *Pool) NewLogicalReplicationConn(ctx context.Context) (*Conn, error) {
 	p.mu.Lock()
 	if p.closed {
 		p.mu.Unlock()
-		return nil, errors.New("reserved pool is closed")
+		return nil, fmt.Errorf("reserved pool: %w", connpool.ErrPoolClosed)
 	}
 	p.mu.Unlock()
 
@@ -144,7 +144,7 @@ func (p *Pool) NewLogicalReplicationConn(ctx context.Context) (*Conn, error) {
 		p.mu.Unlock()
 		pooled.Taint()
 		pooled.Recycle()
-		return nil, errors.New("reserved pool is closed")
+		return nil, fmt.Errorf("reserved pool: %w", connpool.ErrPoolClosed)
 	}
 	p.active[connID] = c
 	p.mu.Unlock()

--- a/go/services/multipooler/internal/pools/reserved/reserved_pool.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_pool.go
@@ -16,7 +16,6 @@ package reserved
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -174,7 +173,7 @@ func (p *Pool) NewConn(ctx context.Context, settings *connstate.Settings, opts .
 	p.mu.Lock()
 	if p.closed {
 		p.mu.Unlock()
-		return nil, errors.New("reserved pool is closed")
+		return nil, fmt.Errorf("reserved pool: %w", connpool.ErrPoolClosed)
 	}
 	p.mu.Unlock()
 


### PR DESCRIPTION
## Problem

The user-pool garbage collector (`garbageCollectInactivePools`, run every `connpool-rebalance-interval`) closes any pool whose `lastActivity` exceeds `connpool-inactive-timeout` (default 5m). `lastActivity` is touched only on acquire, so a connection held across GC cycles never counts as activity.

The pubsub listener holds a reserved conn from the `PgUser` pool with `SetInactivityTimeout(0)`. On a quiet project that pool goes acquire-idle, the GC closes it, and `reserved.Pool.Close` hard-closes the LISTEN socket. The listener reconnects after ~2s, and every NOTIFY fired in that window is lost (PG NOTIFY is fire-and-forget; no counter can see them). Losing PostgREST's `NOTIFY pgrst, 'reload schema'` leaves a stale schema cache and `PGRST205` for newly created tables. The cycle recurs every ~5 minutes on any project where the `PgUser` pool idles.

Repro: LISTEN via gateway as role A, pump sequenced NOTIFYs as role B ≠ PgUser. At ~5m04s the PgUser pool is GC'd and 10–11 consecutive seqs are lost, timestamps matching the GC log lines.

## Analysis notes

- Only the LISTEN conn actually dies. Logical replication detaches its socket before tunneling, so pool Close no-ops on it. A borrowed regular conn is not hard-closed either: `connpool.Close` waits for drain and the conn is closed on recycle.
- But that drain wait runs with `createMu` held, so a GC hitting a pool with a statement in flight blocked the rebalancer and all first-time user-pool creation for up to `PoolCloseTimeout` (10s).

## Fix

- `UserPool.HasCheckedOutConns()`: true when the regular pool has a borrowed conn or the reserved pool has an active conn. Existing counters, no new state.
- GC skips such pools in both the candidate scan and the locked double-check. A pool with a lent-out conn is in use by definition, so this is the general rule rather than a pubsub special case, and it removes the `createMu` stall as a side effect.
- The reserved pool's three closed-path errors now wrap `connpool.ErrPoolClosed`, so a request that races the GC is retried by `withReopenRetry` against the fresh pool instead of surfacing an error.

Pinning is bounded: regular borrows return at end of statement; reserved conns have their own inactivity killer except pubsub, which sets 0 deliberately and releases on last unsubscribe.

## Tests

- `TestManager_GarbageCollectSkipsPoolWithHeldReservedConn`: held reserved conn with timeout 0 (the listener's shape), backdated pool survives GC and the conn stays open; after release the pool is collected.
- `TestManager_GarbageCollectSkipsPoolWithBorrowedRegularConn`: same for a borrowed regular conn.

Both pass 5× under `-race`. Full multipooler unit suite passes.

## Live validation (local 3-node cluster, `connpool.inactive-timeout: 30s`)

Probe: LISTEN via gateway as `postgres` (the PgUser), `pg_notify` pump every 200ms via gateway as a different role, 110s (covers two GC cycles). A/B on the same cluster, same settings.

| binary | sent | received | gaps | pooler log |
|---|---|---|---|---|
| pre-fix | 550 | 530 | 2 (10 lost each, at 40s and 80s) | `pubsub: reader error` + `garbage collected inactive user pool user=postgres` at the same millisecond, twice |
| with fix | 550 | 550 | 0 | no reader error, no GC of the `postgres` pool while held |

With the fix, the `postgres` pool was collected 6s after the probe disconnected (`inactive_duration` 117s), i.e. GC still reclaims it once the LISTEN conn is released.

## Not done here

- No delivered-notification metric: postgres never sends the notifications lost in the gap, so nothing on the pooler side can count them. `mg.pubsub.reconnects` above zero on a stable leader is the alert signal.
