### PR TITLE
fix(shardsetup): join cleanup before releasing port leases

### DIFF
--- a/go/test/endtoend/shardsetup/cluster.go
+++ b/go/test/endtoend/shardsetup/cluster.go
@@ -53,6 +53,7 @@ type MultipoolerInstance struct {
 // ShardSetup holds shared test infrastructure for a single shard.
 // MultipoolerInstances are stored in a map by name for flexible access.
 type ShardSetup struct {
+	lifetime       *Lifetime
 	TempDir        string
 	TempDirCleanup func()
 	EtcdClientAddr string
@@ -271,13 +272,13 @@ func (s *ShardSetup) CreateMultipoolerInstance(t *testing.T, name string, grpcPo
 	}
 
 	// Allocate a port for pgBackRest server (one per multipooler)
-	pgbackrestPort := utils.GetFreePort(t)
+	pgbackrestPort := s.port(t)
 
 	// Allocate an HTTP port for pgctld health endpoints
-	pgctldHttpPort := utils.GetFreePort(t)
+	pgctldHttpPort := s.port(t)
 
 	// Allocate an HTTP port for multipooler (prevents port collision with dynamic allocation)
-	multipoolerHttpPort := utils.GetFreePort(t)
+	multipoolerHttpPort := s.port(t)
 
 	// Create pgctld instance
 	pgbackrestCertDir := filepath.Join(s.TempDir, "certs")
@@ -295,6 +296,7 @@ func (s *ShardSetup) CreateMultipoolerInstance(t *testing.T, name string, grpcPo
 		Multipooler: multipooler,
 	}
 
+	inst.Pgctld.lifetime, inst.Multipooler.lifetime = s.lifetime, s.lifetime
 	s.Multipoolers[name] = inst
 	return inst
 }
@@ -379,8 +381,8 @@ func (s *ShardSetup) CreateMultiorchInstance(t *testing.T, name string, watchTar
 	err := os.MkdirAll(orchDataDir, 0o755)
 	require.NoError(t, err)
 
-	grpcPort := utils.GetFreePort(t)
-	httpPort := utils.GetFreePort(t)
+	grpcPort := s.port(t)
+	httpPort := s.port(t)
 
 	instance := &ProcessInstance{
 		Name:                               name,
@@ -408,6 +410,7 @@ func (s *ShardSetup) CreateMultiorchInstance(t *testing.T, name string, watchTar
 		instance.LeaderFailoverGracePeriodMaxJitter = "0s"
 	}
 
+	instance.lifetime = s.lifetime
 	s.MultiorchInstances[name] = instance
 
 	return instance, instance.CleanupFunc(t.Logf)
@@ -439,6 +442,7 @@ func (s *ShardSetup) CreateMultigatewayInstance(t *testing.T, name string, pgPor
 		inst.TLSKeyFile = s.MultigatewayTLSCertPaths.ServerKeyFile
 	}
 
+	inst.lifetime = s.lifetime
 	s.Multigateway = inst
 	s.MultigatewayPgPort = pgPort
 
@@ -463,6 +467,7 @@ func (s *ShardSetup) CreateMultiadminInstance(t *testing.T, name string, httpPor
 		Environment: os.Environ(),
 	}
 
+	inst.lifetime = s.lifetime
 	s.Multiadmin = inst
 	s.MultiadminHttpPort = httpPort
 	s.MultiadminGrpcPort = grpcPort
@@ -536,6 +541,16 @@ func (s *ShardSetup) waitForMultigatewayQueryServingOnPort(t *testing.T, pgPort 
 // If testsFailed is true, preserves the temp directory with logs for debugging.
 // Follows the pattern from multipooler/setup_test.go:cleanupSharedTestSetup.
 func (s *ShardSetup) Cleanup(testsFailed bool) {
+	if s != nil && s.lifetime != nil {
+		if err := s.lifetime.Close(testsFailed); err != nil {
+			fmt.Fprintf(os.Stderr, "setup quarantined: %v\n", err)
+		}
+		return
+	}
+	s.cleanupLegacy(testsFailed)
+}
+
+func (s *ShardSetup) cleanupLegacy(testsFailed bool) {
 	if s == nil {
 		return
 	}
@@ -568,10 +583,14 @@ func (s *ShardSetup) Cleanup(testsFailed bool) {
 		mo.TerminateGracefully(logf, 5*time.Second)
 	}
 
-	// Cancel the context to terminate any remaining processes. Processes
-	// wrapped in run_in_test.sh (etcd) are started with
-	// context.Background() and use a separate goroutine to detect context
-	// cancellation and clean up.
+	if s.EtcdCmd != nil && s.EtcdCmd.Process != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_, _ = s.EtcdCmd.Stop(ctx)
+		cancel()
+	}
+
+	// Cancel the context to terminate any remaining processes. Scoped cleanup
+	// also joins each command's context watcher before releasing its leases.
 	if s.cancel != nil {
 		s.cancel()
 	}

--- a/go/test/endtoend/shardsetup/lifetime.go
+++ b/go/test/endtoend/shardsetup/lifetime.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shardsetup
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/multigres/multigres/go/test/utils"
+	"github.com/multigres/multigres/go/tools/executil"
+)
+
+// Lifetime owns a single constructor attempt before its first acquisition.
+// Register Close with the seed owner before invoking New. A failed Close keeps
+// leases reserved and requires quarantine until the isolated worker is destroyed.
+// Log retention never determines whether leases may be released.
+type Lifetime struct {
+	boundary func(string) // test-only constructor barrier; nil in production
+	ctx      context.Context
+	cancel   context.CancelFunc
+	ports    *utils.PortScope
+	id       string
+	setup    *ShardSetup
+	commands []*executil.Cmd
+	once     sync.Once
+	err      error
+}
+
+func NewLifetime(ctx context.Context, socket string) (*Lifetime, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	ports, err := utils.NewPortScope(socket)
+	if err != nil {
+		return nil, err
+	}
+	var id [16]byte
+	if _, err := rand.Read(id[:]); err != nil {
+		_ = ports.Close()
+		return nil, err
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	return &Lifetime{ctx: ctx, cancel: cancel, ports: ports, id: hex.EncodeToString(id[:])}, nil
+}
+
+func (l *Lifetime) Context() context.Context { return l.ctx }
+
+// WithLifetime uses explicit seed-owned leases and joined constructor unwind.
+// A Lifetime is single-use and must not be shared by concurrent constructors.
+func WithLifetime(l *Lifetime) SetupOption {
+	return func(c *SetupConfig) { c.lifetime = l }
+}
+
+func (l *Lifetime) attach(s *ShardSetup) {
+	if l.setup != nil {
+		panic("shardsetup: lifetime already attached")
+	}
+	l.setup = s
+}
+
+func (l *Lifetime) ownCommand(cmd *executil.Cmd) {
+	cmd.AddEnv("MULTIGRES_SETUP_OWNER=" + l.id)
+	l.commands = append(l.commands, cmd)
+}
+
+func (s *ShardSetup) port(t *testing.T) int {
+	t.Helper()
+	if s.lifetime == nil {
+		return utils.GetFreePort(t)
+	}
+	if err := s.lifetime.ctx.Err(); err != nil {
+		t.Fatalf("setup canceled: %v", err)
+	}
+	port, err := s.lifetime.ports.Alloc()
+	if err != nil {
+		t.Fatalf("setup port allocation: %v", err)
+	}
+	return port
+}
+
+// Close is idempotent, including its error disposition. It must follow runner
+// teardown, which stops monitors and clients, and precede scheduler slot release.
+func (l *Lifetime) Close(failed bool) error {
+	l.once.Do(func() {
+		// Capture descendant identities before parents exit, including detached
+		// PostgreSQL and its watchdog. Only this owner's identities may be joined.
+		owned, err := captureOwnedProcesses(l.id, l.commands)
+		l.err = errors.Join(l.err, err)
+		if owned != nil {
+			defer owned.close()
+		}
+		if l.setup != nil {
+			l.setup.cleanupLegacy(true)
+		}
+		l.cancel()
+		for _, cmd := range l.commands {
+			if cmd.Process == nil {
+				continue
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_, stopped := cmd.Stop(ctx)
+			if !stopped {
+				l.err = errors.Join(l.err, fmt.Errorf("process %d did not join", cmd.Process.Pid))
+			}
+			if err := cmd.JoinWatcher(ctx); err != nil {
+				l.err = errors.Join(l.err, err)
+			}
+			cancel()
+		}
+		if owned != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			l.err = errors.Join(l.err, owned.join(ctx))
+			cancel()
+		}
+		if l.err != nil {
+			return
+		} // Keep leases and diagnostics on ambiguous teardown.
+		if l.boundary != nil {
+			l.boundary("before-lease-release")
+		}
+		l.err = l.ports.Close()
+		if l.err == nil && !failed && l.setup != nil && l.setup.TempDir != "" {
+			// No PID-file-based cleanup is needed after joined teardown.
+			l.err = os.RemoveAll(l.setup.TempDir)
+		}
+	})
+	return l.err
+}
+
+func (s *ShardSetup) checkBoundary(t *testing.T, name string) {
+	if s.lifetime == nil {
+		return
+	}
+	if s.lifetime.boundary != nil {
+		s.lifetime.boundary(name)
+	}
+	if err := s.lifetime.ctx.Err(); err != nil {
+		t.Fatalf("constructor canceled at %s: %v", name, err)
+	}
+}

--- a/go/test/endtoend/shardsetup/lifetime_linux_test.go
+++ b/go/test/endtoend/shardsetup/lifetime_linux_test.go
@@ -1,0 +1,230 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shardsetup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/jackc/pgx/v5"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/multigres/multigres/go/test/utils/poolserver"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLifetimeConstructorUnwind(t *testing.T) {
+	if os.Getenv("MULTIGRES_DISPOSABLE_LINUX") != "1" {
+		t.Skip("requires a new disposable Linux worker")
+	}
+	dir := t.TempDir()
+	server, err := poolserver.NewServer(filepath.Join(dir, "pool.sock"))
+	require.NoError(t, err)
+	serverDone := make(chan struct{})
+	go func() { defer close(serverDone); server.Serve() }()
+	defer func() { server.Stop(); <-serverDone }()
+	b, err := NewLifetime(t.Context(), server.SocketPath())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, b.Close(t.Failed())) }()
+	canary := New(t, WithLifetime(b), WithMultipoolerCount(2), WithMultigateway())
+	bProcesses, err := captureOwnedProcesses(b.id, b.commands)
+	require.NoError(t, err)
+	defer bProcesses.close()
+	checkB := func(t *testing.T) {
+		for pid, proc := range bProcesses.processes {
+			if !proc.direct {
+				continue
+			}
+			_, start, err := processIdentity(pid)
+			require.NoError(t, err)
+			require.Equal(t, proc.start, start)
+		}
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+		conn, err := pgx.Connect(ctx, GetTestUserDSN("localhost", canary.MultigatewayPgPort, "sslmode=disable"))
+		require.NoError(t, err)
+		defer conn.Close(ctx)
+		var one int
+		require.NoError(t, conn.QueryRow(ctx, "SELECT 1").Scan(&one))
+		require.Equal(t, 1, one)
+
+		require.NotEmpty(t, b.ports.Reservations())
+	}
+	checkB(t)
+	for _, boundary := range []string{"before-first-child", "ports-allocated", "etcd-ready", "database-children-ready", "before-transfer"} {
+		for _, canceled := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/canceled=%t", boundary, canceled), func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				a, err := NewLifetime(ctx, server.SocketPath())
+				require.NoError(t, err)
+				entered, release, done := make(chan struct{}), make(chan struct{}), make(chan struct{})
+				var releaseOnce sync.Once
+				unblock := func() { releaseOnce.Do(func() { close(release) }) }
+				defer unblock()
+				var identities *ownedProcesses
+				releaseChecks := 0
+				a.boundary = func(name string) {
+					if name == "before-lease-release" {
+						releaseChecks++
+						if identities != nil {
+							for pid, proc := range identities.processes {
+								_, start, err := processIdentity(pid)
+								if !os.IsNotExist(err) && start == proc.start {
+									t.Errorf("port release preceded process join: %d/%s", pid, start)
+								}
+							}
+						}
+					}
+					if name == boundary {
+						close(entered)
+						<-release
+						runtime.Goexit()
+					}
+				}
+				returned := false
+				go func() { defer close(done); New(t, WithLifetime(a), WithMultipoolerCount(2)); returned = true }()
+				select {
+				case <-entered:
+				case <-done:
+					t.Fatal("constructor exited before requested boundary")
+				}
+				identities, err = captureOwnedProcesses(a.id, a.commands)
+				require.NoError(t, err)
+				defer identities.close()
+				if boundary != "before-first-child" && boundary != "ports-allocated" {
+					require.NotEmpty(t, identities.processes)
+					require.NotEmpty(t, a.ports.Reservations())
+				}
+				for pid, proc := range identities.processes {
+					t.Logf("A pid=%d start=%s direct=%t", pid, proc.start, proc.direct)
+				}
+				for pid, proc := range bProcesses.processes {
+					t.Logf("B pid=%d start=%s direct=%t", pid, proc.start, proc.direct)
+				}
+				if canceled {
+					cancel()
+				}
+				checkB(t)
+				unblock()
+				<-done
+				require.False(t, returned)
+				require.Equal(t, 1, releaseChecks)
+				require.NoError(t, a.Close(true))
+				require.NoError(t, a.Close(true))
+				require.Empty(t, a.ports.Reservations(), "joined teardown must precede lease release")
+				for pid, proc := range identities.processes {
+					_, start, err := processIdentity(pid)
+					require.True(t, os.IsNotExist(err) || start != proc.start, "A identity survived: %d/%s", pid, proc.start)
+				}
+				_, err = os.Stat(a.setup.TempDir)
+				require.NoError(t, err, "failed constructor logs intentionally retained")
+				checkB(t)
+			})
+		}
+	}
+}
+
+// Expected testing.T failures run in a child test process so the parent can
+// assert the actual Fatal/Goexit path without weakening the constructor API.
+func TestLifetimeFatalConstructorUnwind(t *testing.T) {
+	if os.Getenv("MULTIGRES_DISPOSABLE_LINUX") != "1" {
+		t.Skip("requires a new disposable Linux worker")
+	}
+	for _, mode := range []string{"cancellation", "exec-start"} {
+		t.Run(mode, func(t *testing.T) {
+			evidence := filepath.Join(t.TempDir(), "unwind.json")
+			binary, err := os.Executable()
+			require.NoError(t, err)
+			cmd := exec.CommandContext(t.Context(), binary, "-test.v", "-test.run=^TestLifetimeFatalHelper$", "-test.timeout=1m")
+			cmd.Env = append(os.Environ(), "LIFETIME_HELPER="+mode, "LIFETIME_EVIDENCE="+evidence)
+			output, err := cmd.CombinedOutput()
+			require.Error(t, err, string(output))
+			var exitErr *exec.ExitError
+			require.ErrorAs(t, err, &exitErr)
+			require.Equal(t, 1, exitErr.ExitCode(), string(output))
+			if mode == "cancellation" {
+				require.Contains(t, string(output), "constructor canceled at etcd-ready")
+			} else {
+				require.Contains(t, string(output), "failed to start etcd")
+			}
+			data, err := os.ReadFile(evidence)
+			require.NoError(t, err, string(output))
+			var status struct {
+				Joined       bool
+				Reservations []int
+			}
+			require.NoError(t, json.Unmarshal(data, &status))
+			require.True(t, status.Joined, string(output))
+			require.Empty(t, status.Reservations)
+		})
+	}
+}
+
+func TestLifetimeFatalHelper(t *testing.T) {
+	mode := os.Getenv("LIFETIME_HELPER")
+	if os.Getenv("MULTIGRES_DISPOSABLE_LINUX") != "1" || mode == "" {
+		t.Skip("constructor failure subprocess only")
+	}
+	dir := t.TempDir()
+	server, err := poolserver.NewServer(filepath.Join(dir, "s"))
+	require.NoError(t, err)
+	serverDone := make(chan struct{})
+ go func(){ defer close(serverDone);server.Serve() }()
+ defer func(){server.Stop();<-serverDone}()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	owner, err := NewLifetime(ctx, server.SocketPath())
+	require.NoError(t, err)
+	var identities *ownedProcesses
+	t.Cleanup(func() {
+		joined := owner.Close(true) == nil
+		if identities != nil {
+			defer identities.close()
+			for pid, proc := range identities.processes {
+				_, start, err := processIdentity(pid)
+				if !os.IsNotExist(err) && start == proc.start {
+					joined = false
+				}
+			}
+		}
+		data, err := json.Marshal(struct {
+			Joined       bool
+			Reservations []int
+		}{joined, owner.ports.Reservations()})
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(os.Getenv("LIFETIME_EVIDENCE"), data, 0o600))
+	})
+	owner.boundary = func(name string) {
+		if mode == "exec-start" && name == "ports-allocated" {
+			owner.commands[len(owner.commands)-1].Path = filepath.Join(dir, "missing-executable")
+		}
+		if mode == "cancellation" && name == "etcd-ready" {
+			identities, err = captureOwnedProcesses(owner.id, owner.commands)
+			require.NoError(t, err)
+			canceled := make(chan struct{})
+			go func() { cancel(); close(canceled) }()
+			<-canceled
+		}
+	}
+	New(t, WithLifetime(owner))
+	t.Fatal("constructor unexpectedly returned")
+}

--- a/go/test/endtoend/shardsetup/owned_processes_linux.go
+++ b/go/test/endtoend/shardsetup/owned_processes_linux.go
@@ -1,0 +1,226 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shardsetup
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/multigres/multigres/go/tools/executil"
+	"golang.org/x/sys/unix"
+)
+
+type ownedProcess struct {
+	pid, fd int
+	start   string
+	direct  bool
+}
+type ownedProcesses struct {
+	id        string
+	processes map[int]ownedProcess
+}
+
+func processIdentity(pid int) (parent int, start string, err error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0, "", err
+	}
+	end := bytes.LastIndexByte(data, ')')
+	if end < 0 {
+		return 0, "", errors.New("invalid process stat")
+	}
+	fields := strings.Fields(string(data[end+1:]))
+	if len(fields) < 20 {
+		return 0, "", errors.New("short process stat")
+	}
+	parent, err = strconv.Atoi(fields[1])
+	return parent, fields[19], err
+}
+
+func captureOwnedProcesses(id string, commands []*executil.Cmd) (*ownedProcesses, error) {
+	p := &ownedProcesses{id: id, processes: make(map[int]ownedProcess)}
+	for _, cmd := range commands {
+		if cmd.Process == nil || cmd.Exited() {
+			continue
+		}
+		if err := p.add(cmd.Process.Pid, true); err != nil {
+			p.close()
+			return nil, err
+		}
+	}
+	if err := p.scan(); err != nil {
+		p.close()
+		return nil, err
+	}
+	return p, nil
+}
+
+func (p *ownedProcesses) add(pid int, direct bool) error {
+	_, start, err := processIdentity(pid)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if old, ok := p.processes[pid]; ok {
+		if old.start == start {
+			return nil
+		}
+		_ = unix.Close(old.fd)
+		delete(p.processes, pid)
+	}
+	fd, err := unix.PidfdOpen(pid, 0)
+	if errors.Is(err, unix.ESRCH) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("pidfd for %d: %w", pid, err)
+	}
+	_, current, err := processIdentity(pid)
+	if os.IsNotExist(err) {
+		_ = unix.Close(fd)
+		return nil
+	}
+	if err != nil {
+		_ = unix.Close(fd)
+		return err
+	}
+	if current != start {
+		_ = unix.Close(fd)
+		return nil
+	}
+	p.processes[pid] = ownedProcess{pid: pid, fd: fd, start: start, direct: direct}
+	return nil
+}
+
+func (p *ownedProcesses) scan() error {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return err
+	}
+	marker := []byte("MULTIGRES_SETUP_OWNER=" + p.id)
+	parents := make(map[int]int)
+	for _, entry := range entries {
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+		parent, _, err := processIdentity(pid)
+		if err != nil {
+			continue
+		}
+		parents[pid] = parent
+		env, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
+		if err != nil {
+			continue
+		} // Other users' processes are outside this owner.
+		for _, kv := range bytes.Split(env, []byte{0}) {
+			if bytes.Equal(kv, marker) {
+				if err := p.add(pid, false); err != nil {
+					return err
+				}
+				break
+			}
+		}
+	}
+	// Zombies may have an empty environment; retain identities descended from
+	// known parents before those parents exit and PID 1 adopts them.
+	for changed := true; changed; {
+		changed = false
+		for pid, parent := range parents {
+			if _, known := p.processes[pid]; known {
+				continue
+			}
+			ancestor, owned := p.processes[parent]
+			if !owned {
+				continue
+			}
+			_, current, err := processIdentity(parent)
+			if err != nil || current != ancestor.start {
+				continue
+			}
+			if err := p.add(pid, false); err != nil {
+				return err
+			}
+			if _, added := p.processes[pid]; added {
+				changed = true
+			}
+		}
+	}
+	return nil
+}
+
+func (p *ownedProcesses) join(ctx context.Context) error {
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+	killAt := time.Now().Add(2 * time.Second)
+	for {
+		if err := p.scan(); err != nil {
+			return err
+		}
+		alive := 0
+		for pid, proc := range p.processes {
+			_, current, err := processIdentity(pid)
+			if os.IsNotExist(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if current != proc.start {
+				continue
+			}
+			alive++
+			signal := unix.SIGTERM
+			if !time.Now().Before(killAt) {
+				signal = unix.SIGKILL
+			}
+			// pidfd binds the signal to the recorded process, never a reused PID.
+			if err := unix.PidfdSendSignal(proc.fd, signal, nil, 0); err != nil {
+				if errors.Is(err, unix.ESRCH) {
+					continue
+				}
+				return err
+			}
+			if !proc.direct {
+				// Reap only this exact descendant if it was adopted by this process.
+				// Otherwise the disposable worker's init owns the reap.
+				var status unix.WaitStatus
+				_, _ = unix.Wait4(pid, &status, unix.WNOHANG, nil)
+			}
+		}
+		if alive == 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%d owned process identities remain: %w", alive, ctx.Err())
+		case <-tick.C:
+		}
+	}
+}
+
+func (p *ownedProcesses) close() {
+	for _, proc := range p.processes {
+		_ = unix.Close(proc.fd)
+	}
+}

--- a/go/test/endtoend/shardsetup/owned_processes_other.go
+++ b/go/test/endtoend/shardsetup/owned_processes_other.go
@@ -1,0 +1,37 @@
+//go:build !linux
+
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shardsetup
+
+import (
+	"context"
+	"errors"
+
+	"github.com/multigres/multigres/go/tools/executil"
+)
+
+type ownedProcesses struct{}
+
+func captureOwnedProcesses(_ string, commands []*executil.Cmd) (*ownedProcesses, error) {
+	for _, cmd := range commands {
+		if cmd.Process != nil {
+			return nil, errors.New("joined setup ownership requires an isolated Linux worker")
+		}
+	}
+	return &ownedProcesses{}, nil
+}
+func (*ownedProcesses) join(context.Context) error { return nil }
+func (*ownedProcesses) close()                     {}

--- a/go/test/endtoend/shardsetup/process.go
+++ b/go/test/endtoend/shardsetup/process.go
@@ -42,6 +42,7 @@ import (
 // ProcessInstance represents a process instance for testing (pgctld, multipooler, or multiorch).
 // This struct is extracted from multipooler/setup_test.go and extended for multiorch support.
 type ProcessInstance struct {
+	lifetime    *Lifetime
 	Name        string
 	PoolerDir   string // Used by pgctld, multipooler
 	ConfigFile  string // Used by pgctld
@@ -269,7 +270,7 @@ func (p *ProcessInstance) startPgctld(ctx context.Context, t *testing.T) error {
 
 	args := buildPgctldServerArgs(p)
 
-	p.Process = executil.Command(ctx, p.Binary, args...).WithProcessGroup()
+	p.Process = p.command(ctx, args...)
 
 	// Set MULTIGRES_TESTDATA_DIR for directory-deletion triggered cleanup
 	if len(p.Environment) > 0 {
@@ -296,7 +297,7 @@ func (p *ProcessInstance) startMultipooler(ctx context.Context, t *testing.T) er
 	args := p.multipoolerArgs()
 
 	// Start the multipooler server
-	p.Process = executil.Command(ctx, p.Binary, args...).WithProcessGroup()
+	p.Process = p.command(ctx, args...)
 
 	// Set MULTIGRES_TESTDATA_DIR for directory-deletion triggered cleanup
 	if len(p.Environment) > 0 {
@@ -351,7 +352,7 @@ func (p *ProcessInstance) startMultiorch(ctx context.Context, t *testing.T) erro
 		args = append(args, "--verify-replication-timeout", "15s")
 	}
 
-	p.Process = executil.Command(ctx, p.Binary, args...).WithProcessGroup()
+	p.Process = p.command(ctx, args...)
 	if p.PoolerDir != "" {
 		p.Process.SetDir(p.PoolerDir)
 	}
@@ -362,6 +363,7 @@ func (p *ProcessInstance) startMultiorch(ctx context.Context, t *testing.T) erro
 		if err != nil {
 			return fmt.Errorf("failed to create log file: %w", err)
 		}
+		defer logF.Close()
 		p.Process.SetStdout(logF)
 		p.Process.SetStderr(logF)
 	}
@@ -415,7 +417,7 @@ func (p *ProcessInstance) startMultigateway(ctx context.Context, t *testing.T) e
 	// Append any extra args (e.g., buffer configuration flags)
 	args = append(args, p.ExtraArgs...)
 
-	p.Process = executil.Command(ctx, p.Binary, args...).WithProcessGroup()
+	p.Process = p.command(ctx, args...)
 
 	// Set MULTIGRES_TESTDATA_DIR for directory-deletion triggered cleanup
 	if len(p.Environment) > 0 {
@@ -429,6 +431,7 @@ func (p *ProcessInstance) startMultigateway(ctx context.Context, t *testing.T) e
 		if err != nil {
 			return fmt.Errorf("failed to create log file: %w", err)
 		}
+		defer logF.Close()
 		p.Process.SetStdout(logF)
 		p.Process.SetStderr(logF)
 	}
@@ -468,7 +471,7 @@ func (p *ProcessInstance) startMultiadmin(ctx context.Context, t *testing.T) err
 		"--log-level", p.logLevelOrDefault(),
 	}
 
-	p.Process = executil.Command(ctx, p.Binary, args...).WithProcessGroup()
+	p.Process = p.command(ctx, args...)
 
 	if len(p.Environment) > 0 {
 		p.Process.SetEnv(p.Environment)
@@ -479,6 +482,7 @@ func (p *ProcessInstance) startMultiadmin(ctx context.Context, t *testing.T) err
 		if err != nil {
 			return fmt.Errorf("failed to create log file: %w", err)
 		}
+		defer logF.Close()
 		p.Process.SetStdout(logF)
 		p.Process.SetStderr(logF)
 	}
@@ -513,7 +517,7 @@ func (p *ProcessInstance) waitForStartup(ctx context.Context, t *testing.T, time
 	time.Sleep(500 * time.Millisecond)
 
 	// Check if process died immediately
-	if p.Process.ProcessState != nil {
+	if p.Process.Exited() {
 		t.Logf("%s process died immediately: exit code %d", p.Name, p.Process.ProcessState.ExitCode())
 		p.LogRecentOutput(t, "Process died immediately")
 		return fmt.Errorf("%s process died immediately: exit code %d", p.Name, p.Process.ProcessState.ExitCode())
@@ -524,7 +528,7 @@ func (p *ProcessInstance) waitForStartup(ctx context.Context, t *testing.T, time
 	connectAttempts := 0
 	for time.Now().Before(deadline) {
 		// Check if process died during startup
-		if p.Process.ProcessState != nil {
+		if p.Process.Exited() {
 			t.Logf("%s process died during startup: exit code %d", p.Name, p.Process.ProcessState.ExitCode())
 			p.LogRecentOutput(t, "Process died during startup")
 			return fmt.Errorf("%s process died: exit code %d", p.Name, p.Process.ProcessState.ExitCode())
@@ -545,7 +549,7 @@ func (p *ProcessInstance) waitForStartup(ctx context.Context, t *testing.T, time
 	}
 
 	// If we timed out, try to get process status
-	if p.Process.ProcessState == nil {
+	if !p.Process.Exited() {
 		t.Logf("%s process is still running but not responding on gRPC port %d", p.Name, p.GrpcPort)
 	}
 
@@ -585,7 +589,7 @@ func (p *ProcessInstance) IsRunning() bool {
 		return false
 	}
 	// ProcessState is set after Wait() returns, meaning process has exited
-	if p.Process.ProcessState != nil {
+	if p.Process.Exited() {
 		return false
 	}
 	// Signal 0 checks if process exists without actually sending a signal
@@ -694,4 +698,14 @@ func WaitForPortReady(t *testing.T, name string, grpcPort int, timeout time.Dura
 	}
 
 	return fmt.Errorf("timeout: %s failed to start listening on port %d after %d attempts", name, grpcPort, connectAttempts)
+}
+
+func (p *ProcessInstance) command(ctx context.Context, args ...string) *executil.Cmd {
+	cmd := executil.Command(ctx, p.Binary, args...)
+	if p.lifetime != nil {
+		p.lifetime.ownCommand(cmd)
+	} else {
+		cmd.WithProcessGroup()
+	}
+	return cmd
 }

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -61,6 +61,7 @@ import (
 
 // SetupConfig holds the configuration for creating a ShardSetup.
 type SetupConfig struct {
+	lifetime                           *Lifetime
 	MultipoolerCount                   int
 	MultiorchCount                     int
 	EnableMultigateway                 bool // Enable multigateway (opt-in, default: false)
@@ -469,7 +470,7 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 
 	// Get context from testing.T and create root span
 	ctx := t.Context()
-	ctx, span := telemetry.Tracer().Start(ctx, "shardsetup/New")
+	_, span := telemetry.Tracer().Start(ctx, "shardsetup/New")
 	defer span.End()
 
 	// Default configuration
@@ -517,26 +518,45 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 		t.Fatalf("PostgreSQL binaries not found, make sure to install PostgreSQL and add it to the PATH")
 	}
 
+	runningCtx := context.Background()
+	if config.lifetime != nil {
+		runningCtx = config.lifetime.Context()
+	}
+	runningCtx, cancel := context.WithCancel(runningCtx)
+	setup := &ShardSetup{
+		runningCtx: runningCtx, cancel: cancel, lifetime: config.lifetime,
+		CellName: config.CellName, Multipoolers: make(map[string]*MultipoolerInstance),
+		MultiorchInstances: make(map[string]*ProcessInstance), MetricsPorts: make(map[string]int),
+	}
+	if config.lifetime != nil {
+		config.lifetime.attach(setup)
+	}
+	complete := false
+	defer func() {
+		if !complete {
+			setup.Cleanup(true)
+		}
+	}()
 	tempDir, tempDirCleanup := testutil.TempDir(t, "shardsetup_test")
-
-	// Create a long-lived context for all processes in this ShardSetup.
-	// This context is cancelled in Cleanup() to gracefully terminate all processes.
-	// Derive from context.Background() rather than the span context to avoid premature cancellation.
-	runningCtx, cancel := context.WithCancel(context.Background())
+	setup.TempDir, setup.TempDirCleanup = tempDir, tempDirCleanup
 
 	// Start etcd for topology
 	t.Logf("Starting etcd for topology...")
 
+	setup.checkBoundary(t, "before-first-child")
 	etcdDataDir := filepath.Join(tempDir, "etcd_data")
 	if err := os.MkdirAll(etcdDataDir, 0o755); err != nil {
 		cancel()
 		t.Fatalf("failed to create etcd data directory: %v", err)
 	}
-	etcdClientAddr, etcdCmd, err := startEtcd(runningCtx, t, etcdDataDir)
+	etcdClientAddr, etcdCmd, err := setup.startEtcd(runningCtx, t, etcdDataDir)
 	if err != nil {
 		cancel()
 		t.Fatalf("failed to start etcd: %v", err)
 	}
+
+	setup.EtcdClientAddr = etcdClientAddr
+	setup.checkBoundary(t, "etcd-ready")
 
 	// Create topology server and cell
 	testRoot := "/multigres"
@@ -548,8 +568,10 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 		t.Fatalf("failed to open topology server: %v", err)
 	}
 
+	setup.TopoServer = ts
+
 	// Create the cell
-	err = ts.CreateCell(context.Background(), config.CellName, &clustermetadatapb.Cell{
+	err = ts.CreateCell(runningCtx, config.CellName, &clustermetadatapb.Cell{
 		ServerAddresses: []string{etcdClientAddr},
 		Root:            cellRoot,
 	})
@@ -605,7 +627,7 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 		t.Fatalf("invalid durability policy %q: %v", config.DurabilityPolicy, err)
 	}
 
-	err = ts.CreateDatabase(context.Background(), config.Database, &clustermetadatapb.Database{
+	err = ts.CreateDatabase(runningCtx, config.Database, &clustermetadatapb.Database{
 		Name:                      config.Database,
 		BackupLocation:            backupLocation,
 		BootstrapDurabilityPolicy: bootstrapPolicy,
@@ -615,21 +637,8 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 		t.Fatalf("failed to create database in topology: %v", err)
 	}
 
-	setup := &ShardSetup{
-		TempDir:            tempDir,
-		TempDirCleanup:     tempDirCleanup,
-		EtcdClientAddr:     etcdClientAddr,
-		EtcdCmd:            etcdCmd,
-		TopoServer:         ts,
-		CellName:           config.CellName,
-		runningCtx:         runningCtx,
-		cancel:             cancel,
-		Multipoolers:       make(map[string]*MultipoolerInstance),
-		MultiorchInstances: make(map[string]*ProcessInstance),
-		MetricsPorts:       make(map[string]int),
-		BackupLocation:     backupLocation,
-		BackupCipherKey:    backupCipherKey,
-	}
+	setup.EtcdClientAddr, setup.EtcdCmd = etcdClientAddr, etcdCmd
+	setup.BackupLocation, setup.BackupCipherKey = backupLocation, backupCipherKey
 
 	// Provision postgres-side TLS assets up front so every pgctld + multipooler
 	// shares the same CA / server cert. Done before the per-pooler loop so the
@@ -642,9 +651,9 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 	var multipoolerInstances []*MultipoolerInstance
 	for i := 0; i < config.MultipoolerCount; i++ {
 		name := multipoolerName(i)
-		grpcPort := utils.GetFreePort(t)
-		pgPort := utils.GetFreePort(t)
-		multipoolerPort := utils.GetFreePort(t)
+		grpcPort := setup.port(t)
+		pgPort := setup.port(t)
+		multipoolerPort := setup.port(t)
 
 		inst := setup.CreateMultipoolerInstance(t, name, grpcPort, pgPort, multipoolerPort)
 		inst.Multipooler.ExtraArgs = append(inst.Multipooler.ExtraArgs, config.MultipoolerExtraArgs...)
@@ -670,7 +679,7 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 
 		// Configure Prometheus metrics export on multipooler if enabled.
 		if config.EnableMetricsExport {
-			metricsPort := utils.GetFreePort(t)
+			metricsPort := setup.port(t)
 			setup.MetricsPorts[name] = metricsPort
 			inst.Multipooler.Environment = append(inst.Multipooler.Environment,
 				"OTEL_METRICS_EXPORTER=prometheus",
@@ -692,6 +701,7 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 	// Start all processes (pgctld, multipooler, pgbackrest) for all nodes
 	// Use setup.ctx for process lifetime, passed ctx only for tracing
 	startMultipoolerInstances(setup.runningCtx, t, multipoolerInstances, config.DeferMultipoolerStart)
+	setup.checkBoundary(t, "database-children-ready")
 
 	// Create multiorch instances (if any requested by the test)
 	setup.createMultiorchInstances(t, config)
@@ -704,14 +714,14 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 		}
 
 		// Allocate ports for multigateway
-		pgPort := utils.GetFreePort(t)
-		httpPort := utils.GetFreePort(t)
-		grpcPort := utils.GetFreePort(t)
+		pgPort := setup.port(t)
+		httpPort := setup.port(t)
+		grpcPort := setup.port(t)
 
 		// Allocate replica port if enabled
 		var replicaPgPort int
 		if config.EnableMultigatewayReplicaPort {
-			replicaPgPort = utils.GetFreePort(t)
+			replicaPgPort = setup.port(t)
 		}
 
 		// Create multigateway instance (doesn't start it)
@@ -733,7 +743,7 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 
 		// Configure Prometheus metrics export if enabled.
 		if config.EnableMetricsExport {
-			metricsPort := utils.GetFreePort(t)
+			metricsPort := setup.port(t)
 			setup.MetricsPorts["multigateway"] = metricsPort
 			mgw.Environment = append(mgw.Environment,
 				"OTEL_METRICS_EXPORTER=prometheus",
@@ -755,8 +765,8 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 	// Multiadmin is a passive observer of topology — order vs. bootstrap
 	// doesn't matter the way it does for multigateway query serving.
 	if config.EnableMultiadmin {
-		httpPort := utils.GetFreePort(t)
-		grpcPort := utils.GetFreePort(t)
+		httpPort := setup.port(t)
+		grpcPort := setup.port(t)
 
 		ma := setup.CreateMultiadminInstance(t, "multiadmin", httpPort, grpcPort)
 		ma.LogLevel = config.LogLevel
@@ -772,11 +782,13 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 	if config.SkipInitialization {
 		t.Logf("Shard setup complete (uninitialized): %d multipoolers, %d multiorchs",
 			config.MultipoolerCount, config.MultiorchCount)
+		setup.checkBoundary(t, "before-transfer")
+		complete = true
 		return setup
 	}
 
 	// Use multiorch to bootstrap the shard organically
-	initializeWithMultiorch(ctx, t, setup, config)
+	initializeWithMultiorch(runningCtx, t, setup, config)
 
 	// Verify multigateway can execute queries (if enabled)
 	if config.EnableMultigateway {
@@ -786,6 +798,8 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 	t.Logf("Shard setup complete: %d multipoolers, %d multiorchs, multigateway: %v",
 		config.MultipoolerCount, config.MultiorchCount, config.EnableMultigateway)
 
+	setup.checkBoundary(t, "before-transfer")
+	complete = true
 	return setup
 }
 
@@ -814,14 +828,16 @@ func (s *ShardSetup) StartMultiorchs(ctx context.Context, t *testing.T) {
 		if err := mo.Start(ctx, t); err != nil {
 			t.Fatalf("StartMultiorchs: failed to start multiorch %s: %v", name, err)
 		}
-		t.Cleanup(mo.CleanupFunc(t.Logf))
+		if s.lifetime == nil {
+			t.Cleanup(mo.CleanupFunc(t.Logf))
+		}
 
 		// Register cleanup to ensure recovery is always enabled
 		// This prevents test failures from leaving recovery disabled
 		moInstance := mo // Capture for closure
-		t.Cleanup(func() {
-			ensureRecoveryEnabled(t, moInstance)
-		})
+		if s.lifetime == nil {
+			t.Cleanup(func() { ensureRecoveryEnabled(t, moInstance) })
+		}
 
 		t.Logf("StartMultiorchs: Started multiorch '%s': gRPC=%d, HTTP=%d", name, mo.GrpcPort, mo.HttpPort)
 	}
@@ -1490,7 +1506,7 @@ func startMultipoolerInstances(ctx context.Context, t *testing.T, instances []*M
 // startEtcd starts etcd without registering t.Cleanup() handlers
 // since cleanup is handled manually by TestMain via Cleanup().
 // Follows the pattern from multipooler/setup_test.go:startEtcdForSharedSetup.
-func startEtcd(ctx context.Context, t *testing.T, dataDir string) (string, *executil.Cmd, error) {
+func (s *ShardSetup) startEtcd(ctx context.Context, t *testing.T, dataDir string) (string, *executil.Cmd, error) {
 	t.Helper()
 
 	ctx, span := telemetry.Tracer().Start(ctx, "shardsetup/startEtcd")
@@ -1505,9 +1521,9 @@ func startEtcd(ctx context.Context, t *testing.T, dataDir string) (string, *exec
 	}
 
 	// Get ports for etcd (client, peer, and metrics)
-	clientPort := utils.GetFreePort(t)
-	peerPort := utils.GetFreePort(t)
-	metricsPort := utils.GetFreePort(t)
+	clientPort := s.port(t)
+	peerPort := s.port(t)
+	metricsPort := s.port(t)
 
 	span.SetAttributes(
 		attribute.Int("etcd.client_port", clientPort),
@@ -1536,6 +1552,11 @@ func startEtcd(ctx context.Context, t *testing.T, dataDir string) (string, *exec
 	// Set MULTIGRES_TESTDATA_DIR for directory-deletion triggered cleanup
 	cmd.AddEnv("MULTIGRES_TESTDATA_DIR=" + dataDir)
 
+	s.EtcdCmd = cmd
+	if s.lifetime != nil {
+		s.lifetime.ownCommand(cmd)
+	}
+	s.checkBoundary(t, "ports-allocated")
 	if err := cmd.Start(); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to start etcd")

--- a/go/test/utils/poolserver/client.go
+++ b/go/test/utils/poolserver/client.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 // Client is a connection to a running pool server.
@@ -100,8 +101,8 @@ func (c *Client) Ping() error {
 }
 
 // Close closes the connection to the server.
-// The server will automatically clean up any ports still held for this
-// connection.
+// The server reclaims legacy ALLOC reservations for this connection. Identity
+// leases survive disconnect and must be explicitly released after joined cleanup.
 func (c *Client) Close() error {
 	return c.conn.Close()
 }
@@ -109,6 +110,9 @@ func (c *Client) Close() error {
 func (c *Client) send(msg string) (string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if err := c.conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return "", err
+	}
 	if _, err := fmt.Fprintln(c.writer, msg); err != nil {
 		return "", fmt.Errorf("send %q: %w", msg, err)
 	}

--- a/go/test/utils/poolserver/lease.go
+++ b/go/test/utils/poolserver/lease.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package poolserver
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// AllocLease allocates a port for a unique acquisition identity. The lease is
+// retained on disconnect: connection loss does not prove that its user exited.
+// An ambiguous reply must quarantine the owner, not retry with a new identity.
+func (c *Client) AllocLease(id string) (int, error) {
+	response, err := c.send("LEASE " + id)
+	if err != nil {
+		return 0, err
+	}
+	fields := strings.Fields(response)
+	if len(fields) != 3 || fields[0] != "LEASE" || fields[2] != id {
+		return 0, fmt.Errorf("lease %s: unexpected response %q", id, response)
+	}
+	port, err := strconv.Atoi(fields[1])
+	if err != nil || port < 1 || port > 65535 {
+		return 0, fmt.Errorf("invalid lease port %q", fields[1])
+	}
+	return port, nil
+}
+
+// ReleaseLease is safe to repeat after a lost acknowledgement, even if the port
+// has been reassigned. Only the exact acquisition identity can release it.
+func (c *Client) ReleaseLease(port int, id string) error {
+	response, err := c.send(fmt.Sprintf("RELEASE %d %s", port, id))
+	if err != nil {
+		return err
+	}
+	if response != respOK {
+		return fmt.Errorf("release lease %s: %s", id, response)
+	}
+	return nil
+}
+
+func (s *Server) handleLease(fields []string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if fields[0] == "RELEASE" {
+		if len(fields) != 3 {
+			return "ERR invalid release"
+		}
+		port, err := strconv.Atoi(fields[1])
+		if err != nil {
+			return "ERR invalid port"
+		}
+		held, exists := s.leaseIDs[fields[2]]
+		if !exists {
+			return "ERR unknown lease"
+		}
+		if held == 0 {
+			return respOK
+		}
+		if held != port || s.leases[port] != fields[2] {
+			return "ERR lease mismatch"
+		}
+		delete(s.allocated, port)
+		delete(s.leases, port)
+		s.leaseIDs[fields[2]] = 0
+		return respOK
+	}
+	if len(fields) != 2 || len(fields[1]) < 16 || len(fields[1]) > 128 {
+		return "ERR invalid lease identity"
+	}
+	id := fields[1]
+	if port, exists := s.leaseIDs[id]; exists {
+		if port == 0 {
+			return "ERR lease already released"
+		}
+		return fmt.Sprintf("LEASE %d %s", port, id)
+	}
+	// Hold collisions open until allocation finishes, bounding retries without
+	// accidentally choosing a port already reserved by either protocol.
+	var held []net.Listener
+	defer func() {
+		for _, l := range held {
+			_ = l.Close()
+		}
+	}()
+	for range maxAllocRetries {
+		l, err := s.listenPort()
+		if err != nil {
+			return "ERR " + err.Error()
+		}
+		held = append(held, l)
+		port := l.Addr().(*net.TCPAddr).Port
+		if _, exists := s.allocated[port]; exists {
+			continue
+		}
+		s.allocated[port] = struct{}{}
+		s.leases[port] = id
+		s.leaseIDs[id] = port
+		return fmt.Sprintf("LEASE %d %s", port, id)
+	}
+	return respErrCollision
+}

--- a/go/test/utils/poolserver/lease_test.go
+++ b/go/test/utils/poolserver/lease_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package poolserver
+
+import (
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fixedListener struct{ port int }
+
+func (l fixedListener) Accept() (net.Conn, error) { return nil, errors.New("unused") }
+func (l fixedListener) Close() error              { return nil }
+func (l fixedListener) Addr() net.Addr            { return &net.TCPAddr{Port: l.port} }
+
+func leaseServer(t *testing.T) (*Server, *Client) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "lease-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	s, err := NewServer(filepath.Join(dir, "s"))
+	require.NoError(t, err)
+	s.listenPort = func() (net.Listener, error) { return fixedListener{26001}, nil }
+	done := make(chan struct{})
+	go func() { defer close(done); s.Serve() }()
+	t.Cleanup(func() { s.Stop(); <-done })
+	c, err := Connect(s.SocketPath())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+	return s, c
+}
+
+func TestLeaseStaleReleaseCannotReleaseNewOwner(t *testing.T) {
+	_, c := leaseServer(t)
+	a, err := c.AllocLease("aaaaaaaaaaaaaaaa")
+	require.NoError(t, err)
+	require.NoError(t, c.ReleaseLease(a, "aaaaaaaaaaaaaaaa"))
+	b, err := c.AllocLease("bbbbbbbbbbbbbbbb")
+	require.NoError(t, err)
+	require.Equal(t, a, b)
+	for range 2 {
+		require.NoError(t, c.ReleaseLease(a, "aaaaaaaaaaaaaaaa"))
+	}
+	require.Error(t, c.ReturnPort(a), "integer-only RETURN must not affect an identity lease")
+	_, err = c.AllocLease("cccccccccccccccc")
+	require.Error(t, err, "C must not receive active B's number")
+	require.NoError(t, c.ReleaseLease(b, "bbbbbbbbbbbbbbbb"))
+}
+
+func TestLeaseDisconnectRetainsOwnership(t *testing.T) {
+	s, c := leaseServer(t)
+	a, err := c.AllocLease("aaaaaaaaaaaaaaaa")
+	require.NoError(t, err)
+	require.NoError(t, c.Close())
+	b, err := Connect(s.SocketPath())
+	require.NoError(t, err)
+	defer b.Close()
+	// Replaying the same acquisition reconciles a lost allocation acknowledgement.
+	again, err := b.AllocLease("aaaaaaaaaaaaaaaa")
+	require.NoError(t, err)
+	require.Equal(t, a, again)
+	_, err = b.AllocLease("bbbbbbbbbbbbbbbb")
+	require.Error(t, err)
+	require.NoError(t, b.ReleaseLease(a, "aaaaaaaaaaaaaaaa"))
+	require.NoError(t, b.ReleaseLease(a, "aaaaaaaaaaaaaaaa"), "lost release ack is safe to replay")
+	_, err = b.AllocLease("bbbbbbbbbbbbbbbb")
+	require.NoError(t, err)
+}

--- a/go/test/utils/poolserver/server.go
+++ b/go/test/utils/poolserver/server.go
@@ -68,6 +68,13 @@
 //	ALLOC          → PORT <n>   (server records port n; caller may bind immediately)
 //	RETURN <n>     → OK         (test done; server forgets the port)
 //	PING           → PONG
+//	LEASE <id>     → LEASE <n> <id> (reserve for a unique acquisition identity)
+//	RELEASE <n> <id> → OK       (release only that identity; safe to repeat)
+//
+// Identity leases survive client disconnects. Their owner must join its children
+// before release, and quarantine the worker on an ambiguous acknowledgement.
+// Legacy RETURN cannot release an identity lease. Released identities remain as
+// tombstones for the server lifetime so delayed retries cannot free a later lease.
 package poolserver
 
 import (
@@ -86,8 +93,11 @@ type Server struct {
 	socketPath string
 	listener   net.Listener // Unix-socket listener
 
-	mu        sync.Mutex
-	allocated map[int]struct{} // ports handed out and not yet returned
+	mu         sync.Mutex
+	allocated  map[int]struct{} // ports handed out and not yet returned
+	listenPort func() (net.Listener, error)
+	leases     map[int]string // identity leases survive connection loss
+	leaseIDs   map[string]int // zero records an already released identity
 }
 
 // NewServer creates a pool server that listens on socketPath.
@@ -100,8 +110,11 @@ func NewServer(socketPath string) (*Server, error) {
 	}
 	return &Server{
 		socketPath: socketPath,
+		listenPort: func() (net.Listener, error) { return net.Listen("tcp", "localhost:0") },
 		listener:   l,
 		allocated:  make(map[int]struct{}),
+		leases:     make(map[int]string),
+		leaseIDs:   make(map[string]int),
 	}, nil
 }
 
@@ -141,6 +154,8 @@ func (s *Server) handleRequest(request string, clientPorts *[]int) string {
 	}
 
 	switch fields[0] {
+	case "LEASE", "RELEASE":
+		return s.handleLease(fields)
 	case cmdPing:
 		return respPong
 
@@ -159,6 +174,14 @@ func (s *Server) handleRequest(request string, clientPorts *[]int) string {
 		if port, err := strconv.Atoi(fields[1]); err != nil {
 			return respPrefixErr + " invalid port"
 		} else {
+			// A legacy return may only release this connection's legacy port.
+			owned := false
+			for _, p := range *clientPorts {
+				owned = owned || p == port
+			}
+			if !owned {
+				return respPrefixErr + " port not owned by connection"
+			}
 			s.returnPort(port)
 			*clientPorts = removePort(*clientPorts, port)
 			return respOK

--- a/go/test/utils/portscope.go
+++ b/go/test/utils/portscope.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"sort"
+	"sync"
+
+	"github.com/multigres/multigres/go/test/utils/poolserver"
+)
+
+// PortScope owns explicit leases, independent of testing.T cleanup. Close must
+// only be called after every process using its ports has exited and joined.
+// Failed or ambiguous operations quarantine the scope until worker destruction.
+// A configured but unavailable server never silently falls back to local ports.
+type PortScope struct {
+	mu     sync.Mutex
+	client *poolserver.Client
+	ports  map[int]string
+	closed bool
+	err    error
+}
+
+func NewPortScope(socket string) (*PortScope, error) {
+	s := &PortScope{ports: make(map[int]string)}
+	if socket != "" {
+		c, err := poolserver.Connect(socket)
+		if err != nil {
+			return nil, err
+		}
+		s.client = c
+	}
+	return s, nil
+}
+
+func (s *PortScope) Alloc() (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed || s.err != nil {
+		return 0, fmt.Errorf("port scope closed or quarantined: %w", errors.Join(s.err, errors.New("allocation unavailable")))
+	}
+	var token [16]byte
+	if _, err := rand.Read(token[:]); err != nil {
+		return 0, err
+	}
+	id := hex.EncodeToString(token[:])
+	if s.client != nil {
+		port, err := s.client.AllocLease(id)
+		if err != nil {
+			s.err = err
+			return 0, err
+		}
+		if _, exists := portCache.LoadOrStore(port, id); exists {
+			s.err = fmt.Errorf("pool returned locally reserved port %d", port)
+			return 0, s.err
+		}
+		s.ports[port] = id
+		return port, nil
+	}
+	var held []net.Listener
+	defer func() {
+		for _, l := range held {
+			_ = l.Close()
+		}
+	}()
+	for {
+		l, err := net.Listen("tcp", "localhost:0")
+		if err != nil {
+			return 0, err
+		}
+		held = append(held, l)
+		port := l.Addr().(*net.TCPAddr).Port
+		if _, exists := portCache.LoadOrStore(port, id); exists {
+			continue
+		}
+		s.ports[port] = id
+		return port, nil
+	}
+}
+
+// Close returns the same status on every call. On uncertainty, the local cache
+// and server lease are left reserved; no integer-only RETURN or reconnect occurs.
+func (s *PortScope) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return s.err
+	}
+	s.closed = true
+	if s.err == nil {
+		for port, id := range s.ports {
+			if s.client != nil {
+				if err := s.client.ReleaseLease(port, id); err != nil {
+					s.err = errors.Join(s.err, fmt.Errorf("port %d quarantined: %w", port, err))
+					continue
+				}
+			}
+			portCache.CompareAndDelete(port, id)
+			delete(s.ports, port)
+		}
+	}
+	if s.client != nil {
+		s.err = errors.Join(s.err, s.client.Close())
+	}
+	return s.err
+}
+
+// Reservations returns ports still owned or quarantined by this scope.
+func (s *PortScope) Reservations() []int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ports := make([]int, 0, len(s.ports))
+	for port := range s.ports {
+		ports = append(ports, port)
+	}
+	sort.Ints(ports)
+	return ports
+}

--- a/go/test/utils/portscope_test.go
+++ b/go/test/utils/portscope_test.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type scopePool struct {
+	mu       sync.Mutex
+	held     map[int]string
+	returns  int
+	mode     string
+	listener net.Listener
+	clients  []net.Conn
+	wg       sync.WaitGroup
+}
+
+func newScopePool(t *testing.T, mode string) *scopePool {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "scope-pool-")
+	require.NoError(t, err)
+	listener, err := net.Listen("unix", filepath.Join(dir, "s"))
+	require.NoError(t, err)
+	p := &scopePool{held: map[int]string{}, mode: mode, listener: listener}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			c, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			p.mu.Lock()
+			p.clients = append(p.clients, c)
+			p.mu.Unlock()
+			p.wg.Go(func() {
+				defer c.Close()
+				scanner := bufio.NewScanner(c)
+				for scanner.Scan() {
+					f := strings.Fields(scanner.Text())
+					reply := "ERR invalid"
+					p.mu.Lock()
+					switch f[0] {
+					case "LEASE":
+						port := 25001
+						for p.held[port] != "" && port < 25004 {
+							port++
+						}
+						if port == 25004 {
+							reply = "ERR capacity"
+						} else {
+							p.held[port] = f[1]
+							reply = fmt.Sprintf("LEASE %d %s", port, f[1])
+						}
+					case "RELEASE":
+						p.returns++
+						port, _ := strconv.Atoi(f[1])
+						if p.mode == "rejected" {
+							reply = "ERR controlled rejection"
+						} else {
+							if p.held[port] == f[2] {
+								delete(p.held, port)
+							}
+							reply = "OK"
+						}
+						if p.mode == "lost-ack" {
+							p.mu.Unlock()
+							return
+						}
+					}
+					p.mu.Unlock()
+					if _, err := fmt.Fprintln(c, reply); err != nil {
+						return
+					}
+				}
+			})
+		}
+	}()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		<-done
+		p.mu.Lock()
+		for _, c := range p.clients {
+			_ = c.Close()
+		}
+		p.mu.Unlock()
+		p.wg.Wait()
+		_ = os.RemoveAll(dir)
+	})
+	return p
+}
+
+func (p *scopePool) scope(t *testing.T) *PortScope {
+	t.Helper()
+	s, err := NewPortScope(p.listener.Addr().String())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = s.Close()
+		// The fake worker is now destroyed. Remove only its quarantined test entries.
+		for port, id := range s.ports {
+			portCache.CompareAndDelete(port, id)
+		}
+	})
+	return s
+}
+
+func TestPortScopeSeedLifetime(t *testing.T) {
+	p := newScopePool(t, "")
+	b := p.scope(t)
+	bp, err := b.Alloc()
+	require.NoError(t, err)
+	for range 12 {
+		a := p.scope(t)
+		ap, err := a.Alloc()
+		require.NoError(t, err)
+		require.NotEqual(t, bp, ap)
+		require.NoError(t, a.Close())
+		require.NoError(t, a.Close())
+		_, held := portCache.Load(ap)
+		require.False(t, held)
+		p.mu.Lock()
+		bHeld := p.held[bp] != ""
+		p.mu.Unlock()
+		require.True(t, bHeld)
+	}
+	require.NoError(t, b.Close())
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	require.Empty(t, p.held)
+	require.Equal(t, 13, p.returns)
+}
+
+func TestPortScopeLocalLifetime(t *testing.T) {
+	b, err := NewPortScope("")
+	require.NoError(t, err)
+	defer b.Close()
+	bp, err := b.Alloc()
+	require.NoError(t, err)
+	for range 12 {
+		a, err := NewPortScope("")
+		require.NoError(t, err)
+		ap, err := a.Alloc()
+		require.NoError(t, err)
+		require.NotEqual(t, bp, ap)
+		require.NoError(t, a.Close())
+		require.NoError(t, a.Close())
+		_, aHeld := portCache.Load(ap)
+		_, bHeld := portCache.Load(bp)
+		require.False(t, aHeld)
+		require.True(t, bHeld)
+	}
+}
+
+func TestPortScopeFailedReleaseQuarantines(t *testing.T) {
+	for _, mode := range []string{"rejected", "lost-ack", "disconnect"} {
+		t.Run(mode, func(t *testing.T) {
+			p := newScopePool(t, mode)
+			a := p.scope(t)
+			b := p.scope(t)
+			ap, err := a.Alloc()
+			require.NoError(t, err)
+			bp, err := b.Alloc()
+			require.NoError(t, err)
+			if mode == "disconnect" {
+				require.NoError(t, a.client.Close())
+			}
+			err = a.Close()
+			require.Error(t, err)
+			require.Equal(t, err, a.Close())
+			_, aHeld := portCache.Load(ap)
+			require.True(t, aHeld, "uncertainty must retain local reservation")
+			p.mu.Lock()
+			bHeld := p.held[bp] != ""
+			p.mu.Unlock()
+			require.True(t, bHeld)
+			_, err = a.Alloc()
+			require.Error(t, err)
+		})
+	}
+}

--- a/go/test/utils/process.go
+++ b/go/test/utils/process.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/multigres/multigres/go/common/constants"
-	"github.com/multigres/multigres/go/tools/ctxutil"
 	"github.com/multigres/multigres/go/tools/executil"
 )
 
@@ -67,22 +66,13 @@ func BaseTestEnv() []string {
 }
 
 // CommandWithOrphanProtection creates a command wrapped in run_in_test.sh for orphan
-// process protection. The process uses context.Background() for its lifetime, avoiding
-// premature SIGKILL when the monitoring context is cancelled. Instead, Stop() is called
-// when monitorCtx is cancelled, giving run_in_test.sh time to send SIGTERM to its child
-// process before exiting.
+// process protection. Cancellation gives run_in_test.sh five seconds to terminate
+// its child before escalation. The context watcher starts only after a successful
+// Start and can be joined with Cmd.JoinWatcher during explicit owner cleanup.
 //
 // Callers should set any required environment variables (e.g. MULTIGRES_TESTDATA_DIR)
 // on the returned Cmd before calling Start().
 func CommandWithOrphanProtection(monitorCtx context.Context, name string, args ...string) *executil.Cmd {
 	allArgs := append([]string{name}, args...)
-	backgroundCtx := ctxutil.Detach(monitorCtx)
-	cmd := executil.Command(backgroundCtx, "run_in_test.sh", allArgs...)
-	go func() {
-		<-monitorCtx.Done()
-		stopCtx, cancel := context.WithTimeout(backgroundCtx, 5*time.Second)
-		_, _ = cmd.Stop(stopCtx)
-		cancel()
-	}()
-	return cmd
+	return executil.CommandWithGracePeriod(monitorCtx, 5*time.Second, "run_in_test.sh", allArgs...)
 }

--- a/go/tools/executil/command.go
+++ b/go/tools/executil/command.go
@@ -119,6 +119,7 @@ type Cmd struct {
 	terminated    chan struct{} // Closed when Terminate() is called
 	waitDone      chan struct{} // Closed when Wait() completes
 	waitErr       error         // Result of Wait() (valid after waitDone closed)
+	watchDone     chan struct{}
 	waitOnce      sync.Once
 }
 
@@ -149,6 +150,7 @@ func CommandWithGracePeriod(ctx context.Context, gracePeriod time.Duration, name
 		defaultGracePeriod: gracePeriod,
 		terminated:         make(chan struct{}),
 		waitDone:           make(chan struct{}),
+		watchDone:          make(chan struct{}),
 	}
 }
 
@@ -258,6 +260,7 @@ func (c *Cmd) finalizeEnv() {
 func (c *Cmd) watchContext() {
 	// Watch for parent context cancellation
 	go func() {
+		defer close(c.watchDone)
 		select {
 		case <-c.parentCtx.Done():
 			// Parent context cancelled - terminate with default grace period.
@@ -287,6 +290,9 @@ func (c *Cmd) watchContext() {
 // Note: WithClientSpan() has no effect on Start() since the span cannot be
 // ended until Wait() is called. Use Run() for client span support.
 func (c *Cmd) Start() error {
+	if err := c.parentCtx.Err(); err != nil {
+		return err
+	}
 	c.finalizeEnv()
 	if c.processGroup {
 		if c.Cmd.SysProcAttr == nil {
@@ -341,7 +347,7 @@ func (c *Cmd) Terminate(ctx context.Context) (error, bool) {
 	// Send SIGTERM only once
 	c.terminateOnce.Do(func() {
 		close(c.terminated)
-		if c.Process != nil {
+		if c.Process != nil && !c.Exited() {
 			if c.processGroup {
 				_ = syscall.Kill(-c.Process.Pid, syscall.SIGTERM)
 			} else {
@@ -373,8 +379,8 @@ func (c *Cmd) Terminate(ctx context.Context) (error, bool) {
 //
 // Safe to call after Terminate() times out - reuses the same Wait() call.
 func (c *Cmd) Kill(ctx context.Context) (error, bool) {
-	// Send SIGKILL
-	if c.Process != nil {
+	// Send SIGKILL only while this direct child still owns its PID.
+	if c.Process != nil && !c.Exited() {
 		if c.processGroup {
 			_ = syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
 		} else {
@@ -525,4 +531,27 @@ func (c *Cmd) CombinedOutput() ([]byte, error) {
 		err = c.Wait()
 	}
 	return buf.Bytes(), err
+}
+
+// JoinWatcher waits for the context observer after the started process has joined.
+func (c *Cmd) JoinWatcher(ctx context.Context) error {
+	if c.Process == nil {
+		return nil
+	}
+	select {
+	case <-c.watchDone:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Exited reports whether Wait has completed, synchronizing ProcessState reads.
+func (c *Cmd) Exited() bool {
+	select {
+	case <-c.waitDone:
+		return true
+	default:
+		return false
+	}
 }

--- a/go/tools/executil/executil_test.go
+++ b/go/tools/executil/executil_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -38,6 +39,53 @@ func TestCommand_InheritsEnvironment(t *testing.T) {
 	// Should contain PATH from parent environment
 	if !strings.Contains(string(output), "PATH=") {
 		t.Error("expected inherited PATH environment variable")
+	}
+}
+
+func TestCommand_PreCanceledStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cmd := Command(ctx, "sh", "-c", "exit 0")
+	if err := cmd.Start(); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Start() = %v, want context.Canceled", err)
+	}
+	if cmd.Process != nil {
+		t.Fatal("canceled command acquired a process")
+	}
+	if err := cmd.JoinWatcher(context.Background()); err != nil {
+		t.Fatalf("unstarted watcher: %v", err)
+	}
+}
+
+func TestCommand_JoinWatcher(t *testing.T) {
+	for _, cancelRunning := range []bool{false, true} {
+		t.Run(strconv.FormatBool(cancelRunning), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			args := []string{"-c", "exit 0"}
+			if cancelRunning {
+				args = []string{"-c", "exec sleep 60"}
+			}
+			cmd := Command(ctx, "sh", args...)
+			if err := cmd.Start(); err != nil {
+				t.Fatal(err)
+			}
+			if cancelRunning {
+				cancel()
+			}
+			_ = cmd.Wait()
+			joinCtx, joinCancel := context.WithTimeout(context.Background(), time.Second)
+			defer joinCancel()
+			if err := cmd.JoinWatcher(joinCtx); err != nil {
+				t.Fatal(err)
+			}
+			if !cmd.Exited() {
+				t.Fatal("joined command still appears active")
+			}
+			if err := cmd.JoinWatcher(joinCtx); err != nil {
+				t.Fatalf("repeated join: %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

This PR adds explicit ownership for shard setup resources so successful teardown and partial-constructor cleanup join child processes before releasing port leases. Cleanup failures retain reservations and diagnostics and return an observable error.

Port leases carry unique acquisition identities, preventing delayed cleanup from releasing a number reassigned to another owner. Identity leases survive connection loss; joined descendant cleanup requires Linux.

## Main changes

- Unwind partial constructors through the same idempotent owner used for successful setup.
- Release identity leases only after owned processes and descendants have joined.
- Preserve observable cleanup errors and protect active leases from stale returns and disconnects.
- Cover constructor failure boundaries, delayed teardown, bounded capacity, and ambiguous release acknowledgements.

## Testing

Passed allocator race tests
