### PR TITLE
feat(multipooler): elastic regular/reserved quotas over one shared budget

### DIFF
--- a/docs/query_serving/connection_pooling.md
+++ b/docs/query_serving/connection_pooling.md
@@ -333,6 +333,23 @@ Derived:
   globalReservedCapacity = 500 * 0.2 = 100
 ```
 
+With **elastic quotas** (`--connpool-elastic-quotas`, on by default) these are
+targets under contention, not ceilings. Each rebalance cycle re-splits the
+global capacity from the summed demand of both classes:
+
+1. Each class gets `min(demand, target)`.
+2. Unused capacity is lent to whichever class demands more than its target.
+3. Capacity nobody demands is split by the ratio as burst headroom.
+4. Each class keeps a floor of `min(userPools, target)` slots so every user
+   pool stays usable in both classes.
+
+So a single user running only transactions can hold 499 of 500 slots on the
+reserved side, and when regular demand returns the split drifts back toward
+80/20 as reserved connections are released (nothing is preempted; the shrink
+is applied as connections are recycled, exactly like a per-user shrink).
+Borrowing lags demand by up to one rebalance interval plus the demand window.
+Set `--connpool-elastic-quotas=false` to pin the ratio as a hard split.
+
 A `FairShareAllocator` instance manages each resource type independently. This
 mirrors the `DemandTracker` design (also resource-agnostic, one per pool type).
 
@@ -472,16 +489,19 @@ Rebalancing runs as a **periodic background goroutine**:
 │     └─ regularTracker.GetPeakAndRotate() for each user          │
 │     └─ reservedTracker.GetPeakAndRotate() for each user         │
 │                                                                  │
-│  2. Run fair share algorithm (two allocators, one per resource)  │
+│  2. Split global capacity between classes by summed demand       │
+│     └─ splitClassCapacity() (elastic quotas; else fixed ratio)  │
+│                                                                  │
+│  3. Run fair share algorithm (two allocators, one per resource)  │
 │     └─ regularAlloc.Allocate(regularDemands)                    │
 │     └─ reservedAlloc.Allocate(reservedDemands)                  │
 │                                                                  │
-│  3. Apply new capacities                                         │
+│  4. Apply new capacities                                         │
 │     └─ pool.SetCapacity(ctx, newRegularCap, newReservedCap)     │
 │        (non-blocking - excess borrowed connections closed on     │
 │         recycle)                                                 │
 │                                                                  │
-│  4. Garbage collect inactive pools                               │
+│  5. Garbage collect inactive pools                               │
 │     └─ Remove pools with no activity for > inactive timeout     │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -852,6 +872,7 @@ These flags control how pool capacities are distributed across users:
 | ---------------------------------- | ------- | ---------------------------------------------- |
 | `--connpool-global-capacity`       | 100     | Total PostgreSQL connections to manage         |
 | `--connpool-reserved-ratio`        | 0.2     | Fraction of global capacity for reserved pools |
+| `--connpool-elastic-quotas`        | true    | Let classes borrow each other's unused share   |
 | `--connpool-rebalance-interval`    | 10s     | How often to run rebalancing                   |
 | `--connpool-demand-window`         | 30s     | Sliding window for peak demand tracking        |
 | `--connpool-inactive-timeout`      | 5m      | Remove user pools after this inactivity        |

--- a/go/services/multipooler/internal/connpoolmanager/config.go
+++ b/go/services/multipooler/internal/connpoolmanager/config.go
@@ -149,6 +149,11 @@ type Config struct {
 	// Regular pools get (1 - reservedRatio) of the global capacity.
 	reservedRatio viperutil.Value[float64]
 
+	// Elastic quotas lets each pool class borrow the other class's unused
+	// share of the global capacity. When false, the reserved ratio is a fixed
+	// ceiling for both classes.
+	elasticQuotas viperutil.Value[bool]
+
 	// --- Rebalancer configuration ---
 
 	// Rebalance interval is how often the rebalancer runs to adjust pool capacities.
@@ -308,6 +313,11 @@ func NewConfig(reg *viperutil.Registry) *Config {
 			Default:  reservedRatio,
 			FlagName: "connpool-reserved-ratio",
 		}),
+		elasticQuotas: viperutil.Configure(reg, "connpool.elastic-quotas", viperutil.Options[bool]{
+			Default:  true,
+			FlagName: "connpool-elastic-quotas",
+			EnvVars:  []string{"CONNPOOL_ELASTIC_QUOTAS"},
+		}),
 
 		// Rebalancer
 		rebalanceInterval: viperutil.Configure(reg, "connpool.rebalance-interval", viperutil.Options[time.Duration]{
@@ -373,6 +383,7 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 	// Fair share allocation flags
 	fs.Int64("connpool-global-capacity", c.globalCapacity.Default(), "Total PostgreSQL connections to manage (divided between regular and reserved pools). When not set, derived from the server's max_connections at pool open (env: CONNPOOL_GLOBAL_CAPACITY)")
 	fs.Float64("connpool-reserved-ratio", c.reservedRatio.Default(), "Fraction of global capacity allocated to reserved pools (0.0-1.0)")
+	fs.Bool("connpool-elastic-quotas", c.elasticQuotas.Default(), "Let regular and reserved pools borrow each other's unused share of global capacity; the reserved ratio is then a target under contention, not a ceiling (env: CONNPOOL_ELASTIC_QUOTAS)")
 
 	// Rebalancer flags
 	fs.Duration("connpool-rebalance-interval", c.rebalanceInterval.Default(), "How often to rebalance pool capacities")
@@ -399,6 +410,7 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 		c.settingsCacheSize,
 		c.globalCapacity,
 		c.reservedRatio,
+		c.elasticQuotas,
 		c.rebalanceInterval,
 		c.demandWindow,
 		c.inactiveTimeout,
@@ -641,6 +653,11 @@ func (c *Config) GlobalCapacityExplicit() bool {
 // Regular pools get (1 - reservedRatio) of the global capacity.
 func (c *Config) ReservedRatio() float64 {
 	return c.reservedRatio.Get()
+}
+
+// ElasticQuotas reports whether pool classes may borrow each other's unused capacity.
+func (c *Config) ElasticQuotas() bool {
+	return c.elasticQuotas.Get()
 }
 
 // RebalanceInterval returns how often the rebalancer runs to adjust pool capacities.

--- a/go/services/multipooler/internal/connpoolmanager/dynamic_allocation_integration_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/dynamic_allocation_integration_test.go
@@ -231,20 +231,24 @@ func TestDynamicAllocation_UserArrivalDuringLoad(t *testing.T) {
 	}
 	close(ready)
 
-	// Wait for rebalancer to converge on expected capacity split.
+	// Wait for rebalancer to converge on expected capacity split. With
+	// elastic quotas and no reserved demand, regular borrows the idle reserved
+	// share down to one reserved slot per user: 15 - 2 = 13, split 7/6.
 	// Use Eventually instead of fixed sleep to handle slow CI machines.
 	require.Eventually(t, func() bool {
 		stats := manager.Stats()
 		if len(stats.UserPools) != 2 {
 			return false
 		}
+		var total int64
 		for _, poolStats := range stats.UserPools {
-			if poolStats.Regular.Capacity != 6 {
+			if poolStats.Regular.Capacity < 6 {
 				return false
 			}
+			total += poolStats.Regular.Capacity
 		}
-		return true
-	}, 5*time.Second, 50*time.Millisecond, "both users should have half of total capacity (6)")
+		return total == 13
+	}, 5*time.Second, 50*time.Millisecond, "both users should have about half of the borrowed regular capacity (13)")
 	assert.Equal(t, 2, manager.UserPoolCount())
 
 	// Now add a 3rd user during load

--- a/go/services/multipooler/internal/connpoolmanager/fair_share_allocator.go
+++ b/go/services/multipooler/internal/connpoolmanager/fair_share_allocator.go
@@ -14,6 +14,8 @@
 
 package connpoolmanager
 
+import "sync/atomic"
+
 // FairShareAllocator distributes connection capacity among users using max-min fairness.
 // It is agnostic of resource type - create separate instances for regular and reserved pools.
 //
@@ -23,7 +25,7 @@ package connpoolmanager
 //   - Total allocation does not exceed capacity
 //   - Remaining capacity is distributed fairly among unsatisfied users
 type FairShareAllocator struct {
-	capacity   int64
+	capacity   atomic.Int64 // adjusted each rebalance by the class split
 	minPerUser int64
 }
 
@@ -35,15 +37,19 @@ func NewFairShareAllocator(capacity int64, minPerUser int64) *FairShareAllocator
 	if minPerUser < 1 {
 		minPerUser = 1
 	}
-	return &FairShareAllocator{
-		capacity:   capacity,
-		minPerUser: minPerUser,
-	}
+	a := &FairShareAllocator{minPerUser: minPerUser}
+	a.capacity.Store(capacity)
+	return a
 }
 
 // Capacity returns the total capacity this allocator manages.
 func (a *FairShareAllocator) Capacity() int64 {
-	return a.capacity
+	return a.capacity.Load()
+}
+
+// SetCapacity changes the capacity budget for subsequent Allocate calls.
+func (a *FairShareAllocator) SetCapacity(capacity int64) {
+	a.capacity.Store(capacity)
 }
 
 // Allocate distributes capacity among users based on their demands using max-min fairness.
@@ -73,7 +79,7 @@ func (a *FairShareAllocator) Allocate(demands map[string]int64) map[string]int64
 		unsatisfied[user] = true
 	}
 
-	remaining := a.capacity
+	remaining := a.capacity.Load()
 
 	// Progressive filling: keep distributing until no capacity or all satisfied
 	for remaining > 0 && len(unsatisfied) > 0 {
@@ -140,4 +146,62 @@ func (a *FairShareAllocator) Allocate(demands map[string]int64) map[string]int64
 	}
 
 	return allocs
+}
+
+// splitClassCapacity divides one shared budget between the regular and
+// reserved pool classes according to demand. reservedRatio only fixes each
+// class's nominal target; a class whose demand exceeds its target borrows
+// whatever the other class is not using, so either class can reach almost the
+// whole budget when the other is idle:
+//
+//  1. Each class gets min(demand, target).
+//  2. Unused capacity is lent to demand above target.
+//  3. Capacity nobody demands is split by reservedRatio as burst headroom.
+//
+// Each class then keeps a floor of min(minCap, its target) slots, where
+// minCap is the number of user pools, so the per-user allocator can give
+// every user a non-zero allocation in both classes (a zero-capacity pool
+// refuses acquisitions instead of waiting). Capping the floor at the nominal
+// target means borrowing never leaves a class worse off than the fixed split.
+// The result sums to total for any budget >= 2; a budget of 1 overshoots by
+// one rather than starve a class.
+func splitClassCapacity(total int64, reservedRatio float64, regularDemand, reservedDemand, minCap int64) (regularCap, reservedCap int64) {
+	regularTarget := max(int64(float64(total)*(1-reservedRatio)), 1)
+	reservedTarget := max(total-regularTarget, 1)
+
+	regularCap = min(max(regularDemand, 0), regularTarget)
+	reservedCap = min(max(reservedDemand, 0), reservedTarget)
+	spare := total - regularCap - reservedCap
+
+	// Lend spare capacity to whichever class wants more than its target.
+	// At most one class can be above target when spare > 0.
+	if lend := min(regularDemand-regularCap, spare); lend > 0 {
+		regularCap += lend
+		spare -= lend
+	}
+	if lend := min(reservedDemand-reservedCap, spare); lend > 0 {
+		reservedCap += lend
+		spare -= lend
+	}
+
+	// Undemanded capacity is headroom, shared by the configured ratio.
+	if spare > 0 {
+		extraRegular := int64(float64(spare) * (1 - reservedRatio))
+		regularCap += extraRegular
+		reservedCap += spare - extraRegular
+	}
+
+	// Floor each class, taking the slots from the other class. Floors never
+	// exceed targets, and targets sum to total, so this cannot overshoot.
+	regularFloor := max(min(minCap, regularTarget), 1)
+	reservedFloor := max(min(minCap, reservedTarget), 1)
+	if regularCap < regularFloor {
+		reservedCap = max(reservedCap-(regularFloor-regularCap), reservedFloor)
+		regularCap = regularFloor
+	}
+	if reservedCap < reservedFloor {
+		regularCap = max(regularCap-(reservedFloor-reservedCap), regularFloor)
+		reservedCap = reservedFloor
+	}
+	return regularCap, reservedCap
 }

--- a/go/services/multipooler/internal/connpoolmanager/fair_share_allocator_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/fair_share_allocator_test.go
@@ -380,3 +380,62 @@ func BenchmarkFairShareAllocator_Allocate(b *testing.B) {
 		_ = alloc.Allocate(demands)
 	}
 }
+
+func TestSplitClassCapacity(t *testing.T) {
+	// 40 slots, 80:20 ratio → nominal targets 32 regular / 8 reserved.
+	cases := []struct {
+		name                  string
+		regular, reserved     int64
+		wantRegular, wantResv int64
+	}{
+		{"both saturated keeps ratio", 40, 40, 32, 8},
+		{"reserved borrows unused regular", 8, 32, 8, 32},
+		{"reserved borrows almost everything", 1, 40, 1, 39},
+		{"reserved floor keeps one regular slot", 0, 40, 1, 39},
+		{"regular floor keeps one reserved slot", 40, 0, 39, 1},
+		{"idle splits headroom by ratio", 0, 0, 32, 8},
+		{"partial demand shares headroom by ratio", 10, 0, 34, 6},
+		{"regular over target, reserved at target", 40, 8, 32, 8},
+		{"regular borrows unused reserved", 36, 2, 37, 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, v := splitClassCapacity(40, 0.2, tc.regular, tc.reserved, 1)
+			assert.Equal(t, tc.wantRegular, r, "regular")
+			assert.Equal(t, tc.wantResv, v, "reserved")
+		})
+	}
+
+	// Three user pools keep three reserved slots even with no reserved demand.
+	r, v := splitClassCapacity(12, 0.25, 11, 0, 3)
+	assert.Equal(t, int64(9), r)
+	assert.Equal(t, int64(3), v)
+
+	// The floor is capped at the nominal target: five users on a 10-slot
+	// budget keep the fixed split's 2 reserved slots, not 5.
+	r, v = splitClassCapacity(10, 0.2, 15, 0, 5)
+	assert.Equal(t, int64(8), r)
+	assert.Equal(t, int64(2), v)
+
+	// A budget of 1 overshoots by one so both classes stay usable,
+	// matching the fixed split's behavior.
+	r, v = splitClassCapacity(1, 0.2, 0, 0, 1)
+	assert.Equal(t, int64(1), r)
+	assert.Equal(t, int64(1), v)
+
+	// Property: the split exactly consumes any budget >= 2 and never drops a
+	// class below min(minCap, target) or below 1.
+	for total := int64(2); total <= 60; total++ {
+		regularTarget := int64(float64(total) * 0.8)
+		for minCap := int64(1); minCap <= total+1; minCap += 3 {
+			for rd := int64(0); rd <= total+5; rd += 5 {
+				for vd := int64(0); vd <= total+5; vd += 5 {
+					r, v := splitClassCapacity(total, 0.2, rd, vd, minCap)
+					assert.Equal(t, total, r+v, "total=%d min=%d rd=%d vd=%d", total, minCap, rd, vd)
+					assert.GreaterOrEqual(t, r, max(min(minCap, regularTarget), 1))
+					assert.GreaterOrEqual(t, v, max(min(minCap, total-regularTarget), 1))
+				}
+			}
+		}
+	}
+}

--- a/go/services/multipooler/internal/connpoolmanager/manager.go
+++ b/go/services/multipooler/internal/connpoolmanager/manager.go
@@ -258,6 +258,8 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 
 	// Use configurable minCapacityPerUser as the minimum per-user floor.
 	// This ensures light users always have enough capacity for burst demand.
+	// These are the nominal shares; with elastic quotas the rebalancer moves
+	// capacity between the two allocators each cycle based on demand.
 	m.regularAllocator = NewFairShareAllocator(regularCapacity, regularMinPerUser)
 	m.reservedAllocator = NewFairShareAllocator(reservedCapacity, reservedMinPerUser)
 
@@ -277,6 +279,7 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 		"settings_cache_size", m.config.SettingsCacheSize(),
 		"global_capacity", globalCapacity,
 		"reserved_ratio", reservedRatio,
+		"elastic_quotas", m.config.ElasticQuotas(),
 		"regular_allocation", regularCapacity,
 		"reserved_allocation", reservedCapacity,
 		"rebalance_interval", m.config.RebalanceInterval(),

--- a/go/services/multipooler/internal/connpoolmanager/rebalancer.go
+++ b/go/services/multipooler/internal/connpoolmanager/rebalancer.go
@@ -68,7 +68,8 @@ func (m *Manager) rebalance(ctx context.Context) {
 		reservedDemands[user] = pool.ReservedDemand()
 	}
 
-	// 2. Compute fair allocations
+	// 2. Split the shared budget between classes, then fairly among users.
+	m.splitClassCapacity(ctx, regularDemands, reservedDemands)
 	regularAllocs := m.regularAllocator.Allocate(regularDemands)
 	reservedAllocs := m.reservedAllocator.Allocate(reservedDemands)
 
@@ -95,6 +96,36 @@ func (m *Manager) rebalance(ctx context.Context) {
 
 	// 4. Garbage collect inactive pools
 	m.garbageCollectInactivePools(ctx)
+}
+
+// splitClassCapacity sets each class allocator's budget for this cycle. With
+// elastic quotas, a class whose summed demand exceeds its nominal share
+// borrows whatever the other class is not demanding (see splitClassCapacity).
+// Otherwise the nominal split stands. Only called from the rebalancer goroutine.
+func (m *Manager) splitClassCapacity(ctx context.Context, regularDemands, reservedDemands map[string]int64) {
+	if !m.config.ElasticQuotas() {
+		return
+	}
+	var regularDemand, reservedDemand int64
+	for _, d := range regularDemands {
+		regularDemand += d
+	}
+	for _, d := range reservedDemands {
+		reservedDemand += d
+	}
+	// Every user pool keeps one slot per class, up to the class's nominal
+	// share (see splitClassCapacity).
+	minCap := int64(len(regularDemands))
+	regularCap, reservedCap := splitClassCapacity(m.globalCapacity.Load(), m.config.ReservedRatio(), regularDemand, reservedDemand, minCap)
+	if regularCap != m.regularAllocator.Capacity() || reservedCap != m.reservedAllocator.Capacity() {
+		m.logger.InfoContext(ctx, "class capacity split updated",
+			"regular_demand", regularDemand,
+			"reserved_demand", reservedDemand,
+			"regular_capacity", regularCap,
+			"reserved_capacity", reservedCap)
+	}
+	m.regularAllocator.SetCapacity(regularCap)
+	m.reservedAllocator.SetCapacity(reservedCap)
 }
 
 // garbageCollectInactivePools removes user pools that have been inactive

--- a/go/services/multipooler/internal/connpoolmanager/rebalancer_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/rebalancer_test.go
@@ -17,6 +17,7 @@ package connpoolmanager
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -518,4 +519,98 @@ func TestManager_GarbageCollectSkipsCycleWhenCreateMuHeld(t *testing.T) {
 
 	manager.garbageCollectInactivePools(ctx)
 	assert.False(t, manager.HasUserPool("stale"), "next cycle collects normally")
+}
+
+// holdReservedConns acquires n reserved conns for user concurrently and
+// returns them. Acquisitions that block count as demand, so the rebalancer
+// can grow the pool to satisfy them.
+func holdReservedConns(t *testing.T, ctx context.Context, manager *Manager, user string, n int) []*reserved.Conn {
+	t.Helper()
+	var mu sync.Mutex
+	var held []*reserved.Conn
+	var wg sync.WaitGroup
+	for range n {
+		wg.Go(func() {
+			rc, err := manager.NewReservedConn(ctx, nil, user, nil, nil)
+			if err != nil {
+				return
+			}
+			rc.SetInactivityTimeout(0)
+			mu.Lock()
+			held = append(held, rc)
+			mu.Unlock()
+		})
+	}
+	wg.Wait()
+	return held
+}
+
+// With elastic quotas, reserved demand beyond its nominal 20% share borrows
+// the regular class's unused capacity: 30 concurrent transactions fit in a
+// 40-slot budget whose fixed split would allow only 8.
+func TestManager_ElasticQuotas_ReservedBorrowsFromRegular(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManagerWithConfig(t, server, &DynamicAllocationTestConfig{
+		GlobalCapacity:    40,
+		ReservedRatio:     0.2,
+		RebalanceInterval: 50 * time.Millisecond,
+		DemandWindow:      150 * time.Millisecond,
+	})
+	defer manager.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	held := holdReservedConns(t, ctx, manager, "txuser", 30)
+	require.Len(t, held, 30, "all 30 reserved conns should be acquired by borrowing regular capacity")
+	assert.GreaterOrEqual(t, manager.reservedAllocator.Capacity(), int64(30))
+	assert.LessOrEqual(t, manager.regularAllocator.Capacity()+manager.reservedAllocator.Capacity(), int64(40))
+
+	for _, rc := range held {
+		rc.Release(reserved.ReleaseRollback, nil)
+	}
+
+	// Once reserved demand ages out, capacity drifts back toward the ratio.
+	require.Eventually(t, func() bool {
+		return manager.reservedAllocator.Capacity() == 8 && manager.regularAllocator.Capacity() == 32
+	}, 5*time.Second, 20*time.Millisecond, "split should return to nominal 32/8 once idle")
+}
+
+// With elastic quotas disabled the reserved ratio is a hard ceiling.
+func TestManager_FixedQuotas_ReservedCappedAtShare(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+	config.globalCapacity.Set(40)
+	config.reservedRatio.Set(0.2)
+	config.elasticQuotas.Set(false)
+	config.rebalanceInterval.Set(50 * time.Millisecond)
+	config.demandWindow.Set(150 * time.Millisecond)
+	resolveTestPgPassword(t, config)
+	manager := config.NewManager(slog.Default())
+	manager.Open(context.Background(), &ConnectionConfig{
+		SocketFile: server.ClientConfig().SocketFile,
+		Host:       server.ClientConfig().Host,
+		Port:       server.ClientConfig().Port,
+		Database:   server.ClientConfig().Database,
+	})
+	defer manager.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	held := holdReservedConns(t, ctx, manager, "txuser", 30)
+	assert.Len(t, held, 8, "fixed split must not lend regular capacity to reserved")
+	assert.Equal(t, int64(8), manager.reservedAllocator.Capacity())
+	assert.Equal(t, int64(32), manager.regularAllocator.Capacity())
+
+	for _, rc := range held {
+		rc.Release(reserved.ReleaseRollback, nil)
+	}
 }

--- a/go/services/multipooler/internal/pools/connpool/pool.go
+++ b/go/services/multipooler/internal/pools/connpool/pool.go
@@ -1133,8 +1133,12 @@ func (pool *Pool[C]) Requested() int64 {
 // PeakRequestedAndReset returns the peak demand since the last reset and resets the peak.
 // This captures burst demand that point-in-time sampling might miss. For accurate demand
 // tracking, call this method periodically to get the peak demand over an interval.
+//
+// The peak is reset to the current requested count, not zero: connections held
+// across the whole interval (e.g. a long transaction on a reserved conn) are
+// still demand even though no new Get raised the peak.
 func (pool *Pool[C]) PeakRequestedAndReset() int64 {
-	return pool.peakRequested.Swap(0)
+	return pool.peakRequested.Swap(pool.requested.Load())
 }
 
 // Waiting returns the number of clients currently waiting for a connection.


### PR DESCRIPTION
## Problem

The global connection budget is split into two fixed ceilings by `connpool-reserved-ratio`, e.g. 32 regular / 8 reserved out of 40. A workload of explicit transactions saturates the reserved side while the regular side sits idle. A 32-client pgbench TPC-B run had 24 clients waiting on 8 reserved slots, with mean reserved acquisition around 104 ms and the first UPDATE inflated accordingly.

## Change

Let the existing rebalancer re-split the budget between the two classes each cycle from their summed demand, then run the existing per-user fair share inside each class:

1. Each class gets `min(demand, target)`.
2. Unused capacity is lent to whichever class demands more than its target.
3. Undemanded capacity is split by the ratio as burst headroom.
4. Each class keeps a floor of `min(userPools, target)` so no user pool is ever allocated zero capacity (the pool treats zero as closed). Borrowing therefore never leaves a class worse off than the fixed split.

Reservation IDs, backend affinity, per-user fair share, non-blocking shrink and drain semantics are unchanged. Transient overshoot during a shrink is the same as the existing per-user shrink: excess connections close on recycle.

Peak demand now resets to the current requested count rather than zero, so connections held across a whole interval (long transactions) keep counting as demand.

`--connpool-elastic-quotas=false` (`CONNPOOL_ELASTIC_QUOTAS`) restores the fixed split.

For 40 slots at 80:20:

| regular demand | reserved demand | regular | reserved |
| --- | --- | --- | --- |
| 40 | 40 | 32 | 8 |
| 8 | 32 | 8 | 32 |
| 0 (1 user) | 40 | 1 | 39 |
| 0 | 0 | 32 | 8 |

## Not included

Deliberately left out of this PR after review of the prototype design:

- A hard permit layer at the socket level. The existing per-user rebalancer already tolerates transient overshoot during shrink; a hard cap against `max_connections` is a separate concern.
- Zero-quota pool semantics and start-at-zero user pools, replaced by the per-class floor above.
- Demand-driven rebalance wakeups. The observed borrowing lag comes from the demand window and rebalance interval, both existing knobs.
- New per-class gauges. Per-pool capacity and demand stats already exist.

## Testing

- Table and property tests for the split arithmetic.
- Manager tests: 30 reserved connections on a 40-slot 80:20 budget all acquire and the split returns to 32/8 after release; with the flag off only 8 acquire.
- `connpoolmanager` and `pools/...` pass with `-race`; the elastic and dynamic-allocation tests pass 5x in a row.
- One existing test updated: the user-arrival test asserted the fixed 12 regular split; with reserved idle, regular now borrows down to one reserved slot per user (13, split 7/6).

## Rollout note

Borrowing lags demand by up to one rebalance interval plus the demand window (defaults 10 s and 30 s), in both directions. Under sustained regular saturation the reserved class shrinks to its floor, and a burst of transactions then waits up to that lag for capacity to move back.
