### PR TITLE
fix(multipooler): skip user pools with checked-out conns in inactive-pool GC

### DIFF
--- a/go/services/multipooler/internal/connpoolmanager/manager.go
+++ b/go/services/multipooler/internal/connpoolmanager/manager.go
@@ -352,9 +352,12 @@ func (m *Manager) getOrCreateUserPool(user string, clientKey, serverKey []byte) 
 		return nil, errors.New("user cannot be empty")
 	}
 
-	// Hot path: atomic load + map lookup (no lock)
+	// Hot path: atomic load + map lookup (no lock). A pool GC has claimed
+	// but not yet unpublished is skipped: the slow path takes createMu, which
+	// GC holds until the replacement snapshot is stored, so it sees the
+	// pool gone and builds a fresh one instead of returning ErrPoolClosed.
 	if pools := m.userPoolsSnapshot.Load(); pools != nil {
-		if pool, ok := (*pools)[user]; ok {
+		if pool, ok := (*pools)[user]; ok && !pool.IsClosing() {
 			return pool, nil
 		}
 	}

--- a/go/services/multipooler/internal/connpoolmanager/rebalancer.go
+++ b/go/services/multipooler/internal/connpoolmanager/rebalancer.go
@@ -104,7 +104,9 @@ func (m *Manager) rebalance(ctx context.Context) {
 // decides "idle" and blocks new borrows in one step, the replacement snapshot
 // is published before any pool is closed (so a caller retrying
 // ErrPoolClosed lands on a fresh pool, not the one being torn down), and
-// Close runs outside createMu so it can never stall pool creation.
+// Close runs outside createMu so it can never stall pool creation. createMu
+// itself is only ever TryLock'd here, because shutdown joins the rebalancer
+// while holding it.
 func (m *Manager) garbageCollectInactivePools(ctx context.Context) {
 	inactiveTimeout := m.config.InactiveTimeout()
 	if inactiveTimeout <= 0 {
@@ -131,7 +133,12 @@ func (m *Manager) garbageCollectInactivePools(ctx context.Context) {
 	}
 
 	// Claim and unpublish under createMu (copy-on-write, same as creation).
-	m.createMu.Lock()
+	// TryLock, never Lock: Close and CloseForReopen hold createMu while they
+	// cancel and join this goroutine, so blocking here would deadlock
+	// shutdown. GC is opportunistic — a busy lock just means "next tick".
+	if !m.createMu.TryLock() {
+		return
+	}
 	pools = m.userPoolsSnapshot.Load() // never nil once Open has run
 	newPools := make(map[string]*UserPool, len(*pools))
 	maps.Copy(newPools, *pools)

--- a/go/services/multipooler/internal/connpoolmanager/rebalancer.go
+++ b/go/services/multipooler/internal/connpoolmanager/rebalancer.go
@@ -99,6 +99,12 @@ func (m *Manager) rebalance(ctx context.Context) {
 
 // garbageCollectInactivePools removes user pools that have been inactive
 // longer than the configured timeout.
+//
+// Removal is atomic with respect to acquisitions: UserPool.tryMarkInactive
+// decides "idle" and blocks new borrows in one step, the replacement snapshot
+// is published before any pool is closed (so a caller retrying
+// ErrPoolClosed lands on a fresh pool, not the one being torn down), and
+// Close runs outside createMu so it can never stall pool creation.
 func (m *Manager) garbageCollectInactivePools(ctx context.Context) {
 	inactiveTimeout := m.config.InactiveTimeout()
 	if inactiveTimeout <= 0 {
@@ -113,61 +119,56 @@ func (m *Manager) garbageCollectInactivePools(ctx context.Context) {
 	now := time.Now().UnixNano()
 	cutoff := now - inactiveTimeout.Nanoseconds()
 
-	// Find inactive pools
-	var inactiveUsers []string
+	// Lock-free pre-scan so the common case (nothing to collect) takes no lock.
+	var candidates []string
 	for user, pool := range *pools {
 		if pool.LastActivity() < cutoff && !pool.HasCheckedOutConns() {
-			inactiveUsers = append(inactiveUsers, user)
+			candidates = append(candidates, user)
 		}
 	}
-
-	if len(inactiveUsers) == 0 {
+	if len(candidates) == 0 {
 		return
 	}
 
-	// Remove inactive pools using copy-on-write
+	// Claim and unpublish under createMu (copy-on-write, same as creation).
 	m.createMu.Lock()
-	defer m.createMu.Unlock()
-
-	// Re-read snapshot with lock held
-	pools = m.userPoolsSnapshot.Load()
-	if pools == nil {
-		return
-	}
-
-	// Create new map without inactive pools
-	newPools := make(map[string]*UserPool, len(*pools)-len(inactiveUsers))
+	pools = m.userPoolsSnapshot.Load() // never nil once Open has run
+	newPools := make(map[string]*UserPool, len(*pools))
 	maps.Copy(newPools, *pools)
 
-	var closedCount int
-	for _, user := range inactiveUsers {
+	var removed []*UserPool
+	for _, user := range candidates {
 		pool, ok := newPools[user]
 		if !ok {
 			continue
 		}
-
-		// Double-check activity and checked-out conns (may have changed since
-		// first check). Closing a pool hard-closes its reserved conns and blocks
-		// up to PoolCloseTimeout on borrowed regular conns, so never close a
-		// pool that is in use.
-		if pool.LastActivity() >= cutoff || pool.HasCheckedOutConns() {
+		// Authoritative check: fails if an acquisition is in flight or the
+		// pool was touched/borrowed since the pre-scan.
+		if !pool.tryMarkInactive(cutoff) {
 			continue
 		}
-
-		// Close and remove the pool
-		pool.Close()
 		delete(newPools, user)
-		closedCount++
+		removed = append(removed, pool)
+	}
+	if len(removed) > 0 {
+		m.userPoolsSnapshot.Store(&newPools)
+	}
+	m.createMu.Unlock()
 
+	if len(removed) == 0 {
+		return
+	}
+
+	// Close outside createMu. The pools are unpublished and refuse new
+	// acquisitions, and they hold no checked-out connections, so Close does
+	// not wait on drain.
+	for _, pool := range removed {
+		pool.Close()
 		m.logger.InfoContext(ctx, "garbage collected inactive user pool",
-			"user", user,
+			"user", pool.Username(),
 			"inactive_duration", time.Duration(now-pool.LastActivity()))
 	}
-
-	if closedCount > 0 {
-		m.userPoolsSnapshot.Store(&newPools)
-		m.logger.InfoContext(ctx, "garbage collection complete",
-			"removed_pools", closedCount,
-			"remaining_pools", len(newPools))
-	}
+	m.logger.InfoContext(ctx, "garbage collection complete",
+		"removed_pools", len(removed),
+		"remaining_pools", len(newPools))
 }

--- a/go/services/multipooler/internal/connpoolmanager/rebalancer.go
+++ b/go/services/multipooler/internal/connpoolmanager/rebalancer.go
@@ -116,7 +116,7 @@ func (m *Manager) garbageCollectInactivePools(ctx context.Context) {
 	// Find inactive pools
 	var inactiveUsers []string
 	for user, pool := range *pools {
-		if pool.LastActivity() < cutoff {
+		if pool.LastActivity() < cutoff && !pool.HasCheckedOutConns() {
 			inactiveUsers = append(inactiveUsers, user)
 		}
 	}
@@ -146,8 +146,11 @@ func (m *Manager) garbageCollectInactivePools(ctx context.Context) {
 			continue
 		}
 
-		// Double-check activity timestamp (may have been updated since first check)
-		if pool.LastActivity() >= cutoff {
+		// Double-check activity and checked-out conns (may have changed since
+		// first check). Closing a pool hard-closes its reserved conns and blocks
+		// up to PoolCloseTimeout on borrowed regular conns, so never close a
+		// pool that is in use.
+		if pool.LastActivity() >= cutoff || pool.HasCheckedOutConns() {
 			continue
 		}
 

--- a/go/services/multipooler/internal/connpoolmanager/rebalancer_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/rebalancer_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/fakepgserver"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pools/connpool"
+	"github.com/multigres/multigres/go/services/multipooler/internal/pools/regular"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pools/reserved"
 	"github.com/multigres/multigres/go/tools/viperutil"
 )
@@ -376,4 +377,106 @@ func TestManager_GarbageCollectSkipsPoolWithBorrowedRegularConn(t *testing.T) {
 
 	manager.garbageCollectInactivePools(ctx)
 	assert.False(t, manager.HasUserPool("busy"))
+}
+
+// A reserved conn holds a borrowed slot from before validation until release.
+// GC must (a) count that borrowed-but-unregistered slot as checked out and
+// (b) never block behind, or race, an acquisition in flight.
+func TestManager_GarbageCollectSkipsPoolDuringReservedSetup(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManagerForRebalancer(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	// Prime the pool so the validate hook can reach it through the snapshot.
+	c, err := manager.GetRegularConn(ctx, "setup", nil, nil)
+	require.NoError(t, err)
+	c.Recycle()
+	pool := (*manager.userPoolsSnapshot.Load())["setup"]
+
+	backdate := func() { pool.lastActivity.Store(time.Now().Add(-10 * time.Minute).UnixNano()) }
+
+	// validate runs after the underlying borrow and before registration in
+	// reserved.Pool.active — exactly the setup window the GC used to miss.
+	validated := false
+	validate := func(context.Context, *regular.Conn) error {
+		validated = true
+		assert.True(t, pool.HasCheckedOutConns(), "borrowed-but-unregistered reserved conn must count as checked out")
+		backdate()
+
+		done := make(chan struct{})
+		go func() {
+			manager.garbageCollectInactivePools(ctx)
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("GC blocked behind an in-flight acquisition")
+		}
+		assert.True(t, manager.HasUserPool("setup"), "GC must skip a pool with an acquisition in flight")
+		assert.False(t, pool.IsClosing())
+		return nil
+	}
+	rc, err := manager.NewReservedConn(ctx, nil, "setup", nil, nil, reserved.WithValidate(validate))
+	require.NoError(t, err)
+	require.True(t, validated)
+	assert.False(t, rc.IsClosed(), "conn acquired during GC must stay open")
+
+	// Once released and idle again, the pool is collected as usual.
+	rc.Release(reserved.ReleaseRollback, nil)
+	backdate()
+	manager.garbageCollectInactivePools(ctx)
+	assert.False(t, manager.HasUserPool("setup"))
+	assert.True(t, pool.IsClosing())
+
+	// A subsequent acquisition builds a fresh pool rather than hitting the old one.
+	c2, err := manager.GetRegularConn(ctx, "setup", nil, nil)
+	require.NoError(t, err)
+	c2.Recycle()
+	assert.True(t, manager.HasUserPool("setup"))
+	assert.NotSame(t, pool, (*manager.userPoolsSnapshot.Load())["setup"])
+}
+
+func TestUserPool_TryMarkInactive(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManagerForRebalancer(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+	future := time.Now().Add(time.Hour).UnixNano() // every pool is "stale" against this cutoff
+
+	c, err := manager.GetRegularConn(ctx, "u", nil, nil)
+	require.NoError(t, err)
+	pool := (*manager.userPoolsSnapshot.Load())["u"]
+
+	assert.False(t, pool.tryMarkInactive(future), "must refuse while a conn is borrowed")
+	c.Recycle()
+	assert.False(t, pool.tryMarkInactive(time.Now().Add(-time.Hour).UnixNano()), "must refuse when recently active")
+
+	// An acquisition in flight holds the read lock; GC must give up, not wait.
+	pool.acqMu.RLock()
+	assert.False(t, pool.tryMarkInactive(future), "must refuse while an acquisition is in flight")
+	pool.acqMu.RUnlock()
+
+	require.True(t, pool.tryMarkInactive(future), "idle pool must be claimable")
+	assert.True(t, pool.IsClosing())
+	assert.False(t, pool.tryMarkInactive(future), "a claimed pool must not be claimed twice")
+
+	// Every acquire path refuses a claimed pool so the caller re-looks-up.
+	_, err = pool.GetRegularConn(ctx)
+	assert.ErrorIs(t, err, connpool.ErrPoolClosed)
+	_, err = pool.GetRegularConnWithSettings(ctx, nil)
+	assert.ErrorIs(t, err, connpool.ErrPoolClosed)
+	_, err = pool.NewReservedConn(ctx, nil)
+	assert.ErrorIs(t, err, connpool.ErrPoolClosed)
+	_, err = pool.NewLogicalReplicationConn(ctx)
+	assert.ErrorIs(t, err, connpool.ErrPoolClosed)
 }

--- a/go/services/multipooler/internal/connpoolmanager/rebalancer_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/rebalancer_test.go
@@ -480,3 +480,42 @@ func TestUserPool_TryMarkInactive(t *testing.T) {
 	_, err = pool.NewLogicalReplicationConn(ctx)
 	assert.ErrorIs(t, err, connpool.ErrPoolClosed)
 }
+
+// GC must never block on createMu: Close and CloseForReopen hold it while
+// they cancel and join the rebalancer goroutine, so a blocking acquire in GC
+// would deadlock shutdown. Holding createMu here stands in for shutdown; the
+// property under test (GC returns without the lock) is what makes the
+// shutdown ordering safe.
+func TestManager_GarbageCollectSkipsCycleWhenCreateMuHeld(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManagerForRebalancer(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+	c, err := manager.GetRegularConn(ctx, "stale", nil, nil)
+	require.NoError(t, err)
+	c.Recycle()
+	pool := (*manager.userPoolsSnapshot.Load())["stale"]
+	pool.lastActivity.Store(time.Now().Add(-10 * time.Minute).UnixNano())
+
+	manager.createMu.Lock()
+	done := make(chan struct{})
+	go func() {
+		manager.garbageCollectInactivePools(ctx)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		manager.createMu.Unlock()
+		t.Fatal("GC blocked on createMu")
+	}
+	assert.True(t, manager.HasUserPool("stale"), "GC must skip the cycle, not collect, while createMu is held")
+	manager.createMu.Unlock()
+
+	manager.garbageCollectInactivePools(ctx)
+	assert.False(t, manager.HasUserPool("stale"), "next cycle collects normally")
+}

--- a/go/services/multipooler/internal/connpoolmanager/rebalancer_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/rebalancer_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/fakepgserver"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pools/connpool"
+	"github.com/multigres/multigres/go/services/multipooler/internal/pools/reserved"
 	"github.com/multigres/multigres/go/tools/viperutil"
 )
 
@@ -317,4 +318,62 @@ func TestUserPool_StatsIncludesDemand(t *testing.T) {
 	assert.GreaterOrEqual(t, stats.RegularDemand, int64(0))
 	assert.GreaterOrEqual(t, stats.ReservedDemand, int64(0))
 	assert.Greater(t, stats.LastActivity, int64(0))
+}
+
+// A pool holding a checked-out reserved conn (e.g. the pubsub LISTEN conn,
+// which never touches lastActivity) must survive GC until the conn is released.
+func TestManager_GarbageCollectSkipsPoolWithHeldReservedConn(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManagerForRebalancer(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	rc, err := manager.NewReservedConn(ctx, nil, "listener", nil, nil)
+	require.NoError(t, err)
+	rc.SetInactivityTimeout(0)
+
+	pool := (*manager.userPoolsSnapshot.Load())["listener"]
+	pool.lastActivity.Store(time.Now().Add(-10 * time.Minute).UnixNano())
+
+	manager.garbageCollectInactivePools(ctx)
+	assert.True(t, manager.HasUserPool("listener"), "pool with held reserved conn must not be GC'd")
+	assert.False(t, rc.IsClosed(), "held reserved conn must not be closed by GC")
+
+	rc.Release(reserved.ReleaseRollback, nil)
+	pool.lastActivity.Store(time.Now().Add(-10 * time.Minute).UnixNano())
+
+	manager.garbageCollectInactivePools(ctx)
+	assert.False(t, manager.HasUserPool("listener"), "idle pool must be GC'd once the conn is released")
+}
+
+// A pool with a borrowed regular conn (statement in flight) must survive GC:
+// closing it would block the rebalancer on PoolCloseTimeout waiting for drain.
+func TestManager_GarbageCollectSkipsPoolWithBorrowedRegularConn(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManagerForRebalancer(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	conn, err := manager.GetRegularConn(ctx, "busy", nil, nil)
+	require.NoError(t, err)
+
+	pool := (*manager.userPoolsSnapshot.Load())["busy"]
+	pool.lastActivity.Store(time.Now().Add(-10 * time.Minute).UnixNano())
+
+	manager.garbageCollectInactivePools(ctx)
+	assert.True(t, manager.HasUserPool("busy"))
+
+	conn.Recycle()
+	pool.lastActivity.Store(time.Now().Add(-10 * time.Minute).UnixNano())
+
+	manager.garbageCollectInactivePools(ctx)
+	assert.False(t, manager.HasUserPool("busy"))
 }

--- a/go/services/multipooler/internal/connpoolmanager/user_pool.go
+++ b/go/services/multipooler/internal/connpoolmanager/user_pool.go
@@ -218,6 +218,14 @@ func (p *UserPool) LastActivity() int64 {
 	return p.lastActivity.Load()
 }
 
+// HasCheckedOutConns reports whether any connection is currently lent out:
+// a regular conn mid-statement or a reserved conn held by a client. Such a
+// pool is in use regardless of lastActivity, which is touched only on
+// acquire — a long-lived holder (e.g. the pubsub LISTEN conn) never touches it.
+func (p *UserPool) HasCheckedOutConns() bool {
+	return p.regularPool.Stats().Borrowed > 0 || p.reservedPool.Stats().Active > 0
+}
+
 // RegularDemand returns the peak demand for regular connections over the sliding window.
 // It also rotates the demand tracker to the next bucket, aging out old data.
 // This should be called once per rebalance cycle. Returns 0 if demand tracking is disabled.

--- a/go/services/multipooler/internal/connpoolmanager/user_pool.go
+++ b/go/services/multipooler/internal/connpoolmanager/user_pool.go
@@ -49,6 +49,15 @@ type UserPool struct {
 	// Last activity timestamp (Unix nanos) for garbage collection
 	lastActivity atomic.Int64
 
+	// acqMu serialises acquisitions against garbage collection. Every
+	// acquire path holds it for read while it borrows; tryMarkInactive takes
+	// it for write (TryLock, never blocking) to decide "idle" and set closing
+	// in one step, so no acquisition can slip in between the check and the
+	// close. closing is written only under the write lock; it is atomic so
+	// the manager's lock-free lookup can skip a pool GC has already claimed.
+	acqMu   sync.RWMutex
+	closing atomic.Bool
+
 	mu sync.Mutex
 	// lastLoggedRegularCap and lastLoggedReservedCap are the capacities from
 	// the most recent SetCapacity log line, seeded from the pool's
@@ -222,8 +231,50 @@ func (p *UserPool) LastActivity() int64 {
 // a regular conn mid-statement or a reserved conn held by a client. Such a
 // pool is in use regardless of lastActivity, which is touched only on
 // acquire — a long-lived holder (e.g. the pubsub LISTEN conn) never touches it.
+//
+// The reserved side counts borrows from the reserved pool's underlying
+// regular pool rather than registered reserved conns: a reserved conn holds
+// its borrowed slot from before validation/dialing until release, so this is
+// a superset of the registered set and also covers setup in progress.
 func (p *UserPool) HasCheckedOutConns() bool {
-	return p.regularPool.Stats().Borrowed > 0 || p.reservedPool.Stats().Active > 0
+	return p.regularPool.Stats().Borrowed > 0 || p.reservedPool.Stats().RegularPool.Borrowed > 0
+}
+
+// IsClosing reports whether garbage collection has claimed this pool. A
+// closing pool refuses new acquisitions with connpool.ErrPoolClosed; callers
+// should look up a fresh pool instead.
+func (p *UserPool) IsClosing() bool {
+	return p.closing.Load()
+}
+
+// tryMarkInactive atomically decides whether this pool may be garbage
+// collected. It succeeds — and blocks all further acquisitions — only when no
+// acquisition is in flight, the last acquire predates cutoff, and no
+// connection is checked out. It never blocks: an in-flight acquisition makes
+// TryLock fail, which is the correct answer ("busy") for this cycle.
+func (p *UserPool) tryMarkInactive(cutoff int64) bool {
+	if !p.acqMu.TryLock() {
+		return false
+	}
+	defer p.acqMu.Unlock()
+	if p.closing.Load() || p.LastActivity() >= cutoff || p.HasCheckedOutConns() {
+		return false
+	}
+	p.closing.Store(true)
+	return true
+}
+
+// acquire runs op under the acquisition read lock so it cannot interleave
+// with tryMarkInactive. It records activity and refuses pools GC has claimed.
+func acquire[T any](p *UserPool, op func() (T, error)) (T, error) {
+	p.acqMu.RLock()
+	defer p.acqMu.RUnlock()
+	if p.closing.Load() {
+		var zero T
+		return zero, connpool.ErrPoolClosed
+	}
+	p.touchActivity()
+	return op()
 }
 
 // RegularDemand returns the peak demand for regular connections over the sliding window.
@@ -249,23 +300,20 @@ func (p *UserPool) ReservedDemand() int64 {
 // GetRegularConn acquires a regular connection from the pool.
 // The connection is already authenticated as the pool's user.
 func (p *UserPool) GetRegularConn(ctx context.Context) (regular.PooledConn, error) {
-	p.touchActivity()
-	return p.regularPool.Get(ctx)
+	return acquire(p, func() (regular.PooledConn, error) { return p.regularPool.Get(ctx) })
 }
 
 // GetRegularConnWithSettings acquires a regular connection with the given settings.
 // The connection is already authenticated as the pool's user.
 func (p *UserPool) GetRegularConnWithSettings(ctx context.Context, settings *connstate.Settings) (regular.PooledConn, error) {
-	p.touchActivity()
-	return p.regularPool.GetWithSettings(ctx, settings)
+	return acquire(p, func() (regular.PooledConn, error) { return p.regularPool.GetWithSettings(ctx, settings) })
 }
 
 // NewReservedConn creates a new reserved connection for transactions or portal operations.
 // The connection is already authenticated as the pool's user. Optional
 // ReservedConnOption values configure validate-with-retry behavior.
 func (p *UserPool) NewReservedConn(ctx context.Context, settings *connstate.Settings, opts ...reserved.ReservedConnOption) (*reserved.Conn, error) {
-	p.touchActivity()
-	return p.reservedPool.NewConn(ctx, settings, opts...)
+	return acquire(p, func() (*reserved.Conn, error) { return p.reservedPool.NewConn(ctx, settings, opts...) })
 }
 
 // NewLogicalReplicationConn returns a Postgres connection opened with
@@ -275,8 +323,7 @@ func (p *UserPool) NewReservedConn(ctx context.Context, settings *connstate.Sett
 // replication=database startup parameter is rejected for roles without the
 // REPLICATION attribute.
 func (p *UserPool) NewLogicalReplicationConn(ctx context.Context) (*reserved.Conn, error) {
-	p.touchActivity()
-	return p.reservedPool.NewLogicalReplicationConn(ctx)
+	return acquire(p, func() (*reserved.Conn, error) { return p.reservedPool.NewLogicalReplicationConn(ctx) })
 }
 
 // GetReservedConn retrieves an existing reserved connection by ID.

--- a/go/services/multipooler/internal/pools/reserved/logical_replication.go
+++ b/go/services/multipooler/internal/pools/reserved/logical_replication.go
@@ -16,7 +16,6 @@ package reserved
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"strconv"
@@ -24,6 +23,7 @@ import (
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/protoutil"
+	"github.com/multigres/multigres/go/services/multipooler/internal/pools/connpool"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pools/regular"
 )
 
@@ -92,7 +92,7 @@ func (p *Pool) NewLogicalReplicationConn(ctx context.Context) (*Conn, error) {
 	p.mu.Lock()
 	if p.closed {
 		p.mu.Unlock()
-		return nil, errors.New("reserved pool is closed")
+		return nil, fmt.Errorf("reserved pool: %w", connpool.ErrPoolClosed)
 	}
 	p.mu.Unlock()
 
@@ -144,7 +144,7 @@ func (p *Pool) NewLogicalReplicationConn(ctx context.Context) (*Conn, error) {
 		p.mu.Unlock()
 		pooled.Taint()
 		pooled.Recycle()
-		return nil, errors.New("reserved pool is closed")
+		return nil, fmt.Errorf("reserved pool: %w", connpool.ErrPoolClosed)
 	}
 	p.active[connID] = c
 	p.mu.Unlock()

--- a/go/services/multipooler/internal/pools/reserved/logical_replication_test.go
+++ b/go/services/multipooler/internal/pools/reserved/logical_replication_test.go
@@ -330,3 +330,15 @@ func TestPoolStatsLogicalReplicationActive(t *testing.T) {
 	c2.Release(ReleaseError, nil)
 	plain.Release(ReleaseCommit, nil)
 }
+
+func TestNewLogicalReplicationConnAfterCloseReturnsErrPoolClosed(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetCredentialProvider(fakeReplicationCredentialProvider{})
+
+	pool := newTestPool(t, server)
+	pool.Close()
+
+	_, err := pool.NewLogicalReplicationConn(context.Background())
+	require.ErrorIs(t, err, connpool.ErrPoolClosed, "must be retryable by the manager's closed-pool path")
+}

--- a/go/services/multipooler/internal/pools/reserved/reserved_pool.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_pool.go
@@ -16,7 +16,6 @@ package reserved
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -174,7 +173,7 @@ func (p *Pool) NewConn(ctx context.Context, settings *connstate.Settings, opts .
 	p.mu.Lock()
 	if p.closed {
 		p.mu.Unlock()
-		return nil, errors.New("reserved pool is closed")
+		return nil, fmt.Errorf("reserved pool: %w", connpool.ErrPoolClosed)
 	}
 	p.mu.Unlock()
 

--- a/go/services/multipooler/internal/pools/reserved/reserved_pool_test.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_pool_test.go
@@ -1141,3 +1141,14 @@ func TestPool_CleanReleaseWithoutSettingsCacheTaints(t *testing.T) {
 	conn.Release(ReleaseCommit, map[string]string{"work_mem": "64MB"})
 	assert.False(t, underlying.IsClosed(), "with a cache the clean release relabels and recycles")
 }
+
+func TestPool_NewConnAfterCloseReturnsErrPoolClosed(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	pool := newTestPool(t, server)
+	pool.Close()
+
+	_, err := pool.NewConn(context.Background(), nil)
+	require.ErrorIs(t, err, connpool.ErrPoolClosed, "must be retryable by the manager's closed-pool path")
+}


### PR DESCRIPTION
## Problem

The user-pool garbage collector (`garbageCollectInactivePools`, run every `connpool-rebalance-interval`) closes any pool whose `lastActivity` exceeds `connpool-inactive-timeout` (default 5m). `lastActivity` is touched only on acquire, so a connection held across GC cycles never counts as activity.

The pubsub listener holds a reserved conn from the `PgUser` pool with `SetInactivityTimeout(0)`. On a quiet project that pool goes acquire-idle, the GC closes it, and `reserved.Pool.Close` hard-closes the LISTEN socket. The listener reconnects after ~2s, and every NOTIFY fired in that window is lost (PG NOTIFY is fire-and-forget; no counter can see them). Losing PostgREST's `NOTIFY pgrst, 'reload schema'` leaves a stale schema cache and `PGRST205` for newly created tables. The cycle recurs every ~5 minutes on any project where the `PgUser` pool idles.

## Analysis notes

- Only the LISTEN conn actually dies. Logical replication detaches its socket before tunneling, so pool Close no-ops on it. A borrowed regular conn is not hard-closed either: `connpool.Close` waits for drain and the conn is closed on recycle.
- But that drain wait ran with `createMu` held, so a GC hitting a pool with a statement in flight blocked the rebalancer and all first-time user-pool creation for up to `PoolCloseTimeout` (10s).
- The idle check and `Close` were not atomic against the lock-free acquire path, and the closed pool stayed published until every `Close` finished, so a retrying caller could keep hitting it.
- Pre-existing since the GC was introduced: `Close`/`CloseForReopen` hold `createMu` while cancelling and joining the rebalancer goroutine, and GC (on that goroutine) took `createMu` with a blocking `Lock` after its pre-scan. A shutdown landing on a tick with collectable pools deadlocked.

## Fix

**A pool with a lent-out connection is in use, regardless of `lastActivity`.**
`UserPool.HasCheckedOutConns()` reports a borrowed regular conn or a borrow from the reserved pool's underlying regular pool. The reserved side counts underlying borrows rather than registered reserved conns: a reserved conn holds its slot from before validation/dialing until release, so this is a superset that also covers setup in progress.

**GC removal is atomic with respect to acquisitions.**
- Each `UserPool` has an acquisition `RWMutex` and an atomic `closing` flag. Every acquire path holds the read lock across touch+borrow and returns `connpool.ErrPoolClosed` once the pool is claimed.
- GC claims a pool via `tryMarkInactive`: `TryLock` (never blocks; an in-flight acquisition means "busy this cycle"), then idle check and `closing = true` in one step under the write lock.
- GC publishes the replacement snapshot before closing anything, and closes outside `createMu`. The manager's lock-free lookup skips a claimed pool and falls to the slow path, which takes `createMu` and therefore always sees the pool already unpublished, so a `withReopenRetry` retry lands on a fresh pool.

**GC never blocks on `createMu`.**
GC uses `TryLock` on `createMu`; a busy lock defers collection to the next tick. Shutdown always finds the rebalancer able to observe its cancelled context, so the lock cycle above cannot form.

**Closed reserved pools are retryable.**
The reserved pool's closed-path errors wrap `connpool.ErrPoolClosed`, so a request that races GC is retried by `withReopenRetry` instead of surfacing.

Pinning is bounded: regular borrows return at end of statement; reserved conns have their own inactivity killer except pubsub, which sets 0 deliberately and releases on last unsubscribe.

## Tests

- `TestManager_GarbageCollectSkipsPoolWithHeldReservedConn` / `...BorrowedRegularConn`: held conn, backdated pool survives GC; collected after release.
- `TestManager_GarbageCollectSkipsPoolDuringReservedSetup`: pauses inside the `WithValidate` hook (borrowed, not yet registered), asserts the slot counts as checked out, runs GC concurrently and asserts it returns promptly without collecting, then verifies collection after release and that the next acquisition builds a fresh pool.
- `TestUserPool_TryMarkInactive`: refuses while borrowed, recently active, or read-locked; claims once; refuses twice; all four acquire paths return `ErrPoolClosed` afterward.
- `TestManager_GarbageCollectSkipsCycleWhenCreateMuHeld`: holds `createMu`, asserts GC returns promptly without collecting, then collects on the next cycle. Fails deterministically with a blocking `Lock` (verified). Holding the lock stands in for shutdown; a hook-free test that parks the real rebalancer goroutine on `createMu` at the instant `Close` takes it is not possible, and this property is what makes both `Close` and `CloseForReopen` safe.
- `TestPool_NewConnAfterCloseReturnsErrPoolClosed`, `TestNewLogicalReplicationConnAfterCloseReturnsErrPoolClosed`.

All pass 10× under `-race`; full multipooler unit suite passes. Patch coverage of changed non-test lines is 56/58 statements (misses: a user evicted between pre-scan and lock, and the post-dial closed re-check in logical replication — neither reachable deterministically).

## Live validation (local 3-node cluster, `connpool.inactive-timeout: 30s`)

Probe: LISTEN via gateway as `postgres` (the PgUser), `pg_notify` pump every 200ms via gateway as a different role, 110s (covers two GC cycles). A/B on the same cluster, same settings.

| binary | sent | received | gaps | pooler log |
|---|---|---|---|---|
| pre-fix | 550 | 530 | 2 (10 lost each, at 40s and 80s) | `pubsub: reader error` + `garbage collected inactive user pool user=postgres` at the same millisecond, twice |
| with fix | 550 | 550 | 0 | no reader error, no GC of the `postgres` pool while held |

With the fix, the `postgres` pool was collected 6s after the probe disconnected (`inactive_duration` 117s), i.e. GC still reclaims it once the LISTEN conn is released.

## Not done here

- No delivered-notification metric: postgres never sends the notifications lost in the gap, so nothing on the pooler side can count them. `mg.pubsub.reconnects` above zero on a stable leader is the alert signal.
- `evictUserPool` (stale credentials) has the same check-then-close shape; the `closing` flag makes that a small follow-up.
