### PR TITLE
fix(parser): preserve trailing clauses on VALUES statements

### DIFF
--- a/go/common/parser/ast/statements.go
+++ b/go/common/parser/ast/statements.go
@@ -662,14 +662,7 @@ func (s *SelectStmt) SqlString() string {
 				valueRows = append(valueRows, fmt.Sprintf("(%s)", strings.Join(values, ", ")))
 			}
 		}
-		// WITH cte(...) AS (...) VALUES (...) attaches WithClause to the
-		// outer SelectStmt; same drop-on-round-trip class as the set-op
-		// branch above.
-		result := "VALUES " + strings.Join(valueRows, ", ")
-		if s.WithClause != nil {
-			result = s.WithClause.SqlString() + " " + result
-		}
-		return result
+		return s.sqlStringWithClauses([]string{"VALUES " + strings.Join(valueRows, ", ")})
 	}
 
 	// Regular SELECT statement
@@ -772,6 +765,11 @@ func (s *SelectStmt) SqlString() string {
 		}
 	}
 
+	return s.sqlStringWithClauses(parts)
+}
+
+// sqlStringWithClauses preserves the clauses shared by SELECT and VALUES.
+func (s *SelectStmt) sqlStringWithClauses(parts []string) string {
 	// ORDER BY clause (from SortClause)
 	if s.SortClause != nil && s.SortClause.Len() > 0 {
 		var sortItems []string

--- a/go/common/parser/values_clauses_test.go
+++ b/go/common/parser/values_clauses_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValuesClausesRoundTrip(t *testing.T) {
+	for _, sql := range []string{
+		"VALUES (2), (1) ORDER BY 1",
+		"VALUES (2), (1) LIMIT 0",
+		"VALUES (2), (1) LIMIT ALL",
+		"VALUES (2), (1) OFFSET 1",
+		"VALUES (2), (1) ORDER BY 1 LIMIT 1 OFFSET 1",
+		"VALUES (2), (1), (1) ORDER BY 1 FETCH FIRST ROW WITH TIES",
+		"VALUES (2), (1), (1) ORDER BY 1 FETCH FIRST 2 ROWS WITH TIES",
+		"VALUES ($1), ($2) ORDER BY 1 LIMIT $3 OFFSET $4",
+		"WITH x AS (VALUES (1)) VALUES (2), (1) ORDER BY 1 LIMIT 0",
+		"SELECT * FROM (VALUES (2), (1) ORDER BY 1 LIMIT 1) AS v",
+		"DELETE FROM orders WHERE id IN (VALUES (1), (2) LIMIT 0)",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			stmts, err := ParseSQL(sql)
+			require.NoError(t, err)
+			require.Len(t, stmts, 1)
+			deparsed := stmts[0].SqlString()
+			require.Equal(t, sql, deparsed)
+			_, err = ParseSQL(deparsed)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/go/services/multigateway/executor/executor_test.go
+++ b/go/services/multigateway/executor/executor_test.go
@@ -372,6 +372,26 @@ func TestCrossProtocol_PortalCachesForSimpleProtocol(t *testing.T) {
 	assert.True(t, res2.CacheHit, "simple protocol should hit plan cached by portal")
 }
 
+func TestValuesClausesPreservedInBackendSQL(t *testing.T) {
+	for _, sql := range []string{
+		"VALUES (2), (1) ORDER BY 1 LIMIT 1 OFFSET 1",
+		"DELETE FROM orders WHERE id IN (VALUES (1), (2) LIMIT 1)",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			mock := &mockExec{}
+			exec := newTestExecutor(mock)
+			defer exec.planCache.Close()
+			_, err := exec.StreamExecute(t.Context(), testConn(), nil, sql, parseOne(t, sql), noopCallback)
+			require.NoError(t, err)
+			require.Equal(t, sql, mock.lastStreamExecuteSQL.Load())
+			require.Eventually(t, func() bool {
+				result, err := exec.StreamExecute(t.Context(), testConn(), nil, sql, parseOne(t, sql), noopCallback)
+				return err == nil && result.CacheHit && mock.lastStreamExecuteSQL.Load() == sql
+			}, time.Second, time.Millisecond, "cached execution must preserve VALUES clauses")
+		})
+	}
+}
+
 func TestCrossProtocol_PortalCachedPlanReconstructsSQL(t *testing.T) {
 	mock := &mockExec{}
 	exec := newTestExecutor(mock)

--- a/go/test/endtoend/queryserving/values_clauses_test.go
+++ b/go/test/endtoend/queryserving/values_clauses_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+func TestValuesLimitDoesNotWidenDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping VALUES integration test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found")
+	}
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	for _, target := range setup.GetComparisonTargets(t) {
+		t.Run(target.Name, func(t *testing.T) {
+			conn, err := pgx.Connect(ctx, shardsetup.GetTestUserDSN("localhost", target.Port, "sslmode=disable"))
+			require.NoError(t, err)
+			defer conn.Close(ctx)
+
+			for _, protocol := range []string{"simple", "extended"} {
+				t.Run(protocol, func(t *testing.T) {
+					tx, err := conn.Begin(ctx)
+					require.NoError(t, err)
+					defer tx.Rollback(ctx)
+					_, err = tx.Exec(ctx, "CREATE TABLE values_limit_delete (id int PRIMARY KEY)")
+					require.NoError(t, err)
+					_, err = tx.Exec(ctx, "INSERT INTO values_limit_delete VALUES (1), (2)")
+					require.NoError(t, err)
+
+					// LIMIT 0 must exclude every candidate, independent of row order.
+					const query = "DELETE FROM values_limit_delete WHERE id IN (VALUES (1), (2) LIMIT 0)"
+					var deleted int64
+					if protocol == "extended" {
+						// ExecParams uses extended protocol even without bind arguments.
+						result := conn.PgConn().ExecParams(ctx, query, nil, nil, nil, nil).Read()
+						require.NoError(t, result.Err)
+						deleted = result.CommandTag.RowsAffected()
+					} else {
+						tag, err := tx.Exec(ctx, query)
+						require.NoError(t, err)
+						deleted = tag.RowsAffected()
+					}
+					t.Logf("deleted rows: %d", deleted)
+					require.Zero(t, deleted)
+					var remaining int
+					err = tx.QueryRow(ctx, "SELECT count(*) FROM values_limit_delete").Scan(&remaining)
+					require.NoError(t, err)
+					require.Equal(t, 2, remaining)
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
VALUES serialization drops ORDER BY, LIMIT, OFFSET, and FETCH clauses. In a DELETE subquery, losing LIMIT can delete rows that should remain untouched.

Reuse SELECT’s trailing-clause rendering for VALUES statements.

Add parser, executor/cache-hit, and end-to-end regression tests. PostgreSQL deletes zero rows for the LIMIT 0 reproduction; unpatched Multigres deletes two. The fix restores zero deletions in both simple and extended protocols.

Validation: parser/executor and gateway tests passed, targeted race tests passed, and the end-to-end regression passed across 10 repetitions.