### PR TITLE
feat(topoclient): support in-memory etcd TLS

### DIFF
--- a/go/common/topoclient/etcdtopo/store.go
+++ b/go/common/topoclient/etcdtopo/store.go
@@ -36,6 +36,7 @@ package etcdtopo
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -55,7 +56,10 @@ var (
 	serverCaPath   string
 )
 
-var _ topoclient.Conn = (*etcdtopo)(nil)
+var (
+	_ topoclient.Conn           = (*etcdtopo)(nil)
+	_ topoclient.FactoryWithTLS = Factory{}
+)
 
 // remoteOperationTimeout is used for operations where we have to
 // call out to etcd for initial data fetches (e.g., watch setup).
@@ -72,6 +76,11 @@ func (f Factory) HasGlobalReadOnlyCell(serverAddr, root string) bool {
 // Create is part of the topoclient.Factory interface.
 func (f Factory) Create(cell, root string, serverAddrs []string) (topoclient.Conn, error) {
 	return NewEtcdTopo(serverAddrs, root)
+}
+
+// CreateWithTLS creates an etcd topology client with per-connection TLS options.
+func (f Factory) CreateWithTLS(cell, root string, serverAddrs []string, tlsOptions *topoclient.TLSOptions) (topoclient.Conn, error) {
+	return NewServerWithTLS(serverAddrs, root, tlsOptions)
 }
 
 // etcdtopo is the implementation of topoclient.Conn for etcd.
@@ -99,9 +108,7 @@ func registerEtcdTopoFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&serverCaPath, "topo-etcd-tls-ca", serverCaPath, "path to the ca to use to validate the server cert when connecting to the etcd topo server")
 }
 
-// Close implements topoclient.Conn.Close.
-// It will nil out the global and cells fields, so any attempt to
-// reuse this server will panic.
+// Close closes the etcd client.
 func (s *etcdtopo) Close() error {
 	close(s.running)
 	if err := s.cli.Close(); err != nil {
@@ -112,54 +119,99 @@ func (s *etcdtopo) Close() error {
 }
 
 func newTLSConfig(certPath, keyPath, caPath string) (*tls.Config, error) {
-	var tlscfg *tls.Config
-	// If TLS is enabled, attach TLS config info.
-	if certPath != "" && keyPath != "" {
-		var (
-			cert *tls.Certificate
-			cp   *x509.CertPool
-			err  error
-		)
-
-		cert, err = tlsutil.NewCert(certPath, keyPath, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		if caPath != "" {
-			cp, err = tlsutil.NewCertPool([]string{caPath})
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		tlscfg = &tls.Config{
-			MinVersion:         tls.VersionTLS12,
-			RootCAs:            cp,
-			InsecureSkipVerify: false,
-		}
-		if cert != nil {
-			tlscfg.Certificates = []tls.Certificate{*cert}
-		}
-	}
-	return tlscfg, nil
-}
-
-// NewServerWithOpts creates a new server with the provided TLS options
-func NewServerWithOpts(serverAddrs []string, root, certPath, keyPath, caPath string) (*etcdtopo, error) {
-	// TODO: Rename this to NewServer and change NewServer to a name that signifies it uses the process-wide TLS settings.
-	config := clientv3.Config{
-		Endpoints:   serverAddrs,
-		DialTimeout: time.Second,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()}, // grpc.WithBlock is deprecated but required by etcd client
+	if certPath == "" || keyPath == "" {
+		return nil, nil
 	}
 
-	tlscfg, err := newTLSConfig(certPath, keyPath, caPath)
+	cert, err := tlsutil.NewCert(certPath, keyPath, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	config.TLS = tlscfg
+	var caPool *x509.CertPool
+	if caPath != "" {
+		caPool, err = tlsutil.NewCertPool([]string{caPath})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return newTLSConfigWithCertificate(cert, caPool), nil
+}
+
+func newTLSConfigFromPEM(certPEM, keyPEM, caPEM []byte) (*tls.Config, error) {
+	if len(certPEM) == 0 && len(keyPEM) == 0 {
+		if len(caPEM) != 0 {
+			return nil, errors.New("client certificate and key PEM are required when CA PEM is provided")
+		}
+		return nil, nil
+	}
+	if len(certPEM) == 0 || len(keyPEM) == 0 {
+		return nil, errors.New("both client certificate and key PEM must be provided for TLS")
+	}
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	var caPool *x509.CertPool
+	if len(caPEM) > 0 {
+		caPool = x509.NewCertPool()
+		if !caPool.AppendCertsFromPEM(caPEM) {
+			return nil, errors.New("failed to parse CA certificate PEM")
+		}
+	}
+
+	return newTLSConfigWithCertificate(&cert, caPool), nil
+}
+
+func newTLSConfigWithCertificate(cert *tls.Certificate, caPool *x509.CertPool) *tls.Config {
+	config := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		RootCAs:            caPool,
+		InsecureSkipVerify: false,
+	}
+	if cert != nil {
+		config.Certificates = []tls.Certificate{*cert}
+	}
+	return config
+}
+
+func newTLSConfigFromOptions(tlsOptions *topoclient.TLSOptions) (*tls.Config, error) {
+	if tlsOptions == nil {
+		return nil, nil
+	}
+	if tlsOptions.Config != nil {
+		if len(tlsOptions.CertPEM) != 0 || len(tlsOptions.KeyPEM) != 0 || len(tlsOptions.CAPEM) != 0 {
+			return nil, errors.New("TLS config cannot be combined with TLS PEM material")
+		}
+		config := tlsOptions.Config.Clone()
+		if config.MinVersion < tls.VersionTLS12 {
+			config.MinVersion = tls.VersionTLS12
+		}
+		config.InsecureSkipVerify = false
+		return config, nil
+	}
+	return newTLSConfigFromPEM(tlsOptions.CertPEM, tlsOptions.KeyPEM, tlsOptions.CAPEM)
+}
+
+func newEtcdClientConfig(serverAddrs []string, tlsConfig *tls.Config) clientv3.Config {
+	return clientv3.Config{
+		Endpoints:   serverAddrs,
+		DialTimeout: time.Second,
+		DialOptions: []grpc.DialOption{grpc.WithBlock()}, // grpc.WithBlock is deprecated but required by etcd client
+		TLS:         tlsConfig,
+	}
+}
+
+// NewServerWithOpts creates a new server with TLS material loaded from file paths.
+func NewServerWithOpts(serverAddrs []string, root, certPath, keyPath, caPath string) (*etcdtopo, error) {
+	tlscfg, err := newTLSConfig(certPath, keyPath, caPath)
+	if err != nil {
+		return nil, err
+	}
+	config := newEtcdClientConfig(serverAddrs, tlscfg)
 
 	cli, err := clientv3.New(config)
 	if err != nil {
@@ -173,8 +225,27 @@ func NewServerWithOpts(serverAddrs []string, root, certPath, keyPath, caPath str
 	}, nil
 }
 
-// NewEtcdTopo returns a new etcdtopo.Server.
+// NewServerWithTLS creates a new server with in-memory TLS options.
+func NewServerWithTLS(serverAddrs []string, root string, tlsOptions *topoclient.TLSOptions) (*etcdtopo, error) {
+	tlscfg, err := newTLSConfigFromOptions(tlsOptions)
+	if err != nil {
+		return nil, err
+	}
+	config := newEtcdClientConfig(serverAddrs, tlscfg)
+
+	cli, err := clientv3.New(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &etcdtopo{
+		cli:     cli,
+		root:    root,
+		running: make(chan struct{}),
+	}, nil
+}
+
+// NewEtcdTopo creates a new server using the TLS paths configured by command-line flags.
 func NewEtcdTopo(serverAddrs []string, root string) (*etcdtopo, error) {
-	// TODO: Rename this to a name to signifies this function uses the process-wide TLS settings.
 	return NewServerWithOpts(serverAddrs, root, clientCertPath, clientKeyPath, serverCaPath)
 }

--- a/go/common/topoclient/etcdtopo/store.go
+++ b/go/common/topoclient/etcdtopo/store.go
@@ -196,6 +196,9 @@ func newTLSConfigFromOptions(tlsOptions *topoclient.TLSOptions) (*tls.Config, er
 		config.InsecureSkipVerify = false
 		return config, nil
 	}
+	if len(tlsOptions.CertPEM) == 0 && len(tlsOptions.KeyPEM) == 0 && len(tlsOptions.CAPEM) == 0 {
+		return nil, errors.New("TLS options require a client certificate and key or TLS config")
+	}
 	return newTLSConfigFromPEM(tlsOptions.CertPEM, tlsOptions.KeyPEM, tlsOptions.CAPEM)
 }
 

--- a/go/common/topoclient/etcdtopo/store.go
+++ b/go/common/topoclient/etcdtopo/store.go
@@ -37,6 +37,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -205,6 +208,22 @@ func newEtcdClientConfig(serverAddrs []string, tlsConfig *tls.Config) clientv3.C
 	}
 }
 
+func validateTLSEndpoints(serverAddrs []string, tlsConfig *tls.Config) error {
+	if tlsConfig == nil {
+		return nil
+	}
+	for _, serverAddr := range serverAddrs {
+		endpoint, err := url.Parse(serverAddr)
+		if err != nil {
+			continue
+		}
+		if strings.EqualFold(endpoint.Scheme, "http") {
+			return fmt.Errorf("TLS cannot use HTTP endpoint %q", serverAddr)
+		}
+	}
+	return nil
+}
+
 // NewServerWithOpts creates a new server with TLS material loaded from file paths.
 func NewServerWithOpts(serverAddrs []string, root, certPath, keyPath, caPath string) (*etcdtopo, error) {
 	tlscfg, err := newTLSConfig(certPath, keyPath, caPath)
@@ -229,6 +248,9 @@ func NewServerWithOpts(serverAddrs []string, root, certPath, keyPath, caPath str
 func NewServerWithTLS(serverAddrs []string, root string, tlsOptions *topoclient.TLSOptions) (*etcdtopo, error) {
 	tlscfg, err := newTLSConfigFromOptions(tlsOptions)
 	if err != nil {
+		return nil, err
+	}
+	if err := validateTLSEndpoints(serverAddrs, tlscfg); err != nil {
 		return nil, err
 	}
 	config := newEtcdClientConfig(serverAddrs, tlscfg)

--- a/go/common/topoclient/etcdtopo/store_test.go
+++ b/go/common/topoclient/etcdtopo/store_test.go
@@ -56,6 +56,12 @@ func TestNewTLSConfigFromPEMWithoutMaterialUsesPlaintext(t *testing.T) {
 	assert.Nil(t, clientConfig.TLS)
 }
 
+func TestNewTLSConfigFromOptionsWithoutOptionsUsesPlaintext(t *testing.T) {
+	tlsConfig, err := newTLSConfigFromOptions(nil)
+	require.NoError(t, err)
+	assert.Nil(t, tlsConfig)
+}
+
 func TestNewServerWithTLSRequiresCertificateAndKey(t *testing.T) {
 	certPEM, keyPEM, _ := newTestTLSMaterial(t)
 
@@ -82,6 +88,11 @@ func TestNewServerWithTLSRejectsCAWithoutClientCredentials(t *testing.T) {
 
 	_, err := NewServerWithTLS([]string{"http://etcd.example"}, "/topology", &topoclient.TLSOptions{CAPEM: caPEM})
 	require.ErrorContains(t, err, "client certificate and key PEM are required when CA PEM is provided")
+}
+
+func TestNewServerWithTLSRequiresMaterial(t *testing.T) {
+	_, err := NewServerWithTLS([]string{"http://etcd.example"}, "/topology", &topoclient.TLSOptions{})
+	require.ErrorContains(t, err, "TLS options require a client certificate and key or TLS config")
 }
 
 func TestNewServerWithTLSRejectsHTTPEndpoint(t *testing.T) {

--- a/go/common/topoclient/etcdtopo/store_test.go
+++ b/go/common/topoclient/etcdtopo/store_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdtopo
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/topoclient"
+)
+
+func TestNewTLSConfigFromPEM(t *testing.T) {
+	certPEM, keyPEM, caPEM := newTestTLSMaterial(t)
+
+	tlsConfig, err := newTLSConfigFromPEM(certPEM, keyPEM, caPEM)
+	require.NoError(t, err)
+	require.NotNil(t, tlsConfig)
+	assert.Len(t, tlsConfig.Certificates, 1)
+	assert.NotNil(t, tlsConfig.RootCAs)
+	assert.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion)
+	assert.False(t, tlsConfig.InsecureSkipVerify)
+
+	clientConfig := newEtcdClientConfig([]string{"https://etcd.example"}, tlsConfig)
+	assert.Same(t, tlsConfig, clientConfig.TLS)
+}
+
+func TestNewTLSConfigFromPEMWithoutMaterialUsesPlaintext(t *testing.T) {
+	tlsConfig, err := newTLSConfigFromPEM(nil, nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, tlsConfig)
+
+	clientConfig := newEtcdClientConfig([]string{"http://etcd.example"}, tlsConfig)
+	assert.Nil(t, clientConfig.TLS)
+}
+
+func TestNewServerWithTLSRequiresCertificateAndKey(t *testing.T) {
+	certPEM, keyPEM, _ := newTestTLSMaterial(t)
+
+	for _, testCase := range []struct {
+		name    string
+		certPEM []byte
+		keyPEM  []byte
+	}{
+		{name: "certificate without key", certPEM: certPEM},
+		{name: "key without certificate", keyPEM: keyPEM},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := NewServerWithTLS([]string{"http://etcd.example"}, "/topology", &topoclient.TLSOptions{
+				CertPEM: testCase.certPEM,
+				KeyPEM:  testCase.keyPEM,
+			})
+			require.ErrorContains(t, err, "both client certificate and key PEM must be provided")
+		})
+	}
+}
+
+func TestNewServerWithTLSRejectsCAWithoutClientCredentials(t *testing.T) {
+	_, _, caPEM := newTestTLSMaterial(t)
+
+	_, err := NewServerWithTLS([]string{"http://etcd.example"}, "/topology", &topoclient.TLSOptions{CAPEM: caPEM})
+	require.ErrorContains(t, err, "client certificate and key PEM are required when CA PEM is provided")
+}
+
+func TestNewTLSConfigFromOptionsUsesPrebuiltConfig(t *testing.T) {
+	insecureSkipVerify := true
+	source := &tls.Config{
+		MinVersion: tls.VersionTLS10,
+		// #nosec G402 - NewServerWithTLS clears this test-only input.
+		InsecureSkipVerify: insecureSkipVerify,
+	}
+
+	tlsConfig, err := newTLSConfigFromOptions(&topoclient.TLSOptions{Config: source})
+	require.NoError(t, err)
+	require.NotNil(t, tlsConfig)
+	assert.NotSame(t, source, tlsConfig)
+	assert.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion)
+	assert.False(t, tlsConfig.InsecureSkipVerify)
+	assert.Equal(t, uint16(tls.VersionTLS10), source.MinVersion)
+	assert.True(t, source.InsecureSkipVerify)
+}
+
+func TestNewTLSConfigFromOptionsRejectsMixedSources(t *testing.T) {
+	_, err := newTLSConfigFromOptions(&topoclient.TLSOptions{
+		CertPEM: []byte("certificate"),
+		Config:  &tls.Config{},
+	})
+	require.ErrorContains(t, err, "TLS config cannot be combined with TLS PEM material")
+}
+
+func newTestTLSMaterial(t *testing.T) (certPEM, keyPEM, caPEM []byte) {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	caTemplate := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test CA"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, caKey.Public(), caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	clientTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test client"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, &clientTemplate, caCert, clientKey.Public(), caKey)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalECPrivateKey(clientKey)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}),
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+}

--- a/go/common/topoclient/etcdtopo/store_test.go
+++ b/go/common/topoclient/etcdtopo/store_test.go
@@ -84,6 +84,39 @@ func TestNewServerWithTLSRejectsCAWithoutClientCredentials(t *testing.T) {
 	require.ErrorContains(t, err, "client certificate and key PEM are required when CA PEM is provided")
 }
 
+func TestNewServerWithTLSRejectsHTTPEndpoint(t *testing.T) {
+	certPEM, keyPEM, _ := newTestTLSMaterial(t)
+
+	_, err := NewServerWithTLS([]string{"http://etcd.example"}, "/topology", &topoclient.TLSOptions{
+		CertPEM: certPEM,
+		KeyPEM:  keyPEM,
+	})
+	require.ErrorContains(t, err, "TLS cannot use HTTP endpoint")
+}
+
+func TestValidateTLSEndpoints(t *testing.T) {
+	for _, testCase := range []struct {
+		name      string
+		endpoint  string
+		tlsConfig *tls.Config
+		wantErr   string
+	}{
+		{name: "plaintext HTTP", endpoint: "http://etcd.example"},
+		{name: "TLS HTTP", endpoint: "http://etcd.example", tlsConfig: &tls.Config{}, wantErr: "TLS cannot use HTTP endpoint"},
+		{name: "TLS HTTPS", endpoint: "https://etcd.example", tlsConfig: &tls.Config{}},
+		{name: "TLS bare address", endpoint: "etcd.example:2379", tlsConfig: &tls.Config{}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := validateTLSEndpoints([]string{testCase.endpoint}, testCase.tlsConfig)
+			if testCase.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, testCase.wantErr)
+		})
+	}
+}
+
 func TestNewTLSConfigFromOptionsUsesPrebuiltConfig(t *testing.T) {
 	insecureSkipVerify := true
 	source := &tls.Config{

--- a/go/common/topoclient/store.go
+++ b/go/common/topoclient/store.go
@@ -60,6 +60,7 @@ package topoclient
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -116,6 +117,22 @@ const (
 // Topology implementations must provide an implementation for this interface.
 type Factory interface {
 	Create(topoName, root string, serverAddrs []string) (Conn, error)
+}
+
+// TLSOptions holds per-connection TLS material for topology clients.
+// Config cannot be combined with the PEM fields.
+type TLSOptions struct {
+	CertPEM []byte
+	KeyPEM  []byte
+	CAPEM   []byte
+	Config  *tls.Config
+}
+
+// FactoryWithTLS creates topology connections with caller-provided TLS options.
+// Implementations that do not support TLS can continue to implement Factory.
+type FactoryWithTLS interface {
+	Factory
+	CreateWithTLS(topoName, root string, serverAddrs []string, tlsOptions *TLSOptions) (Conn, error)
 }
 
 // GlobalStore defines APIs for cluster-level static metadata.
@@ -310,8 +327,10 @@ type cellConn struct {
 	conn Conn
 }
 
-// TopoConfig holds topology configuration using viperutil values
+// TopoConfig holds topology connection settings.
 type TopoConfig struct {
+	// TLS applies to connections created by this topology store.
+	TLS                    *TLSOptions
 	globalServerAddresses  viperutil.Value[[]string]
 	globalRoot             viperutil.Value[string]
 	readConcurrency        viperutil.Value[int64]
@@ -396,6 +415,23 @@ func (tc *TopoConfig) SetRemoteOperationTimeout(d time.Duration) {
 	tc.remoteOperationTimeout.Set(d)
 }
 
+func createConn(factory Factory, topoName, root string, serverAddrs []string, tlsOptions *TLSOptions) (Conn, error) {
+	if tlsOptions != nil {
+		if tlsFactory, ok := factory.(FactoryWithTLS); ok {
+			return tlsFactory.CreateWithTLS(topoName, root, serverAddrs, tlsOptions)
+		}
+		return nil, fmt.Errorf("topology factory %T does not support TLS connections", factory)
+	}
+	return factory.Create(topoName, root, serverAddrs)
+}
+
+func tlsOptionsFromConfig(config *TopoConfig) *TLSOptions {
+	if config == nil {
+		return nil
+	}
+	return config.TLS
+}
+
 // factories contains the registered factories for creating topology connections.
 // Each implementation (e.g., etcd, memory) registers its factory here.
 var factories = make(map[string]Factory)
@@ -433,7 +469,7 @@ func NewWithFactory(factory Factory, root string, serverAddrs []string, config *
 	ts.status[GlobalCell] = ""
 	conn := NewWrapperConn(
 		func() (Conn, error) {
-			return factory.Create(GlobalCell, root, serverAddrs)
+			return createConn(factory, GlobalCell, root, serverAddrs, tlsOptionsFromConfig(config))
 		},
 		func(s string) {
 			ts.setStatus(GlobalCell, s)
@@ -530,7 +566,7 @@ func (ts *store) ConnForCell(ctx context.Context, cell string) (Conn, error) {
 	ts.setStatus(cell, "")
 	conn := NewWrapperConn(
 		func() (Conn, error) {
-			return ts.factory.Create(cell, ci.Root, ci.ServerAddresses)
+			return createConn(ts.factory, cell, ci.Root, ci.ServerAddresses, tlsOptionsFromConfig(ts.config))
 		},
 		func(s string) {
 			ts.setStatus(cell, s)

--- a/go/common/topoclient/store_test.go
+++ b/go/common/topoclient/store_test.go
@@ -76,6 +76,17 @@ func TestNewWithFactory(t *testing.T) {
 	ts.Close()
 }
 
+func TestNewWithFactoryWithoutConfig(t *testing.T) {
+	factory := newMockFactory()
+	ts := NewWithFactory(factory, "/test/root", []string{"localhost:2181"}, nil)
+	require.NotNil(t, ts)
+
+	require.Eventually(t, func() bool {
+		return factory.getCreateCount() > 0
+	}, time.Second, time.Millisecond)
+	ts.Close()
+}
+
 func TestOpenServer(t *testing.T) {
 	// Save and restore the original factories map
 	originalFactories := factories
@@ -109,6 +120,60 @@ func TestOpenServer(t *testing.T) {
 		assert.Nil(t, ts, "Store should be nil")
 		assert.Contains(t, err.Error(), "no topology implementations registered", "Error should mention no implementations")
 	})
+}
+
+func TestOpenServerPassesTLSOptionsToSupportingFactory(t *testing.T) {
+	originalFactories := factories
+	defer func() { factories = originalFactories }()
+
+	factories = make(map[string]Factory)
+	factory := newMockFactoryWithTLS()
+	RegisterFactory("test-impl", factory)
+
+	tlsOptions := &TLSOptions{
+		CertPEM: []byte("client certificate"),
+		KeyPEM:  []byte("client key"),
+		CAPEM:   []byte("server CA"),
+	}
+	config := NewDefaultTopoConfig()
+	config.TLS = tlsOptions
+
+	ts, err := OpenServer("test-impl", "/test", []string{"localhost:2379"}, config)
+	require.NoError(t, err)
+	defer ts.Close()
+
+	require.Eventually(t, func() bool {
+		return factory.getTLSOptions() != nil
+	}, time.Second, time.Millisecond)
+	assert.Same(t, tlsOptions, factory.getTLSOptions())
+}
+
+func TestCreateConnRejectsTLSOptionsForUnsupportedFactory(t *testing.T) {
+	_, err := createConn(newMockFactory(), GlobalCell, "/test", []string{"localhost:2379"}, &TLSOptions{})
+	require.ErrorContains(t, err, "does not support TLS connections")
+}
+
+type mockFactoryWithTLS struct {
+	*mockFactory
+	tlsOptionsMu sync.Mutex
+	tlsOptions   *TLSOptions
+}
+
+func newMockFactoryWithTLS() *mockFactoryWithTLS {
+	return &mockFactoryWithTLS{mockFactory: newMockFactory()}
+}
+
+func (f *mockFactoryWithTLS) CreateWithTLS(topoName, root string, serverAddrs []string, tlsOptions *TLSOptions) (Conn, error) {
+	f.tlsOptionsMu.Lock()
+	f.tlsOptions = tlsOptions
+	f.tlsOptionsMu.Unlock()
+	return f.Create(topoName, root, serverAddrs)
+}
+
+func (f *mockFactoryWithTLS) getTLSOptions() *TLSOptions {
+	f.tlsOptionsMu.Lock()
+	defer f.tlsOptionsMu.Unlock()
+	return f.tlsOptions
 }
 
 func TestConnForCell_GlobalCell(t *testing.T) {


### PR DESCRIPTION
## Description

this PR adds an in-memory TLS path so a single process can connect to different topology targets with different client certificates. File-path and process-wide flag paths cannot select client credentials independently per target.

## Main changes

- Adds TLSOptions and additive FactoryWithTLS support so OpenServer forwards per-call TLS settings without changing Factory.Create.
- Adds NewServerWithTLS for PEM bytes or a prebuilt TLS configuration, enforcing TLS 1.2 minimum and certificate verification.
- Preserves all existing constructors, flags, factory signatures, and no-options behavior.

## Testing

Focused topology tests and required build, vet, and naming lint passed.