### PR TITLE
feat(multipooler): derive --socket-file from pooler-dir and pg-port

### DIFF
--- a/demo/k8s/k8s-multipooler-statefulset.yaml
+++ b/demo/k8s/k8s-multipooler-statefulset.yaml
@@ -121,7 +121,7 @@ spec:
             - --pooler-dir=/data
             - --pgctld-addr=localhost:16200
             - --pg-port=5432
-            - --socket-file=/data/pg_sockets/.s.PGSQL.5432
+            # --socket-file is derived from --pooler-dir and --pg-port
             - --grpc-socket-file=/data/multipooler.sock
             - --connpool-global-capacity=50
             - --service-map=grpc-pooler

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -14,7 +14,11 @@
 
 package constants
 
-import "time"
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+)
 
 // PostgreSQL default values - semantically separate concepts.
 // These are distinct constants despite having the same string value because
@@ -230,6 +234,11 @@ const (
 		" UNION ALL SELECT 'role', pg_catalog.current_setting('role'), 'identity'" +
 		" UNION ALL SELECT 'session_authorization', session_user::text, 'identity'"
 
+	// PostgresSocketDirName is the directory under the pooler directory where
+	// pgctld points postgres's unix_socket_directories. Use PostgresSocketDir /
+	// PostgresSocketFilePath to build paths rather than joining this by hand.
+	PostgresSocketDirName = "pg_sockets"
+
 	// RestoreCommandPIDFile is the filename (joined onto the pooler directory)
 	// that `pgctld restore-wrapper` writes its own PID to, so pgctld's
 	// StopRestoreCommand RPC can check liveness or signal it. Shared between
@@ -247,3 +256,19 @@ const (
 	// among other fields. Fixed by PostgreSQL itself, not configurable.
 	PostmasterPIDFile = "postmaster.pid"
 )
+
+// PostgresSocketDir returns the Unix socket directory for a pooler directory:
+// <poolerDir>/pg_sockets. This is the value pgctld passes to postgres as
+// unix_socket_directories, so every component that dials the socket must build
+// paths from here. Shared by pgctld, multipooler, and the provisioner — the
+// canonical home for the formula, since services cannot import each other.
+func PostgresSocketDir(poolerDir string) string {
+	return filepath.Join(poolerDir, PostgresSocketDirName)
+}
+
+// PostgresSocketFilePath returns the full path of the socket file postgres
+// creates in PostgresSocketDir for the given port: .s.PGSQL.<port> (the name
+// is fixed by postgres, not configurable).
+func PostgresSocketFilePath(poolerDir string, pgPort int) string {
+	return filepath.Join(PostgresSocketDir(poolerDir), fmt.Sprintf(".s.PGSQL.%d", pgPort))
+}

--- a/go/common/constants/postgres_test.go
+++ b/go/common/constants/postgres_test.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPostgresSocketPaths(t *testing.T) {
+	assert.Equal(t, "/data/pooler-1/pg_sockets", PostgresSocketDir("/data/pooler-1"))
+	assert.Equal(t, "/data/pooler-1/pg_sockets/.s.PGSQL.5433", PostgresSocketFilePath("/data/pooler-1", 5433))
+}

--- a/go/provisioner/local/local.go
+++ b/go/provisioner/local/local.go
@@ -857,9 +857,6 @@ func (p *localProvisioner) provisionMultipooler(ctx context.Context, req *provis
 		return nil, fmt.Errorf("failed to provision pgctld for multipooler: %w", err)
 	}
 
-	// Construct the PostgreSQL socket file path: <poolerDir>/pg_sockets/.s.PGSQL.<port>
-	pgSocketFile := filepath.Join(poolerDir, "pg_sockets", fmt.Sprintf(".s.PGSQL.%d", pgPort))
-
 	// Build command arguments with pgctld-addr
 	args := []string{
 		"--http-port", strconv.Itoa(httpPort),
@@ -877,7 +874,8 @@ func (p *localProvisioner) provisionMultipooler(ctx context.Context, req *provis
 		"--pooler-dir", poolerDir,
 		"--pg-port", strconv.Itoa(pgPort),
 		"--hostname", "localhost",
-		"--socket-file", pgSocketFile, // PostgreSQL Unix socket for trust auth
+		// No --socket-file: the multipooler derives the postgres Unix socket
+		// path (for trust auth) from --pooler-dir and --pg-port.
 	}
 
 	// Add socket file if configured
@@ -2090,15 +2088,10 @@ func (p *localProvisioner) validateUnixSocketPathLength(config *LocalProvisioner
 	// Path structure: <rootWorkingDir>/data/pooler_<serviceID>/pg_sockets/.s.PGSQL.5432
 	// We use a worst-case service ID length (8 chars) to be safe
 	maxServiceIDLength := 8
-	worstCasePoolerSocketPath := []string{
-		"data",
-		"pooler_" + strings.Repeat("x", maxServiceIDLength),
-		"pg_sockets",
-		".s.PGSQL.5432",
-	}
-	worstCaseCurrentSocketPath := filepath.Join(append([]string{absRootWorkingDir}, worstCasePoolerSocketPath...)...)
+	worstCasePoolerDir := filepath.Join("data", "pooler_"+strings.Repeat("x", maxServiceIDLength))
+	worstCaseCurrentSocketPath := constants.PostgresSocketFilePath(filepath.Join(absRootWorkingDir, worstCasePoolerDir), 5432)
 
-	worstCaseProposedSocketPath := filepath.Join(append([]string{"/tmp/mt"}, worstCasePoolerSocketPath...)...)
+	worstCaseProposedSocketPath := constants.PostgresSocketFilePath(filepath.Join("/tmp/mt", worstCasePoolerDir), 5432)
 
 	if len(worstCaseCurrentSocketPath) > maxSocketPathLength {
 		return fmt.Errorf("unix socket path would exceed system limit (%d bytes): %s\n\n"+

--- a/go/services/multipooler/init.go
+++ b/go/services/multipooler/init.go
@@ -267,8 +267,8 @@ func (mp *Multipooler) RegisterFlags(flags *pflag.FlagSet) {
 	flags.String("table-group", mp.tableGroup.Default(), "table group this multipooler serves (required)")
 	flags.String("shard", mp.shard.Default(), "shard this multipooler serves (required)")
 	flags.String("service-id", mp.serviceID.Default(), "optional service ID (if empty, a random ID will be generated)")
-	flags.String("socket-file", mp.socketFilePath.Default(), "PostgreSQL Unix socket file path (if empty, TCP connection will be used)")
-	flags.String("pooler-dir", mp.poolerDir.Default(), "pooler directory path (if empty, socket-file path will be used as-is)")
+	flags.String("socket-file", mp.socketFilePath.Default(), "PostgreSQL Unix socket file path. If unset, derived as <pooler-dir>/pg_sockets/.s.PGSQL.<pg-port> when --pooler-dir is set; set explicitly to empty (--socket-file='') to force a TCP connection")
+	flags.String("pooler-dir", mp.poolerDir.Default(), "pooler directory path")
 	flags.Int("pg-port", mp.pgPort.Default(), "PostgreSQL port number")
 	flags.Int("heartbeat-interval-milliseconds", mp.heartbeatIntervalMs.Default(), "interval in milliseconds between heartbeat writes")
 	flags.Duration("health-stream-staleness-timeout", mp.healthStreamStalenessTimeout.Default(), "staleness window advertised to the gateway health stream; 0 keeps the built-in default")
@@ -426,11 +426,19 @@ func (mp *Multipooler) Init(startCtx context.Context) error {
 		return errors.New("PGDATA environment variable is required")
 	}
 
+	// Resolve the postgres socket path: an unset --socket-file derives it from
+	// pooler-dir + pg-port (the same formula pgctld uses to configure
+	// unix_socket_directories), so co-located deployments need not repeat it.
+	socketFilePath := resolveSocketFilePath(mp.socketFilePath.Get(), mp.flagExplicitlySet("socket-file"), mp.poolerDir.Get(), mp.pgPort.Get())
+	if socketFilePath != mp.socketFilePath.Get() {
+		logger.InfoContext(startCtx, "derived postgres socket file from pooler-dir and pg-port", "socket_file", socketFilePath)
+	}
+
 	// Validate libpq-style sslmode + sslrootcert before any pool opens. A typo
 	// or missing CA bundle should fail startup rather than silently downgrading
 	// the multipooler → postgres dials to plaintext.
 	pgHost := ""
-	if mp.socketFilePath.Get() == "" {
+	if socketFilePath == "" {
 		pgHost = mp.senv.GetHostname()
 	}
 	if err := mp.connPoolConfig.ValidatePGSSL(pgHost); err != nil {
@@ -459,7 +467,7 @@ func (mp *Multipooler) Init(startCtx context.Context) error {
 
 	logger.InfoContext(startCtx, "initializing MultipoolerManager")
 	poolerManager, err := manager.NewMultipoolerManager(logger, multipooler, &manager.Config{
-		SocketFilePath:                 mp.socketFilePath.Get(),
+		SocketFilePath:                 socketFilePath,
 		TopoClient:                     mp.ts,
 		HeartbeatIntervalMs:            mp.heartbeatIntervalMs.Get(),
 		HealthStreamStalenessTimeout:   mp.healthStreamStalenessTimeout.Get(),
@@ -549,4 +557,29 @@ func (mp *Multipooler) Shutdown(ctx context.Context) {
 		mp.poolerManager.StopTopoRegistration(ctx)
 	}
 	mp.ts.Close()
+}
+
+// flagExplicitlySet reports whether the named flag was set on the command
+// line, even to its default or an empty value (pflag.Flag.Changed) — a
+// distinction viperutil's Get cannot make. False when RegisterFlags has not
+// run (e.g. minimal test setups).
+func (mp *Multipooler) flagExplicitlySet(name string) bool {
+	if mp.flagSet == nil {
+		return false
+	}
+	f := mp.flagSet.Lookup(name)
+	return f != nil && f.Changed
+}
+
+// resolveSocketFilePath returns the postgres socket path the pooler should
+// dial. An explicitly set --socket-file wins, including one explicitly set to
+// empty, which forces a TCP dial. When the flag is untouched and a pooler
+// directory is configured, the path is derived from pooler-dir + pg-port —
+// the same formula pgctld uses for unix_socket_directories, so the two can
+// never disagree. With neither, empty is returned and the pooler dials TCP.
+func resolveSocketFilePath(configured string, explicitlySet bool, poolerDir string, pgPort int) string {
+	if configured != "" || explicitlySet || poolerDir == "" {
+		return configured
+	}
+	return constants.PostgresSocketFilePath(poolerDir, pgPort)
 }

--- a/go/services/multipooler/init.go
+++ b/go/services/multipooler/init.go
@@ -107,6 +107,11 @@ type Multipooler struct {
 	// explicitly-set-but-empty flag from an unset one (pflag.Flag.Changed),
 	// which viperutil.Get cannot.
 	flagSet *pflag.FlagSet
+	// reg is the registry the values above were configured against, saved so
+	// explicitness checks can also see keys written in the loaded config file
+	// (Registry.InStaticConfig) — a config file sets neither Flag.Changed nor
+	// an env var.
+	reg *viperutil.Registry
 	// GrpcServer is the grpc server
 	grpcServer *servenv.GrpcServer
 	// Senv is the serving environment
@@ -130,6 +135,7 @@ func (mp *Multipooler) CobraPreRunE(cmd *cobra.Command) error {
 func NewMultipooler(telemetry *telemetry.Telemetry) *Multipooler {
 	reg := viperutil.NewRegistry()
 	mp := &Multipooler{
+		reg: reg,
 		pgctldAddr: viperutil.Configure(reg, "pgctld-addr", viperutil.Options[string]{
 			Default:  "localhost:15200",
 			FlagName: "pgctld-addr",
@@ -559,16 +565,22 @@ func (mp *Multipooler) Shutdown(ctx context.Context) {
 	mp.ts.Close()
 }
 
-// flagExplicitlySet reports whether the named flag was set on the command
-// line, even to its default or an empty value (pflag.Flag.Changed) — a
-// distinction viperutil's Get cannot make. False when RegisterFlags has not
-// run (e.g. minimal test setups).
+// flagExplicitlySet reports whether the named flag was explicitly configured:
+// set on the command line, even to its default or an empty value
+// (pflag.Flag.Changed), or present as a key in the loaded config file
+// (Registry.InStaticConfig) — distinctions viperutil's Get cannot make. The
+// flag name must equal the value's viper key for the config-file check to
+// apply. False when RegisterFlags has not run (e.g. minimal test setups) and
+// no config file mentions the key.
 func (mp *Multipooler) flagExplicitlySet(name string) bool {
-	if mp.flagSet == nil {
-		return false
+	if mp.flagSet != nil {
+		if f := mp.flagSet.Lookup(name); f != nil && f.Changed {
+			return true
+		}
 	}
-	f := mp.flagSet.Lookup(name)
-	return f != nil && f.Changed
+	// A config file writing e.g. `socket-file: ""` is as deliberate as
+	// --socket-file='' and must equally force the TCP path.
+	return mp.reg != nil && mp.reg.InStaticConfig(name)
 }
 
 // resolveSocketFilePath returns the postgres socket path the pooler should

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1105,7 +1104,7 @@ func (pm *MultipoolerManager) loadShardConfigFromGlobalTopo() {
 		// need to repeat the check here, since pgctld and multipooler are
 		// co-located and share the same pgbackrest binary.
 		pgPort := int(pm.record.Port("postgres"))
-		socketDir := filepath.Join(pm.record.PoolerDir(), "pg_sockets")
+		socketDir := constants.PostgresSocketDir(pm.record.PoolerDir())
 		pg1User := constants.DefaultPostgresUser
 		pg1Password := os.Getenv(constants.PgPasswordEnvVar)
 		if pm.connPoolMgr != nil {

--- a/go/services/multipooler/socket_file_test.go
+++ b/go/services/multipooler/socket_file_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multipooler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveSocketFilePath(t *testing.T) {
+	tests := []struct {
+		name          string
+		configured    string
+		explicitlySet bool
+		poolerDir     string
+		pgPort        int
+		want          string
+	}{
+		{
+			name:      "unset flag with pooler-dir derives the socket path",
+			poolerDir: "/data/pooler-1", pgPort: 5433,
+			want: "/data/pooler-1/pg_sockets/.s.PGSQL.5433",
+		},
+		{
+			name:       "explicit path wins over derivation",
+			configured: "/custom/.s.PGSQL.5432", poolerDir: "/data/pooler-1", pgPort: 5432,
+			want: "/custom/.s.PGSQL.5432",
+		},
+		{
+			name:          "explicitly empty forces TCP",
+			explicitlySet: true, poolerDir: "/data/pooler-1", pgPort: 5432,
+			want: "",
+		},
+		{
+			name:   "no pooler-dir keeps TCP",
+			pgPort: 5432,
+			want:   "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolveSocketFilePath(tt.configured, tt.explicitlySet, tt.poolerDir, tt.pgPort))
+		})
+	}
+}

--- a/go/services/multipooler/socket_file_test.go
+++ b/go/services/multipooler/socket_file_test.go
@@ -15,11 +15,15 @@
 package multipooler
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/tools/viperutil"
 )
 
 func TestResolveSocketFilePath(t *testing.T) {
@@ -73,4 +77,30 @@ func TestFlagExplicitlySet(t *testing.T) {
 
 	require.NoError(t, fs.Set("socket-file", ""))
 	assert.True(t, mp.flagExplicitlySet("socket-file"), "explicitly set to empty is still explicit")
+}
+
+func TestFlagExplicitlySet_ConfigFile(t *testing.T) {
+	reg := viperutil.NewRegistry()
+	mp := &Multipooler{reg: reg}
+	viperutil.Configure(reg, "socket-file", viperutil.Options[string]{Default: "", FlagName: "socket-file"})
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.String("socket-file", "", "")
+	mp.flagSet = fs
+
+	assert.False(t, mp.flagExplicitlySet("socket-file"), "no flag, no config file: not explicit")
+
+	// A config file pinning socket-file to empty is as deliberate as
+	// --socket-file='' and must equally count as explicit.
+	path := filepath.Join(t.TempDir(), "mtconfig.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("socket-file: \"\"\n"), 0o644))
+	vc := viperutil.NewViperConfig(reg)
+	vc.RegisterFlags(fs)
+	require.NoError(t, fs.Set("config-file", path))
+	cancel, err := vc.LoadConfig(reg)
+	require.NoError(t, err)
+	t.Cleanup(cancel)
+
+	assert.True(t, mp.flagExplicitlySet("socket-file"))
+	// Through the resolver: the TCP dial is preserved despite a pooler-dir.
+	assert.Equal(t, "", resolveSocketFilePath("", mp.flagExplicitlySet("socket-file"), "/data/pooler-1", 5432))
 }

--- a/go/services/multipooler/socket_file_test.go
+++ b/go/services/multipooler/socket_file_test.go
@@ -17,7 +17,9 @@ package multipooler
 import (
 	"testing"
 
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResolveSocketFilePath(t *testing.T) {
@@ -55,4 +57,20 @@ func TestResolveSocketFilePath(t *testing.T) {
 			assert.Equal(t, tt.want, resolveSocketFilePath(tt.configured, tt.explicitlySet, tt.poolerDir, tt.pgPort))
 		})
 	}
+}
+
+func TestFlagExplicitlySet(t *testing.T) {
+	// No FlagSet registered (minimal test setups): never explicit.
+	mp := &Multipooler{}
+	assert.False(t, mp.flagExplicitlySet("socket-file"))
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.String("socket-file", "", "")
+	mp.flagSet = fs
+
+	assert.False(t, mp.flagExplicitlySet("socket-file"), "registered but untouched flag is not explicit")
+	assert.False(t, mp.flagExplicitlySet("no-such-flag"))
+
+	require.NoError(t, fs.Set("socket-file", ""))
+	assert.True(t, mp.flagExplicitlySet("socket-file"), "explicitly set to empty is still explicit")
 }

--- a/go/services/pgctld/postgresconfig_gen.go
+++ b/go/services/pgctld/postgresconfig_gen.go
@@ -210,9 +210,11 @@ func PostgresDataDir() string {
 	return os.Getenv(constants.PgDataDirEnvVar)
 }
 
-// PostgresSocketDir returns the default location of the PostgreSQL Unix sockets.
+// PostgresSocketDir returns the default location of the PostgreSQL Unix
+// sockets. Thin alias over the canonical formula in go/common/constants so
+// pgctld's many call sites keep their local name.
 func PostgresSocketDir(poolerDir string) string {
-	return path.Join(poolerDir, "pg_sockets")
+	return constants.PostgresSocketDir(poolerDir)
 }
 
 // RestoreCommandPIDFile returns the path the restore_command wrapper (see

--- a/go/test/endtoend/shardsetup/cluster.go
+++ b/go/test/endtoend/shardsetup/cluster.go
@@ -338,7 +338,7 @@ func CreateMultipoolerProcessInstance(t *testing.T, name, baseDir string, grpcPo
 
 	// Default to the standard Unix socket path under the pgctld data dir.
 	// Tests that need the TCP path (e.g. PG TLS) clear this after creation.
-	socketFile := filepath.Join(pgctldDataDir, "pg_sockets", fmt.Sprintf(".s.PGSQL.%d", pgPort))
+	socketFile := constants.PostgresSocketFilePath(pgctldDataDir, pgPort)
 
 	inst := &ProcessInstance{
 		Name:        name,

--- a/go/test/endtoend/shardsetup/process.go
+++ b/go/test/endtoend/shardsetup/process.go
@@ -159,7 +159,8 @@ func (p *ProcessInstance) logLevelOrDefault() string {
 //
 // p.SocketFile defaults to the standard Unix socket path during instance
 // creation; tests that need to exercise the TCP path (e.g. PG TLS) clear
-// it before Start to omit --socket-file and force a TCP dial.
+// it before Start, which passes an explicitly empty --socket-file to force a
+// TCP dial (an omitted flag would derive the socket path from --pooler-dir).
 func (p *ProcessInstance) multipoolerArgs() []string {
 	args := []string{
 		"--grpc-port", strconv.Itoa(p.GrpcPort),
@@ -184,9 +185,9 @@ func (p *ProcessInstance) multipoolerArgs() []string {
 		// on SIGTERM.
 		"--onterm-timeout", "80s",
 	}
-	if p.SocketFile != "" {
-		args = append(args, "--socket-file", p.SocketFile)
-	}
+	// Always pass the flag: explicit-empty forces TCP, while omitting it
+	// would let the multipooler derive the socket path from --pooler-dir.
+	args = append(args, "--socket-file="+p.SocketFile)
 	if p.PgClientSSLMode != "" {
 		args = append(args, "--pg-client-sslmode", p.PgClientSSLMode)
 	}


### PR DESCRIPTION
## Description

Part of MUL-497 (infer query-serving flags instead of duplicating them); closes MUL-1518.

The postgres Unix socket path is a pure function of two other flags — `<pooler-dir>/pg_sockets/.s.PGSQL.<pg-port>` — but multipooler required `--socket-file` to be passed explicitly, and the formula was hand-copied in five places: pgctld's `PostgresSocketDir` (the value actually passed to postgres as `unix_socket_directories`), the pooler's pgBackRest path, two provisioner sites, and the shardsetup test helper.

**The formula now lives in one canonical helper** (`go/common/constants`: `PostgresSocketDir` / `PostgresSocketFilePath` — `common` because services cannot import each other) and every copy routes through it; pgctld keeps a thin alias so its ~9 call sites are untouched.

**Derivation semantics** (`resolveSocketFilePath` in multipooler init):
- An explicitly set `--socket-file` wins — *including explicitly empty* (`--socket-file=''`), which forces a TCP dial.
- Unset flag + `--pooler-dir` configured → the path is derived, so the pooler and pgctld can never disagree about where the socket lives.
- Neither → empty, TCP as before.

**Behavior change worth noting for external manifests:** previously an omitted `--socket-file` always meant TCP. After this change, a deployment that sets `--pooler-dir` but omits `--socket-file` flips from a TCP dial to the colocated socket that pgctld itself configures. All in-repo callers are updated (the local provisioner and the k8s demo manifest now omit the flag deliberately to exercise derivation; shardsetup passes explicit-empty for its PG-TLS TCP tests). An external manifest that wants to keep TCP sets `--socket-file=''`.

Also fixes the stale `--pooler-dir` help text that claimed a socket-file fallback which never existed (cleanup item from the MUL-497 audit).

## Testing

- Unit: table-driven test for `resolveSocketFilePath` (derive / explicit-wins / explicit-empty-forces-TCP / no-pooler-dir); full `go test -short ./go/...` green.
- Integration: full `go/test/endtoend/...` suite green locally (two packages that failed under machine-wide shared-memory exhaustion pass cleanly in isolation). `localprovisioner` now boots every pooler with **no** `--socket-file`, exercising derivation end-to-end; `TestPGClientTLS_*` exercise the explicit-empty TCP opt-out.
- Manual: 3-pooler local cluster — all poolers logged the derived path, `.s.PGSQL.<port>` present at the derived location, direct-socket psql and full gateway→pooler→postgres write/read verified.
