### PR TITLE
feat(multipooler): derive connpool global capacity from postgres max_connections

### DIFF
--- a/go/services/multipooler/internal/connpoolmanager/config.go
+++ b/go/services/multipooler/internal/connpoolmanager/config.go
@@ -137,6 +137,8 @@ type Config struct {
 
 	// Global capacity is the total number of PostgreSQL connections to manage.
 	// This is divided between regular and reserved pools based on reservedRatio.
+	// When not explicitly configured (see GlobalCapacityExplicit), the manager
+	// derives it from the server's max_connections at admin-pool open.
 	globalCapacity viperutil.Value[int64]
 
 	// Reserved ratio is the fraction of global capacity allocated to reserved pools (0.0-1.0).
@@ -364,7 +366,7 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 	fs.Int64("connpool-settings-cache-size", c.settingsCacheSize.Default(), "Maximum number of unique settings combinations to cache (0 = use default)")
 
 	// Fair share allocation flags
-	fs.Int64("connpool-global-capacity", c.globalCapacity.Default(), "Total PostgreSQL connections to manage (divided between regular and reserved pools) (env: CONNPOOL_GLOBAL_CAPACITY)")
+	fs.Int64("connpool-global-capacity", c.globalCapacity.Default(), "Total PostgreSQL connections to manage (divided between regular and reserved pools). When not set, derived from the server's max_connections at pool open (env: CONNPOOL_GLOBAL_CAPACITY)")
 	fs.Float64("connpool-reserved-ratio", c.reservedRatio.Default(), "Fraction of global capacity allocated to reserved pools (0.0-1.0)")
 
 	// Rebalancer flags
@@ -603,10 +605,31 @@ func (c *Config) SettingsCacheSize() int {
 	return int(c.settingsCacheSize.Get())
 }
 
-// GlobalCapacity returns the total PostgreSQL connections to manage.
+// GlobalCapacity returns the configured total PostgreSQL connections to manage.
 // This is divided between regular and reserved pools based on ReservedRatio.
+// Manager.GlobalCapacity returns the value actually in effect, which is derived
+// from the server when this one was not explicitly configured.
 func (c *Config) GlobalCapacity() int64 {
 	return c.globalCapacity.Get()
+}
+
+// GlobalCapacityExplicit reports whether the operator explicitly configured
+// the global capacity (flag, env var, or config file). When false, the manager
+// derives the capacity from the server's max_connections at admin-pool open.
+func (c *Config) GlobalCapacityExplicit() bool {
+	if c.flagSet != nil {
+		if flag := c.flagSet.Lookup("connpool-global-capacity"); flag != nil && flag.Changed {
+			return true
+		}
+	}
+	if _, ok := os.LookupEnv("CONNPOOL_GLOBAL_CAPACITY"); ok {
+		return true
+	}
+	// Config-file values set neither Flag.Changed nor the env var; a resolved
+	// value that differs from the default can only come from an explicit source.
+	// (A config file pinning the capacity to exactly the default value is
+	// indistinguishable from "unset" and falls through to derivation.)
+	return c.globalCapacity.Get() != c.globalCapacity.Default()
 }
 
 // ReservedRatio returns the fraction of global capacity allocated to reserved pools (0.0-1.0).

--- a/go/services/multipooler/internal/connpoolmanager/config.go
+++ b/go/services/multipooler/internal/connpoolmanager/config.go
@@ -98,6 +98,10 @@ type Config struct {
 	// flag's resolved value. nil when RegisterFlags has not run (e.g. in
 	// tests that exercise only the env-var or file paths).
 	flagSet *pflag.FlagSet
+	// reg is the registry the values below were configured against, saved so
+	// explicitness checks can ask whether a key was present in the loaded
+	// config file (Registry.InStaticConfig).
+	reg *viperutil.Registry
 
 	// --- PostgreSQL TLS (multipooler → postgres leg) ---
 	// libpq-style server verification. Mode + optional CA bundle. Client cert
@@ -220,6 +224,7 @@ func NewConfig(reg *viperutil.Registry) *Config {
 	)
 
 	return &Config{
+		reg: reg,
 		// PostgreSQL superuser credentials (also used for internal system queries)
 		pgUser: viperutil.Configure(reg, "connpool.pg.user", viperutil.Options[string]{
 			Default:  constants.DefaultPostgresUser,
@@ -625,11 +630,11 @@ func (c *Config) GlobalCapacityExplicit() bool {
 	if _, ok := os.LookupEnv("CONNPOOL_GLOBAL_CAPACITY"); ok {
 		return true
 	}
-	// Config-file values set neither Flag.Changed nor the env var; a resolved
-	// value that differs from the default can only come from an explicit source.
-	// (A config file pinning the capacity to exactly the default value is
-	// indistinguishable from "unset" and falls through to derivation.)
-	return c.globalCapacity.Get() != c.globalCapacity.Default()
+	// Config-file values set neither Flag.Changed nor the env var; ask the
+	// registry whether the key was present in the loaded config file, so a
+	// config file pinning the capacity to exactly the default value still
+	// counts as explicit.
+	return c.reg.InStaticConfig(c.globalCapacity.Key())
 }
 
 // ReservedRatio returns the fraction of global capacity allocated to reserved pools (0.0-1.0).

--- a/go/services/multipooler/internal/connpoolmanager/config_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/config_test.go
@@ -441,3 +441,52 @@ func TestConfig_PgUser_EnvVar(t *testing.T) {
 
 	assert.Equal(t, "multigres", config.PgUser())
 }
+
+func TestConfig_GlobalCapacityExplicit(t *testing.T) {
+	t.Run("default is not explicit", func(t *testing.T) {
+		viper.Reset()
+		defer viper.Reset()
+		reg := viperutil.NewRegistry()
+		config := NewConfig(reg)
+		cmd := &cobra.Command{}
+		config.RegisterFlags(cmd.Flags())
+
+		assert.False(t, config.GlobalCapacityExplicit())
+	})
+
+	t.Run("flag set is explicit", func(t *testing.T) {
+		viper.Reset()
+		defer viper.Reset()
+		reg := viperutil.NewRegistry()
+		config := NewConfig(reg)
+		cmd := &cobra.Command{}
+		config.RegisterFlags(cmd.Flags())
+		require.NoError(t, cmd.Flags().Set("connpool-global-capacity", "50"))
+
+		assert.True(t, config.GlobalCapacityExplicit())
+	})
+
+	t.Run("flag set to the default value is explicit", func(t *testing.T) {
+		viper.Reset()
+		defer viper.Reset()
+		reg := viperutil.NewRegistry()
+		config := NewConfig(reg)
+		cmd := &cobra.Command{}
+		config.RegisterFlags(cmd.Flags())
+		require.NoError(t, cmd.Flags().Set("connpool-global-capacity", "100"))
+
+		assert.True(t, config.GlobalCapacityExplicit())
+	})
+
+	t.Run("env var is explicit", func(t *testing.T) {
+		viper.Reset()
+		defer viper.Reset()
+		t.Setenv("CONNPOOL_GLOBAL_CAPACITY", "90")
+		reg := viperutil.NewRegistry()
+		config := NewConfig(reg)
+		cmd := &cobra.Command{}
+		config.RegisterFlags(cmd.Flags())
+
+		assert.True(t, config.GlobalCapacityExplicit())
+	})
+}

--- a/go/services/multipooler/internal/connpoolmanager/config_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/config_test.go
@@ -489,4 +489,45 @@ func TestConfig_GlobalCapacityExplicit(t *testing.T) {
 
 		assert.True(t, config.GlobalCapacityExplicit())
 	})
+
+	// loadConfigFile writes the given YAML to a temp config file and loads it
+	// into the registry through the production ViperConfig path.
+	loadConfigFile := func(t *testing.T, reg *viperutil.Registry, fs *pflag.FlagSet, yaml string) {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "mtconfig.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(yaml), 0o644))
+		vc := viperutil.NewViperConfig(reg)
+		vc.RegisterFlags(fs)
+		require.NoError(t, fs.Set("config-file", path))
+		cancel, err := vc.LoadConfig(reg)
+		require.NoError(t, err)
+		t.Cleanup(cancel)
+	}
+
+	t.Run("config file pinning the default value is explicit", func(t *testing.T) {
+		viper.Reset()
+		defer viper.Reset()
+		reg := viperutil.NewRegistry()
+		config := NewConfig(reg)
+		cmd := &cobra.Command{}
+		config.RegisterFlags(cmd.Flags())
+		loadConfigFile(t, reg, cmd.Flags(), "connpool:\n  global-capacity: 100\n")
+
+		// The value equals the default, but the operator wrote it down — the
+		// config-file presence check must still count it as explicit.
+		assert.Equal(t, int64(100), config.GlobalCapacity())
+		assert.True(t, config.GlobalCapacityExplicit())
+	})
+
+	t.Run("config file without the key is not explicit", func(t *testing.T) {
+		viper.Reset()
+		defer viper.Reset()
+		reg := viperutil.NewRegistry()
+		config := NewConfig(reg)
+		cmd := &cobra.Command{}
+		config.RegisterFlags(cmd.Flags())
+		loadConfigFile(t, reg, cmd.Flags(), "connpool:\n  admin-capacity: 7\n")
+
+		assert.False(t, config.GlobalCapacityExplicit())
+	})
 }

--- a/go/services/multipooler/internal/connpoolmanager/manager.go
+++ b/go/services/multipooler/internal/connpoolmanager/manager.go
@@ -247,8 +247,12 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 	m.globalCapacity.Store(globalCapacity)
 	reservedRatio := m.config.ReservedRatio()
 	minPerUser := m.config.MinCapacityPerUser()
-	regularCapacity := int64(float64(globalCapacity) * (1 - reservedRatio))
-	reservedCapacity := globalCapacity - regularCapacity
+	// Guarantee each pool class at least one connection: a tiny budget (e.g. a
+	// derived capacity clamped to 1) would otherwise truncate the regular share
+	// to 0 and disable ordinary queries entirely. For such an already-unusable
+	// budget, overshooting it by one connection is the lesser evil.
+	regularCapacity := max(int64(float64(globalCapacity)*(1-reservedRatio)), 1)
+	reservedCapacity := max(globalCapacity-regularCapacity, 1)
 	regularMinPerUser := max(int64(float64(minPerUser)*(1-reservedRatio)), 1)
 	reservedMinPerUser := max(minPerUser-regularMinPerUser, 1)
 

--- a/go/services/multipooler/internal/connpoolmanager/manager.go
+++ b/go/services/multipooler/internal/connpoolmanager/manager.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"strconv"
 	"sync"
 	"sync/atomic"
 
@@ -141,6 +142,12 @@ type Manager struct {
 	regularAllocator  *FairShareAllocator
 	reservedAllocator *FairShareAllocator
 
+	// globalCapacity is the total connection budget in effect, resolved in Open:
+	// derived from the server's max_connections unless explicitly configured
+	// (see resolveGlobalCapacity). Atomic because the metrics callback reads it
+	// concurrently. Zero until the first Open.
+	globalCapacity atomic.Int64
+
 	// Drain tracking: counts connections currently lent out across all pools.
 	// Used for graceful drain during state transitions (not-serving).
 	//
@@ -236,7 +243,8 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 	m.adminPool.Open()
 
 	// Create fair share allocators based on global capacity and reserved ratio
-	globalCapacity := m.config.GlobalCapacity()
+	globalCapacity := m.resolveGlobalCapacity(ctx)
+	m.globalCapacity.Store(globalCapacity)
 	reservedRatio := m.config.ReservedRatio()
 	minPerUser := m.config.MinCapacityPerUser()
 	regularCapacity := int64(float64(globalCapacity) * (1 - reservedRatio))
@@ -254,7 +262,7 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 	m.startRebalancer()
 
 	// Register observable metric callbacks for pool statistics.
-	if err := m.metrics.RegisterManagerCallbacks(m.Stats, m.UserPoolCount, m.config.GlobalCapacity, m.IsClosed); err != nil {
+	if err := m.metrics.RegisterManagerCallbacks(m.Stats, m.UserPoolCount, m.GlobalCapacity, m.IsClosed); err != nil {
 		m.logger.WarnContext(ctx, "failed to register pool metrics callbacks", "error", err)
 	}
 
@@ -273,6 +281,71 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 	// If this Open is the second half of a reopen, end the window now that the
 	// fresh pools are ready, waking any withReopenRetry waiters so they retry.
 	m.endReopen()
+}
+
+// globalCapacityQuery reads the server-side connection budget in one round
+// trip. reserved_connections is PG 16+; missing_ok=true + COALESCE yields 0 on
+// older servers.
+const globalCapacityQuery = "SELECT pg_catalog.current_setting('max_connections'), pg_catalog.current_setting('superuser_reserved_connections'), COALESCE(pg_catalog.current_setting('reserved_connections', true), '0')"
+
+// resolveGlobalCapacity returns the pool's total connection budget. An
+// explicitly configured --connpool-global-capacity (flag, env, or config file)
+// is authoritative. Otherwise the budget is derived from the server the admin
+// pool just opened against, so the pooler's demand can never exceed what
+// postgres accepts ("sorry, too many clients already"). Any failure falls back
+// to the configured default with a warning — Open is infallible by design, and
+// the postgres monitor reopens the manager (re-running this) after every
+// postgres restart.
+func (m *Manager) resolveGlobalCapacity(ctx context.Context) int64 {
+	configured := m.config.GlobalCapacity()
+	if m.config.GlobalCapacityExplicit() {
+		return configured
+	}
+	queryCtx, cancel := context.WithTimeout(ctx, 2*m.config.DialTimeout())
+	defer cancel()
+	pooled, err := m.adminPool.Get(queryCtx)
+	if err != nil {
+		m.logger.WarnContext(ctx, "could not derive connpool global capacity from postgres; using configured value",
+			"error", err, "global_capacity", configured)
+		return configured
+	}
+	defer pooled.Recycle()
+	results, err := pooled.Conn.QueryWithRetry(queryCtx, globalCapacityQuery)
+	if err == nil && (len(results) != 1 || len(results[0].Rows) != 1 || len(results[0].Rows[0].Values) != 3) {
+		err = fmt.Errorf("unexpected result shape for %q", globalCapacityQuery)
+	}
+	var settings [3]int64
+	if err == nil {
+		for i, v := range results[0].Rows[0].Values {
+			if settings[i], err = strconv.ParseInt(string(v), 10, 64); err != nil {
+				break
+			}
+		}
+	}
+	if err != nil {
+		m.logger.WarnContext(ctx, "could not derive connpool global capacity from postgres; using configured value",
+			"error", err, "global_capacity", configured)
+		return configured
+	}
+	maxConns, superuserReserved, reservedConns := settings[0], settings[1], settings[2]
+	derived := deriveGlobalCapacity(maxConns, superuserReserved, reservedConns, m.config.AdminCapacity())
+	m.logger.InfoContext(ctx, "derived connpool global capacity from postgres",
+		"global_capacity", derived,
+		"max_connections", maxConns,
+		"superuser_reserved_connections", superuserReserved,
+		"reserved_connections", reservedConns,
+		"admin_capacity", m.config.AdminCapacity(),
+	)
+	return derived
+}
+
+// deriveGlobalCapacity computes the usable connection budget from the server's
+// limits: user pools dial as regular roles, so slots withheld for superusers
+// (and PG 16+ reserved_connections roles) are never usable, and the manager's
+// own admin pool consumes adminCapacity slots on top. Clamped to at least 1 so
+// a pathological server config still leaves the pooler able to serve.
+func deriveGlobalCapacity(maxConns, superuserReserved, reservedConns, adminCapacity int64) int64 {
+	return max(maxConns-superuserReserved-reservedConns-adminCapacity, 1)
 }
 
 // buildClientConfig creates a client.Config with the specified user and password.
@@ -547,6 +620,12 @@ func (m *Manager) teardownLocked() {
 // PgUser returns the configured PostgreSQL user for system queries.
 func (m *Manager) PgUser() string {
 	return m.config.PgUser()
+}
+
+// GlobalCapacity returns the total connection budget in effect — derived from
+// the server at Open unless explicitly configured. Zero before the first Open.
+func (m *Manager) GlobalCapacity() int64 {
+	return m.globalCapacity.Load()
 }
 
 // PgDatabase returns the PostgreSQL database the pooler connects to, taken from

--- a/go/services/multipooler/internal/connpoolmanager/manager_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/manager_test.go
@@ -996,3 +996,54 @@ func bytes32(seed byte) []byte {
 	}
 	return out
 }
+
+func TestDeriveGlobalCapacity(t *testing.T) {
+	// max_connections − superuser_reserved − reserved − admin capacity.
+	assert.Equal(t, int64(100), deriveGlobalCapacity(110, 3, 2, 5))
+	// Clamped to 1 when the server budget is smaller than the overheads.
+	assert.Equal(t, int64(1), deriveGlobalCapacity(5, 3, 0, 5))
+}
+
+func TestManager_Open_DerivesGlobalCapacity(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.AddQuery(globalCapacityQuery, fakepgserver.MakeResult(
+		[]string{"max_connections", "superuser_reserved_connections", "reserved_connections"},
+		[][]any{{"200", "3", "2"}},
+	))
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	// 200 − 3 − 2 − 5 (admin capacity default).
+	assert.Equal(t, int64(190), manager.GlobalCapacity())
+	assert.Equal(t, int64(190), manager.regularAllocator.Capacity()+manager.reservedAllocator.Capacity())
+}
+
+func TestManager_Open_DeriveFails_UsesConfigured(t *testing.T) {
+	// No registered query: the derivation query errors and the configured
+	// default must be used.
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	assert.Equal(t, int64(100), manager.GlobalCapacity())
+}
+
+func TestManager_Open_ExplicitGlobalCapacity_SkipsDerivation(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.AddQuery(globalCapacityQuery, fakepgserver.MakeResult(
+		[]string{"max_connections", "superuser_reserved_connections", "reserved_connections"},
+		[][]any{{"200", "3", "2"}},
+	))
+	t.Setenv("CONNPOOL_GLOBAL_CAPACITY", "42")
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	assert.Equal(t, int64(42), manager.GlobalCapacity())
+	assert.Equal(t, 0, server.GetQueryCalledNum(globalCapacityQuery))
+}

--- a/go/services/multipooler/internal/connpoolmanager/manager_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/manager_test.go
@@ -1047,3 +1047,37 @@ func TestManager_Open_ExplicitGlobalCapacity_SkipsDerivation(t *testing.T) {
 	assert.Equal(t, int64(42), manager.GlobalCapacity())
 	assert.Equal(t, 0, server.GetQueryCalledNum(globalCapacityQuery))
 }
+
+func TestManager_Open_TinyBudget_KeepsRegularPoolUsable(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+	server.AddQuery(globalCapacityQuery, fakepgserver.MakeResult(
+		[]string{"max_connections", "superuser_reserved_connections", "reserved_connections"},
+		[][]any{{"10", "3", "2"}},
+	))
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	// 10 − 3 − 2 − 5 (admin capacity) = 0, clamped to a derived budget of 1.
+	// Each pool class still gets one connection so ordinary queries and
+	// transactions both stay possible on a pathologically small server.
+	assert.Equal(t, int64(1), manager.GlobalCapacity())
+	assert.Equal(t, int64(1), manager.regularAllocator.Capacity())
+	assert.Equal(t, int64(1), manager.reservedAllocator.Capacity())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := manager.GetRegularConn(ctx, "user1", nil, nil)
+	require.NoError(t, err)
+	conn.Recycle()
+
+	// A rebalance must not zero the regular pool: with a zero-capacity
+	// allocator every user would be allocated 0 and the Get below would hang
+	// until the deadline.
+	manager.rebalance(ctx)
+	conn, err = manager.GetRegularConn(ctx, "user1", nil, nil)
+	require.NoError(t, err)
+	conn.Recycle()
+}

--- a/go/services/multipooler/internal/connpoolmanager/metrics.go
+++ b/go/services/multipooler/internal/connpoolmanager/metrics.go
@@ -383,7 +383,7 @@ func (m *Metrics) routingRoleOption() metric.MeasurementOption {
 // Parameters:
 //   - statsGetter: returns a snapshot of all pool statistics
 //   - poolCountGetter: returns the number of active user pools
-//   - globalCapacityGetter: returns the configured global connection capacity
+//   - globalCapacityGetter: returns the global connection capacity in effect (derived or configured)
 //   - isClosedGetter: returns whether the manager is closed
 func (m *Metrics) RegisterManagerCallbacks(
 	statsGetter func() ManagerStats,

--- a/go/test/endtoend/metrics/metrics_test.go
+++ b/go/test/endtoend/metrics/metrics_test.go
@@ -141,8 +141,10 @@ func TestPoolerMetricValues(t *testing.T) {
 	// Database count: always 1 per multipooler instance.
 	utils.AssertMetricValue(t, poolerVals, "mg_pooler_databases", nil, 1)
 
-	// Global capacity: default is 100.
-	utils.AssertMetricValue(t, poolerVals, "mg_pooler_config_max_server_connections", nil, 100)
+	// Global capacity: derived from the server at admin-pool open —
+	// max_connections (110, pgctld default) − superuser_reserved_connections
+	// (3, PG default) − reserved_connections (0) − admin pool capacity (5).
+	utils.AssertMetricValue(t, poolerVals, "mg_pooler_config_max_server_connections", nil, 102)
 
 	// Pool count: at least 1 user pool (the test user).
 	utils.AssertMetricGE(t, poolerVals, "mg_pooler_pools", nil, 1)

--- a/go/tools/viperutil/registry.go
+++ b/go/tools/viperutil/registry.go
@@ -57,6 +57,16 @@ func NewRegistry() *Registry {
 	}
 }
 
+// InStaticConfig reports whether the key was present in the loaded static
+// config file. Unlike viper's IsSet — which is true for every registered value
+// because Configure installs its default via SetDefault — this consults only
+// the parsed config-file contents, so callers can distinguish "operator wrote
+// this key" from "value fell through to the default". Always false before
+// LoadConfig has run (or when no config file was found).
+func (reg *Registry) InStaticConfig(key string) bool {
+	return reg.static.InConfig(key)
+}
+
 // Combined returns a viper instance combining the static and dynamic registries.
 // This is useful for debug handlers and other utilities that need to access
 // all configuration values.


### PR DESCRIPTION
## Description

Part of MUL-497 (infer query-serving flags from PostgreSQL instead of duplicating them).

The pooler's total demand on postgres (`--connpool-global-capacity`, default 100) and pgctld's `max_connections` (110) are hand-balanced twins maintained in files that never reference each other. When they drift, the failure is `sorry, too many clients already` at runtime — under load, the worst possible time.

This PR derives the capacity from the server itself. At admin-pool open, when `--connpool-global-capacity` was not explicitly configured (flag, env var, or config file), the manager runs one query on the admin pool it opened one line earlier:

```
capacity = max_connections − superuser_reserved_connections − reserved_connections − admin_capacity
```

- `reserved_connections` is PG 16+; `missing_ok` + COALESCE yields 0 on older servers. Functions are `pg_catalog`-qualified.
- An explicitly configured value remains authoritative. Explicitness is detected per source: `pflag.Flag.Changed` for the flag, `os.LookupEnv` for `CONNPOOL_GLOBAL_CAPACITY` (the docker image sets this today, so that path is unchanged), and key presence in the loaded config file via a new `viperutil Registry.InStaticConfig` — so a config file pinning the capacity to exactly the default still counts as explicit (viper's `IsSet` can't do this: it is unconditionally true for registered values because `Configure` installs defaults via `SetDefault`).
- Any derivation failure falls back to the configured value with a warning — `Open` is infallible by design, and the postgres monitor reopens the manager (re-running the derivation) after every postgres restart.
- A tiny budget (e.g. a derived capacity clamped to 1) previously truncated the regular pool's share to 0, letting the rebalancer disable ordinary queries entirely; the split now guarantees each pool class at least one connection, overshooting an already-unusable budget by one connection as the lesser evil.
- The `multigres_connpool_config_max_server_connections` metric now reports the value in effect (derived or configured) instead of always the configured flag.

On a default deployment (pgctld's `max_connections = 110`, PG default `superuser_reserved_connections = 3`, admin capacity 5) the derived budget is 102 — and it now follows `max_connections` automatically when an operator raises it.

## Testing

- New unit tests: derivation math incl. clamp-to-1; Open derives against fakepgserver (also asserted as the sum of both allocator capacities); derivation failure falls back to the configured value; explicit env value skips the query entirely; config-file-pinned-to-default counts as explicit (driven through the production `ViperConfig.LoadConfig` path); tiny-budget open keeps the regular pool usable across a rebalance (verified to fail pre-fix).
- `go test -short ./go/services/multipooler/...` and `./go/tools/viperutil/...` green; race-run of the new tests green.
- Integration: `go/test/endtoend/multipooler` and `.../backupfaults` pass against real postgres.
