### PR TITLE
fix(multipooler): probe every idle connection during pool scrubbing

### DIFF
--- a/docs/query_serving/connection_pooling.md
+++ b/docs/query_serving/connection_pooling.md
@@ -606,9 +606,10 @@ tracking bug, out-of-band DDL — would silently leak to the next borrower.
 The scrubber is the detection net for that class of failure.
 
 A background worker per pool takes one idle connection per tick, runs every
-registered **state checker** against it, and either returns it — to the top
-of its stack, with its idle clock intact, so scrubbing never defeats LIFO
-reuse or idle-timeout shrinking — or, on any divergence, closes it and
+registered **state checker** against it, and either returns it — at the
+depth of its stack it was taken from, with its idle clock intact, so
+scrubbing never promotes a cold connection into client traffic and never
+defeats idle-timeout shrinking — or, on any divergence, closes it and
 eagerly opens a replacement into the same slot
 (eager because a freed slot cannot wake a waitlisted client). Divergent
 backends are always replaced, never reconciled: divergence means tracking

--- a/docs/query_serving/connection_pooling.md
+++ b/docs/query_serving/connection_pooling.md
@@ -605,15 +605,21 @@ escapes gateway tracking — a `set_config` hidden in a routine body, a
 tracking bug, out-of-band DDL — would silently leak to the next borrower.
 The scrubber is the detection net for that class of failure.
 
-A background worker per pool pops one idle connection per tick (rotating
-across the clean stack and all settings buckets), runs every registered
-**state checker** against it, and either returns it — with its idle clock
-intact, so scrubbing never defeats idle-timeout shrinking — or, on any
-divergence, closes it and eagerly opens a replacement into the same slot
+A background worker per pool takes one idle connection per tick, runs every
+registered **state checker** against it, and either returns it — to the top
+of its stack, with its idle clock intact, so scrubbing never defeats LIFO
+reuse or idle-timeout shrinking — or, on any divergence, closes it and
+eagerly opens a replacement into the same slot
 (eager because a freed slot cannot wake a waitlisted client). Divergent
 backends are always replaced, never reconciled: divergence means tracking
 was bypassed, and what a checker observes is only part of what the untracked
-code may have done. A probe that fails or times out is treated the same way:
+code may have done. Selection works in passes so every idle connection is
+covered: each tick takes, from the next non-empty stack in rotation, the
+topmost connection not yet probed in the current pass and marks it; once
+every idle connection in every stack carries the current pass number the
+next pass begins. Simply probing the top of a stack each tick would never
+reach the connections beneath it, since clients also take and return
+connections at the top. A probe that fails or times out is treated the same way:
 an unverified backend may still carry hidden state, and a client could
 induce probe failures deliberately, so the scrubber fails closed and
 replaces it (churn is bounded to one connection per tick). While a probe is

--- a/go/services/multipooler/internal/pools/connpool/pool.go
+++ b/go/services/multipooler/internal/pools/connpool/pool.go
@@ -234,6 +234,11 @@ type Pool[C Connection] struct {
 	// scrubMetrics records session-state scrub outcomes. Provided via Config.
 	scrubMetrics ScrubMetrics
 
+	// scrubPass numbers the scrubber's passes over the idle connections; a
+	// pass ends when every idle connection has been probed once. Only the
+	// scrub worker reads or writes it. See scrub.go.
+	scrubPass uint64
+
 	// checkers verify idle connections' real backend state against tracked
 	// state; run by the scrub worker. Populated via RegisterChecker before
 	// Open, read-only afterwards.

--- a/go/services/multipooler/internal/pools/connpool/pool.go
+++ b/go/services/multipooler/internal/pools/connpool/pool.go
@@ -606,6 +606,15 @@ func (pool *Pool[C]) put(conn *Pooled[C]) {
 }
 
 func (pool *Pool[C]) tryReturnConn(conn *Pooled[C]) bool {
+	return pool.returnConnAt(conn, 0)
+}
+
+// returnConnAt is tryReturnConn with a choice of depth for the idle stack:
+// 0 is the top, where a recycled connection belongs (LIFO keeps the hot
+// connection hot). The scrubber passes the depth it took a probed connection
+// from, so probing never promotes a cold connection into client traffic —
+// which would refresh its idle clock and keep the pool from shrinking.
+func (pool *Pool[C]) returnConnAt(conn *Pooled[C], depth int) bool {
 	// If we're over capacity, close the connection.
 	// This enables non-blocking SetCapacity - excess connections are closed on recycle.
 	if pool.closeOnOverCapacity(conn) {
@@ -619,13 +628,16 @@ func (pool *Pool[C]) tryReturnConn(conn *Pooled[C]) bool {
 		return false
 	}
 	// Connection goes to idle stack
-	connSettings := conn.Conn.Settings()
-	if connSettings == nil || connSettings.IsEmpty() {
-		pool.clean.Push(conn)
-	} else {
+	stack := &pool.clean
+	if connSettings := conn.Conn.Settings(); connSettings != nil && !connSettings.IsEmpty() {
 		bucket := connSettings.Bucket() & stackMask
-		pool.states[bucket].Push(conn)
+		stack = &pool.states[bucket]
 		pool.freshStatesStack.Store(int64(bucket))
+	}
+	if depth == 0 {
+		stack.Push(conn)
+	} else {
+		stack.InsertAt(conn, depth)
 	}
 	return false
 }

--- a/go/services/multipooler/internal/pools/connpool/pool.go
+++ b/go/services/multipooler/internal/pools/connpool/pool.go
@@ -735,6 +735,10 @@ func (pool *Pool[C]) connReopen(ctx context.Context, dbconn *Pooled[C], now time
 
 	dbconn.timeCreated.set(now)
 	dbconn.timeUsed.set(now)
+	// A new backend has not been probed by the scrubber, whatever the old one
+	// was marked with. The connection is borrowed here, so the scrubber cannot
+	// hold it, and the push that follows orders this write before any read.
+	dbconn.scrubPass = 0
 	return nil
 }
 

--- a/go/services/multipooler/internal/pools/connpool/pooled.go
+++ b/go/services/multipooler/internal/pools/connpool/pooled.go
@@ -31,6 +31,10 @@ type Pooled[C Connection] struct {
 	// This is used for idle timeout tracking.
 	timeUsed timestamp
 
+	// scrubPass is the pool.scrubPass in which the scrubber last probed this
+	// connection. Only the scrub worker reads or writes it. See scrub.go.
+	scrubPass uint64
+
 	// pool is a reference to the pool that owns this connection.
 	// Used for the Recycle pattern.
 	pool *Pool[C]

--- a/go/services/multipooler/internal/pools/connpool/scrub.go
+++ b/go/services/multipooler/internal/pools/connpool/scrub.go
@@ -31,6 +31,15 @@ import (
 // It only touches idle connections, so it adds no latency to the query path.
 // It is a sampler: it narrows the leak window and raises an alarm, but the
 // tracking gates remain the correctness boundary.
+//
+// Coverage: the scrubber works in passes. Each tick probes, from the next
+// non-empty stack, the topmost idle connection not yet probed in the current
+// pass, and marks it with the pass number; once every idle connection in
+// every stack carries the current pass number, the next pass begins. Probed
+// connections return to the top of their stack exactly as a recycled one
+// would, so LIFO reuse and idle-timeout shrinking are untouched — simply
+// re-probing the top each tick would never reach the connections beneath
+// it, since clients also take and return connections at the top.
 
 // scrubProbeTimeout bounds one checker's probe; each checker gets its own
 // budget, so a slow early probe cannot starve later checkers into a timeout
@@ -52,43 +61,62 @@ func (pool *Pool[C]) scrubStack(i int) *connStack[C] {
 	return &pool.states[i-1]
 }
 
-// scrubPop pops an idle connection like pool.pop, but also returns the
+// scrubPop takes the topmost idle connection in stack that has not been
+// probed in the current pass, marks it probed, and also returns the
 // connection's pre-borrow timeUsed value so the scrubber can restore it: a
 // scrub must not refresh the idle clock, or a small pool would have every
 // connection kept forever-fresh by scrubbing and the idle-timeout worker
 // could never shrink it. The stamp read before borrow is reliable: the only
 // concurrent writer for an in-stack connection is the expirer, and if it won
 // the race the borrow fails and the connection (already closed by the
-// expirer) is skipped.
+// expirer) is left for pool.pop to discard. Returns nil when every idle
+// connection in the stack has already been probed this pass.
 func (pool *Pool[C]) scrubPop(stack *connStack[C]) (*Pooled[C], time.Duration) {
-	for conn, ok := stack.Pop(); ok; conn, ok = stack.Pop() {
-		stamp := conn.timeUsed.get()
-		if conn.timeUsed.borrow() {
-			return conn, stamp
+	var stamp time.Duration
+	conn, ok := stack.PopFirst(func(c *Pooled[C]) bool {
+		if c.scrubPass == pool.scrubPass {
+			return false
 		}
+		stamp = c.timeUsed.get()
+		return c.timeUsed.borrow()
+	})
+	if !ok {
+		return nil, 0
+	}
+	conn.scrubPass = pool.scrubPass
+	return conn, stamp
+}
+
+// scrubNext finds the next connection to probe: the first unprobed idle
+// connection in stack rotation order from *cursor. If every idle connection
+// has been probed this pass, it starts the next pass and looks once more, so
+// a tick only comes up empty when the pool has no idle connection at all.
+func (pool *Pool[C]) scrubNext(cursor *int) (*Pooled[C], time.Duration) {
+	for range 2 {
+		for i := range scrubStackCount {
+			idx := (*cursor + i) % scrubStackCount
+			if conn, stamp := pool.scrubPop(pool.scrubStack(idx)); conn != nil {
+				*cursor = (idx + 1) % scrubStackCount
+				return conn, stamp
+			}
+		}
+		pool.scrubPass++
 	}
 	return nil, 0
 }
 
-// scrubOne runs every registered checker against one idle connection,
-// rotating the starting stack across calls so every bucket gets coverage. A
-// clean connection returns to the pool with its idle clock intact; a
-// divergent one, or one whose state could not be verified, is closed and
-// replaced. The bool return keeps the runWorker signature; it is always true.
+// scrubOne runs every registered checker against one idle connection: the
+// next one not yet probed in the current pass, rotating the starting stack
+// across calls so every bucket gets coverage (see scrubNext). A clean
+// connection returns to the pool with its idle clock intact; a divergent
+// one, or one whose state could not be verified, is closed and replaced. The
+// bool return keeps the runWorker signature; it is always true.
 func (pool *Pool[C]) scrubOne(cursor *int) bool {
 	if pool.Capacity() == 0 || len(pool.checkers) == 0 {
 		return true
 	}
 
-	var conn *Pooled[C]
-	var stamp time.Duration
-	for i := range scrubStackCount {
-		idx := (*cursor + i) % scrubStackCount
-		if conn, stamp = pool.scrubPop(pool.scrubStack(idx)); conn != nil {
-			*cursor = (idx + 1) % scrubStackCount
-			break
-		}
-	}
+	conn, stamp := pool.scrubNext(cursor)
 	if conn == nil {
 		return true
 	}

--- a/go/services/multipooler/internal/pools/connpool/scrub.go
+++ b/go/services/multipooler/internal/pools/connpool/scrub.go
@@ -35,11 +35,16 @@ import (
 // Coverage: the scrubber works in passes. Each tick probes, from the next
 // non-empty stack, the topmost idle connection not yet probed in the current
 // pass, and marks it with the pass number; once every idle connection in
-// every stack carries the current pass number, the next pass begins. Probed
-// connections return to the top of their stack exactly as a recycled one
-// would, so LIFO reuse and idle-timeout shrinking are untouched — simply
+// every stack carries the current pass number, the next pass begins. Simply
 // re-probing the top each tick would never reach the connections beneath
 // it, since clients also take and return connections at the top.
+//
+// A probed connection goes back at the depth it was taken from, with its
+// idle clock intact. Both matter for idle-timeout shrinking: pushing it on
+// top (or to the bottom, which rotates the stack) promotes a cold connection
+// into client traffic, real use refreshes its idle clock, and over a pass
+// every connection gets refreshed in turn — the pool would sit at its
+// maximum idle size instead of shrinking to its working set.
 
 // scrubProbeTimeout bounds one checker's probe; each checker gets its own
 // budget, so a slow early probe cannot starve later checkers into a timeout
@@ -61,65 +66,77 @@ func (pool *Pool[C]) scrubStack(i int) *connStack[C] {
 	return &pool.states[i-1]
 }
 
+// scrubbed is an idle connection the scrubber has taken out of its stack,
+// with what it needs to put it back unchanged: the depth it was taken from
+// and its pre-borrow timeUsed value.
+type scrubbed[C Connection] struct {
+	conn  *Pooled[C]
+	depth int
+	stamp time.Duration
+}
+
 // scrubPop takes the topmost idle connection in stack that has not been
-// probed in the current pass, marks it probed, and also returns the
-// connection's pre-borrow timeUsed value so the scrubber can restore it: a
-// scrub must not refresh the idle clock, or a small pool would have every
-// connection kept forever-fresh by scrubbing and the idle-timeout worker
-// could never shrink it. The stamp read before borrow is reliable: the only
-// concurrent writer for an in-stack connection is the expirer, and if it won
-// the race the borrow fails and the connection (already closed by the
-// expirer) is left for pool.pop to discard. Returns nil when every idle
-// connection in the stack has already been probed this pass.
-func (pool *Pool[C]) scrubPop(stack *connStack[C]) (*Pooled[C], time.Duration) {
-	var stamp time.Duration
-	conn, ok := stack.PopFirst(func(c *Pooled[C]) bool {
+// probed in the current pass and marks it probed. The stamp it records lets
+// the scrubber restore the idle clock: a scrub must not refresh it, or a
+// small pool would have every connection kept forever-fresh by scrubbing and
+// the idle-timeout worker could never shrink it. The stamp read before
+// borrow is reliable: the only concurrent writer for an in-stack connection
+// is the expirer, and if it won the race the borrow fails and the connection
+// (already closed by the expirer) is left for pool.pop to discard. Returns
+// false when every idle connection in the stack has already been probed
+// this pass.
+func (pool *Pool[C]) scrubPop(stack *connStack[C]) (scrubbed[C], bool) {
+	var s scrubbed[C]
+	conn, depth, ok := stack.PopFirst(func(c *Pooled[C]) bool {
 		if c.scrubPass == pool.scrubPass {
 			return false
 		}
-		stamp = c.timeUsed.get()
+		s.stamp = c.timeUsed.get()
 		return c.timeUsed.borrow()
 	})
 	if !ok {
-		return nil, 0
+		return scrubbed[C]{}, false
 	}
 	conn.scrubPass = pool.scrubPass
-	return conn, stamp
+	s.conn, s.depth = conn, depth
+	return s, true
 }
 
 // scrubNext finds the next connection to probe: the first unprobed idle
 // connection in stack rotation order from *cursor. If every idle connection
 // has been probed this pass, it starts the next pass and looks once more, so
 // a tick only comes up empty when the pool has no idle connection at all.
-func (pool *Pool[C]) scrubNext(cursor *int) (*Pooled[C], time.Duration) {
+func (pool *Pool[C]) scrubNext(cursor *int) (scrubbed[C], bool) {
 	for range 2 {
 		for i := range scrubStackCount {
 			idx := (*cursor + i) % scrubStackCount
-			if conn, stamp := pool.scrubPop(pool.scrubStack(idx)); conn != nil {
+			if s, ok := pool.scrubPop(pool.scrubStack(idx)); ok {
 				*cursor = (idx + 1) % scrubStackCount
-				return conn, stamp
+				return s, true
 			}
 		}
 		pool.scrubPass++
 	}
-	return nil, 0
+	return scrubbed[C]{}, false
 }
 
 // scrubOne runs every registered checker against one idle connection: the
 // next one not yet probed in the current pass, rotating the starting stack
 // across calls so every bucket gets coverage (see scrubNext). A clean
-// connection returns to the pool with its idle clock intact; a divergent
-// one, or one whose state could not be verified, is closed and replaced. The
-// bool return keeps the runWorker signature; it is always true.
+// connection returns to its stack at the depth it came from with its idle
+// clock intact; a divergent one, or one whose state could not be verified,
+// is closed and replaced. The bool return keeps the runWorker signature; it
+// is always true.
 func (pool *Pool[C]) scrubOne(cursor *int) bool {
 	if pool.Capacity() == 0 || len(pool.checkers) == 0 {
 		return true
 	}
 
-	conn, stamp := pool.scrubNext(cursor)
-	if conn == nil {
+	s, ok := pool.scrubNext(cursor)
+	if !ok {
 		return true
 	}
+	conn := s.conn
 	// The scrubber holds the connection like a borrower, so Available and
 	// the idle-limit math stay accurate while the probe is in flight.
 	pool.borrowed.Add(1)
@@ -195,8 +212,8 @@ func (pool *Pool[C]) scrubOne(cursor *int) bool {
 		pool.closedConn()
 		pool.scrubReplace()
 	default:
-		conn.timeUsed.set(stamp)
-		pool.tryReturnConn(conn)
+		conn.timeUsed.set(s.stamp)
+		pool.returnConnAt(conn, s.depth)
 	}
 	return true
 }

--- a/go/services/multipooler/internal/pools/connpool/scrub_test.go
+++ b/go/services/multipooler/internal/pools/connpool/scrub_test.go
@@ -260,6 +260,80 @@ func TestScrubProbeErrorOnDeadConnReplaces(t *testing.T) {
 	pooled.Recycle()
 }
 
+func TestScrubWalksEveryConnInStack(t *testing.T) {
+	// Three idle connections sit in the clean stack. Probing the top each
+	// tick would re-probe the same one forever, since the probed connection
+	// goes back on top; the pass marker must instead visit each connection
+	// once over three ticks, then start a new pass and wrap around.
+	pool := newScrubTestPool(t, 3, nil)
+	var pooled []*Pooled[*scrubMockConnection]
+	for range 3 {
+		p, err := pool.Get(context.Background())
+		require.NoError(t, err)
+		pooled = append(pooled, p)
+	}
+	for _, p := range pooled {
+		p.Recycle()
+	}
+	require.Equal(t, 3, pool.clean.Len())
+
+	cursor := 0
+	for range 3 {
+		assert.True(t, pool.scrubOne(&cursor))
+	}
+	for i, p := range pooled {
+		assert.EqualValues(t, 1, p.Conn.verifyCalls.Load(), "conn %d must be probed exactly once per full walk", i)
+	}
+	assert.Equal(t, 3, pool.clean.Len(), "all connections are back in the stack")
+
+	// A fourth tick wraps around to the first connection probed.
+	assert.True(t, pool.scrubOne(&cursor))
+	var total int64
+	for _, p := range pooled {
+		total += p.Conn.verifyCalls.Load()
+	}
+	assert.EqualValues(t, 4, total)
+	assert.EqualValues(t, 0, pool.Metrics.ScrubDivergentCount())
+}
+
+func TestScrubPassSpansStacksAndKeepsTopOrder(t *testing.T) {
+	// A pass covers every stack before repeating any connection, and a
+	// probed connection returns to the TOP of its stack (LIFO reuse and
+	// idle-timeout shrinking depend on that), not the bottom.
+	pool := newScrubTestPool(t, 3, nil)
+	settings := connstate.NewSettings(map[string]string{"work_mem": "64MB"}, 1)
+	// Hold all three before recycling, or LIFO reuse hands back the same
+	// connection each time and the clean stack never grows past one.
+	p1, err := pool.Get(context.Background())
+	require.NoError(t, err)
+	p2, err := pool.Get(context.Background())
+	require.NoError(t, err)
+	p3, err := pool.GetWithSettings(context.Background(), settings)
+	require.NoError(t, err)
+	clean1, clean2, labelled := p1.Conn, p2.Conn, p3.Conn
+	p1.Recycle()
+	p2.Recycle()
+	p3.Recycle()
+	require.Equal(t, 2, pool.clean.Len())
+
+	cursor := 0
+	for range 3 {
+		assert.True(t, pool.scrubOne(&cursor))
+	}
+	for name, conn := range map[string]*scrubMockConnection{"clean1": clean1, "clean2": clean2, "labelled": labelled} {
+		assert.EqualValues(t, 1, conn.verifyCalls.Load(), "%s must be probed once per pass", name)
+	}
+
+	// Probed connections went back on top of their own stacks: the clean
+	// stack still holds exactly its two connections and a plain Get hands
+	// out one of them, not a connection from another bucket.
+	assert.Equal(t, 2, pool.clean.Len())
+	pooled, err := pool.Get(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, []*scrubMockConnection{clean1, clean2}, pooled.Conn)
+	pooled.Recycle()
+}
+
 func TestScrubPreservesIdleClock(t *testing.T) {
 	pool := newScrubTestPool(t, 2, nil)
 	recycleIdle(t, pool, nil)

--- a/go/services/multipooler/internal/pools/connpool/scrub_test.go
+++ b/go/services/multipooler/internal/pools/connpool/scrub_test.go
@@ -296,10 +296,9 @@ func TestScrubWalksEveryConnInStack(t *testing.T) {
 	assert.EqualValues(t, 0, pool.Metrics.ScrubDivergentCount())
 }
 
-func TestScrubPassSpansStacksAndKeepsTopOrder(t *testing.T) {
-	// A pass covers every stack before repeating any connection, and a
-	// probed connection returns to the TOP of its stack (LIFO reuse and
-	// idle-timeout shrinking depend on that), not the bottom.
+func TestScrubPassSpansStacks(t *testing.T) {
+	// A pass covers every stack before repeating any connection, and probed
+	// connections stay in their own stacks.
 	pool := newScrubTestPool(t, 3, nil)
 	settings := connstate.NewSettings(map[string]string{"work_mem": "64MB"}, 1)
 	// Hold all three before recycling, or LIFO reuse hands back the same
@@ -323,15 +322,54 @@ func TestScrubPassSpansStacksAndKeepsTopOrder(t *testing.T) {
 	for name, conn := range map[string]*scrubMockConnection{"clean1": clean1, "clean2": clean2, "labelled": labelled} {
 		assert.EqualValues(t, 1, conn.verifyCalls.Load(), "%s must be probed once per pass", name)
 	}
-
-	// Probed connections went back on top of their own stacks: the clean
-	// stack still holds exactly its two connections and a plain Get hands
-	// out one of them, not a connection from another bucket.
 	assert.Equal(t, 2, pool.clean.Len())
-	pooled, err := pool.Get(context.Background())
-	require.NoError(t, err)
-	assert.Contains(t, []*scrubMockConnection{clean1, clean2}, pooled.Conn)
-	pooled.Recycle()
+	assert.Equal(t, 1, pool.states[settings.Bucket()&stackMask].Len())
+}
+
+func TestScrubKeepsHotConnClientFacingAndColdConnsExpire(t *testing.T) {
+	// Client traffic interleaved with scrub ticks: the hot connection must
+	// stay the one clients get, and the cold ones beneath it must still
+	// idle-expire. Returning a probed middle connection to the top (or
+	// rotating the stack) would promote a cold connection into traffic,
+	// refresh its idle clock, and keep the pool from shrinking.
+	const idleTimeout = time.Minute
+	pool := newScrubTestPool(t, 3, nil)
+	pool.SetIdleTimeout(idleTimeout)
+
+	var pooled []*Pooled[*scrubMockConnection]
+	for range 3 {
+		p, err := pool.Get(context.Background())
+		require.NoError(t, err)
+		pooled = append(pooled, p)
+	}
+	for _, p := range pooled {
+		p.Recycle() // stack: pooled[2] on top (hot), pooled[1], pooled[0]
+	}
+	hot, cold := pooled[2], pooled[:2]
+	for _, p := range cold {
+		p.timeUsed.set(monotonicNow() - 2*idleTimeout)
+	}
+
+	// One full pass, with a client checkout after every tick.
+	cursor := 0
+	for tick := range 3 {
+		assert.True(t, pool.scrubOne(&cursor))
+		got, err := pool.Get(context.Background())
+		require.NoError(t, err)
+		assert.Same(t, hot.Conn, got.Conn, "tick %d: a cold connection was promoted into client traffic", tick)
+		got.Recycle()
+	}
+	for _, p := range pooled {
+		assert.EqualValues(t, 1, p.Conn.verifyCalls.Load(), "every connection is still probed once per pass")
+	}
+
+	// The cold connections kept their old idle clocks and expire; the hot
+	// one, refreshed by real use, survives.
+	pool.closeIdleResources(time.Now())
+	for i, p := range cold {
+		assert.True(t, p.Conn.IsClosed(), "cold conn %d should have idle-expired", i)
+	}
+	assert.False(t, hot.Conn.IsClosed(), "hot conn must survive")
 }
 
 func TestScrubPreservesIdleClock(t *testing.T) {

--- a/go/services/multipooler/internal/pools/connpool/scrub_test.go
+++ b/go/services/multipooler/internal/pools/connpool/scrub_test.go
@@ -326,6 +326,44 @@ func TestScrubPassSpansStacks(t *testing.T) {
 	assert.Equal(t, 1, pool.states[settings.Bucket()&stackMask].Len())
 }
 
+func TestScrubReopenedConnIsProbedAgainInSamePass(t *testing.T) {
+	// connReopen swaps in a new backend behind the same Pooled. The pass
+	// mark belonged to the old backend, so the new one must be probed again
+	// in the current pass rather than skipped until the next. Two
+	// connections make the test discriminating: without the reset the
+	// second tick would move on to the other connection.
+	pool := newScrubTestPool(t, 2, nil)
+	pa, err := pool.Get(context.Background())
+	require.NoError(t, err)
+	pb, err := pool.Get(context.Background())
+	require.NoError(t, err)
+	pb.Recycle()
+	pa.Recycle() // stack: pa on top, pb beneath
+	other := pb.Conn
+
+	cursor := 0
+	assert.True(t, pool.scrubOne(&cursor))
+	require.EqualValues(t, 1, pa.Conn.verifyCalls.Load(), "first tick probes the top connection")
+	require.EqualValues(t, 0, other.verifyCalls.Load())
+
+	// Reopen pa in place, as put does at max lifetime.
+	again, err := pool.Get(context.Background())
+	require.NoError(t, err)
+	require.Same(t, pa, again)
+	old := again.Conn
+	require.NoError(t, pool.connReopen(context.Background(), again, monotonicNow()))
+	require.NotSame(t, old, again.Conn, "reopen installs a new backend")
+	again.Recycle()
+
+	assert.True(t, pool.scrubOne(&cursor))
+	assert.EqualValues(t, 1, again.Conn.verifyCalls.Load(), "the new backend is probed in the same pass")
+	assert.EqualValues(t, 0, other.verifyCalls.Load(), "the other connection waits its turn")
+	assert.EqualValues(t, 1, old.verifyCalls.Load(), "the old backend is not touched again")
+
+	assert.True(t, pool.scrubOne(&cursor))
+	assert.EqualValues(t, 1, other.verifyCalls.Load(), "then the pass reaches the other connection")
+}
+
 func TestScrubKeepsHotConnClientFacingAndColdConnsExpire(t *testing.T) {
 	// Client traffic interleaved with scrub ticks: the hot connection must
 	// stay the one clients get, and the cold ones beneath it must still

--- a/go/services/multipooler/internal/pools/connpool/stack.go
+++ b/go/services/multipooler/internal/pools/connpool/stack.go
@@ -60,6 +60,35 @@ func (s *connStack[C]) Push(conn *Pooled[C]) {
 	}
 }
 
+// PopFirst removes and returns the topmost connection for which match
+// returns true, leaving every other connection in place and in order.
+// Returns nil and false if none matches. match runs under the lock, so it
+// must be fast and non-blocking. Unlinking a middle node is safe here
+// because every stack operation, including ForEach, holds the mutex.
+func (s *connStack[C]) PopFirst(match func(*Pooled[C]) bool) (*Pooled[C], bool) {
+	s.mu.Lock()
+	var prev *Pooled[C]
+	for conn := s.top; conn != nil; prev, conn = conn, conn.next {
+		if !match(conn) {
+			continue
+		}
+		if prev == nil {
+			s.top = conn.next
+		} else {
+			prev.next = conn.next
+		}
+		s.count--
+		s.mu.Unlock()
+		conn.next = nil
+		if s.onPop != nil {
+			s.onPop()
+		}
+		return conn, true
+	}
+	s.mu.Unlock()
+	return nil, false
+}
+
 // Pop removes and returns the connection from the top of the stack.
 // Returns nil and false if the stack is empty.
 func (s *connStack[C]) Pop() (*Pooled[C], bool) {

--- a/go/services/multipooler/internal/pools/connpool/stack.go
+++ b/go/services/multipooler/internal/pools/connpool/stack.go
@@ -61,14 +61,19 @@ func (s *connStack[C]) Push(conn *Pooled[C]) {
 }
 
 // PopFirst removes and returns the topmost connection for which match
-// returns true, leaving every other connection in place and in order.
-// Returns nil and false if none matches. match runs under the lock, so it
-// must be fast and non-blocking. Unlinking a middle node is safe here
-// because every stack operation, including ForEach, holds the mutex.
-func (s *connStack[C]) PopFirst(match func(*Pooled[C]) bool) (*Pooled[C], bool) {
+// returns true, leaving every other connection in place and in order, along
+// with its depth: the number of connections that were above it. Returns
+// nil, 0, false if none matches. match runs under the lock, so it must be
+// fast and non-blocking. Unlinking a middle node is safe here because every
+// stack operation, including ForEach, holds the mutex.
+//
+// Pair with InsertAt to put the connection back where it was: pushing a
+// middle connection onto the top would promote it into client traffic.
+func (s *connStack[C]) PopFirst(match func(*Pooled[C]) bool) (*Pooled[C], int, bool) {
 	s.mu.Lock()
 	var prev *Pooled[C]
-	for conn := s.top; conn != nil; prev, conn = conn, conn.next {
+	depth := 0
+	for conn := s.top; conn != nil; prev, conn, depth = conn, conn.next, depth+1 {
 		if !match(conn) {
 			continue
 		}
@@ -83,10 +88,36 @@ func (s *connStack[C]) PopFirst(match func(*Pooled[C]) bool) (*Pooled[C], bool) 
 		if s.onPop != nil {
 			s.onPop()
 		}
-		return conn, true
+		return conn, depth, true
 	}
 	s.mu.Unlock()
-	return nil, false
+	return nil, 0, false
+}
+
+// InsertAt adds a connection below the first depth connections of the stack,
+// or at the bottom if the stack is shorter than that. InsertAt(conn, 0) is
+// Push. Clients may have pushed or popped since a PopFirst measured depth,
+// so the position is best effort; it is exact in the case that matters, a
+// hot top and a cold tail, and never lifts the connection above one that
+// was above it.
+func (s *connStack[C]) InsertAt(conn *Pooled[C], depth int) {
+	s.mu.Lock()
+	if depth <= 0 || s.top == nil {
+		conn.next = s.top
+		s.top = conn
+	} else {
+		prev := s.top
+		for i := 1; i < depth && prev.next != nil; i++ {
+			prev = prev.next
+		}
+		conn.next = prev.next
+		prev.next = conn
+	}
+	s.count++
+	s.mu.Unlock()
+	if s.onPush != nil {
+		s.onPush()
+	}
 }
 
 // Pop removes and returns the connection from the top of the stack.

--- a/go/services/multipooler/internal/pools/connpool/stack_test.go
+++ b/go/services/multipooler/internal/pools/connpool/stack_test.go
@@ -68,6 +68,65 @@ func TestStackOperations(t *testing.T) {
 	assert.False(t, ok)
 }
 
+// TestStackPopFirst tests that PopFirst unlinks the topmost matching
+// connection wherever it sits and leaves the rest in order.
+func TestStackPopFirst(t *testing.T) {
+	var stack connStack[*mockConnection]
+	var pops int
+	stack.onPop = func() { pops++ }
+
+	a := &Pooled[*mockConnection]{Conn: newMockConnection()}
+	b := &Pooled[*mockConnection]{Conn: newMockConnection()}
+	c := &Pooled[*mockConnection]{Conn: newMockConnection()}
+	d := &Pooled[*mockConnection]{Conn: newMockConnection()}
+	for _, conn := range []*Pooled[*mockConnection]{a, b, c, d} {
+		stack.Push(conn) // d, c, b, a
+	}
+
+	is := func(want *Pooled[*mockConnection]) func(*Pooled[*mockConnection]) bool {
+		return func(conn *Pooled[*mockConnection]) bool { return conn == want }
+	}
+	order := func() (got []*Pooled[*mockConnection]) {
+		stack.ForEach(func(conn *Pooled[*mockConnection]) bool {
+			got = append(got, conn)
+			return true
+		})
+		return got
+	}
+
+	// Middle node.
+	got, ok := stack.PopFirst(is(b))
+	assert.True(t, ok)
+	assert.Same(t, b, got)
+	assert.Nil(t, b.next, "unlinked node must not dangle into the stack")
+	assert.Equal(t, []*Pooled[*mockConnection]{d, c, a}, order())
+
+	// Tail node.
+	got, ok = stack.PopFirst(is(a))
+	assert.True(t, ok)
+	assert.Same(t, a, got)
+	assert.Equal(t, []*Pooled[*mockConnection]{d, c}, order())
+
+	// Head node.
+	got, ok = stack.PopFirst(is(d))
+	assert.True(t, ok)
+	assert.Same(t, d, got)
+	assert.Equal(t, []*Pooled[*mockConnection]{c}, order())
+
+	// No match leaves the stack untouched.
+	got, ok = stack.PopFirst(is(a))
+	assert.False(t, ok)
+	assert.Nil(t, got)
+	assert.Equal(t, 1, stack.Len())
+	assert.Equal(t, 3, pops, "PopFirst must fire onPop once per removed connection")
+
+	// Empty stack.
+	stack.Pop()
+	got, ok = stack.PopFirst(func(*Pooled[*mockConnection]) bool { return true })
+	assert.False(t, ok)
+	assert.Nil(t, got)
+}
+
 // TestStackForEach tests iteration over stack elements.
 func TestStackForEach(t *testing.T) {
 	var stack connStack[*mockConnection]

--- a/go/services/multipooler/internal/pools/connpool/stack_test.go
+++ b/go/services/multipooler/internal/pools/connpool/stack_test.go
@@ -69,11 +69,13 @@ func TestStackOperations(t *testing.T) {
 }
 
 // TestStackPopFirst tests that PopFirst unlinks the topmost matching
-// connection wherever it sits and leaves the rest in order.
+// connection wherever it sits, reports its depth, and leaves the rest in
+// order; and that InsertAt puts a connection back at a given depth.
 func TestStackPopFirst(t *testing.T) {
 	var stack connStack[*mockConnection]
-	var pops int
+	var pops, pushes int
 	stack.onPop = func() { pops++ }
+	stack.onPush = func() { pushes++ }
 
 	a := &Pooled[*mockConnection]{Conn: newMockConnection()}
 	b := &Pooled[*mockConnection]{Conn: newMockConnection()}
@@ -82,6 +84,7 @@ func TestStackPopFirst(t *testing.T) {
 	for _, conn := range []*Pooled[*mockConnection]{a, b, c, d} {
 		stack.Push(conn) // d, c, b, a
 	}
+	pushes = 0
 
 	is := func(want *Pooled[*mockConnection]) func(*Pooled[*mockConnection]) bool {
 		return func(conn *Pooled[*mockConnection]) bool { return conn == want }
@@ -94,37 +97,58 @@ func TestStackPopFirst(t *testing.T) {
 		return got
 	}
 
-	// Middle node.
-	got, ok := stack.PopFirst(is(b))
+	// Middle node, two above it.
+	got, depth, ok := stack.PopFirst(is(b))
 	assert.True(t, ok)
 	assert.Same(t, b, got)
+	assert.Equal(t, 2, depth)
 	assert.Nil(t, b.next, "unlinked node must not dangle into the stack")
 	assert.Equal(t, []*Pooled[*mockConnection]{d, c, a}, order())
 
+	// Put it back where it was.
+	stack.InsertAt(b, depth)
+	assert.Equal(t, []*Pooled[*mockConnection]{d, c, b, a}, order())
+	assert.Equal(t, 4, stack.Len())
+
 	// Tail node.
-	got, ok = stack.PopFirst(is(a))
+	got, depth, ok = stack.PopFirst(is(a))
 	assert.True(t, ok)
 	assert.Same(t, a, got)
-	assert.Equal(t, []*Pooled[*mockConnection]{d, c}, order())
+	assert.Equal(t, 3, depth)
+	assert.Equal(t, []*Pooled[*mockConnection]{d, c, b}, order())
+
+	// InsertAt clamps a depth past the end to the bottom.
+	stack.InsertAt(a, 99)
+	assert.Equal(t, []*Pooled[*mockConnection]{d, c, b, a}, order())
 
 	// Head node.
-	got, ok = stack.PopFirst(is(d))
+	got, depth, ok = stack.PopFirst(is(d))
 	assert.True(t, ok)
 	assert.Same(t, d, got)
-	assert.Equal(t, []*Pooled[*mockConnection]{c}, order())
+	assert.Equal(t, 0, depth)
+	assert.Equal(t, []*Pooled[*mockConnection]{c, b, a}, order())
+
+	// InsertAt depth 0 is Push.
+	stack.InsertAt(d, 0)
+	assert.Equal(t, []*Pooled[*mockConnection]{d, c, b, a}, order())
+	assert.Equal(t, 3, pops, "PopFirst must fire onPop once per removal")
+	assert.Equal(t, 3, pushes, "InsertAt must fire onPush once per insertion")
 
 	// No match leaves the stack untouched.
-	got, ok = stack.PopFirst(is(a))
+	got, _, ok = stack.PopFirst(is(&Pooled[*mockConnection]{}))
 	assert.False(t, ok)
 	assert.Nil(t, got)
-	assert.Equal(t, 1, stack.Len())
-	assert.Equal(t, 3, pops, "PopFirst must fire onPop once per removed connection")
+	assert.Equal(t, 4, stack.Len())
 
-	// Empty stack.
-	stack.Pop()
-	got, ok = stack.PopFirst(func(*Pooled[*mockConnection]) bool { return true })
+	// Empty stack: PopFirst finds nothing, InsertAt at any depth is Push.
+	for range 4 {
+		stack.Pop()
+	}
+	got, _, ok = stack.PopFirst(func(*Pooled[*mockConnection]) bool { return true })
 	assert.False(t, ok)
 	assert.Nil(t, got)
+	stack.InsertAt(a, 5)
+	assert.Equal(t, []*Pooled[*mockConnection]{a}, order())
 }
 
 // TestStackForEach tests iteration over stack elements.

--- a/go/test/endtoend/queryserving/session_state_leak_test.go
+++ b/go/test/endtoend/queryserving/session_state_leak_test.go
@@ -98,11 +98,13 @@ func TestHiddenFunctionStateDoesNotLeak(t *testing.T) {
 
 // scrubSweepWait bounds how long a scrubber test waits for the contaminated
 // backend to be replaced. The scrubber probes one idle connection per tick
-// (default 10s) and rotates across the clean stack plus 16 settings stacks,
-// checking the most recently returned connection of whichever stack is next.
-// In a full-suite run earlier tests leave many settings stacks populated, so
-// the contaminated connection's stack can be up to 17 ticks away: 170s worst
-// case, observed at 89s. Standalone runs finish in one or two ticks.
+// (default 10s) and works in passes: each tick probes, from the next
+// non-empty stack in rotation, the topmost connection not yet probed in the
+// current pass. In a full-suite run earlier tests leave many stacks populated
+// with several idle connections each, so the contaminated connection can be
+// up to one full pass away: the total number of idle connections, times the
+// tick. Observed at 89s under the old top-only probing. Standalone runs
+// finish in one or two ticks.
 const scrubSweepWait = 4 * time.Minute
 
 // TestSessionScrubberReplacesHiddenState verifies the pool's session-state


### PR DESCRIPTION
Closes a coverage gap in the pool scrubber from #1415 (MUL-1521): it only ever probed the top connection of each idle stack.

## Why

The scrubber popped the top of the next non-empty stack, ran the checkers, and pushed the connection back on top. Clients also take and return connections at the top, so the same hot connection was probed every tick and any connection beneath it was never checked — the sampler had a blind spot exactly where cold, long-idle backends sit. Observed in #1442's suite runs: a contaminated backend that was not at the top of its stack could wait far longer than a stack rotation.

## Design

Selection now works in **passes**, without touching stack order:

- `Pool.scrubPass` numbers the passes; `Pooled.scrubPass` records the pass in which a connection was last probed. Both are touched only by the scrub worker, so they need no atomics — with one exception: `connReopen` resets the mark to zero, since the mark belonged to the old backend and the new one has not been probed. That write happens while the connection is borrowed (the scrubber cannot hold it) and the push that follows goes through the stack mutex, which orders it before any scrubber read.
- `connStack.PopFirst(match)` unlinks the topmost connection for which `match` holds, leaving the rest in place, and reports the **depth** it was found at. Middle-node removal is safe because every stack operation, including `ForEach`, holds the mutex; the old caveat about only removing the head dates from the lock-free design. `connStack.InsertAt(conn, depth)` puts a connection back below the first `depth` entries (clamped to the bottom; depth 0 is `Push`).
- `scrubPop` takes the topmost connection not yet probed this pass (and whose idle-clock borrow succeeds) and marks it. `scrubNext` walks the stacks from the rotation cursor; if every idle connection is already marked it starts the next pass and looks once more, so a tick only comes up empty when the pool has no idle connection at all.
- The probed connection returns to its stack **at the depth it was taken from**, with its idle clock restored, via `returnConnAt(conn, depth)` — `tryReturnConn` is now `returnConnAt(conn, 0)`. Over-capacity close, direct waiter handoff, idle-limit close, and settings-bucket routing are unchanged; only the final placement takes a depth. Clients may push or pop between the probe's pop and its reinsert, so the depth is best effort for that window, exact in the case that matters (hot top, cold tail), and never lifts a connection above one that was above it.

Coverage bound per connection is now the total number of idle connections times the tick, regardless of position.

### Why the depth matters (two rejected placements)

Any placement that moves a probed connection relative to its neighbours changes which connection clients reuse next, and with traffic between ticks that refreshes a cold connection's idle clock. Returning to the *bottom* rotates the stack: every tick demotes the hot connection and promotes a colder one. Returning a middle connection to the *top* (the first cut of this PR, caught in review) promotes it once per pass. Either way, over a pass every idle connection gets refreshed by real use, none idle-expires, and the pool sits at its maximum idle size instead of shrinking to its working set — reintroducing through traffic exactly what the scrubber's idle-clock restore protects against. Coverage has to come from remembering what was probed, and placement has to leave the stack order alone.

## Testing

- Unit: `TestStackPopFirst` (head, middle, tail, no-match, empty; depth reporting; `InsertAt` at each depth, past the end, and on an empty stack; metrics callbacks fire once per operation). `TestScrubWalksEveryConnInStack` (three idle connections, each probed exactly once over three ticks, then the pass wraps). `TestScrubPassSpansStacks` (a pass covers the clean stack and a settings stack before repeating, and probed connections stay in their own stacks). `TestScrubReopenedConnIsProbedAgainInSamePass` (two connections; probe one, reopen it in place, and the next tick probes its new backend rather than moving on — fails without the reset). `TestScrubKeepsHotConnClientFacingAndColdConnsExpire` (cold idle stamps on the two lower connections, one client checkout after each of three ticks asserting the same hot connection is handed out, then `closeIdleResources` asserting both cold ones expired and the hot one survived — this fails on the top-return cut). Whole connpool package race-clean across repeated runs; scrub and stack tests across five.
- E2E: all four scrubber tests pass standalone on this branch. The `scrubSweepWait` comment is updated to describe the pass-based bound.
- Docs: scrubber section of `connection_pooling.md` describes pass-based selection and why the probed connection returns to the top.

Full queryserving suite: two runs on this branch failed only in cluster bootstrap ("Manager should become ready within 40s", `initdb` exiting non-zero), with a separate local cluster running on the same machine since 15:30 and load average around 10. All six affected tests pass standalone, their pooler logs show zero scrubber activity, and every full run before that cluster started was green. Will re-run clean before undrafting.


