### PR TITLE
feat(multigres): read multiadmin address from env var

### DIFF
--- a/go/cmd/multigres/command/admin/client.go
+++ b/go/cmd/multigres/command/admin/client.go
@@ -65,6 +65,11 @@ func GetServerAddress(cmd *cobra.Command) (string, error) {
 		return adminServer, nil
 	}
 
+	// Fall back to the MULTIGRES_ADMIN_SERVER environment variable
+	if v := os.Getenv("MULTIGRES_ADMIN_SERVER"); v != "" {
+		return v, nil
+	}
+
 	// Fall back to config file
 	configPaths, err := cmd.Flags().GetStringSlice("config-path")
 	if err != nil {

--- a/go/cmd/multigres/command/admin/client_test.go
+++ b/go/cmd/multigres/command/admin/client_test.go
@@ -114,6 +114,9 @@ provisioner-config:
 	})
 
 	t.Run("falls back to config path", func(t *testing.T) {
+		// Ensure the env var doesn't interfere with the config-path fallback.
+		t.Setenv("MULTIGRES_ADMIN_SERVER", "")
+
 		// Create a mock command with only config-path set
 		cmd := &cobra.Command{}
 		cmd.Flags().String("admin-server", "", "")
@@ -127,7 +130,37 @@ provisioner-config:
 		assert.Equal(t, "localhost:12345", address)
 	})
 
+	t.Run("falls back to MULTIGRES_ADMIN_SERVER env var", func(t *testing.T) {
+		// Env var is used when the flag is empty and no config-path is given.
+		t.Setenv("MULTIGRES_ADMIN_SERVER", "env:8080")
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("admin-server", "", "")
+		cmd.Flags().StringSlice("config-path", []string{}, "")
+
+		address, err := GetServerAddress(cmd)
+		require.NoError(t, err)
+		assert.Equal(t, "env:8080", address)
+	})
+
+	t.Run("admin-server flag takes precedence over env var", func(t *testing.T) {
+		t.Setenv("MULTIGRES_ADMIN_SERVER", "env:8080")
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("admin-server", "", "")
+		cmd.Flags().StringSlice("config-path", []string{}, "")
+
+		require.NoError(t, cmd.Flags().Set("admin-server", "flag:9999"))
+
+		address, err := GetServerAddress(cmd)
+		require.NoError(t, err)
+		assert.Equal(t, "flag:9999", address)
+	})
+
 	t.Run("error when neither flag is provided", func(t *testing.T) {
+		// Ensure the env var doesn't interfere with the error path.
+		t.Setenv("MULTIGRES_ADMIN_SERVER", "")
+
 		// Create a mock command with no flags set
 		cmd := &cobra.Command{}
 		cmd.Flags().String("admin-server", "", "")

--- a/go/cmd/multigres/command/cluster/apply_rule_change.go
+++ b/go/cmd/multigres/command/cluster/apply_rule_change.go
@@ -162,7 +162,7 @@ Examples:
 	cmd.Flags().String("reason", a.reason.Default(), "Free-text reason for the rule change (recorded for audit)")
 	cmd.Flags().Bool("yes", a.yes.Default(), "Skip the interactive confirmation prompt")
 	cmd.Flags().Duration("timeout", a.timeout.Default(), "Timeout for the RPC call")
-	cmd.Flags().String("admin-server", "", "host:port of the multiadmin server (overrides config)")
+	cmd.Flags().String("admin-server", "", "host:port of the multiadmin server (overrides config; env: MULTIGRES_ADMIN_SERVER)")
 
 	viperutil.BindFlags(cmd.Flags(),
 		a.database, a.tableGroup, a.shard,

--- a/go/cmd/multigres/command/cluster/backup.go
+++ b/go/cmd/multigres/command/cluster/backup.go
@@ -79,7 +79,7 @@ func AddBackupCommand(clusterCmd *cobra.Command) {
 	cmd.Flags().String("type", bcmd.backupType.Default(), "Backup type: full, differential, or incremental")
 	cmd.Flags().Bool("primary", bcmd.primary.Default(), "Force backup on primary instead of replica (use with caution)")
 	cmd.Flags().Duration("timeout", bcmd.timeout.Default(), "Timeout for initial backup call")
-	cmd.Flags().String("admin-server", "", "host:port of the multiadmin server (overrides config)")
+	cmd.Flags().String("admin-server", "", "host:port of the multiadmin server (overrides config; env: MULTIGRES_ADMIN_SERVER)")
 
 	viperutil.BindFlags(cmd.Flags(), bcmd.database, bcmd.backupType, bcmd.primary, bcmd.timeout)
 

--- a/go/cmd/multigres/command/cluster/expire_backups.go
+++ b/go/cmd/multigres/command/cluster/expire_backups.go
@@ -58,7 +58,7 @@ func AddExpireBackupsCommand(clusterCmd *cobra.Command) {
 
 	cmd.Flags().String("database", ecmd.database.Default(), "Database name")
 	cmd.Flags().Duration("timeout", ecmd.timeout.Default(), "Timeout for the expire operation")
-	cmd.Flags().String("admin-server", "", "host:port of the multiadmin server (overrides config)")
+	cmd.Flags().String("admin-server", "", "host:port of the multiadmin server (overrides config; env: MULTIGRES_ADMIN_SERVER)")
 
 	viperutil.BindFlags(cmd.Flags(), ecmd.database, ecmd.timeout)
 

--- a/go/cmd/multigres/command/cluster/list_backups.go
+++ b/go/cmd/multigres/command/cluster/list_backups.go
@@ -39,7 +39,7 @@ func AddListBackupsCommand(clusterCmd *cobra.Command) {
 
 	cmd.Flags().String("database", "postgres", "Database name to list backups for")
 	cmd.Flags().Uint32("limit", 0, "Maximum number of backups to return (0 = no limit)")
-	cmd.Flags().String("admin-server", "", "Address of the multiadmin server (overrides config)")
+	cmd.Flags().String("admin-server", "", "Address of the multiadmin server (overrides config; env: MULTIGRES_ADMIN_SERVER)")
 
 	clusterCmd.AddCommand(cmd)
 }

--- a/go/cmd/multigres/command/cluster/switch_primary.go
+++ b/go/cmd/multigres/command/cluster/switch_primary.go
@@ -96,7 +96,7 @@ Examples:
 	cmd.Flags().String("reason", pf.reason.Default(), "Free-text reason for the failover (recorded for audit)")
 	cmd.Flags().Bool("yes", pf.yes.Default(), "Skip the interactive confirmation prompt")
 	cmd.Flags().Duration("timeout", pf.timeout.Default(), "Overall RPC timeout")
-	cmd.Flags().String("admin-server", "", "host:port of the multiadmin server (overrides config)")
+	cmd.Flags().String("admin-server", "", "host:port of the multiadmin server (overrides config; env: MULTIGRES_ADMIN_SERVER)")
 
 	viperutil.BindFlags(cmd.Flags(),
 		pf.database, pf.tableGroup, pf.shard,

--- a/go/cmd/multigres/command/cluster/verify_backups.go
+++ b/go/cmd/multigres/command/cluster/verify_backups.go
@@ -54,7 +54,7 @@ func AddVerifyBackupsCommand(clusterCmd *cobra.Command) {
 	}
 
 	cmd.Flags().Duration("timeout", vcmd.timeout.Default(), "Timeout for the verify operation")
-	cmd.Flags().String("admin-server", "", "host:port of the multiadmin server (overrides config)")
+	cmd.Flags().String("admin-server", "", "host:port of the multiadmin server (overrides config; env: MULTIGRES_ADMIN_SERVER)")
 
 	viperutil.BindFlags(cmd.Flags(), vcmd.timeout)
 

--- a/go/cmd/multigres/command/pooler/status.go
+++ b/go/cmd/multigres/command/pooler/status.go
@@ -54,7 +54,7 @@ require an active database connection.`,
 
 	cmd.Flags().String("cell", "", "Cell name where the pooler resides (required)")
 	cmd.Flags().String("service-id", "", "Service ID (name) of the pooler (required)")
-	cmd.Flags().String("admin-server", "", "gRPC address of the multiadmin server (e.g., localhost:18070)")
+	cmd.Flags().String("admin-server", "", "gRPC address of the multiadmin server (e.g., localhost:18070; env: MULTIGRES_ADMIN_SERVER)")
 
 	_ = cmd.MarkFlagRequired("cell")
 	_ = cmd.MarkFlagRequired("service-id")

--- a/go/cmd/multigres/command/topo/getcell.go
+++ b/go/cmd/multigres/command/topo/getcell.go
@@ -37,7 +37,7 @@ func AddGetCellCommand() *cobra.Command {
 
 	// Add command-specific flags
 	cmd.Flags().String("name", "", "Name of the cell to retrieve (required)")
-	cmd.Flags().String("admin-server", "", "gRPC address of the multiadmin server (e.g., localhost:15990)")
+	cmd.Flags().String("admin-server", "", "gRPC address of the multiadmin server (e.g., localhost:15990; env: MULTIGRES_ADMIN_SERVER)")
 
 	// Mark the name flag as required
 	_ = cmd.MarkFlagRequired("name")

--- a/go/cmd/multigres/command/topo/getcellnames.go
+++ b/go/cmd/multigres/command/topo/getcellnames.go
@@ -57,7 +57,7 @@ func AddGetCellNamesCommand() *cobra.Command {
 		RunE:  runGetCellNames,
 	}
 
-	cmd.Flags().String("admin-server", "", "Address of the multiadmin server (overrides config)")
+	cmd.Flags().String("admin-server", "", "Address of the multiadmin server (overrides config; env: MULTIGRES_ADMIN_SERVER)")
 
 	return cmd
 }

--- a/go/cmd/multigres/command/topo/getdatabase.go
+++ b/go/cmd/multigres/command/topo/getdatabase.go
@@ -37,7 +37,7 @@ func AddGetDatabaseCommand() *cobra.Command {
 
 	// Add command-specific flags
 	cmd.Flags().String("name", "", "Name of the database to retrieve (required)")
-	cmd.Flags().String("admin-server", "", "gRPC address of the multiadmin server (e.g., localhost:15990)")
+	cmd.Flags().String("admin-server", "", "gRPC address of the multiadmin server (e.g., localhost:15990; env: MULTIGRES_ADMIN_SERVER)")
 
 	// Mark the name flag as required
 	_ = cmd.MarkFlagRequired("name")

--- a/go/cmd/multigres/command/topo/getdatabasenames.go
+++ b/go/cmd/multigres/command/topo/getdatabasenames.go
@@ -57,7 +57,7 @@ func AddGetDatabaseNamesCommand() *cobra.Command {
 		RunE:  runGetDatabaseNames,
 	}
 
-	cmd.Flags().String("admin-server", "", "Address of the multiadmin server (overrides config)")
+	cmd.Flags().String("admin-server", "", "Address of the multiadmin server (overrides config; env: MULTIGRES_ADMIN_SERVER)")
 
 	return cmd
 }

--- a/go/cmd/multigres/command/topo/getgateways.go
+++ b/go/cmd/multigres/command/topo/getgateways.go
@@ -78,7 +78,7 @@ func AddGetGatewaysCommand() *cobra.Command {
 		RunE:  runGetGateways,
 	}
 
-	cmd.Flags().String("admin-server", "", "Address of the multiadmin server (overrides config)")
+	cmd.Flags().String("admin-server", "", "Address of the multiadmin server (overrides config; env: MULTIGRES_ADMIN_SERVER)")
 	cmd.Flags().String("cells", "", "Comma-separated list of cell names to query (optional)")
 
 	return cmd

--- a/go/cmd/multigres/command/topo/getorchs.go
+++ b/go/cmd/multigres/command/topo/getorchs.go
@@ -78,7 +78,7 @@ func AddGetOrchsCommand() *cobra.Command {
 		RunE:  runGetOrchs,
 	}
 
-	cmd.Flags().String("admin-server", "", "Address of the multiadmin server (overrides config)")
+	cmd.Flags().String("admin-server", "", "Address of the multiadmin server (overrides config; env: MULTIGRES_ADMIN_SERVER)")
 	cmd.Flags().String("cells", "", "Comma-separated list of cell names to query (optional)")
 
 	return cmd

--- a/go/cmd/multigres/command/topo/getpoolers.go
+++ b/go/cmd/multigres/command/topo/getpoolers.go
@@ -88,7 +88,7 @@ func AddGetPoolersCommand() *cobra.Command {
 		RunE:  runGetPoolers,
 	}
 
-	cmd.Flags().String("admin-server", "", "Address of the multiadmin server (overrides config)")
+	cmd.Flags().String("admin-server", "", "Address of the multiadmin server (overrides config; env: MULTIGRES_ADMIN_SERVER)")
 	cmd.Flags().String("cells", "", "Comma-separated list of cell names to query (optional)")
 	cmd.Flags().String("database", "", "Database name to filter by (optional)")
 


### PR DESCRIPTION
Every admin-facing `multigres` CLI command resolves the multiadmin server address through a single function, `GetServerAddress` in `go/cmd/multigres/command/admin/client.go`. Today it only checks the `--admin-server` flag and then falls back to a `--config-path` → `multigres.yaml` lookup. With no environment-variable fallback, the ~21 admin commands (all `topo/get*`, `getpoolerstatus`, the `cluster` backup / switch-primary / apply-rule-change commands, and every `*-migration` command) require `--admin-server` to be repeated on each invocation.

This PR adds a `MULTIGRES_ADMIN_SERVER` environment-variable fallback so the address can be set once for a shell session. Precedence is:

1. `--admin-server` flag (if non-empty) — unchanged, highest priority.
2. `MULTIGRES_ADMIN_SERVER` environment variable (if non-empty) — new.
3. `--config-path` → `multigres.yaml` — unchanged.

The existing "either --admin-server or --config-path must be provided" error still applies when flag, env, and config are all absent. The `MULTIGRES_` prefix matches the existing `MULTIGRES_PORT_POOL_ADDR` convention.

The `--admin-server` flag help text is updated across all registering commands to mention the env var so it's discoverable via `--help`.

Unit tests in `client_test.go` cover the env-var fallback (used when the flag is empty and no config-path is given) and that the flag still takes precedence over the env var; env-sensitive existing subtests clear the variable via `t.Setenv` to stay hermetic.
