### PR TITLE
feat(multipooler): add prepared-statement, advisory-lock, and temp-object scrubber checkers

### DIFF
--- a/docs/query_serving/connection_pooling.md
+++ b/docs/query_serving/connection_pooling.md
@@ -622,18 +622,26 @@ Three more checkers cover the rest of the backend state the pool trusts:
   against `pg_prepared_statements`. Idle connections legitimately keep
   prepared statements across borrowers, so this is a two-sided comparison:
   a backend statement tracking does not know is untracked, a tracked
-  statement the backend lost is phantom. Names are consolidator identifiers,
-  never client SQL.
+  statement the backend lost is phantom. Tracked names are consolidator
+  identifiers and are reported verbatim; an untracked name is reported
+  verbatim only when it has the consolidator's shape (a tracking bug),
+  otherwise it is redacted to `foreign_name`, since a name that arrived on a
+  backend by another route may embed client data.
 - `advisory_locks` reports a single `session_advisory_lock` finding when the
   idle backend holds any advisory lock. Acquiring functions route to a
   reserved connection whose release runs `pg_advisory_unlock_all`, so a lock
   on an idle pooled backend means the acquisition escaped tracking. Lock keys
   are never reported.
 - `temp_objects` reports one finding per kind of object (`table`, `index`,
-  `sequence`, `function`, ...) in the backend's temporary schema. Temp
-  statements pin a reserved connection that is closed at release and
-  pg_temp-qualified CREATE is rejected, so any object on an idle backend
-  escaped tracking. Object names are never reported.
+  `sequence`, `function`, `domain`, `enum`, `range`, ...) in the backend's
+  temporary schema, covering `pg_class`, `pg_proc`, and standalone `pg_type`
+  entries — the same object classes the gateway's pg_temp CREATE rejection
+  recognizes. Temp statements pin a reserved connection that is closed at
+  release and pg_temp-qualified CREATE is rejected, so any object on an idle
+  backend escaped tracking. A leftover temp type is not inert: pg_temp is
+  searched before `pg_catalog` for unqualified type names as well as
+  relation names, so it would shadow a catalog type for the next borrower.
+  Object names are never reported.
 
 All four checkers run against the same idle connection each tick; the
 divergence log line and the `checker` metric attribute name which one fired.

--- a/docs/query_serving/connection_pooling.md
+++ b/docs/query_serving/connection_pooling.md
@@ -633,15 +633,21 @@ Three more checkers cover the rest of the backend state the pool trusts:
   on an idle pooled backend means the acquisition escaped tracking. Lock keys
   are never reported.
 - `temp_objects` reports one finding per kind of object (`table`, `index`,
-  `sequence`, `function`, `domain`, `enum`, `range`, ...) in the backend's
-  temporary schema, covering `pg_class`, `pg_proc`, and standalone `pg_type`
-  entries — the same object classes the gateway's pg_temp CREATE rejection
-  recognizes. Temp statements pin a reserved connection that is closed at
-  release and pg_temp-qualified CREATE is rejected, so any object on an idle
-  backend escaped tracking. A leftover temp type is not inert: pg_temp is
-  searched before `pg_catalog` for unqualified type names as well as
-  relation names, so it would shadow a catalog type for the next borrower.
-  Object names are never reported.
+  `sequence`, `function`, `domain`, `enum`, `range`, `operator`,
+  `collation`, `statistics`, ...) in the backend's temporary schema. It
+  scans every namespace-scoped catalog the gateway's pg_temp CREATE
+  rejection covers: `pg_class`, `pg_proc` (aggregates included), standalone
+  `pg_type` entries, `pg_operator`, `pg_collation`, `pg_statistic_ext`,
+  `pg_opclass`, `pg_opfamily`, `pg_conversion`, and the four text-search
+  catalogs. Temp statements pin a reserved connection that is closed at
+  release and pg_temp-qualified CREATE is rejected, so any object on an
+  idle backend escaped tracking. Relations and types are the dangerous
+  classes: pg_temp is searched before `pg_catalog` for unqualified relation
+  and type names (a pg_temp domain named `text` captures an unqualified
+  `::text`), so a leftover shadows the catalog for the next borrower.
+  Operators, collations, and the other classes are never resolved through
+  pg_temp, even with it listed in `search_path`, and are reported as stale
+  state for completeness. Object names are never reported.
 
 All four checkers run against the same idle connection each tick; the
 divergence log line and the `checker` metric attribute name which one fired.

--- a/docs/query_serving/connection_pooling.md
+++ b/docs/query_serving/connection_pooling.md
@@ -616,17 +616,26 @@ values. One blind spot remains: an _untracked_ custom GUC set behind
 tracking's back is unenumerable from SQL; the creation-time rejection gates
 are the defense for that class.
 
-Three more checkers cover the rest of the backend state the pool trusts:
+Four more checkers cover the rest of the backend state the pool trusts:
 
 - `prepared_statements` diffs the connection's tracked prepared statements
-  against `pg_prepared_statements`. Idle connections legitimately keep
-  prepared statements across borrowers, so this is a two-sided comparison:
-  a backend statement tracking does not know is untracked, a tracked
-  statement the backend lost is phantom. Tracked names are consolidator
-  identifiers and are reported verbatim; an untracked name is reported
-  verbatim only when it has the consolidator's shape (a tracking bug),
-  otherwise it is redacted to `foreign_name`, since a name that arrived on a
-  backend by another route may embed client data.
+  against `pg_prepared_statements`, names and bodies. Idle connections
+  legitimately keep prepared statements across borrowers, so this is a
+  two-sided comparison: a backend statement tracking does not know is
+  untracked, a tracked statement the backend lost is phantom, and a tracked
+  statement whose backend body differs from the tracked query is mismatched
+  — a hidden `DEALLOCATE` plus re-`PREPARE` keeps the name, and the pool
+  would otherwise hand the redefined statement to the next borrower's
+  `EXECUTE`. Tracked names are consolidator identifiers and are reported
+  verbatim; every untracked name is redacted to `foreign_name`, one entry
+  per statement, since a name that arrived on a backend by another route
+  may embed client data and the consolidator's `ppstmt<N>` shape is
+  reachable from any session.
+- `holdable_cursors` reports one `holdable_cursor` finding per cursor still
+  open on the idle backend. Outside a transaction only `WITH HOLD` cursors
+  remain, and portals pin a reserved connection, so an open cursor here was
+  declared behind tracking (an `EXECUTE 'DECLARE ... WITH HOLD'` inside a
+  routine body). Cursor names are never reported.
 - `advisory_locks` reports a single `session_advisory_lock` finding when the
   idle backend holds any advisory lock. Acquiring functions route to a
   reserved connection whose release runs `pg_advisory_unlock_all`, so a lock
@@ -649,7 +658,7 @@ Three more checkers cover the rest of the backend state the pool trusts:
   pg_temp, even with it listed in `search_path`, and are reported as stale
   state for completeness. Object names are never reported.
 
-All four checkers run against the same idle connection each tick; the
+All five checkers run against the same idle connection each tick; the
 divergence log line and the `checker` metric attribute name which one fired.
 
 The untracked rule imposes a bootstrap invariant: connection setup must not

--- a/docs/query_serving/connection_pooling.md
+++ b/docs/query_serving/connection_pooling.md
@@ -614,9 +614,29 @@ statement-local `set_config(..., is_local := true)` probe so `'65536'` vs
 `'64MB'` never counts as divergence. Findings carry GUC names only, never
 values. One blind spot remains: an _untracked_ custom GUC set behind
 tracking's back is unenumerable from SQL; the creation-time rejection gates
-are the defense for that class. Future checkers (prepared statements vs
-`pg_prepared_statements`, residual advisory locks, temp-schema leftovers)
-register the same way.
+are the defense for that class.
+
+Three more checkers cover the rest of the backend state the pool trusts:
+
+- `prepared_statements` diffs the connection's tracked prepared statements
+  against `pg_prepared_statements`. Idle connections legitimately keep
+  prepared statements across borrowers, so this is a two-sided comparison:
+  a backend statement tracking does not know is untracked, a tracked
+  statement the backend lost is phantom. Names are consolidator identifiers,
+  never client SQL.
+- `advisory_locks` reports a single `session_advisory_lock` finding when the
+  idle backend holds any advisory lock. Acquiring functions route to a
+  reserved connection whose release runs `pg_advisory_unlock_all`, so a lock
+  on an idle pooled backend means the acquisition escaped tracking. Lock keys
+  are never reported.
+- `temp_objects` reports one finding per kind of object (`table`, `index`,
+  `sequence`, `function`, ...) in the backend's temporary schema. Temp
+  statements pin a reserved connection that is closed at release and
+  pg_temp-qualified CREATE is rejected, so any object on an idle backend
+  escaped tracking. Object names are never reported.
+
+All four checkers run against the same idle connection each tick; the
+divergence log line and the `checker` metric attribute name which one fired.
 
 The untracked rule imposes a bootstrap invariant: connection setup must not
 create session-source GUC state outside the settings label — bootstrap

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -151,12 +151,20 @@ const (
 	PreparedStatementsProbeSQL = "SELECT name FROM pg_catalog.pg_prepared_statements"
 
 	// TempObjectsProbeSQL returns one row per object in the current backend's
-	// temporary schema: a relkind code per pg_class entry plus 'function' per
-	// pg_proc entry. pg_my_temp_schema() is 0 when the session has no temp
-	// schema, which no namespace OID matches, so the probe returns no rows.
-	// Run by the multipooler scrubber; an idle pooled backend must own none.
+	// temporary schema: a relkind code per pg_class entry, 'function' per
+	// pg_proc entry, and 'type:' plus the typtype code per standalone pg_type
+	// entry (domains, enums, ranges, multiranges). Composite types are counted
+	// through pg_class, and the array type PostgreSQL creates alongside every
+	// type is skipped, so each user-created object yields one row.
+	// pg_my_temp_schema() is 0 when the session has no temp schema, which no
+	// namespace OID matches, so the probe returns no rows. Run by the
+	// multipooler scrubber; an idle pooled backend must own none — and a temp
+	// type shadows same-named catalog types for unqualified references, since
+	// pg_temp is searched first for type names as well as relation names.
 	TempObjectsProbeSQL = "SELECT relkind::text FROM pg_catalog.pg_class WHERE relnamespace = pg_catalog.pg_my_temp_schema()" +
-		" UNION ALL SELECT 'function' FROM pg_catalog.pg_proc WHERE pronamespace = pg_catalog.pg_my_temp_schema()"
+		" UNION ALL SELECT 'function' FROM pg_catalog.pg_proc WHERE pronamespace = pg_catalog.pg_my_temp_schema()" +
+		" UNION ALL SELECT 'type:' || typtype::text FROM pg_catalog.pg_type WHERE typnamespace = pg_catalog.pg_my_temp_schema()" +
+		" AND typtype <> 'c' AND NOT (typtype = 'b' AND typelem <> 0)"
 
 	// SessionSourceProbeSQL is the session-state probe run by the multipooler
 	// scrubber. It reads the backend's real session GUC state in one

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -151,20 +151,39 @@ const (
 	PreparedStatementsProbeSQL = "SELECT name FROM pg_catalog.pg_prepared_statements"
 
 	// TempObjectsProbeSQL returns one row per object in the current backend's
-	// temporary schema: a relkind code per pg_class entry, 'function' per
-	// pg_proc entry, and 'type:' plus the typtype code per standalone pg_type
-	// entry (domains, enums, ranges, multiranges). Composite types are counted
-	// through pg_class, and the array type PostgreSQL creates alongside every
-	// type is skipped, so each user-created object yields one row.
-	// pg_my_temp_schema() is 0 when the session has no temp schema, which no
-	// namespace OID matches, so the probe returns no rows. Run by the
-	// multipooler scrubber; an idle pooled backend must own none — and a temp
-	// type shadows same-named catalog types for unqualified references, since
-	// pg_temp is searched first for type names as well as relation names.
+	// temporary schema, tagged by kind, across every namespace-scoped catalog
+	// the gateway's pg_temp CREATE rejection covers: a relkind code per
+	// pg_class entry, 'function' per pg_proc entry (aggregates included),
+	// 'type:' plus the typtype code per standalone pg_type entry (domains,
+	// enums, ranges, multiranges), and a fixed tag per operator, collation,
+	// statistics object, operator class, operator family, conversion, and
+	// text-search parser/dictionary/template/configuration. Composite types
+	// are counted through pg_class, and the array type PostgreSQL creates
+	// alongside every type is skipped, so each user-created object yields
+	// one row. pg_my_temp_schema() is 0 when the session has no temp schema,
+	// which no namespace OID matches, so the probe returns no rows.
+	//
+	// Run by the multipooler scrubber; an idle pooled backend must own none.
+	// Relations and types are the dangerous classes: pg_temp is searched
+	// before pg_catalog for unqualified relation and type names (verified: a
+	// pg_temp domain named text captures unqualified ::text), so a leftover
+	// shadows the catalog for the next borrower. Operators, collations, and
+	// the rest are never resolved through pg_temp, even with pg_temp listed
+	// in search_path; they are reported as stale state for completeness.
 	TempObjectsProbeSQL = "SELECT relkind::text FROM pg_catalog.pg_class WHERE relnamespace = pg_catalog.pg_my_temp_schema()" +
 		" UNION ALL SELECT 'function' FROM pg_catalog.pg_proc WHERE pronamespace = pg_catalog.pg_my_temp_schema()" +
 		" UNION ALL SELECT 'type:' || typtype::text FROM pg_catalog.pg_type WHERE typnamespace = pg_catalog.pg_my_temp_schema()" +
-		" AND typtype <> 'c' AND NOT (typtype = 'b' AND typelem <> 0)"
+		" AND typtype <> 'c' AND NOT (typtype = 'b' AND typelem <> 0)" +
+		" UNION ALL SELECT 'operator' FROM pg_catalog.pg_operator WHERE oprnamespace = pg_catalog.pg_my_temp_schema()" +
+		" UNION ALL SELECT 'collation' FROM pg_catalog.pg_collation WHERE collnamespace = pg_catalog.pg_my_temp_schema()" +
+		" UNION ALL SELECT 'statistics' FROM pg_catalog.pg_statistic_ext WHERE stxnamespace = pg_catalog.pg_my_temp_schema()" +
+		" UNION ALL SELECT 'operator_class' FROM pg_catalog.pg_opclass WHERE opcnamespace = pg_catalog.pg_my_temp_schema()" +
+		" UNION ALL SELECT 'operator_family' FROM pg_catalog.pg_opfamily WHERE opfnamespace = pg_catalog.pg_my_temp_schema()" +
+		" UNION ALL SELECT 'conversion' FROM pg_catalog.pg_conversion WHERE connamespace = pg_catalog.pg_my_temp_schema()" +
+		" UNION ALL SELECT 'ts_parser' FROM pg_catalog.pg_ts_parser WHERE prsnamespace = pg_catalog.pg_my_temp_schema()" +
+		" UNION ALL SELECT 'ts_dictionary' FROM pg_catalog.pg_ts_dict WHERE dictnamespace = pg_catalog.pg_my_temp_schema()" +
+		" UNION ALL SELECT 'ts_template' FROM pg_catalog.pg_ts_template WHERE tmplnamespace = pg_catalog.pg_my_temp_schema()" +
+		" UNION ALL SELECT 'ts_config' FROM pg_catalog.pg_ts_config WHERE cfgnamespace = pg_catalog.pg_my_temp_schema()"
 
 	// SessionSourceProbeSQL is the session-state probe run by the multipooler
 	// scrubber. It reads the backend's real session GUC state in one

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -140,7 +140,23 @@ const (
 	// visible here is session-level (transaction-level advisory locks are
 	// released at transaction end), so a false result means the session has
 	// released all of its advisory locks and the backend can be unpinned.
-	PgLocksAdvisoryProbeSQL = "SELECT EXISTS (SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND pid = pg_backend_pid())"
+	// Schema-qualified so a pg_temp relation or a search_path function cannot
+	// shadow the catalog (see SessionSourceProbeSQL).
+	PgLocksAdvisoryProbeSQL = "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_locks WHERE locktype = 'advisory' AND pid = pg_catalog.pg_backend_pid())"
+
+	// PreparedStatementsProbeSQL lists the named prepared statements the
+	// current backend holds, protocol-level (Parse) and SQL-level (PREPARE)
+	// alike. The unnamed statement is never listed. Run by the multipooler
+	// scrubber to compare against the pool's tracked prepared statements.
+	PreparedStatementsProbeSQL = "SELECT name FROM pg_catalog.pg_prepared_statements"
+
+	// TempObjectsProbeSQL returns one row per object in the current backend's
+	// temporary schema: a relkind code per pg_class entry plus 'function' per
+	// pg_proc entry. pg_my_temp_schema() is 0 when the session has no temp
+	// schema, which no namespace OID matches, so the probe returns no rows.
+	// Run by the multipooler scrubber; an idle pooled backend must own none.
+	TempObjectsProbeSQL = "SELECT relkind::text FROM pg_catalog.pg_class WHERE relnamespace = pg_catalog.pg_my_temp_schema()" +
+		" UNION ALL SELECT 'function' FROM pg_catalog.pg_proc WHERE pronamespace = pg_catalog.pg_my_temp_schema()"
 
 	// SessionSourceProbeSQL is the session-state probe run by the multipooler
 	// scrubber. It reads the backend's real session GUC state in one

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -145,10 +145,21 @@ const (
 	PgLocksAdvisoryProbeSQL = "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_locks WHERE locktype = 'advisory' AND pid = pg_catalog.pg_backend_pid())"
 
 	// PreparedStatementsProbeSQL lists the named prepared statements the
-	// current backend holds, protocol-level (Parse) and SQL-level (PREPARE)
-	// alike. The unnamed statement is never listed. Run by the multipooler
-	// scrubber to compare against the pool's tracked prepared statements.
-	PreparedStatementsProbeSQL = "SELECT name FROM pg_catalog.pg_prepared_statements"
+	// current backend holds with their bodies, protocol-level (Parse) and
+	// SQL-level (PREPARE) alike. The unnamed statement is never listed. For a
+	// Parse-created statement the body is the query string as submitted; for
+	// a SQL PREPARE it is the full PREPARE text. Run by the multipooler
+	// scrubber to compare against the pool's tracked prepared statements,
+	// body included: a name can survive a hidden DEALLOCATE plus re-PREPARE
+	// with a different body.
+	PreparedStatementsProbeSQL = "SELECT name, statement FROM pg_catalog.pg_prepared_statements"
+
+	// HoldableCursorsProbeSQL lists the current backend's open cursors. Run
+	// only outside a transaction, where every cursor still listed is WITH
+	// HOLD (others close at transaction end), so any row means a holdable
+	// cursor outlived its transaction on a pooled backend. Run by the
+	// multipooler scrubber; an idle pooled backend must hold none.
+	HoldableCursorsProbeSQL = "SELECT name FROM pg_catalog.pg_cursors"
 
 	// TempObjectsProbeSQL returns one row per object in the current backend's
 	// temporary schema, tagged by kind, across every namespace-scoped catalog

--- a/go/common/preparedstatement/pooler_consolidator.go
+++ b/go/common/preparedstatement/pooler_consolidator.go
@@ -20,6 +20,27 @@ import (
 	"sync"
 )
 
+// CanonicalNamePrefix is the prefix of every name PoolerConsolidator assigns;
+// the rest of the name is a decimal counter.
+const CanonicalNamePrefix = "ppstmt"
+
+// IsCanonicalName reports whether name has the shape PoolerConsolidator
+// assigns (prefix followed by one or more decimal digits). Used to tell a
+// pooler-generated statement name apart from one that arrived on a backend
+// by some other route.
+func IsCanonicalName(name string) bool {
+	digits, ok := strings.CutPrefix(name, CanonicalNamePrefix)
+	if !ok || digits == "" {
+		return false
+	}
+	for _, r := range digits {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 // PoolerConsolidator deduplicates prepared statements at the multipooler level.
 //
 // Unlike the gateway Consolidator which tracks per-connection name mappings,
@@ -59,7 +80,7 @@ func (pc *PoolerConsolidator) CanonicalName(query string, paramTypes []uint32) s
 		return name
 	}
 
-	name := fmt.Sprintf("ppstmt%d", pc.lastID)
+	name := fmt.Sprintf("%s%d", CanonicalNamePrefix, pc.lastID)
 	pc.lastID++
 	pc.stmts[key] = name
 	return name

--- a/go/common/preparedstatement/pooler_consolidator.go
+++ b/go/common/preparedstatement/pooler_consolidator.go
@@ -24,23 +24,6 @@ import (
 // the rest of the name is a decimal counter.
 const CanonicalNamePrefix = "ppstmt"
 
-// IsCanonicalName reports whether name has the shape PoolerConsolidator
-// assigns (prefix followed by one or more decimal digits). Used to tell a
-// pooler-generated statement name apart from one that arrived on a backend
-// by some other route.
-func IsCanonicalName(name string) bool {
-	digits, ok := strings.CutPrefix(name, CanonicalNamePrefix)
-	if !ok || digits == "" {
-		return false
-	}
-	for _, r := range digits {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-	return true
-}
-
 // PoolerConsolidator deduplicates prepared statements at the multipooler level.
 //
 // Unlike the gateway Consolidator which tracks per-connection name mappings,

--- a/go/common/preparedstatement/pooler_consolidator_test.go
+++ b/go/common/preparedstatement/pooler_consolidator_test.go
@@ -120,3 +120,14 @@ func TestPoolerConsolidator_ConcurrentAccess(t *testing.T) {
 		require.Equal(t, results[i], pc.CanonicalName(q, nil))
 	}
 }
+
+func TestIsCanonicalName(t *testing.T) {
+	pc := NewPoolerConsolidator()
+	require.True(t, IsCanonicalName(pc.CanonicalName("SELECT 1", nil)))
+	require.True(t, IsCanonicalName("ppstmt0"))
+	require.True(t, IsCanonicalName("ppstmt123456"))
+
+	for _, name := range []string{"", "ppstmt", "ppstmtx", "ppstmt1x", "PPSTMT1", "stmt_ssn_123", "ppstmt-1", " ppstmt1"} {
+		require.False(t, IsCanonicalName(name), "%q", name)
+	}
+}

--- a/go/common/preparedstatement/pooler_consolidator_test.go
+++ b/go/common/preparedstatement/pooler_consolidator_test.go
@@ -120,14 +120,3 @@ func TestPoolerConsolidator_ConcurrentAccess(t *testing.T) {
 		require.Equal(t, results[i], pc.CanonicalName(q, nil))
 	}
 }
-
-func TestIsCanonicalName(t *testing.T) {
-	pc := NewPoolerConsolidator()
-	require.True(t, IsCanonicalName(pc.CanonicalName("SELECT 1", nil)))
-	require.True(t, IsCanonicalName("ppstmt0"))
-	require.True(t, IsCanonicalName("ppstmt123456"))
-
-	for _, name := range []string{"", "ppstmt", "ppstmtx", "ppstmt1x", "PPSTMT1", "stmt_ssn_123", "ppstmt-1", " ppstmt1"} {
-		require.False(t, IsCanonicalName(name), "%q", name)
-	}
-}

--- a/go/services/multipooler/internal/connpoolmanager/config.go
+++ b/go/services/multipooler/internal/connpoolmanager/config.go
@@ -365,7 +365,7 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 	fs.Duration("connpool-user-reserved-max-lifetime", c.userReservedMaxLifetime.Default(), "Maximum lifetime of a user's reserved connection before recycling")
 
 	// Session-state scrub flag
-	fs.Duration("connpool-session-scrub-interval", c.sessionScrubInterval.Default(), "How often each user pool probes one idle connection for divergence between tracked and real backend state (session GUCs, prepared statements, advisory locks, temp objects), replacing divergent connections (0 = disabled)")
+	fs.Duration("connpool-session-scrub-interval", c.sessionScrubInterval.Default(), "How often each user pool probes one idle connection for divergence between tracked and real backend state (session GUCs, prepared statements, advisory locks, holdable cursors, temp objects), replacing divergent connections (0 = disabled)")
 
 	// Settings cache size flag
 	fs.Int64("connpool-settings-cache-size", c.settingsCacheSize.Default(), "Maximum number of unique settings combinations to cache (0 = use default)")

--- a/go/services/multipooler/internal/connpoolmanager/config.go
+++ b/go/services/multipooler/internal/connpoolmanager/config.go
@@ -365,7 +365,7 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 	fs.Duration("connpool-user-reserved-max-lifetime", c.userReservedMaxLifetime.Default(), "Maximum lifetime of a user's reserved connection before recycling")
 
 	// Session-state scrub flag
-	fs.Duration("connpool-session-scrub-interval", c.sessionScrubInterval.Default(), "How often each user pool probes one idle connection for divergence between tracked and real session GUC state, replacing divergent connections (0 = disabled)")
+	fs.Duration("connpool-session-scrub-interval", c.sessionScrubInterval.Default(), "How often each user pool probes one idle connection for divergence between tracked and real backend state (session GUCs, prepared statements, advisory locks, temp objects), replacing divergent connections (0 = disabled)")
 
 	// Settings cache size flag
 	fs.Int64("connpool-settings-cache-size", c.settingsCacheSize.Default(), "Maximum number of unique settings combinations to cache (0 = use default)")

--- a/go/services/multipooler/internal/connstate/connection_state.go
+++ b/go/services/multipooler/internal/connstate/connection_state.go
@@ -190,6 +190,23 @@ func (s *ConnectionState) GetPreparedStatement(name string) *query.PreparedState
 	return s.PreparedStatements[name]
 }
 
+// PreparedStatementNames returns the names of all tracked prepared
+// statements, in no particular order.
+func (s *ConnectionState) PreparedStatementNames() []string {
+	if s == nil {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	names := make([]string, 0, len(s.PreparedStatements))
+	for name := range s.PreparedStatements {
+		names = append(names, name)
+	}
+	return names
+}
+
 // DeletePreparedStatement removes a prepared statement by name.
 func (s *ConnectionState) DeletePreparedStatement(name string) {
 	if s == nil {

--- a/go/services/multipooler/internal/connstate/connection_state_test.go
+++ b/go/services/multipooler/internal/connstate/connection_state_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/multigres/multigres/go/pb/query"
 )
 
 func TestConnectionStateGetSetSettings(t *testing.T) {
@@ -45,4 +47,18 @@ func TestConnectionStateNilReceiverSafe(t *testing.T) {
 		state.SetSettings(NewSettings(nil, 0))
 		state.Close()
 	})
+}
+
+func TestConnectionStatePreparedStatementNames(t *testing.T) {
+	var nilState *ConnectionState
+	assert.Nil(t, nilState.PreparedStatementNames())
+
+	state := NewConnectionState()
+	assert.Empty(t, state.PreparedStatementNames())
+
+	state.StorePreparedStatement(&query.PreparedStatement{Name: "ppstmt1"})
+	state.StorePreparedStatement(&query.PreparedStatement{Name: ""})
+	state.DeletePreparedStatement("ppstmt1")
+	state.StorePreparedStatement(&query.PreparedStatement{Name: "ppstmt2"})
+	assert.ElementsMatch(t, []string{"", "ppstmt2"}, state.PreparedStatementNames())
 }

--- a/go/services/multipooler/internal/pools/connpool/interfaces.go
+++ b/go/services/multipooler/internal/pools/connpool/interfaces.go
@@ -59,8 +59,9 @@ type ConnChecker[C Connection] interface {
 
 	// Check compares the connection's real backend state against its
 	// tracked state. It must be side-effect-free and runs only on idle
-	// connections. An error means no verdict could be produced (the
-	// connection is not punished for it).
+	// connections. An error means no verdict could be produced; the
+	// scrubber then fails closed and replaces the connection, since an
+	// unverified backend may still carry hidden state.
 	Check(ctx context.Context, conn C) (Divergence, error)
 }
 

--- a/go/services/multipooler/internal/pools/connpool/scrub.go
+++ b/go/services/multipooler/internal/pools/connpool/scrub.go
@@ -32,8 +32,10 @@ import (
 // It is a sampler: it narrows the leak window and raises an alarm, but the
 // tracking gates remain the correctness boundary.
 
-// scrubProbeTimeout bounds one verification probe. Pool close cancels
-// pool.scrubCtx before draining, so an in-flight probe never stalls
+// scrubProbeTimeout bounds one checker's probe; each checker gets its own
+// budget, so a slow early probe cannot starve later checkers into a timeout
+// that the fail-closed error path would turn into needless churn. Pool close
+// cancels pool.scrubCtx before draining, so in-flight probes never stall
 // shutdown; this timeout only bounds probes against a hung backend.
 const scrubProbeTimeout = 5 * time.Second
 
@@ -105,9 +107,10 @@ func (pool *Pool[C]) scrubOne(cursor *int) bool {
 	var findings []finding
 	var checkErr error
 	var errChecker string
-	ctx, cancel := context.WithTimeout(pool.scrubCtx, scrubProbeTimeout)
 	for _, checker := range pool.checkers {
+		ctx, cancel := context.WithTimeout(pool.scrubCtx, scrubProbeTimeout)
 		div, err := checker.Check(ctx, conn.Conn)
+		cancel()
 		if err != nil {
 			checkErr, errChecker = err, checker.Name()
 			break
@@ -119,7 +122,6 @@ func (pool *Pool[C]) scrubOne(cursor *int) bool {
 			break
 		}
 	}
-	cancel()
 
 	pool.Metrics.scrubChecked.Add(1)
 	pool.scrubMetrics.RecordCheck(pool.ctx, pool.poolType)

--- a/go/services/multipooler/internal/pools/connpool/scrub_test.go
+++ b/go/services/multipooler/internal/pools/connpool/scrub_test.go
@@ -187,6 +187,33 @@ func TestScrubCountsHeldConnAsBorrowed(t *testing.T) {
 	assert.EqualValues(t, 0, pool.InUse())
 }
 
+func TestScrubEachCheckerGetsOwnTimeout(t *testing.T) {
+	// A slow early checker must not eat into the next checker's budget:
+	// with one shared context the second checker would see a deadline
+	// shortened by the first's run time and could fail closed for nothing.
+	pool := newScrubTestPool(t, 2, nil)
+	recycleIdle(t, pool, nil)
+
+	const slow = 200 * time.Millisecond
+	pool.RegisterChecker(funcChecker(func(ctx context.Context, _ *scrubMockConnection) (Divergence, error) {
+		time.Sleep(slow)
+		return Divergence{}, nil
+	}))
+	var remaining time.Duration
+	pool.RegisterChecker(funcChecker(func(ctx context.Context, _ *scrubMockConnection) (Divergence, error) {
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok, "checker context must carry a deadline")
+		remaining = time.Until(deadline)
+		return Divergence{}, nil
+	}))
+
+	cursor := 0
+	assert.True(t, pool.scrubOne(&cursor))
+	assert.Greater(t, remaining, scrubProbeTimeout-slow/2,
+		"second checker's budget was shortened by the first checker's run time")
+	assert.EqualValues(t, 0, pool.Metrics.ScrubErrorCount())
+}
+
 func TestScrubCloseCancelsInFlightProbe(t *testing.T) {
 	// Close must not wait out a slow probe: cancelling the scrub context
 	// aborts it and the freed connection is closed by the drain.

--- a/go/services/multipooler/internal/pools/regular/backend_state_verify.go
+++ b/go/services/multipooler/internal/pools/regular/backend_state_verify.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 
 	"github.com/multigres/multigres/go/common/constants"
-	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pools/connpool"
 )
 
@@ -30,7 +29,10 @@ import (
 //
 //   - prepared statements: tracked per connection in ConnectionState and
 //     legitimately kept across borrowers, so this is a two-sided diff
-//     against pg_prepared_statements.
+//     against pg_prepared_statements, bodies included.
+//   - holdable cursors: never legitimate on an idle pooled backend. Portals
+//     pin a reserved connection, and only a WITH HOLD cursor survives its
+//     transaction; one still open means it was declared behind tracking.
 //   - session-level advisory locks: never legitimate on an idle pooled
 //     backend. Acquiring functions route to a reserved connection whose
 //     release runs pg_advisory_unlock_all; a lock still held means the
@@ -56,21 +58,24 @@ func (PreparedStatementChecker) Check(ctx context.Context, conn *Conn) (connpool
 	return conn.VerifyPreparedStatements(ctx)
 }
 
-// foreignPreparedStatementName is reported in place of an untracked
-// statement name that does not have the consolidator's shape. Such a name
-// reached the backend outside the pooler (e.g. a PREPARE hidden in a routine
-// body) and may embed client data, so it never enters Divergence or logs.
-// One entry is reported per statement so counts survive redaction.
+// foreignPreparedStatementName is reported in place of every untracked
+// statement name. Such a name reached the backend outside the pooler (e.g. a
+// PREPARE hidden in a routine body) and may embed client data; the
+// consolidator's ppstmt<N> shape is no safety signal, since any session can
+// PREPARE a name of that shape. One entry is reported per statement so
+// counts survive redaction.
 const foreignPreparedStatementName = "foreign_name"
 
 // VerifyPreparedStatements compares the connection's tracked prepared
-// statements against pg_prepared_statements. A statement the backend holds
-// but tracking does not know is Untracked (the next borrower could collide
-// with or execute it); a tracked statement the backend no longer has is
-// Phantom (the next EXECUTE would fail). Tracked names are consolidator
-// assigned and reported verbatim; an untracked name is reported verbatim
-// only when it has the consolidator's shape (pointing at a tracking bug),
-// otherwise it is redacted to foreignPreparedStatementName.
+// statements against pg_prepared_statements, names and bodies. A statement
+// the backend holds but tracking does not know is Untracked (the next
+// borrower could collide with or execute it), reported redacted; a tracked
+// statement the backend no longer has is Phantom (the next EXECUTE would
+// fail); a tracked statement whose backend body differs from the tracked
+// query is Mismatched — a hidden DEALLOCATE plus re-PREPARE keeps the name,
+// and ensurePrepared would otherwise hand the redefined statement to the
+// next borrower. Tracked names are consolidator assigned and reported
+// verbatim.
 func (c *Conn) VerifyPreparedStatements(ctx context.Context) (connpool.Divergence, error) {
 	var div connpool.Divergence
 	if !c.IsIdle() {
@@ -85,38 +90,39 @@ func (c *Conn) VerifyPreparedStatements(ctx context.Context) (connpool.Divergenc
 		return div, errors.New("prepared statement probe returned unexpected result count")
 	}
 
-	backend := make(map[string]struct{}, results[0].RowCount())
+	backend := make(map[string]string, results[0].RowCount()) // name → body
 	for _, row := range results[0].StructuredRows() {
-		if len(row.Values) != 1 || row.Values[0].IsNull() {
+		if len(row.Values) != 2 || row.Values[0].IsNull() || row.Values[1].IsNull() {
 			return div, errors.New("prepared statement probe returned malformed row")
 		}
-		backend[string(row.Values[0])] = struct{}{}
+		backend[string(row.Values[0])] = string(row.Values[1])
 	}
 
+	state := c.State()
 	tracked := make(map[string]struct{})
-	for _, name := range c.State().PreparedStatementNames() {
+	for _, name := range state.PreparedStatementNames() {
 		// The unnamed statement is tracked under "" but never listed by
 		// pg_prepared_statements.
 		if name == "" {
 			continue
 		}
 		tracked[name] = struct{}{}
-		if _, ok := backend[name]; !ok {
+		body, ok := backend[name]
+		switch {
+		case !ok:
 			div.Phantom = append(div.Phantom, name)
+		case body != state.GetPreparedStatement(name).GetQuery():
+			div.Mismatched = append(div.Mismatched, name)
 		}
 	}
 	for name := range backend {
-		if _, ok := tracked[name]; ok {
-			continue
+		if _, ok := tracked[name]; !ok {
+			div.Untracked = append(div.Untracked, foreignPreparedStatementName)
 		}
-		if !preparedstatement.IsCanonicalName(name) {
-			name = foreignPreparedStatementName
-		}
-		div.Untracked = append(div.Untracked, name)
 	}
 
-	sort.Strings(div.Untracked)
 	sort.Strings(div.Phantom)
+	sort.Strings(div.Mismatched)
 	return div, nil
 }
 
@@ -164,6 +170,50 @@ func (c *Conn) VerifyAdvisoryLocks(ctx context.Context) (connpool.Divergence, er
 	}
 	if held {
 		div.Untracked = []string{advisoryLockDivergenceName}
+	}
+	return div, nil
+}
+
+// HoldableCursorChecker is the connpool.ConnChecker that verifies a
+// connection has no open WITH HOLD cursor; it delegates to
+// VerifyHoldableCursors.
+type HoldableCursorChecker struct{}
+
+// Name implements connpool.ConnChecker.
+func (HoldableCursorChecker) Name() string { return "holdable_cursors" }
+
+// Check implements connpool.ConnChecker.
+func (HoldableCursorChecker) Check(ctx context.Context, conn *Conn) (connpool.Divergence, error) {
+	return conn.VerifyHoldableCursors(ctx)
+}
+
+// holdableCursorDivergenceName is reported once per open cursor. Cursor
+// names are client chosen and are never reported.
+const holdableCursorDivergenceName = "holdable_cursor"
+
+// VerifyHoldableCursors reports one Untracked entry per cursor still open on
+// the idle backend. Outside a transaction only WITH HOLD cursors remain, and
+// tracking never leaves one on a pooled connection: portals pin a reserved
+// connection, so an open cursor here was declared behind tracking (e.g.
+// EXECUTE 'DECLARE ... WITH HOLD' inside a routine body).
+func (c *Conn) VerifyHoldableCursors(ctx context.Context) (connpool.Divergence, error) {
+	var div connpool.Divergence
+	if !c.IsIdle() {
+		return div, errors.New("connection is not idle")
+	}
+
+	results, err := c.Query(ctx, constants.HoldableCursorsProbeSQL)
+	if err != nil {
+		return div, err
+	}
+	if len(results) != 1 {
+		return div, errors.New("holdable cursor probe returned unexpected result count")
+	}
+	for _, row := range results[0].StructuredRows() {
+		if len(row.Values) != 1 || row.Values[0].IsNull() {
+			return div, errors.New("holdable cursor probe returned malformed row")
+		}
+		div.Untracked = append(div.Untracked, holdableCursorDivergenceName)
 	}
 	return div, nil
 }

--- a/go/services/multipooler/internal/pools/regular/backend_state_verify.go
+++ b/go/services/multipooler/internal/pools/regular/backend_state_verify.go
@@ -181,26 +181,37 @@ func (TempObjectChecker) Check(ctx context.Context, conn *Conn) (connpool.Diverg
 }
 
 // tempObjectKinds maps the codes the temp probe can return — pg_class
-// relkinds, 'function', and 'type:' plus a pg_type typtype — to bounded
-// labels for logs and metrics. Object names are never reported.
+// relkinds, 'type:' plus a pg_type typtype, and the fixed tags of the other
+// catalogs — to bounded labels for logs and metrics. Object names are never
+// reported. A code outside this map is reported as unknown_<code>.
 var tempObjectKinds = map[string]string{
-	"r":        "table",
-	"p":        "partitioned_table",
-	"i":        "index",
-	"I":        "partitioned_index",
-	"S":        "sequence",
-	"v":        "view",
-	"m":        "materialized_view",
-	"c":        "composite_type",
-	"t":        "toast_table",
-	"f":        "foreign_table",
-	"function": "function",
-	"type:d":   "domain",
-	"type:e":   "enum",
-	"type:r":   "range",
-	"type:m":   "multirange",
-	"type:b":   "base_type",
-	"type:p":   "pseudo_type",
+	"r":               "table",
+	"p":               "partitioned_table",
+	"i":               "index",
+	"I":               "partitioned_index",
+	"S":               "sequence",
+	"v":               "view",
+	"m":               "materialized_view",
+	"c":               "composite_type",
+	"t":               "toast_table",
+	"f":               "foreign_table",
+	"function":        "function",
+	"type:d":          "domain",
+	"type:e":          "enum",
+	"type:r":          "range",
+	"type:m":          "multirange",
+	"type:b":          "base_type",
+	"type:p":          "pseudo_type",
+	"operator":        "operator",
+	"collation":       "collation",
+	"statistics":      "statistics",
+	"operator_class":  "operator_class",
+	"operator_family": "operator_family",
+	"conversion":      "conversion",
+	"ts_parser":       "ts_parser",
+	"ts_dictionary":   "ts_dictionary",
+	"ts_template":     "ts_template",
+	"ts_config":       "ts_config",
 }
 
 // VerifyTempObjects reports one Untracked entry per kind of object found in

--- a/go/services/multipooler/internal/pools/regular/backend_state_verify.go
+++ b/go/services/multipooler/internal/pools/regular/backend_state_verify.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pools/connpool"
 )
 
@@ -55,12 +56,21 @@ func (PreparedStatementChecker) Check(ctx context.Context, conn *Conn) (connpool
 	return conn.VerifyPreparedStatements(ctx)
 }
 
+// foreignPreparedStatementName is reported in place of an untracked
+// statement name that does not have the consolidator's shape. Such a name
+// reached the backend outside the pooler (e.g. a PREPARE hidden in a routine
+// body) and may embed client data, so it never enters Divergence or logs.
+// One entry is reported per statement so counts survive redaction.
+const foreignPreparedStatementName = "foreign_name"
+
 // VerifyPreparedStatements compares the connection's tracked prepared
 // statements against pg_prepared_statements. A statement the backend holds
 // but tracking does not know is Untracked (the next borrower could collide
 // with or execute it); a tracked statement the backend no longer has is
-// Phantom (the next EXECUTE would fail). Names are consolidator-assigned
-// identifiers, never client SQL, so they are safe to report.
+// Phantom (the next EXECUTE would fail). Tracked names are consolidator
+// assigned and reported verbatim; an untracked name is reported verbatim
+// only when it has the consolidator's shape (pointing at a tracking bug),
+// otherwise it is redacted to foreignPreparedStatementName.
 func (c *Conn) VerifyPreparedStatements(ctx context.Context) (connpool.Divergence, error) {
 	var div connpool.Divergence
 	if !c.IsIdle() {
@@ -96,9 +106,13 @@ func (c *Conn) VerifyPreparedStatements(ctx context.Context) (connpool.Divergenc
 		}
 	}
 	for name := range backend {
-		if _, ok := tracked[name]; !ok {
-			div.Untracked = append(div.Untracked, name)
+		if _, ok := tracked[name]; ok {
+			continue
 		}
+		if !preparedstatement.IsCanonicalName(name) {
+			name = foreignPreparedStatementName
+		}
+		div.Untracked = append(div.Untracked, name)
 	}
 
 	sort.Strings(div.Untracked)
@@ -166,19 +180,27 @@ func (TempObjectChecker) Check(ctx context.Context, conn *Conn) (connpool.Diverg
 	return conn.VerifyTempObjects(ctx)
 }
 
-// tempObjectKinds maps the pg_class relkind codes the temp probe can return
-// to bounded labels for logs and metrics. Object names are never reported.
+// tempObjectKinds maps the codes the temp probe can return — pg_class
+// relkinds, 'function', and 'type:' plus a pg_type typtype — to bounded
+// labels for logs and metrics. Object names are never reported.
 var tempObjectKinds = map[string]string{
-	"r": "table",
-	"p": "partitioned_table",
-	"i": "index",
-	"I": "partitioned_index",
-	"S": "sequence",
-	"v": "view",
-	"m": "materialized_view",
-	"c": "composite_type",
-	"t": "toast_table",
-	"f": "foreign_table",
+	"r":        "table",
+	"p":        "partitioned_table",
+	"i":        "index",
+	"I":        "partitioned_index",
+	"S":        "sequence",
+	"v":        "view",
+	"m":        "materialized_view",
+	"c":        "composite_type",
+	"t":        "toast_table",
+	"f":        "foreign_table",
+	"function": "function",
+	"type:d":   "domain",
+	"type:e":   "enum",
+	"type:r":   "range",
+	"type:m":   "multirange",
+	"type:b":   "base_type",
+	"type:p":   "pseudo_type",
 }
 
 // VerifyTempObjects reports one Untracked entry per kind of object found in
@@ -205,10 +227,7 @@ func (c *Conn) VerifyTempObjects(ctx context.Context) (connpool.Divergence, erro
 		code := string(row.Values[0])
 		kind, ok := tempObjectKinds[code]
 		if !ok {
-			kind = "relkind_" + code
-			if code == "function" {
-				kind = code
-			}
+			kind = "unknown_" + code
 		}
 		kinds[kind] = struct{}{}
 	}

--- a/go/services/multipooler/internal/pools/regular/backend_state_verify.go
+++ b/go/services/multipooler/internal/pools/regular/backend_state_verify.go
@@ -1,0 +1,220 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regular
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strconv"
+
+	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/services/multipooler/internal/pools/connpool"
+)
+
+// The checkers in this file cover the backend state the pool trusts without
+// verification beyond session GUCs (see session_verify.go for those):
+//
+//   - prepared statements: tracked per connection in ConnectionState and
+//     legitimately kept across borrowers, so this is a two-sided diff
+//     against pg_prepared_statements.
+//   - session-level advisory locks: never legitimate on an idle pooled
+//     backend. Acquiring functions route to a reserved connection whose
+//     release runs pg_advisory_unlock_all; a lock still held means the
+//     acquisition escaped tracking (e.g. inside a routine body).
+//   - temp-schema objects: never legitimate on an idle pooled backend. Temp
+//     statements pin a reserved connection that is closed at release, and
+//     pg_temp-qualified CREATE is rejected at the gateway; an object still
+//     present means the creation escaped tracking.
+//
+// All probes are read-only single statements. Like VerifySessionState they
+// use plain Query, never the retry variants: a retry reconnects the socket,
+// which resets the very state being inspected and would mask divergence.
+
+// PreparedStatementChecker is the connpool.ConnChecker that verifies a
+// connection's prepared statements; it delegates to VerifyPreparedStatements.
+type PreparedStatementChecker struct{}
+
+// Name implements connpool.ConnChecker.
+func (PreparedStatementChecker) Name() string { return "prepared_statements" }
+
+// Check implements connpool.ConnChecker.
+func (PreparedStatementChecker) Check(ctx context.Context, conn *Conn) (connpool.Divergence, error) {
+	return conn.VerifyPreparedStatements(ctx)
+}
+
+// VerifyPreparedStatements compares the connection's tracked prepared
+// statements against pg_prepared_statements. A statement the backend holds
+// but tracking does not know is Untracked (the next borrower could collide
+// with or execute it); a tracked statement the backend no longer has is
+// Phantom (the next EXECUTE would fail). Names are consolidator-assigned
+// identifiers, never client SQL, so they are safe to report.
+func (c *Conn) VerifyPreparedStatements(ctx context.Context) (connpool.Divergence, error) {
+	var div connpool.Divergence
+	if !c.IsIdle() {
+		return div, errors.New("connection is not idle")
+	}
+
+	results, err := c.Query(ctx, constants.PreparedStatementsProbeSQL)
+	if err != nil {
+		return div, err
+	}
+	if len(results) != 1 {
+		return div, errors.New("prepared statement probe returned unexpected result count")
+	}
+
+	backend := make(map[string]struct{}, results[0].RowCount())
+	for _, row := range results[0].StructuredRows() {
+		if len(row.Values) != 1 || row.Values[0].IsNull() {
+			return div, errors.New("prepared statement probe returned malformed row")
+		}
+		backend[string(row.Values[0])] = struct{}{}
+	}
+
+	tracked := make(map[string]struct{})
+	for _, name := range c.State().PreparedStatementNames() {
+		// The unnamed statement is tracked under "" but never listed by
+		// pg_prepared_statements.
+		if name == "" {
+			continue
+		}
+		tracked[name] = struct{}{}
+		if _, ok := backend[name]; !ok {
+			div.Phantom = append(div.Phantom, name)
+		}
+	}
+	for name := range backend {
+		if _, ok := tracked[name]; !ok {
+			div.Untracked = append(div.Untracked, name)
+		}
+	}
+
+	sort.Strings(div.Untracked)
+	sort.Strings(div.Phantom)
+	return div, nil
+}
+
+// AdvisoryLockChecker is the connpool.ConnChecker that verifies a connection
+// holds no session-level advisory lock; it delegates to VerifyAdvisoryLocks.
+type AdvisoryLockChecker struct{}
+
+// Name implements connpool.ConnChecker.
+func (AdvisoryLockChecker) Name() string { return "advisory_locks" }
+
+// Check implements connpool.ConnChecker.
+func (AdvisoryLockChecker) Check(ctx context.Context, conn *Conn) (connpool.Divergence, error) {
+	return conn.VerifyAdvisoryLocks(ctx)
+}
+
+// advisoryLockDivergenceName is the single Untracked entry reported when an
+// idle backend still holds an advisory lock. Lock keys are client data and
+// are never reported.
+const advisoryLockDivergenceName = "session_advisory_lock"
+
+// VerifyAdvisoryLocks reports Untracked divergence when the idle backend
+// holds any advisory lock. Outside a transaction every advisory lock in
+// pg_locks is session-level, and tracking never leaves one on a pooled
+// connection.
+func (c *Conn) VerifyAdvisoryLocks(ctx context.Context) (connpool.Divergence, error) {
+	var div connpool.Divergence
+	if !c.IsIdle() {
+		return div, errors.New("connection is not idle")
+	}
+
+	results, err := c.Query(ctx, constants.PgLocksAdvisoryProbeSQL)
+	if err != nil {
+		return div, err
+	}
+	if len(results) != 1 || results[0].RowCount() != 1 {
+		return div, errors.New("advisory lock probe returned unexpected result shape")
+	}
+	row := results[0].StructuredRows()[0]
+	if len(row.Values) != 1 || row.Values[0].IsNull() {
+		return div, errors.New("advisory lock probe returned malformed row")
+	}
+	held, err := strconv.ParseBool(string(row.Values[0]))
+	if err != nil {
+		return div, errors.New("advisory lock probe returned a non-boolean value")
+	}
+	if held {
+		div.Untracked = []string{advisoryLockDivergenceName}
+	}
+	return div, nil
+}
+
+// TempObjectChecker is the connpool.ConnChecker that verifies a connection's
+// temporary schema is empty; it delegates to VerifyTempObjects.
+type TempObjectChecker struct{}
+
+// Name implements connpool.ConnChecker.
+func (TempObjectChecker) Name() string { return "temp_objects" }
+
+// Check implements connpool.ConnChecker.
+func (TempObjectChecker) Check(ctx context.Context, conn *Conn) (connpool.Divergence, error) {
+	return conn.VerifyTempObjects(ctx)
+}
+
+// tempObjectKinds maps the pg_class relkind codes the temp probe can return
+// to bounded labels for logs and metrics. Object names are never reported.
+var tempObjectKinds = map[string]string{
+	"r": "table",
+	"p": "partitioned_table",
+	"i": "index",
+	"I": "partitioned_index",
+	"S": "sequence",
+	"v": "view",
+	"m": "materialized_view",
+	"c": "composite_type",
+	"t": "toast_table",
+	"f": "foreign_table",
+}
+
+// VerifyTempObjects reports one Untracked entry per kind of object found in
+// the backend's temporary schema. An idle pooled backend must own none.
+func (c *Conn) VerifyTempObjects(ctx context.Context) (connpool.Divergence, error) {
+	var div connpool.Divergence
+	if !c.IsIdle() {
+		return div, errors.New("connection is not idle")
+	}
+
+	results, err := c.Query(ctx, constants.TempObjectsProbeSQL)
+	if err != nil {
+		return div, err
+	}
+	if len(results) != 1 {
+		return div, errors.New("temp object probe returned unexpected result count")
+	}
+
+	kinds := make(map[string]struct{})
+	for _, row := range results[0].StructuredRows() {
+		if len(row.Values) != 1 || row.Values[0].IsNull() {
+			return div, errors.New("temp object probe returned malformed row")
+		}
+		code := string(row.Values[0])
+		kind, ok := tempObjectKinds[code]
+		if !ok {
+			kind = "relkind_" + code
+			if code == "function" {
+				kind = code
+			}
+		}
+		kinds[kind] = struct{}{}
+	}
+	for kind := range kinds {
+		div.Untracked = append(div.Untracked, kind)
+	}
+	sort.Strings(div.Untracked)
+	return div, nil
+}

--- a/go/services/multipooler/internal/pools/regular/backend_state_verify_test.go
+++ b/go/services/multipooler/internal/pools/regular/backend_state_verify_test.go
@@ -17,6 +17,7 @@ package regular
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,18 +28,28 @@ import (
 	"github.com/multigres/multigres/go/pb/query"
 )
 
-func scriptPreparedProbe(server *fakepgserver.Server, names ...string) {
-	rows := make([][]any, 0, len(names))
-	for _, n := range names {
-		rows = append(rows, []any{n})
+// trackedQuery is the body every tracked test statement was prepared with.
+const trackedQuery = "SELECT 1"
+
+// scriptPreparedProbe scripts the probe to list the given statements, each
+// with trackedQuery as its body unless the name is followed by "=" and a
+// different body (e.g. "ppstmt1=SELECT 2").
+func scriptPreparedProbe(server *fakepgserver.Server, entries ...string) {
+	rows := make([][]any, 0, len(entries))
+	for _, e := range entries {
+		name, body, ok := strings.Cut(e, "=")
+		if !ok {
+			body = trackedQuery
+		}
+		rows = append(rows, []any{name, body})
 	}
 	server.AddQuery(constants.PreparedStatementsProbeSQL,
-		fakepgserver.MakeResult([]string{"name"}, rows))
+		fakepgserver.MakeResult([]string{"name", "statement"}, rows))
 }
 
 func trackPrepared(conn *Conn, names ...string) {
 	for _, n := range names {
-		conn.State().StorePreparedStatement(&query.PreparedStatement{Name: n, Query: "SELECT 1"})
+		conn.State().StorePreparedStatement(&query.PreparedStatement{Name: n, Query: trackedQuery})
 	}
 }
 
@@ -68,18 +79,40 @@ func TestVerifyPreparedStatementsUntrackedAndPhantom(t *testing.T) {
 
 	div, err := conn.VerifyPreparedStatements(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, []string{foreignPreparedStatementName}, div.Untracked, "a non-consolidator name is redacted")
+	assert.Equal(t, []string{foreignPreparedStatementName}, div.Untracked, "untracked names are redacted")
 	assert.Equal(t, []string{"ppstmt9"}, div.Phantom)
 	assert.Empty(t, div.Mismatched)
 }
 
-func TestVerifyPreparedStatementsRedactsForeignNames(t *testing.T) {
-	// An untracked name that is not consolidator-shaped may embed client
-	// data (a PREPARE hidden in a routine body); it must never reach the
-	// Divergence that flows into logs. Counts survive: one entry each.
+func TestVerifyPreparedStatementsRedefinedBody(t *testing.T) {
+	// A hidden DEALLOCATE plus re-PREPARE keeps the tracked name but swaps
+	// the body (a SQL PREPARE also stores the full PREPARE text). The name
+	// alone would look clean; the body comparison must flag it, or
+	// ensurePrepared hands the redefined statement to the next borrower.
 	server := fakepgserver.New(t)
 	defer server.Close()
-	scriptPreparedProbe(server, "ppstmt1", "ppstmt7", `stmt_ssn_123-45-6789`, "get_user_by_email")
+	scriptPreparedProbe(server, "ppstmt1", "ppstmt2=PREPARE ppstmt2 AS SELECT 2 AS evil")
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	trackPrepared(conn, "ppstmt1", "ppstmt2")
+
+	div, err := conn.VerifyPreparedStatements(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ppstmt2"}, div.Mismatched)
+	assert.Empty(t, div.Untracked)
+	assert.Empty(t, div.Phantom)
+}
+
+func TestVerifyPreparedStatementsRedactsAllUntrackedNames(t *testing.T) {
+	// Every untracked name may embed client data — a PREPARE hidden in a
+	// routine body chooses the name, and the consolidator's ppstmt<N> shape
+	// is reachable too (ppstmt1234567890 with an account number). None may
+	// reach the Divergence that flows into logs. Counts survive: one entry
+	// per statement.
+	server := fakepgserver.New(t)
+	defer server.Close()
+	scriptPreparedProbe(server, "ppstmt1", "ppstmt1234567890", `stmt_ssn_123-45-6789`, "get_user_by_email")
 
 	conn := newTestDirectConn(t, server)
 	defer conn.Close()
@@ -87,12 +120,9 @@ func TestVerifyPreparedStatementsRedactsForeignNames(t *testing.T) {
 
 	div, err := conn.VerifyPreparedStatements(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"foreign_name", "foreign_name", "ppstmt7"}, div.Untracked)
+	assert.Equal(t, []string{"foreign_name", "foreign_name", "foreign_name"}, div.Untracked)
 	assert.Empty(t, div.Phantom)
-	for _, name := range div.Untracked {
-		assert.NotContains(t, name, "ssn")
-		assert.NotContains(t, name, "email")
-	}
+	assert.Empty(t, div.Mismatched)
 }
 
 func TestVerifyPreparedStatementsProbeError(t *testing.T) {
@@ -148,6 +178,41 @@ func TestVerifyAdvisoryLocksMalformed(t *testing.T) {
 
 	_, err := conn.VerifyAdvisoryLocks(context.Background())
 	require.Error(t, err, "a non-boolean probe result must be a probe failure, not a clean verdict")
+}
+
+func scriptCursorProbe(server *fakepgserver.Server, names ...string) {
+	rows := make([][]any, 0, len(names))
+	for _, n := range names {
+		rows = append(rows, []any{n})
+	}
+	server.AddQuery(constants.HoldableCursorsProbeSQL,
+		fakepgserver.MakeResult([]string{"name"}, rows))
+}
+
+func TestVerifyHoldableCursorsNone(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	scriptCursorProbe(server)
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+
+	div, err := HoldableCursorChecker{}.Check(context.Background(), conn)
+	require.NoError(t, err)
+	assert.False(t, div.IsDiverged())
+}
+
+func TestVerifyHoldableCursorsReportsCountNotNames(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	scriptCursorProbe(server, "cur_tenant_42", "hidden_hold")
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+
+	div, err := conn.VerifyHoldableCursors(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{holdableCursorDivergenceName, holdableCursorDivergenceName}, div.Untracked)
 }
 
 func scriptTempProbe(server *fakepgserver.Server, codes ...string) {

--- a/go/services/multipooler/internal/pools/regular/backend_state_verify_test.go
+++ b/go/services/multipooler/internal/pools/regular/backend_state_verify_test.go
@@ -68,9 +68,31 @@ func TestVerifyPreparedStatementsUntrackedAndPhantom(t *testing.T) {
 
 	div, err := conn.VerifyPreparedStatements(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"rogue"}, div.Untracked)
+	assert.Equal(t, []string{foreignPreparedStatementName}, div.Untracked, "a non-consolidator name is redacted")
 	assert.Equal(t, []string{"ppstmt9"}, div.Phantom)
 	assert.Empty(t, div.Mismatched)
+}
+
+func TestVerifyPreparedStatementsRedactsForeignNames(t *testing.T) {
+	// An untracked name that is not consolidator-shaped may embed client
+	// data (a PREPARE hidden in a routine body); it must never reach the
+	// Divergence that flows into logs. Counts survive: one entry each.
+	server := fakepgserver.New(t)
+	defer server.Close()
+	scriptPreparedProbe(server, "ppstmt1", "ppstmt7", `stmt_ssn_123-45-6789`, "get_user_by_email")
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	trackPrepared(conn, "ppstmt1")
+
+	div, err := conn.VerifyPreparedStatements(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"foreign_name", "foreign_name", "ppstmt7"}, div.Untracked)
+	assert.Empty(t, div.Phantom)
+	for _, name := range div.Untracked {
+		assert.NotContains(t, name, "ssn")
+		assert.NotContains(t, name, "email")
+	}
 }
 
 func TestVerifyPreparedStatementsProbeError(t *testing.T) {
@@ -153,15 +175,16 @@ func TestVerifyTempObjectsEmpty(t *testing.T) {
 func TestVerifyTempObjectsReportsKindsNotNames(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
-	// Two tables, their toast tables, an index, a function, and an unknown
-	// relkind code: kinds are deduplicated and unknown codes stay bounded.
-	scriptTempProbe(server, "r", "r", "t", "t", "i", "function", "z")
+	// Two tables, their toast tables, an index, a function, a domain, an
+	// enum, a range with its multirange, and an unknown code: kinds are
+	// deduplicated and unknown codes stay bounded.
+	scriptTempProbe(server, "r", "r", "t", "t", "i", "function", "type:d", "type:e", "type:r", "type:m", "z")
 
 	conn := newTestDirectConn(t, server)
 	defer conn.Close()
 
 	div, err := conn.VerifyTempObjects(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"function", "index", "relkind_z", "table", "toast_table"}, div.Untracked)
+	assert.Equal(t, []string{"domain", "enum", "function", "index", "multirange", "range", "table", "toast_table", "unknown_z"}, div.Untracked)
 	assert.Empty(t, div.Phantom)
 }

--- a/go/services/multipooler/internal/pools/regular/backend_state_verify_test.go
+++ b/go/services/multipooler/internal/pools/regular/backend_state_verify_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regular
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/common/fakepgserver"
+	"github.com/multigres/multigres/go/pb/query"
+)
+
+func scriptPreparedProbe(server *fakepgserver.Server, names ...string) {
+	rows := make([][]any, 0, len(names))
+	for _, n := range names {
+		rows = append(rows, []any{n})
+	}
+	server.AddQuery(constants.PreparedStatementsProbeSQL,
+		fakepgserver.MakeResult([]string{"name"}, rows))
+}
+
+func trackPrepared(conn *Conn, names ...string) {
+	for _, n := range names {
+		conn.State().StorePreparedStatement(&query.PreparedStatement{Name: n, Query: "SELECT 1"})
+	}
+}
+
+func TestVerifyPreparedStatementsInSync(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	scriptPreparedProbe(server, "ppstmt1", "ppstmt2")
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	// The unnamed statement is tracked but never listed by the backend.
+	trackPrepared(conn, "ppstmt1", "ppstmt2", "")
+
+	div, err := PreparedStatementChecker{}.Check(context.Background(), conn)
+	require.NoError(t, err)
+	assert.False(t, div.IsDiverged())
+}
+
+func TestVerifyPreparedStatementsUntrackedAndPhantom(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	scriptPreparedProbe(server, "ppstmt1", "rogue")
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+	trackPrepared(conn, "ppstmt1", "ppstmt9")
+
+	div, err := conn.VerifyPreparedStatements(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"rogue"}, div.Untracked)
+	assert.Equal(t, []string{"ppstmt9"}, div.Phantom)
+	assert.Empty(t, div.Mismatched)
+}
+
+func TestVerifyPreparedStatementsProbeError(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.AddRejectedQuery(constants.PreparedStatementsProbeSQL, errors.New("backend on fire"))
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+
+	_, err := conn.VerifyPreparedStatements(context.Background())
+	require.Error(t, err)
+}
+
+func scriptAdvisoryProbe(server *fakepgserver.Server, held any) {
+	server.AddQuery(constants.PgLocksAdvisoryProbeSQL,
+		fakepgserver.MakeResult([]string{"exists"}, [][]any{{held}}))
+}
+
+func TestVerifyAdvisoryLocksNoneHeld(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	scriptAdvisoryProbe(server, "f")
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+
+	div, err := AdvisoryLockChecker{}.Check(context.Background(), conn)
+	require.NoError(t, err)
+	assert.False(t, div.IsDiverged())
+}
+
+func TestVerifyAdvisoryLocksHeld(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	scriptAdvisoryProbe(server, "t")
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+
+	div, err := conn.VerifyAdvisoryLocks(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{advisoryLockDivergenceName}, div.Untracked)
+}
+
+func TestVerifyAdvisoryLocksMalformed(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	scriptAdvisoryProbe(server, "maybe")
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+
+	_, err := conn.VerifyAdvisoryLocks(context.Background())
+	require.Error(t, err, "a non-boolean probe result must be a probe failure, not a clean verdict")
+}
+
+func scriptTempProbe(server *fakepgserver.Server, codes ...string) {
+	rows := make([][]any, 0, len(codes))
+	for _, c := range codes {
+		rows = append(rows, []any{c})
+	}
+	server.AddQuery(constants.TempObjectsProbeSQL,
+		fakepgserver.MakeResult([]string{"relkind"}, rows))
+}
+
+func TestVerifyTempObjectsEmpty(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	scriptTempProbe(server)
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+
+	div, err := TempObjectChecker{}.Check(context.Background(), conn)
+	require.NoError(t, err)
+	assert.False(t, div.IsDiverged())
+}
+
+func TestVerifyTempObjectsReportsKindsNotNames(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	// Two tables, their toast tables, an index, a function, and an unknown
+	// relkind code: kinds are deduplicated and unknown codes stay bounded.
+	scriptTempProbe(server, "r", "r", "t", "t", "i", "function", "z")
+
+	conn := newTestDirectConn(t, server)
+	defer conn.Close()
+
+	div, err := conn.VerifyTempObjects(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"function", "index", "relkind_z", "table", "toast_table"}, div.Untracked)
+	assert.Empty(t, div.Phantom)
+}

--- a/go/services/multipooler/internal/pools/regular/backend_state_verify_test.go
+++ b/go/services/multipooler/internal/pools/regular/backend_state_verify_test.go
@@ -176,15 +176,22 @@ func TestVerifyTempObjectsReportsKindsNotNames(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
 	// Two tables, their toast tables, an index, a function, a domain, an
-	// enum, a range with its multirange, and an unknown code: kinds are
-	// deduplicated and unknown codes stay bounded.
-	scriptTempProbe(server, "r", "r", "t", "t", "i", "function", "type:d", "type:e", "type:r", "type:m", "z")
+	// enum, a range with its multirange, one of each other catalog's tag,
+	// and an unknown code: kinds are deduplicated and unknown codes stay
+	// bounded.
+	scriptTempProbe(server, "r", "r", "t", "t", "i", "function", "type:d", "type:e", "type:r", "type:m",
+		"operator", "collation", "statistics", "operator_class", "operator_family", "conversion",
+		"ts_parser", "ts_dictionary", "ts_template", "ts_config", "z")
 
 	conn := newTestDirectConn(t, server)
 	defer conn.Close()
 
 	div, err := conn.VerifyTempObjects(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"domain", "enum", "function", "index", "multirange", "range", "table", "toast_table", "unknown_z"}, div.Untracked)
+	assert.Equal(t, []string{
+		"collation", "conversion", "domain", "enum", "function", "index", "multirange",
+		"operator", "operator_class", "operator_family", "range", "statistics", "table",
+		"toast_table", "ts_config", "ts_dictionary", "ts_parser", "ts_template", "unknown_z",
+	}, div.Untracked)
 	assert.Empty(t, div.Phantom)
 }

--- a/go/services/multipooler/internal/pools/regular/pool.go
+++ b/go/services/multipooler/internal/pools/regular/pool.go
@@ -63,6 +63,7 @@ func NewPool(ctx context.Context, config *PoolConfig) *Pool {
 	pool.RegisterChecker(SessionStateChecker{})
 	pool.RegisterChecker(PreparedStatementChecker{})
 	pool.RegisterChecker(AdvisoryLockChecker{})
+	pool.RegisterChecker(HoldableCursorChecker{})
 	pool.RegisterChecker(TempObjectChecker{})
 
 	return &Pool{

--- a/go/services/multipooler/internal/pools/regular/pool.go
+++ b/go/services/multipooler/internal/pools/regular/pool.go
@@ -61,6 +61,9 @@ func NewPool(ctx context.Context, config *PoolConfig) *Pool {
 
 	pool := connpool.NewPool[*Conn](ctx, config.ConnPoolConfig)
 	pool.RegisterChecker(SessionStateChecker{})
+	pool.RegisterChecker(PreparedStatementChecker{})
+	pool.RegisterChecker(AdvisoryLockChecker{})
+	pool.RegisterChecker(TempObjectChecker{})
 
 	return &Pool{
 		pool:   pool,

--- a/go/test/endtoend/queryserving/session_state_leak_test.go
+++ b/go/test/endtoend/queryserving/session_state_leak_test.go
@@ -96,6 +96,15 @@ func TestHiddenFunctionStateDoesNotLeak(t *testing.T) {
 	require.NotEqual(t, "123MB", workMem, "hidden reserved-pool state leaked across logical clients")
 }
 
+// scrubSweepWait bounds how long a scrubber test waits for the contaminated
+// backend to be replaced. The scrubber probes one idle connection per tick
+// (default 10s) and rotates across the clean stack plus 16 settings stacks,
+// checking the most recently returned connection of whichever stack is next.
+// In a full-suite run earlier tests leave many settings stacks populated, so
+// the contaminated connection's stack can be up to 17 ticks away: 170s worst
+// case, observed at 89s. Standalone runs finish in one or two ticks.
+const scrubSweepWait = 4 * time.Minute
+
 // TestSessionScrubberReplacesHiddenState verifies the pool's session-state
 // scrubber: a set_config hidden inside a SQL function body escapes the
 // gateway's session tracking and leaves real session GUC state on a pooled
@@ -114,7 +123,7 @@ func TestSessionScrubberReplacesHiddenState(t *testing.T) {
 	}
 	setup := getSharedSetup(t)
 	setup.SetupTest(t)
-	ctx := utils.WithTimeout(t, 3*time.Minute)
+	ctx := utils.WithTimeout(t, scrubSweepWait+2*time.Minute)
 
 	gatewayDSN := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
 	primaryDSN := shardsetup.GetTestUserDSN("localhost", setup.GetPrimary(t).Pgctld.PgPort, "sslmode=disable", "connect_timeout=5")
@@ -167,7 +176,7 @@ func TestSessionScrubberReplacesHiddenState(t *testing.T) {
 			return false
 		}
 		return alive == 0
-	}, 90*time.Second, time.Second, "scrubber should have replaced the contaminated backend (pid %d)", leakedPID)
+	}, scrubSweepWait, time.Second, "scrubber should have replaced the contaminated backend (pid %d)", leakedPID)
 
 	// The replacement must have been the scrubber's doing, not routine pool
 	// churn: the multipooler logged the divergence with the leaked GUC name.
@@ -187,4 +196,66 @@ func TestSessionScrubberReplacesHiddenState(t *testing.T) {
 	var workMem string
 	require.NoError(t, connB.QueryRowContext(ctx, "SHOW work_mem").Scan(&workMem))
 	require.NotEqual(t, "123MB", workMem, "hidden session state leaked past the scrubber")
+}
+
+// TestSessionScrubberReplacesHiddenAdvisoryLock covers the advisory-lock
+// checker end to end: a session-level advisory lock acquired inside a SQL
+// function body escapes the gateway's reservation routing (the call site is
+// an opaque UDF, so the backend is never pinned and pg_advisory_unlock_all
+// never runs at release). The lock stays on a pooled backend; the scrubber
+// must detect it and replace the backend.
+func TestSessionScrubberReplacesHiddenAdvisoryLock(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping session scrubber test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found")
+	}
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, scrubSweepWait+2*time.Minute)
+
+	gatewayDSN := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	primaryDSN := shardsetup.GetTestUserDSN("localhost", setup.GetPrimary(t).Pgctld.PgPort, "sslmode=disable", "connect_timeout=5")
+	primary, err := sql.Open("postgres", primaryDSN)
+	require.NoError(t, err)
+	defer primary.Close()
+
+	// Install directly so the acquisition is absent from the client's
+	// top-level SQL. The key is arbitrary; it must never appear in the log.
+	const lockKey = "987654321"
+	_, err = primary.ExecContext(ctx, `CREATE OR REPLACE FUNCTION hidden_scrub_lock()
+		RETURNS bool LANGUAGE sql AS $$SELECT pg_catalog.pg_advisory_lock(`+lockKey+`); SELECT true$$`)
+	require.NoError(t, err)
+	defer primary.ExecContext(ctx, "DROP FUNCTION IF EXISTS hidden_scrub_lock()") //nolint:errcheck
+
+	connA, err := sql.Open("postgres", gatewayDSN)
+	require.NoError(t, err)
+	connA.SetMaxIdleConns(0)
+	var ignored bool
+	var leakedPID int
+	err = connA.QueryRowContext(ctx, "SELECT hidden_scrub_lock(), pg_backend_pid()").Scan(&ignored, &leakedPID)
+	require.NoError(t, err)
+	require.NoError(t, connA.Close())
+
+	// The lock really is on the pooled backend, unpinned and idle.
+	var held bool
+	require.NoError(t, primary.QueryRowContext(ctx,
+		"SELECT EXISTS (SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND pid = $1)", leakedPID).Scan(&held))
+	require.True(t, held, "test setup: hidden advisory lock should be held by backend %d", leakedPID)
+
+	require.Eventually(t, func() bool {
+		var alive int
+		if err := primary.QueryRowContext(ctx, "SELECT count(*) FROM pg_stat_activity WHERE pid = $1", leakedPID).Scan(&alive); err != nil {
+			return false
+		}
+		return alive == 0
+	}, scrubSweepWait, time.Second, "scrubber should have replaced the backend holding the hidden advisory lock (pid %d)", leakedPID)
+
+	poolerLog, err := os.ReadFile(setup.PrimaryMultipooler(t).LogFile)
+	require.NoError(t, err)
+	require.Contains(t, string(poolerLog), "advisory_locks",
+		"multipooler log should attribute the replacement to the advisory-lock checker")
+	require.NotContains(t, string(poolerLog), lockKey,
+		"divergence log must never carry the lock key")
 }

--- a/go/test/endtoend/queryserving/session_state_leak_test.go
+++ b/go/test/endtoend/queryserving/session_state_leak_test.go
@@ -260,14 +260,16 @@ func TestSessionScrubberReplacesHiddenAdvisoryLock(t *testing.T) {
 		"divergence log must never carry the lock key")
 }
 
-// TestSessionScrubberReplacesHiddenTempType covers the temp-object checker's
-// pg_type arm end to end: a domain created in pg_temp inside a SQL function
-// body escapes the gateway's pg_temp CREATE rejection (the call site is an
-// opaque UDF) and its temp-statement reservation, so it stays on a pooled
-// backend where it would shadow the same-named catalog type for the next
-// borrower's unqualified references. The scrubber must detect it and replace
-// the backend.
-func TestSessionScrubberReplacesHiddenTempType(t *testing.T) {
+// TestSessionScrubberReplacesHiddenTempObjects covers the temp-object checker
+// end to end across catalogs: a SQL function body creates a domain, an
+// operator, a collation, and a statistics object in pg_temp. The call site is
+// an opaque UDF, so the gateway's pg_temp CREATE rejection and its
+// temp-statement reservation never see the creations, and the objects stay on
+// a pooled backend. The domain is the dangerous one (pg_temp is searched
+// before pg_catalog for unqualified type names, so it would shadow a catalog
+// type for the next borrower); the others are stale state. The scrubber must
+// detect all four kinds on one sweep and replace the backend.
+func TestSessionScrubberReplacesHiddenTempObjects(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping session scrubber test in short mode")
 	}
@@ -284,20 +286,28 @@ func TestSessionScrubberReplacesHiddenTempType(t *testing.T) {
 	require.NoError(t, err)
 	defer primary.Close()
 
-	// Install directly so the CREATE is absent from the client's top-level
-	// SQL. The domain name must never appear in the log.
-	const domainName = "hidden_scrub_secret_domain"
-	_, err = primary.ExecContext(ctx, `CREATE OR REPLACE FUNCTION hidden_scrub_domain()
-		RETURNS bool LANGUAGE sql AS $$CREATE DOMAIN pg_temp.`+domainName+` AS int; SELECT true$$`)
+	// Install directly so the CREATEs are absent from the client's top-level
+	// SQL. Object names share a marker that must never appear in the log.
+	const nameMarker = "hidden_scrub_secret"
+	_, err = primary.ExecContext(ctx, "CREATE TABLE IF NOT EXISTS "+nameMarker+"_t (a int, b int)")
 	require.NoError(t, err)
-	defer primary.ExecContext(ctx, "DROP FUNCTION IF EXISTS hidden_scrub_domain()") //nolint:errcheck
+	defer primary.ExecContext(ctx, "DROP TABLE IF EXISTS "+nameMarker+"_t") //nolint:errcheck
+	_, err = primary.ExecContext(ctx, `CREATE OR REPLACE FUNCTION hidden_scrub_temp_objects()
+		RETURNS bool LANGUAGE sql AS $$
+		CREATE DOMAIN pg_temp.`+nameMarker+`_d AS int;
+		CREATE OPERATOR pg_temp.=== (LEFTARG = int, RIGHTARG = int, FUNCTION = int4eq);
+		CREATE COLLATION pg_temp.`+nameMarker+`_c (locale = 'C');
+		CREATE STATISTICS pg_temp.`+nameMarker+`_s ON a, b FROM `+nameMarker+`_t;
+		SELECT true$$`)
+	require.NoError(t, err)
+	defer primary.ExecContext(ctx, "DROP FUNCTION IF EXISTS hidden_scrub_temp_objects()") //nolint:errcheck
 
 	connA, err := sql.Open("postgres", gatewayDSN)
 	require.NoError(t, err)
 	connA.SetMaxIdleConns(0)
 	var ignored bool
 	var leakedPID int
-	err = connA.QueryRowContext(ctx, "SELECT hidden_scrub_domain(), pg_backend_pid()").Scan(&ignored, &leakedPID)
+	err = connA.QueryRowContext(ctx, "SELECT hidden_scrub_temp_objects(), pg_backend_pid()").Scan(&ignored, &leakedPID)
 	require.NoError(t, err)
 	require.NoError(t, connA.Close())
 
@@ -307,14 +317,16 @@ func TestSessionScrubberReplacesHiddenTempType(t *testing.T) {
 			return false
 		}
 		return alive == 0
-	}, scrubSweepWait, time.Second, "scrubber should have replaced the backend holding the hidden temp domain (pid %d)", leakedPID)
+	}, scrubSweepWait, time.Second, "scrubber should have replaced the backend holding the hidden temp objects (pid %d)", leakedPID)
 
 	poolerLog, err := os.ReadFile(setup.PrimaryMultipooler(t).LogFile)
 	require.NoError(t, err)
 	require.Contains(t, string(poolerLog), "temp_objects",
 		"multipooler log should attribute the replacement to the temp-object checker")
-	require.Contains(t, string(poolerLog), `"domain"`,
-		"divergence log should name the kind of leaked object")
-	require.NotContains(t, string(poolerLog), domainName,
-		"divergence log must never carry the object name")
+	for _, kind := range []string{"domain", "operator", "collation", "statistics"} {
+		require.Contains(t, string(poolerLog), `"`+kind+`"`,
+			"divergence log should name the %s kind", kind)
+	}
+	require.NotContains(t, string(poolerLog), nameMarker,
+		"divergence log must never carry object names")
 }

--- a/go/test/endtoend/queryserving/session_state_leak_test.go
+++ b/go/test/endtoend/queryserving/session_state_leak_test.go
@@ -259,3 +259,62 @@ func TestSessionScrubberReplacesHiddenAdvisoryLock(t *testing.T) {
 	require.NotContains(t, string(poolerLog), lockKey,
 		"divergence log must never carry the lock key")
 }
+
+// TestSessionScrubberReplacesHiddenTempType covers the temp-object checker's
+// pg_type arm end to end: a domain created in pg_temp inside a SQL function
+// body escapes the gateway's pg_temp CREATE rejection (the call site is an
+// opaque UDF) and its temp-statement reservation, so it stays on a pooled
+// backend where it would shadow the same-named catalog type for the next
+// borrower's unqualified references. The scrubber must detect it and replace
+// the backend.
+func TestSessionScrubberReplacesHiddenTempType(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping session scrubber test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found")
+	}
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, scrubSweepWait+2*time.Minute)
+
+	gatewayDSN := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	primaryDSN := shardsetup.GetTestUserDSN("localhost", setup.GetPrimary(t).Pgctld.PgPort, "sslmode=disable", "connect_timeout=5")
+	primary, err := sql.Open("postgres", primaryDSN)
+	require.NoError(t, err)
+	defer primary.Close()
+
+	// Install directly so the CREATE is absent from the client's top-level
+	// SQL. The domain name must never appear in the log.
+	const domainName = "hidden_scrub_secret_domain"
+	_, err = primary.ExecContext(ctx, `CREATE OR REPLACE FUNCTION hidden_scrub_domain()
+		RETURNS bool LANGUAGE sql AS $$CREATE DOMAIN pg_temp.`+domainName+` AS int; SELECT true$$`)
+	require.NoError(t, err)
+	defer primary.ExecContext(ctx, "DROP FUNCTION IF EXISTS hidden_scrub_domain()") //nolint:errcheck
+
+	connA, err := sql.Open("postgres", gatewayDSN)
+	require.NoError(t, err)
+	connA.SetMaxIdleConns(0)
+	var ignored bool
+	var leakedPID int
+	err = connA.QueryRowContext(ctx, "SELECT hidden_scrub_domain(), pg_backend_pid()").Scan(&ignored, &leakedPID)
+	require.NoError(t, err)
+	require.NoError(t, connA.Close())
+
+	require.Eventually(t, func() bool {
+		var alive int
+		if err := primary.QueryRowContext(ctx, "SELECT count(*) FROM pg_stat_activity WHERE pid = $1", leakedPID).Scan(&alive); err != nil {
+			return false
+		}
+		return alive == 0
+	}, scrubSweepWait, time.Second, "scrubber should have replaced the backend holding the hidden temp domain (pid %d)", leakedPID)
+
+	poolerLog, err := os.ReadFile(setup.PrimaryMultipooler(t).LogFile)
+	require.NoError(t, err)
+	require.Contains(t, string(poolerLog), "temp_objects",
+		"multipooler log should attribute the replacement to the temp-object checker")
+	require.Contains(t, string(poolerLog), `"domain"`,
+		"divergence log should name the kind of leaked object")
+	require.NotContains(t, string(poolerLog), domainName,
+		"divergence log must never carry the object name")
+}

--- a/go/test/endtoend/queryserving/session_state_leak_test.go
+++ b/go/test/endtoend/queryserving/session_state_leak_test.go
@@ -330,3 +330,59 @@ func TestSessionScrubberReplacesHiddenTempObjects(t *testing.T) {
 	require.NotContains(t, string(poolerLog), nameMarker,
 		"divergence log must never carry object names")
 }
+
+// TestSessionScrubberReplacesHiddenHoldableCursor covers the holdable-cursor
+// checker end to end: a WITH HOLD cursor declared via dynamic EXECUTE inside
+// a PL/pgSQL body outlives its transaction on a pooled backend. The call site
+// is an opaque UDF, so no portal reservation pins the connection and the
+// cursor stays open on an idle backend. The scrubber must detect it and
+// replace the backend, never logging the cursor name.
+func TestSessionScrubberReplacesHiddenHoldableCursor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping session scrubber test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found")
+	}
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, scrubSweepWait+2*time.Minute)
+
+	gatewayDSN := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	primaryDSN := shardsetup.GetTestUserDSN("localhost", setup.GetPrimary(t).Pgctld.PgPort, "sslmode=disable", "connect_timeout=5")
+	primary, err := sql.Open("postgres", primaryDSN)
+	require.NoError(t, err)
+	defer primary.Close()
+
+	const cursorName = "hidden_scrub_secret_cursor"
+	_, err = primary.ExecContext(ctx, `CREATE OR REPLACE FUNCTION hidden_scrub_cursor()
+		RETURNS bool LANGUAGE plpgsql AS $$BEGIN
+		EXECUTE 'DECLARE `+cursorName+` CURSOR WITH HOLD FOR SELECT 1';
+		RETURN true; END$$`)
+	require.NoError(t, err)
+	defer primary.ExecContext(ctx, "DROP FUNCTION IF EXISTS hidden_scrub_cursor()") //nolint:errcheck
+
+	connA, err := sql.Open("postgres", gatewayDSN)
+	require.NoError(t, err)
+	connA.SetMaxIdleConns(0)
+	var ignored bool
+	var leakedPID int
+	err = connA.QueryRowContext(ctx, "SELECT hidden_scrub_cursor(), pg_backend_pid()").Scan(&ignored, &leakedPID)
+	require.NoError(t, err)
+	require.NoError(t, connA.Close())
+
+	require.Eventually(t, func() bool {
+		var alive int
+		if err := primary.QueryRowContext(ctx, "SELECT count(*) FROM pg_stat_activity WHERE pid = $1", leakedPID).Scan(&alive); err != nil {
+			return false
+		}
+		return alive == 0
+	}, scrubSweepWait, time.Second, "scrubber should have replaced the backend holding the hidden WITH HOLD cursor (pid %d)", leakedPID)
+
+	poolerLog, err := os.ReadFile(setup.PrimaryMultipooler(t).LogFile)
+	require.NoError(t, err)
+	require.Contains(t, string(poolerLog), "holdable_cursors",
+		"multipooler log should attribute the replacement to the holdable-cursor checker")
+	require.NotContains(t, string(poolerLog), cursorName,
+		"divergence log must never carry the cursor name")
+}


### PR DESCRIPTION
Adds the `connpool.ConnChecker`s the #1415 design left open — prepared statements, advisory locks, temp-schema objects, and (from review) holdable cursors — so the pool scrubber covers every class of backend state the pool trusts without verification (MUL-1495).

## Why

#1415 shipped the scrubber with a pluggable checker interface and a single `session_state` checker. The pool also trusts four other things about an idle backend that nothing verified: that its prepared statements match what tracking recorded, that it holds no session-level advisory lock, that no cursor outlived its transaction, and that its temporary schema is empty. Each can be violated by the same failure class the scrubber exists for — state created behind tracking's back, typically inside a routine body.

## Checkers

- **`prepared_statements`** — the only two-sided diff. Idle connections legitimately keep prepared statements across borrowers (tracked in `ConnectionState`, keyed by consolidator name), so the checker compares tracked statements against `pg_catalog.pg_prepared_statements`, **names and bodies**: a backend statement tracking does not know is *untracked*, a tracked statement the backend lost is *phantom*, and a tracked statement whose backend body differs from the tracked query is *mismatched*. The body comparison matters: a hidden `DEALLOCATE` plus re-`PREPARE` keeps a tracked `ppstmt<N>` name with a new body, and `ensurePrepared` would otherwise hand the redefined statement to the next borrower's `EXECUTE` (verified on PostgreSQL 17 from a PL/pgSQL body). The unnamed statement is skipped since the view never lists it. Tracked names are consolidator identifiers and reported verbatim; **every untracked name is redacted** to the bounded label `foreign_name`, one entry per statement so counts survive — a name that reached a backend by another route may embed client data, and the consolidator's `ppstmt<N>` shape is reachable from any session's `PREPARE`, so it is no safety signal.
- **`holdable_cursors`** — an idle pooled backend must have none. Outside a transaction `pg_catalog.pg_cursors` lists only `WITH HOLD` cursors, and portals pin a reserved connection, so an open cursor here was declared behind tracking (verified: `EXECUTE 'DECLARE ... WITH HOLD'` inside a PL/pgSQL body leaves the cursor open after the function returns). Reports one `holdable_cursor` finding per cursor; names are never reported.
- **`advisory_locks`** — an idle pooled backend must hold none: acquiring functions route to a reserved connection whose release runs `pg_advisory_unlock_all`. The checker runs the existing `PgLocksAdvisoryProbeSQL` and reports a single `session_advisory_lock` finding. Lock keys are never reported.
- **`temp_objects`** — an idle pooled backend must own none: temp statements pin a reserved connection that is closed at release, and pg_temp-qualified CREATE is rejected at the gateway. The checker scans every namespace-scoped catalog the gateway's pg_temp CREATE rejection covers — `pg_class`, `pg_proc` (aggregates included), standalone `pg_type` entries (domain, enum, range, multirange; composites via `pg_class`, auto-created array types skipped), `pg_operator`, `pg_collation`, `pg_statistic_ext`, `pg_opclass`, `pg_opfamily`, `pg_conversion`, and the four text-search catalogs — in one round trip, and reports one finding per kind (`table`, `index`, `sequence`, `function`, `domain`, `enum`, `operator`, `collation`, `statistics`, ...). Object names are never reported.

  Severity, measured on a live PostgreSQL 17 rather than reasoned: relations and types are the dangerous classes, since pg_temp is searched before `pg_catalog` for unqualified relation and type names (a `pg_temp` domain named `text` captures an unqualified `::text`, verified by OID; keyword type names like `int` cannot be shadowed). Operators, collations, and the other classes are never resolved through pg_temp, even with `pg_temp` listed first in `search_path`; they are reported as stale state for completeness with the guard, not as a shadowing hole.

All of them mirror `VerifySessionState`: refuse a non-idle connection, use plain `Query` (a retry would reconnect and reset the state under inspection), and treat malformed rows as probe errors, which the scrubber handles fail-closed.

## Also

- `PgLocksAdvisoryProbeSQL` is now schema-qualified (`pg_catalog.pg_locks`, `pg_catalog.pg_backend_pid`), the same shadowing fix applied to the session probe in #1415.
- The `ConnChecker` doc still described the pre-#1415-review "connection is not punished" error path; it now states the fail-closed behavior.
- `--connpool-session-scrub-interval` help text names all five state classes.
- Each checker now gets its own `scrubProbeTimeout` budget. `scrubOne` used to create one five-second context before the checker loop, so a slow early probe could starve the later ones into a timeout that the fail-closed error path turns into a needless replacement. Pool close still cancels the parent scrub context before draining, so shutdown is unaffected.
- Docs: one paragraph per checker in the scrubber section of `connection_pooling.md`.

## Testing

- Unit: each checker against fakepgserver (in sync, untracked/phantom, redefined body, redaction of every untracked name including a `ppstmt<digits>` one, probe error, malformed boolean, cursor count-not-names, temp kinds-not-names), plus the new `ConnectionState.PreparedStatementNames` accessor. Race-clean.
- E2E: new `TestSessionScrubberReplacesHiddenAdvisoryLock` — a `pg_advisory_lock` hidden in a SQL function body installed directly on the primary leaves a lock on an unpinned pooled backend; the scrubber detects it under the `advisory_locks` checker, replaces the backend, and the log never carries the lock key. New `TestSessionScrubberReplacesHiddenTempObjects` hides a domain, an operator, a collation, and a statistics object created in pg_temp inside one SQL function body: all four kinds are detected under `temp_objects` on one sweep, the backend is replaced, and the object names are absent from the log. One test rather than one per class keeps suite time flat, since each scrubber test can wait a full stack rotation. New `TestSessionScrubberReplacesHiddenHoldableCursor` hides a `WITH HOLD` cursor in a PL/pgSQL body and asserts replacement under `holdable_cursors` with the cursor name absent from the log.
- Full queryserving suite green with all five checkers on, re-run after each review round. The last run also confirms the body comparison produces no false mismatches against the suite's PREPARE-heavy traffic.
- Every `pg_temp`-qualified CREATE the gateway guard rejects was exercised against a scratch PostgreSQL 17 to confirm each object class is creatable there, lands in its expected catalog, and is returned by the probe; the same run confirmed the shadowing semantics above. The existing scrubber canary (zero divergence from normal traffic, read across the whole suite's log) confirms the new checkers produce no false positives against the suite's PREPARE-heavy traffic.

A first full-suite run exposed that the scrubber's stack rotation (one connection per 10s tick across the clean stack plus 16 settings stacks) can take up to 170s to reach a given stack once earlier tests have populated many buckets; the advisory divergence fired at 89s against a 90s wait. Both scrubber e2e tests now wait `scrubSweepWait` (4 min) with the reasoning in a comment.

## Follow-ups (not in this PR)

The `session_state` checker still reports untracked custom GUC names verbatim, and a hidden `set_config('my.' || value, ...)` puts a value into a name — the same exposure this PR redacts for prepared statements. Worth deciding once and applying there too.

Within a stack the scrubber only ever probes the top connection: it pops the top, checks it, and pushes it back on top. Colder connections deeper in a stack are never probed unless client traffic reorders them. That coverage gap predates this PR and deserves its own task.




